### PR TITLE
ImmutableSettings.getAsClass shouldn't attempt to load camelCased version of the package name.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -213,16 +213,11 @@ public class ImmutableSettings implements Settings {
             try {
                 return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
             } catch (ClassNotFoundException e1) {
-                fullClassName = prefixPackage + toCamelCase(sValue) + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
+                fullClassName = prefixPackage + toCamelCase(sValue).toLowerCase() + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
                 try {
                     return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
                 } catch (ClassNotFoundException e2) {
-                    fullClassName = prefixPackage + toCamelCase(sValue).toLowerCase() + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
-                    try {
-                        return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
-                    } catch (ClassNotFoundException e3) {
-                        throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + sValue + "]", e);
-                    }
+                    throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + sValue + "]", e);
                 }
             }
         }


### PR DESCRIPTION
I ran into an issue with a discovery module that has a camelCased name. The module's name is org.elasticsearch.discovery.zookeeper.ZooKeeperDiscoveryModule and I am trying to load it using "zoo-keeper" as a discovery type. Unfortunately, ImmutableSettings.getAsClass first tries to load org.elasticsearch.discovery.zooKeeper.ZooKeeperDiscoveryModule and on Mac OS X it fails with NoClassDefFoundError instead of ClassNotFoundException, so the class with correct package name is never loaded. Since using camelCase for package names is somewhat unusual, wouldn't it make sense to not attempt to load a class with such name? 
