### PR TITLE
exec the java process

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -120,7 +120,7 @@ launch_service()
     # but it's up to us not to background.
     if [ "x$foreground" != "x" ]; then
         es_parms="$es_parms -Des-foreground=yes"
-        $JAVA $JAVA_OPTS $ES_JAVA_OPTS $es_parms -cp $CLASSPATH $props \
+        exec $JAVA $JAVA_OPTS $ES_JAVA_OPTS $es_parms -cp $CLASSPATH $props \
                 org.elasticsearch.bootstrap.Bootstrap
     else
         # Startup Bootstrap, background it, and write the pid.


### PR DESCRIPTION
Hi,

We run most of our system tools under daemontools.  bin/elasticsearch would start a separate process for the java process; so daemontools would terminate the shell process but not the java process when asking it to restart.  launchd will have similar issues.

The patch makes it exec in foreground mode, too, which fixes the problem.
