### PR TITLE
Allow plugins to provide additional settings.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/plugins/AbstractPlugin.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/plugins/AbstractPlugin.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.index.CloseableIndexComponent;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A base class for a plugin.
@@ -78,4 +80,9 @@ public abstract class AbstractPlugin implements Plugin {
     @Override public void processModule(Module module) {
         // nothing to do here
     }
+
+    @Override public Map<String, String> additionalSettings() {
+        return Collections.emptyMap();
+    }
+
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.index.CloseableIndexComponent;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * An extension point allowing to plug in custom functionality.
@@ -73,4 +74,9 @@ public interface Plugin {
     Collection<Class<? extends CloseableIndexComponent>> shardServices();
 
     void processModule(Module module);
+
+    /**
+     * Additional node settings loaded by the plugin
+     */
+    Map<String, String> additionalSettings();
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.CloseableIndexComponent;
@@ -81,7 +82,12 @@ public class PluginsService extends AbstractComponent {
     }
 
     public Settings updatedSettings() {
-        return this.settings;
+        ImmutableSettings.Builder builder = ImmutableSettings.settingsBuilder()
+                .put(this.settings);
+        for (Plugin plugin : plugins.values()) {
+            builder.put(plugin.additionalSettings());
+        }
+        return builder.build();
     }
 
     public Collection<Class<? extends Module>> modules() {


### PR DESCRIPTION
I would like to be able to load shared settings from a centralized source (ZooKeeper in my case) using a plug-in. It looks like updatedSettings method of PluginsService was meant to allow that, but it wasn't completely implemented for some reason. Would this implementation be OK?

Thank you,

Igor
