### PR TITLE
Fix possible false matches with multiple percolators.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/percolator/PercolatorExecutor.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/percolator/PercolatorExecutor.java
@@ -340,8 +340,8 @@ public class PercolatorExecutor extends AbstractIndexComponent {
 
         List<String> matches = new ArrayList<String>();
         if (request.query() == null) {
-            Lucene.ExistsCollector collector = new Lucene.ExistsCollector();
             for (Map.Entry<String, Query> entry : queries.entrySet()) {
+                Lucene.ExistsCollector collector = new Lucene.ExistsCollector();
                 try {
                     searcher.search(entry.getValue(), collector);
                 } catch (IOException e) {


### PR DESCRIPTION
When you register multiple percolators, you can get false matches if at least one percolator matches the query. It's caused by not reseting Lucene.ExistsCollector after the match.
