### PR TITLE
Snowball Analyzer Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ modules/test/integration/build/
 modules/test/testng/build/
 modules/benchmark/micro/build/
 plugins/analysis/icu/build
+plugins/analysis/snowball/build
 plugins/cloud/aws/build
 plugins/hadoop/build
 plugins/lang/groovy/build

--- a/.idea/dictionaries/harry.xml
+++ b/.idea/dictionaries/harry.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="harry">
+    <words>
+      <w>stemmer</w>
+    </words>
+  </dictionary>
+</component>

--- a/.idea/libraries/lucene_snowball.xml
+++ b/.idea/libraries/lucene_snowball.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="lucene-snowball">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+    <jarDirectory url="file://$PROJECT_DIR$" recursive="false" />
+  </library>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -6,6 +6,7 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/elasticsearch.iml" filepath="$PROJECT_DIR$/.idea/modules/elasticsearch.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/elasticsearch-root.iml" filepath="$PROJECT_DIR$/.idea/modules/elasticsearch-root.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/plugin-analysis-icu.iml" filepath="$PROJECT_DIR$/.idea/modules/plugin-analysis-icu.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/plugin-analysis-snowball.iml" filepath="$PROJECT_DIR$/.idea/modules/plugin-analysis-snowball.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules//plugin-cloud-aws.iml" filepath="$PROJECT_DIR$/.idea/modules//plugin-cloud-aws.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/plugin-lang-groovy.iml" filepath="$PROJECT_DIR$/.idea/modules/plugin-lang-groovy.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules//plugin-lang-javascript.iml" filepath="$PROJECT_DIR$/.idea/modules//plugin-lang-javascript.iml" />

--- a/.idea/modules/plugin-analysis-snowball.iml
+++ b/.idea/modules/plugin-analysis-snowball.iml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../../plugins/analysis/snowball/build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/../../plugins/analysis/snowball/build/classes/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../plugins/analysis/snowball">
+      <sourceFolder url="file://$MODULE_DIR$/../../plugins/analysis/snowball/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../plugins/analysis/snowball/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/../../plugins/analysis/snowball/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="elasticsearch" />
+    <orderEntry type="module-library">
+      <library name="snowball4j">
+        <CLASSES>
+          <root url="jar://$GRADLE_REPOSITORY$/org.apache.lucene/lucene-snowball/jars/lucene-snowball-3.0.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module" module-name="test-testng" />
+    <orderEntry type="library" name="testng" level="project" />
+    <orderEntry type="library" name="hamcrest" level="project" />
+  </component>
+</module>
+

