### PR TITLE
Adding support for accessing EC2 and S3 over an http proxy.

### DIFF
--- a/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -68,6 +68,18 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
             throw new ElasticSearchIllegalArgumentException("No s3 secret_key defined for s3 gateway");
         }
 
+        String proxyHost = settings.get("network.proxyHost");
+        if (proxyHost != null) {
+            String portString = settings.get("network.proxyPort","80");
+            Integer proxyPort;
+            try {
+                proxyPort = Integer.parseInt(portString,10);
+            } catch (NumberFormatException ex) {
+                throw new ElasticSearchIllegalArgumentException("The configured proxy port value [" + portString + "] is invalid",ex);
+            }
+            clientConfiguration.withProxyHost(proxyHost).setProxyPort(proxyPort);
+        }
+
         this.client = new AmazonEC2Client(new BasicAWSCredentials(account, key), clientConfiguration);
 
         if (componentSettings.get("ec2.endpoint") != null) {

--- a/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -68,6 +68,18 @@ public class AwsS3Service extends AbstractLifecycleComponent<AwsS3Service> {
             throw new ElasticSearchIllegalArgumentException("No s3 secret_key defined for s3 gateway");
         }
 
+        String proxyHost = settings.get("network.proxyHost");
+        if (proxyHost != null) {
+            String portString = settings.get("network.proxyPort","80");
+            Integer proxyPort;
+            try {
+                proxyPort = Integer.parseInt(portString,10);
+            } catch (NumberFormatException ex) {
+                throw new ElasticSearchIllegalArgumentException("The configured proxy port value [" + portString + "] is invalid",ex);
+            }
+            clientConfiguration.withProxyHost(proxyHost).setProxyPort(proxyPort);
+        }
+
         this.client = new AmazonS3Client(new BasicAWSCredentials(account, key), clientConfiguration);
 
         if (componentSettings.get("s3.endpoint") != null) {


### PR DESCRIPTION
Adding support for accessing EC2 and S3 over an http proxy. This is configured using the `network.proxyHost` and `network.proxyPort` settings.
