### PR TITLE
Allow to specify highlighter parameters on a per field level basis

### DIFF
--- a/modules/elasticsearch/src/main/java/org/apache/lucene/search/vectorhighlight/SingleFragListBuilder.java
+++ b/modules/elasticsearch/src/main/java/org/apache/lucene/search/vectorhighlight/SingleFragListBuilder.java
@@ -1,0 +1,31 @@
+package org.apache.lucene.search.vectorhighlight;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Copy from lucene trunk:
+ * http://svn.apache.org/viewvc/lucene/dev/trunk/lucene/contrib/highlighter/src/java/org/apache/lucene/search/vectorhighlight/SingleFragListBuilder.java
+ * This class in not available in 3.0.2 release yet.
+ */
+public class SingleFragListBuilder implements FragListBuilder {
+
+    @Override public FieldFragList createFieldFragList(FieldPhraseList fieldPhraseList, int fragCharSize) {
+        FieldFragList ffl = new FieldFragList(fragCharSize);
+
+        List<FieldPhraseList.WeightedPhraseInfo> wpil = new ArrayList<FieldPhraseList.WeightedPhraseInfo>();
+        Iterator<FieldPhraseList.WeightedPhraseInfo> ite = fieldPhraseList.phraseList.iterator();
+        FieldPhraseList.WeightedPhraseInfo phraseInfo = null;
+        while (true) {
+            if (!ite.hasNext()) break;
+            phraseInfo = ite.next();
+            if (phraseInfo == null) break;
+
+            wpil.add(phraseInfo);
+        }
+        if (wpil.size() > 0)
+            ffl.add(0, Integer.MAX_VALUE, wpil);
+        return ffl;
+    }
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -26,61 +26,68 @@ import java.util.List;
  */
 public class SearchContextHighlight {
 
-    private List<ParsedHighlightField> fields;
+    private final ParsedHighlightSettings global;
 
-    private String[] preTags;
+    private final List<ParsedHighlightField> fields;
 
-    private String[] postTags;
-
-    private boolean scoreOrdered = false;
-
-    private boolean highlightFilter;
-
-    public SearchContextHighlight(List<ParsedHighlightField> fields, String[] preTags, String[] postTags,
-                                  boolean scoreOrdered, boolean highlightFilter) {
+    public SearchContextHighlight(List<ParsedHighlightField> fields, ParsedHighlightSettings settings) {
         this.fields = fields;
-        this.preTags = preTags;
-        this.postTags = postTags;
-        this.scoreOrdered = scoreOrdered;
-        this.highlightFilter = highlightFilter;
-    }
-
-    public boolean highlightFilter() {
-        return highlightFilter;
+        this.global = settings;
     }
 
     public List<ParsedHighlightField> fields() {
         return fields;
     }
 
-    public String[] preTags() {
-        return preTags;
-    }
-
-    public String[] postTags() {
-        return postTags;
-    }
-
-    public boolean scoreOrdered() {
-        return scoreOrdered;
+    public ParsedHighlightSettings global() {
+        return global;
     }
 
     public static class ParsedHighlightField {
 
         private final String field;
 
-        private final int fragmentCharSize;
+        private final ParsedHighlightSettings settings;
 
-        private final int numberOfFragments;
-
-        public ParsedHighlightField(String field, int fragmentCharSize, int numberOfFragments) {
+        public ParsedHighlightField(String field, ParsedHighlightSettings settings) {
             this.field = field;
-            this.fragmentCharSize = fragmentCharSize;
-            this.numberOfFragments = numberOfFragments;
+            this.settings = settings;
         }
 
         public String field() {
             return field;
+        }
+
+        public ParsedHighlightSettings settings() {
+            return settings;
+        }
+    }
+
+    public static class ParsedHighlightSettings {
+
+        private final int fragmentCharSize;
+
+        private final int numberOfFragments;
+
+        private final String[] preTags;
+
+        private final String[] postTags;
+
+        private boolean scoreOrdered = false;
+
+        private boolean highlightFilter = true;
+
+        private boolean fragmentsAllowed = true;
+
+        public ParsedHighlightSettings(int fragmentCharSize, int numberOfFragments, String[] preTags, String[] postTags,
+                                  boolean scoreOrdered, boolean highlightFilter, boolean fragmentsAllowed) {
+            this.fragmentCharSize = fragmentCharSize;
+            this.numberOfFragments = numberOfFragments;
+            this.preTags = preTags;
+            this.postTags = postTags;
+            this.scoreOrdered = scoreOrdered;
+            this.highlightFilter = highlightFilter;
+            this.fragmentsAllowed = fragmentsAllowed;
         }
 
         public int fragmentCharSize() {
@@ -89,6 +96,26 @@ public class SearchContextHighlight {
 
         public int numberOfFragments() {
             return numberOfFragments;
+        }
+
+        public String[] preTags() {
+            return preTags;
+        }
+
+        public String[] postTags() {
+            return postTags;
+        }
+
+        public boolean scoreOrdered() {
+            return scoreOrdered;
+        }
+
+        public boolean highlightFilter() {
+            return highlightFilter;
+        }
+
+        public boolean fragmentsAllowed() {
+            return fragmentsAllowed;
         }
     }
 }


### PR DESCRIPTION
Now it is possible to override global highlighter settings at the field level. On top of this it is also possible to specify "fragment_type" : "content" which will return highlighted content of the field (no fragments).
