### PR TITLE
"geo_distance" parsing bugs

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
@@ -35,7 +35,7 @@ public enum DistanceUnit {
         }@Override public double toMiles(double distance) {
             return distance;
         }@Override public double toKilometers(double distance) {
-            return distance / MILES_KILOMETRES_RATIO;
+            return distance * MILES_KILOMETRES_RATIO;
         }
         @Override public String toString(double distance) {
             return distance + "mi";
@@ -44,7 +44,7 @@ public enum DistanceUnit {
         @Override public String toString() {
             return "km";
         }@Override public double toMiles(double distance) {
-            return distance * MILES_KILOMETRES_RATIO;
+            return distance / MILES_KILOMETRES_RATIO;
         }@Override public double toKilometers(double distance) {
             return distance;
         }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/xcontent/GeoDistanceFilterParser.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/xcontent/GeoDistanceFilterParser.java
@@ -74,7 +74,8 @@ public class GeoDistanceFilterParser extends AbstractIndexComponent implements X
         double lon = 0;
         String fieldName = null;
         double distance = 0;
-        DistanceUnit unit = null;
+        Object vDistance = null;
+        DistanceUnit unit = DistanceUnit.KILOMETERS; // default unit
         GeoDistance geoDistance = GeoDistance.ARC;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -110,9 +111,9 @@ public class GeoDistanceFilterParser extends AbstractIndexComponent implements X
             } else if (token.isValue()) {
                 if (currentFieldName.equals("distance")) {
                     if (token == XContentParser.Token.VALUE_STRING) {
-                        distance = DistanceUnit.parse(parser.text(), DistanceUnit.KILOMETERS, DistanceUnit.MILES);
+                        vDistance = parser.text(); // a String
                     } else {
-                        distance = parser.doubleValue();
+                        vDistance = parser.numberValue(); // a Number
                     }
                 } else if (currentFieldName.equals("unit")) {
                     unit = DistanceUnit.fromString(parser.text());
@@ -150,8 +151,10 @@ public class GeoDistanceFilterParser extends AbstractIndexComponent implements X
             }
         }
 
-        if (unit != null) {
-            distance = unit.toMiles(distance);
+        if (vDistance instanceof Number) {
+            distance = unit.toMiles(((Number)vDistance).doubleValue());
+        } else {
+            distance = DistanceUnit.parse((String)vDistance, unit, DistanceUnit.MILES);
         }
 
         MapperService mapperService = parseContext.mapperService();

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
@@ -1246,6 +1246,31 @@ public class SimpleIndexQueryParserTests {
         assertThat(filter.distance(), closeTo(12, 0.00001));
     }
 
+    @Test public void testGeoDistanceFilter7() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance7.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
+    @Test public void testGeoDistanceFilter8() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance8.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
     @Test public void testGeoBoundingBoxFilterNamed() throws IOException {
         IndexQueryParser queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_boundingbox-named.json");

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
@@ -1271,6 +1271,46 @@ public class SimpleIndexQueryParserTests {
         assertThat(filter.lon(), closeTo(-70, 0.00001));
         assertThat(filter.distance(), closeTo(12, 0.00001));
     }
+
+    @Test public void testGeoDistanceFilter9() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance9.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
+    @Test public void testGeoDistanceFilter10() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance10.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
+    @Test public void testGeoDistanceFilter11() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance11.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
     @Test public void testGeoBoundingBoxFilterNamed() throws IOException {
         IndexQueryParser queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_boundingbox-named.json");

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
@@ -1220,6 +1220,32 @@ public class SimpleIndexQueryParserTests {
         assertThat(filter.distance(), closeTo(12, 0.00001));
     }
 
+    @Test public void testGeoDistanceFilter5() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance5.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
+    @Test public void testGeoDistanceFilter6() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance6.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
     @Test public void testGeoBoundingBoxFilterNamed() throws IOException {
         IndexQueryParser queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_boundingbox-named.json");

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/SimpleIndexQueryParserTests.java
@@ -1311,6 +1311,19 @@ public class SimpleIndexQueryParserTests {
         assertThat(filter.distance(), closeTo(12, 0.00001));
     }
 
+    @Test public void testGeoDistanceFilter12() throws IOException {
+        IndexQueryParser queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_distance12.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) parsedQuery;
+        GeoDistanceFilter filter = (GeoDistanceFilter) filteredQuery.getFilter();
+        assertThat(filter.fieldName(), equalTo("location"));
+        assertThat(filter.lat(), closeTo(40, 0.00001));
+        assertThat(filter.lon(), closeTo(-70, 0.00001));
+        assertThat(filter.distance(), closeTo(12, 0.00001));
+    }
+
     @Test public void testGeoBoundingBoxFilterNamed() throws IOException {
         IndexQueryParser queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/xcontent/geo_boundingbox-named.json");

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance10.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance10.json
@@ -1,0 +1,17 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : 19.312128,
+                "unit": "km",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance11.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance11.json
@@ -1,0 +1,16 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : "19.312128km",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance12.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance12.json
@@ -1,0 +1,17 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : "12mi",
+                "unit": "km",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance5.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance5.json
@@ -1,0 +1,17 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : 12,
+                "unit": "mi",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance6.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance6.json
@@ -1,0 +1,17 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : "12",
+                "unit": "mi",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance7.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance7.json
@@ -1,0 +1,16 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : "19.312128",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance8.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance8.json
@@ -1,0 +1,16 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : 19.312128,
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance9.json
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/query/xcontent/geo_distance9.json
@@ -1,0 +1,17 @@
+{
+    "filtered" : {
+        "query" : {
+            "match_all" : {}
+        },
+        "filter" : {
+            "geo_distance" : {
+                "distance" : "19.312128",
+                "unit": "km",
+                "person.location" : {
+                    "lat" : 40,
+                    "lon" : -70
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
These add a few more tests related to the parsing of "geo_distance" filter – which expose some minor bugs with the handling of "distance" / "unit" parameters.

Then two changes to fix DistanceUnit and GeoDistanceFilterParser classes.

---

A summary of the issues is:
-  distance: number, unit: "mi"   x   distance: "string", unit: "mi"  result in different behavior
-  distance: x, unit: "km"   parses distance as x_1.609_1.096 in miles
-  distance: "12mi", unit: "km"    does not work as    distance: "12mi"
