### PR TITLE
Make URI query decoding more robust

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/support/RestUtils.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/support/RestUtils.java
@@ -39,10 +39,9 @@ public class RestUtils {
         int toIndex;
         while ((toIndex = queryString.indexOf('&', fromIndex)) >= 0) {
             int idx = queryString.indexOf('=', fromIndex);
-            if (idx < 0) {
-                continue;
+            if (fromIndex < idx && idx < toIndex) {
+                params.put(decodeComponent(queryString.substring(fromIndex, idx)), decodeComponent(queryString.substring(idx + 1, toIndex)));
             }
-            params.put(decodeComponent(queryString.substring(fromIndex, idx)), decodeComponent(queryString.substring(idx + 1, toIndex)));
             fromIndex = toIndex + 1;
         }
         int idx = queryString.indexOf('=', fromIndex);

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
@@ -60,4 +60,63 @@ public class RestUtilsTests {
         RestUtils.decodeQueryString(uri, -1, params);
         assertThat(params.size(), equalTo(0));
     }
+
+    @Test
+    public void testDecodeQueryStringEdgeCases() {
+        Map<String, String> params = newHashMap();
+
+        String uri = "something?";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(0));
+
+        params.clear();
+        uri = "something?&";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(0));
+
+        params.clear();
+        uri = "something?p=v&&p1=v1";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(2));
+        assertThat(params.get("p"), equalTo("v"));
+        assertThat(params.get("p1"), equalTo("v1"));
+
+        params.clear();
+        uri = "something?=";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(1));
+        assertThat(params.get(""), equalTo(""));
+
+        params.clear();
+        uri = "something?&=";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(1));
+        assertThat(params.get(""), equalTo(""));
+
+        params.clear();
+        uri = "something?a";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(0));
+
+        params.clear();
+        uri = "something?p=v&a";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(1));
+        assertThat(params.get("p"), equalTo("v"));
+
+        params.clear();
+        uri = "something?p=v&a&p1=v1";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(2));
+        assertThat(params.get("p"), equalTo("v"));
+        assertThat(params.get("p1"), equalTo("v1"));
+
+        params.clear();
+        uri = "something?p=v&a&b&p1=v1";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.size(), equalTo(2));
+        assertThat(params.get("p"), equalTo("v"));
+        assertThat(params.get("p1"), equalTo("v1"));
+    }
+
 }

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
@@ -52,7 +52,12 @@ public class RestUtilsTests {
 
         params.clear();
         uri = "something";
-        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        RestUtils.decodeQueryString(uri, uri.length(), params);
+        assertThat(params.size(), equalTo(0));
+
+        params.clear();
+        uri = "something";
+        RestUtils.decodeQueryString(uri, -1, params);
         assertThat(params.size(), equalTo(0));
     }
 }


### PR DESCRIPTION
With the current ES code, exceptions or infinite loops can be generated while parsing the URI query of a request.

This can be seen with the following examples:

```
curl -XGET localhost:9200/test/_analyze?t&text=this+is+a+test
# the exception stack trace shows up in logs

curl -XGET localhost:9200/test/_analyze?t1&t2&text=this+is+a+test
# never returns, never ends
```

The changes suggested take care of these issues.
