### PR TITLE
Fix double counts when two aliases are pointing to the same index

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -177,13 +177,14 @@ public class MetaData implements Iterable<IndexMetaData> {
         for (String index : indices) {
             if (!this.indices.containsKey(index)) {
                 possiblyAliased = true;
+                break;
             }
         }
         if (!possiblyAliased) {
             return indices;
         }
 
-        ArrayList<String> actualIndices = Lists.newArrayListWithCapacity(indices.length);
+        Set<String> actualIndices = Sets.newHashSetWithExpectedSize(indices.length);
         for (String index : indices) {
             String[] actualLst = aliasAndIndexToIndexMap.get(index);
             if (actualLst == null) {


### PR DESCRIPTION
If you create two aliases pointing to the same index and then execute _count on both aliases, the count is doubled. Search, however, removes duplicates (at least if a small number of records is returned). See https://gist.github.com/967342 for a demo script. I am not entirely sure if this is a bug of a feature. If this is a bug, here is a small fix. 