--- a/plugins/analysis/snowball/build.gradle
+++ b/plugins/analysis/snowball/build.gradle
@@ -1,0 +1,127 @@
+dependsOn(':elasticsearch')
+
+apply plugin: 'java'
+apply plugin: 'maven'
+
+archivesBaseName = "elasticsearch-analysis-snowball"
+
+explodedDistDir = new File(distsDir, 'exploded')
+
+manifest.mainAttributes("Implementation-Title": "ElasticSearch::Plugins::Analysis::Snowball", "Implementation-Version": rootProject.version, "Implementation-Date": buildTimeStr)
+
+configurations.compile.transitive = true
+configurations.testCompile.transitive = true
+
+// no need to use the resource dir
+sourceSets.main.resources.srcDirs 'src/main/java'
+sourceSets.test.resources.srcDirs 'src/test/java'
+
+// add the source files to the dist jar
+//jar {
+//    from sourceSets.main.allJava
+//}
+
+configurations {
+    dists
+    distLib {
+        visible = false
+        transitive = false
+    }
+}
+
+dependencies {
+    compile project(':elasticsearch')
+
+    compile('org.apache.lucene:lucene-snowball:3.0.3') { transitive = false }
+    distLib('org.apache.lucene:lucene-snowball:3.0.3') { transitive = false }
+}
+
+task explodedDist(dependsOn: [jar], description: 'Builds the plugin zip file') << {
+    [explodedDistDir]*.mkdirs()
+
+    copy {
+        from configurations.distLib
+        into explodedDistDir
+    }
+
+    // remove elasticsearch files (compile above adds the elasticsearch one)
+    ant.delete { fileset(dir: explodedDistDir, includes: "elasticsearch-*.jar") }
+
+    copy {
+        from libsDir
+        into explodedDistDir
+    }
+
+    ant.delete { fileset(dir: explodedDistDir, includes: "elasticsearch-*-javadoc.jar") }
+    ant.delete { fileset(dir: explodedDistDir, includes: "elasticsearch-*-sources.jar") }
+}
+
+task zip(type: Zip, dependsOn: ['explodedDist']) {
+    from(explodedDistDir) {
+    }
+}
+
+task release(dependsOn: [zip]) << {
+    ant.delete(dir: explodedDistDir)
+    copy {
+        from distsDir
+        into(new File(rootProject.distsDir, "plugins"))
+    }
+}
+
+configurations {
+    deployerJars
+}
+
+dependencies {
+    deployerJars "org.apache.maven.wagon:wagon-http:1.0-beta-2"
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+uploadArchives {
+    repositories.mavenDeployer {
+        configuration = configurations.deployerJars
+        repository(url: rootProject.mavenRepoUrl) {
+            authentication(userName: rootProject.mavenRepoUser, password: rootProject.mavenRepoPass)
+        }
+        snapshotRepository(url: rootProject.mavenSnapshotRepoUrl) {
+            authentication(userName: rootProject.mavenRepoUser, password: rootProject.mavenRepoPass)
+        }
+
+        pom.project {
+            inceptionYear '2009'
+            name 'elasticsearch-plugins-analysis-snowball'
+            description 'Attachments Plugin for ElasticSearch'
+            licenses {
+                license {
+                    name 'The Apache Software License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution 'repo'
+                }
+            }
+            scm {
+                connection 'git://github.com/elasticsearch/elasticsearch.git'
+                developerConnection 'git@github.com:elasticsearch/elasticsearch.git'
+                url 'http://github.com/elasticsearch/elasticsearch'
+            }
+        }
+
+        pom.whenConfigured {pom ->
+            pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
+        }
+    }
+}

--- a/plugins/analysis/snowball/src/main/java/es-plugin.properties
+++ b/plugins/analysis/snowball/src/main/java/es-plugin.properties
@@ -1,0 +1,1 @@
+plugin=org.elasticsearch.plugin.analysis.snowball.AnalysisSnowballPlugin

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalysisBinderProcessor.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalysisBinderProcessor.java
@@ -24,6 +24,10 @@ package org.elasticsearch.index.analysis;
  */
 public class SnowballAnalysisBinderProcessor extends AnalysisModule.AnalysisBinderProcessor {
 
+    @Override public void processAnalyzers(AnalyzersBindings analyzersBindings) {
+        analyzersBindings.processAnalyzer("snowball", SnowballAnalyzerProvider.class);
+    }
+
     @Override public void processTokenFilters(TokenFiltersBindings tokenFiltersBindings) {
         tokenFiltersBindings.processTokenFilter("snowballFilter", SnowballTokenFilterFactory.class);
         tokenFiltersBindings.processTokenFilter("snowball_filter", SnowballTokenFilterFactory.class);

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalysisBinderProcessor.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalysisBinderProcessor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+/**
+ * @author harryf (Harry Fuecks)
+ */
+public class SnowballAnalysisBinderProcessor extends AnalysisModule.AnalysisBinderProcessor {
+
+    @Override public void processTokenFilters(TokenFiltersBindings tokenFiltersBindings) {
+        tokenFiltersBindings.processTokenFilter("snowballFilter", SnowballTokenFilterFactory.class);
+        tokenFiltersBindings.processTokenFilter("snowball_filter", SnowballTokenFilterFactory.class);
+    }
+}

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalyzerProvider.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalyzerProvider.java
@@ -31,12 +31,12 @@ import org.elasticsearch.index.settings.IndexSettings;
 import java.util.Set;
 
 /**
- * Creates a SnowballAnalyzer with a set of English stopwords and additional
- * stopwords can be passed via configuration using the stopwords attribute.
+ * Creates am English SnowballAnalyzer with a set of English stopwords
+ * Additional stopwords can be passed via configuration using the stopwords
+ * attribute.
  *
  * The SnowballAnalyzer comes with a StandardFilter, LowerCaseFilter, StopFilter
- * and a SnowballFilter. The SnowballFilter is specified by the "name" attribute
- * in the ElasticSearch configuration.
+ * and the SnowballFilter configured to English.
  *
  * @author harryf (Harry Fuecks)
  */
@@ -49,7 +49,7 @@ public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider<Snow
 
         Set<?> stopWords = Analysis.parseStopWords(settings, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
 
-        analyzer = new SnowballAnalyzer(Lucene.VERSION, settings.get("name"), stopWords);
+        analyzer = new SnowballAnalyzer(Lucene.VERSION, "English", stopWords);
     }
 
     @Override public SnowballAnalyzer get() {

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalyzerProvider.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballAnalyzerProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.StopAnalyzer;
+import org.apache.lucene.analysis.snowball.SnowballAnalyzer;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+import java.util.Set;
+
+/**
+ * Creates a SnowballAnalyzer with a set of English stopwords and additional
+ * stopwords can be passed via configuration using the stopwords attribute.
+ *
+ * The SnowballAnalyzer comes with a StandardFilter, LowerCaseFilter, StopFilter
+ * and a SnowballFilter. The SnowballFilter is specified by the "name" attribute
+ * in the ElasticSearch configuration.
+ *
+ * @author harryf (Harry Fuecks)
+ */
+public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider<SnowballAnalyzer> {
+
+    private final SnowballAnalyzer analyzer;
+
+    @Inject public SnowballAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name);
+
+        Set<?> stopWords = Analysis.parseStopWords(settings, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
+
+        analyzer = new SnowballAnalyzer(Lucene.VERSION, settings.get("name"), stopWords);
+    }
+
+    @Override public SnowballAnalyzer get() {
+        return this.analyzer;
+    }
+}

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballTokenFilterFactory.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballTokenFilterFactory.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.lucene.analysis.snowball.SnowballFilter;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.snowball.SnowballFilter;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballTokenFilterFactory.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/index/analysis/SnowballTokenFilterFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.snowball.SnowballFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+/**
+ * Real work actually done here by Sebastian on the ElasticSearch mailing list
+ * http://elasticsearch-users.115913.n3.nabble.com/Using-the-Snowball-stemmers-tp2126106p2127111.html
+ * @author harryf (Harry Fuecks)
+ */
+public class SnowballTokenFilterFactory extends AbstractTokenFilterFactory {
+
+    private String language;
+
+    @Inject public SnowballTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name);
+        this.language = settings.get("language");
+    }
+
+    @Override public TokenStream create(TokenStream tokenStream) {
+        return new SnowballFilter(tokenStream, language);
+    }
+
+}

--- a/plugins/analysis/snowball/src/main/java/org/elasticsearch/plugin/analysis/snowball/AnalysisSnowballPlugin.java
+++ b/plugins/analysis/snowball/src/main/java/org/elasticsearch/plugin/analysis/snowball/AnalysisSnowballPlugin.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.analysis.snowball;
+
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.index.analysis.SnowballAnalysisBinderProcessor;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+/**
+ * @author harryf (Harry Fuecks)
+ */
+public class AnalysisSnowballPlugin extends AbstractPlugin {
+
+    @Override public String name() {
+        return "analysis-snowball";
+    }
+
+    @Override public String description() {
+        return "Snowball stemmer analysis support";
+    }
+
+    @Override public void processModule(Module module) {
+        if (module instanceof AnalysisModule) {
+            AnalysisModule analysisModule = (AnalysisModule) module;
+            analysisModule.addProcessor(new SnowballAnalysisBinderProcessor());
+        }
+    }
+}

--- a/plugins/analysis/snowball/src/test/java/org/elasticsearch/index/analysis/SnowballAnalysisTests.java
+++ b/plugins/analysis/snowball/src/test/java/org/elasticsearch/index/analysis/SnowballAnalysisTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.hamcrest.MatcherAssert;
+import org.testng.annotations.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.Builder.*;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author harryf (Harry Fuecks)
+ */
+public class SnowballAnalysisTests {
+
+    @Test public void testDefaultsSnowballAnalysis() {
+        Index index = new Index("test");
+                Injector injector = new ModulesBuilder().add(
+                new IndexSettingsModule(EMPTY_SETTINGS),
+                new IndexNameModule(index),
+                new AnalysisModule(EMPTY_SETTINGS).addProcessor(new SnowballAnalysisBinderProcessor())).createInjector();
+
+        AnalysisService analysisService = injector.getInstance(AnalysisService.class);
+
+        TokenFilterFactory filterFactory = analysisService.tokenFilter("snowball_filter");
+        MatcherAssert.assertThat(filterFactory, instanceOf(SnowballTokenFilterFactory.class));
+
+    }
+}
+

--- a/plugins/analysis/snowball/src/test/java/org/elasticsearch/index/analysis/SnowballAnalysisTests.java
+++ b/plugins/analysis/snowball/src/test/java/org/elasticsearch/index/analysis/SnowballAnalysisTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.snowball.SnowballAnalyzer;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.index.Index;
@@ -43,6 +45,9 @@ public class SnowballAnalysisTests {
                 new AnalysisModule(EMPTY_SETTINGS).addProcessor(new SnowballAnalysisBinderProcessor())).createInjector();
 
         AnalysisService analysisService = injector.getInstance(AnalysisService.class);
+
+        Analyzer analyzer = analysisService.analyzer("snowball").analyzer();
+        MatcherAssert.assertThat(analyzer, instanceOf(SnowballAnalyzer.class));
 
         TokenFilterFactory filterFactory = analysisService.tokenFilter("snowball_filter");
         MatcherAssert.assertThat(filterFactory, instanceOf(SnowballTokenFilterFactory.class));

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ include 'benchmark-micro'
 include 'plugins-cloud-aws'
 include 'plugins-hadoop'
 include 'plugins-analysis-icu'
+include 'plugins-analysis-snowball'
 include 'plugins-mapper-attachments'
 
 include 'plugins-lang-groovy'


### PR DESCRIPTION
Following on from [this discussion](http://elasticsearch-users.115913.n3.nabble.com/Folding-German-characters-like-umlauts-tp2176078p2176078.html;cid=1294063947726-860) on the mailing list, put together a plugin wrapping lucenes Snowball Stemmer.

For English use cases, the plugin contains an AnalyzerProvider that returns a SnowballAnalyzer hard wired to use an English SnowballFilter and English stopwords. Stopwords were the reason to hard wire to English, as it can't be guaranteed there are default stopword lists available for all languages available to the Snowball Stemmer. This can be used like;

```
index:
    analysis:
        analyzer:
            default:
                type: snowball
```

For non English use, the SnowballFilter can be used as part of a CustomAnalyzer, for example;

```
index:
    analysis:
        analyzer:
            default:
                type: custom
                tokenizer: whitespace
                filter: [snowball]
        filter:
            snowball:
                type: snowball
                language: German2
```

Apologies for not creating a topic branch for this - getting used to git and github and failed to spot that - commits to master this time.
