### PR TITLE
Initial implementation of filtering aliases.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/cluster/ping/broadcast/TransportBroadcastPingAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/cluster/ping/broadcast/TransportBroadcastPingAction.java
@@ -64,8 +64,8 @@ public class TransportBroadcastPingAction extends TransportBroadcastOperationAct
         return new BroadcastPingRequest();
     }
 
-    @Override protected GroupShardsIterator shards(BroadcastPingRequest request, ClusterState clusterState) {
-        return clusterService.operationRouting().searchShards(clusterState, request.indices(), request.queryHint(), null, null);
+    @Override protected GroupShardsIterator shards(BroadcastPingRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, request.queryHint(), null, null);
     }
 
     @Override protected BroadcastPingResponse newResponse(BroadcastPingRequest request, AtomicReferenceArray shardsResponses, ClusterState clusterState) {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.metadata.AliasAction;
 import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.List;
@@ -53,6 +54,28 @@ public class IndicesAliasesRequest extends MasterNodeOperationRequest {
      */
     public IndicesAliasesRequest addAlias(String index, String alias) {
         aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias));
+        return this;
+    }
+
+    /**
+     * Adds an alias to the index.
+     *
+     * @param index The index
+     * @param alias The alias
+     */
+    public IndicesAliasesRequest addAlias(String index, String alias, byte[] filter) {
+        aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias, filter));
+        return this;
+    }
+
+    /**
+     * Adds an alias to the index.
+     *
+     * @param index The index
+     * @param alias The alias
+     */
+    public IndicesAliasesRequest addAlias(String index, String alias, QueryBuilder filter) {
+        aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias, filter.buildAsBytes()));
         return this;
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -142,7 +142,7 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
     /**
      * The refresh request works against *all* shards.
      */
-    @Override protected GroupShardsIterator shards(ClearIndicesCacheRequest request, ClusterState clusterState) {
-        return clusterState.routingTable().allShardsGrouped(request.indices());
+    @Override protected GroupShardsIterator shards(ClearIndicesCacheRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterState.routingTable().allShardsGrouped(concreteIndices);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -118,7 +118,7 @@ public class TransportFlushAction extends TransportBroadcastOperationAction<Flus
     /**
      * The refresh request works against *all* shards.
      */
-    @Override protected GroupShardsIterator shards(FlushRequest request, ClusterState clusterState) {
-        return clusterState.routingTable().allShardsGrouped(request.indices());
+    @Override protected GroupShardsIterator shards(FlushRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterState.routingTable().allShardsGrouped(concreteIndices);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/gateway/snapshot/TransportGatewaySnapshotAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/gateway/snapshot/TransportGatewaySnapshotAction.java
@@ -116,7 +116,7 @@ public class TransportGatewaySnapshotAction extends TransportBroadcastOperationA
     /**
      * The snapshot request works against all primary shards.
      */
-    @Override protected GroupShardsIterator shards(GatewaySnapshotRequest request, ClusterState clusterState) {
-        return clusterState.routingTable().primaryShardsGrouped(request.indices());
+    @Override protected GroupShardsIterator shards(GatewaySnapshotRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterState.routingTable().primaryShardsGrouped(concreteIndices);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -129,7 +129,7 @@ public class TransportOptimizeAction extends TransportBroadcastOperationAction<O
     /**
      * The refresh request works against *all* shards.
      */
-    @Override protected GroupShardsIterator shards(OptimizeRequest request, ClusterState clusterState) {
-        return clusterState.routingTable().allShardsGrouped(request.indices());
+    @Override protected GroupShardsIterator shards(OptimizeRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterState.routingTable().allShardsGrouped(concreteIndices);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -119,7 +119,7 @@ public class TransportRefreshAction extends TransportBroadcastOperationAction<Re
     /**
      * The refresh request works against *all* shards.
      */
-    @Override protected GroupShardsIterator shards(RefreshRequest request, ClusterState clusterState) {
-        return clusterState.routingTable().allShardsGrouped(request.indices());
+    @Override protected GroupShardsIterator shards(RefreshRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterState.routingTable().allShardsGrouped(concreteIndices);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
@@ -92,8 +92,8 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
     /**
      * Status goes across *all* shards.
      */
-    @Override protected GroupShardsIterator shards(IndicesStatusRequest request, ClusterState clusterState) {
-        return clusterState.routingTable().allShardsGrouped(request.indices());
+    @Override protected GroupShardsIterator shards(IndicesStatusRequest request, String[] concreteIndices, ClusterState clusterState) {
+        return clusterState.routingTable().allShardsGrouped(concreteIndices);
     }
 
     /**

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -64,13 +64,14 @@ public class TransportDeleteByQueryAction extends TransportIndicesReplicationOpe
         return TransportActions.DELETE_BY_QUERY;
     }
 
-    @Override protected void checkBlock(DeleteByQueryRequest request, ClusterState state) {
-        for (String index : request.indices()) {
+    @Override protected void checkBlock(DeleteByQueryRequest request, String[] concreteIndices, ClusterState state) {
+        for (String index : concreteIndices) {
             state.blocks().indexBlockedRaiseException(ClusterBlockLevel.WRITE, index);
         }
     }
 
     @Override protected IndexDeleteByQueryRequest newIndexRequestInstance(DeleteByQueryRequest request, String index) {
-        return new IndexDeleteByQueryRequest(request, index);
+        byte[][] aliasFilters = clusterService.state().metaData().aliasFilters(request.indices(), index);
+        return new IndexDeleteByQueryRequest(request, index, aliasFilters);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -70,13 +70,13 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
 
     @Override protected PrimaryResponse<ShardDeleteByQueryResponse> shardOperationOnPrimary(ClusterState clusterState, ShardOperationRequest shardRequest) {
         ShardDeleteByQueryRequest request = shardRequest.request;
-        indexShard(shardRequest).deleteByQuery(request.querySource(), request.queryParserName(), request.types());
+        indexShard(shardRequest).deleteByQuery(request.querySource(), request.queryParserName(), request.aliasFilters(), request.types());
         return new PrimaryResponse<ShardDeleteByQueryResponse>(new ShardDeleteByQueryResponse(), null);
     }
 
     @Override protected void shardOperationOnReplica(ShardOperationRequest shardRequest) {
         ShardDeleteByQueryRequest request = shardRequest.request;
-        indexShard(shardRequest).deleteByQuery(request.querySource(), request.queryParserName(), request.types());
+        indexShard(shardRequest).deleteByQuery(request.querySource(), request.queryParserName(), request.aliasFilters(), request.types());
     }
 
     @Override protected ShardIterator shards(ClusterState clusterState, ShardDeleteByQueryRequest request) {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -84,7 +84,7 @@ public class TransportMoreLikeThisAction extends BaseAction<MoreLikeThisRequest,
         // update to actual index name
         ClusterState clusterState = clusterService.state();
         // update to the concrete index
-        request.index(clusterState.metaData().concreteIndex(request.index()));
+        final String concreteIndex = clusterState.metaData().concreteIndex(request.index());
 
         Set<String> getFields = newHashSet();
         if (request.fields() != null) {
@@ -93,7 +93,7 @@ public class TransportMoreLikeThisAction extends BaseAction<MoreLikeThisRequest,
         // add the source, in case we need to parse it to get fields
         getFields.add(SourceFieldMapper.NAME);
 
-        GetRequest getRequest = getRequest(request.index())
+        GetRequest getRequest = getRequest(concreteIndex)
                 .fields(getFields.toArray(new String[getFields.size()]))
                 .type(request.type())
                 .id(request.id())
@@ -109,7 +109,7 @@ public class TransportMoreLikeThisAction extends BaseAction<MoreLikeThisRequest,
                 }
                 final BoolQueryBuilder boolBuilder = boolQuery();
                 try {
-                    DocumentMapper docMapper = indicesService.indexServiceSafe(request.index()).mapperService().documentMapper(request.type());
+                    DocumentMapper docMapper = indicesService.indexServiceSafe(concreteIndex).mapperService().documentMapper(request.type());
                     final Set<String> fields = newHashSet();
                     if (request.fields() != null) {
                         for (String field : request.fields()) {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -84,8 +84,8 @@ public class TransportSearchAction extends BaseAction<SearchRequest, SearchRespo
         if (optimizeSingleShard && searchRequest.searchType() != SCAN && searchRequest.searchType() != COUNT) {
             try {
                 ClusterState clusterState = clusterService.state();
-                searchRequest.indices(clusterState.metaData().concreteIndices(searchRequest.indices()));
-                GroupShardsIterator groupIt = clusterService.operationRouting().searchShards(clusterState, searchRequest.indices(), searchRequest.queryHint(), searchRequest.routing(), searchRequest.preference());
+                String[] concreteIndices = clusterState.metaData().concreteIndices(searchRequest.indices());
+                GroupShardsIterator groupIt = clusterService.operationRouting().searchShards(clusterState, concreteIndices, searchRequest.queryHint(), searchRequest.routing(), searchRequest.preference());
                 if (groupIt.size() == 1) {
                     // if we only have one group, then we always want Q_A_F, no need for DFS, and no need to do THEN since we hit one shard
                     searchRequest.searchType(QUERY_AND_FETCH);

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/type/TransportSearchHelper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/type/TransportSearchHelper.java
@@ -67,13 +67,14 @@ public abstract class TransportSearchHelper {
         return ret;
     }
 
-    public static InternalSearchRequest internalSearchRequest(ShardRouting shardRouting, int numberOfShards, SearchRequest request) {
+    public static InternalSearchRequest internalSearchRequest(ShardRouting shardRouting, int numberOfShards, SearchRequest request, byte[][] aliasFilters) {
         InternalSearchRequest internalRequest = new InternalSearchRequest(shardRouting, numberOfShards, request.searchType());
         internalRequest.source(request.source(), request.sourceOffset(), request.sourceLength());
         internalRequest.extraSource(request.extraSource(), request.extraSourceOffset(), request.extraSourceLength());
         internalRequest.scroll(request.scroll());
         internalRequest.timeout(request.timeout());
         internalRequest.types(request.types());
+        internalRequest.aliasFilters(aliasFilters);
         return internalRequest;
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -104,13 +104,13 @@ public abstract class TransportSearchTypeAction extends BaseAction<SearchRequest
 
             nodes = clusterState.nodes();
 
-            request.indices(clusterState.metaData().concreteIndices(request.indices()));
+            String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices());
 
-            for (String index : request.indices()) {
+            for (String index : concreteIndices) {
                 clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index);
             }
 
-            shardsIts = clusterService.operationRouting().searchShards(clusterState, request.indices(), request.queryHint(), request.routing(), request.preference());
+            shardsIts = clusterService.operationRouting().searchShards(clusterState, concreteIndices, request.queryHint(), request.routing(), request.preference());
             expectedSuccessfulOps = shardsIts.size();
             // we need to add 1 for non active partition, since we count it in the total!
             expectedTotalOps = shardsIts.totalSizeActiveWith1ForEmpty();
@@ -189,7 +189,8 @@ public abstract class TransportSearchTypeAction extends BaseAction<SearchRequest
                 if (node == null) {
                     onFirstPhaseResult(shard, shardIt, null);
                 } else {
-                    sendExecuteFirstPhase(node, internalSearchRequest(shard, shardsIts.size(), request), new SearchServiceListener<FirstResult>() {
+                    byte[][] aliasFilters = clusterService.state().metaData().aliasFilters(request.indices(), shard.index());
+                    sendExecuteFirstPhase(node, internalSearchRequest(shard, shardsIts.size(), request, aliasFilters), new SearchServiceListener<FirstResult>() {
                         @Override public void onResult(FirstResult result) {
                             onFirstPhaseResult(shard, result, shardIt);
                         }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
@@ -89,7 +89,7 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
 
     protected abstract ShardResponse shardOperation(ShardRequest request) throws ElasticSearchException;
 
-    protected abstract GroupShardsIterator shards(Request request, ClusterState clusterState);
+    protected abstract GroupShardsIterator shards(Request request, String[] concreteIndices, ClusterState clusterState);
 
     /**
      * Allows to override how shard routing is iterated over. Default implementation uses
@@ -119,7 +119,7 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
         return false;
     }
 
-    protected void checkBlock(Request request, ClusterState state) {
+    protected void checkBlock(Request request, String[] indices, ClusterState state) {
 
     }
 
@@ -143,6 +143,8 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
 
         private final AtomicReferenceArray shardsResponses;
 
+        private final String[] concreteIndices;
+
         AsyncBroadcastAction(Request request, ActionListener<Response> listener) {
             this.request = request;
             this.listener = listener;
@@ -150,11 +152,11 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
             clusterState = clusterService.state();
 
             // update to concrete indices
-            request.indices(clusterState.metaData().concreteIndices(request.indices()));
-            checkBlock(request, clusterState);
+            concreteIndices = clusterState.metaData().concreteIndices(request.indices());
+            checkBlock(request, concreteIndices, clusterState);
 
             nodes = clusterState.nodes();
-            shardsIts = shards(request, clusterState);
+            shardsIts = shards(request, concreteIndices, clusterState);
             expectedOps = shardsIts.size();
 
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
@@ -61,12 +61,10 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
     @Override protected void doExecute(final Request request, final ActionListener<Response> listener) {
         ClusterState clusterState = clusterService.state();
 
-        // update to actual indices
-        request.indices(clusterState.metaData().concreteIndices(request.indices()));
+        // get actual indices
+        String[] indices = clusterState.metaData().concreteIndices(request.indices());
 
-        checkBlock(request, clusterState);
-
-        String[] indices = request.indices();
+        checkBlock(request, indices, clusterState);
 
         final AtomicInteger indexCounter = new AtomicInteger();
         final AtomicInteger completionCounter = new AtomicInteger(indices.length);
@@ -108,7 +106,7 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
 
     protected abstract boolean accumulateExceptions();
 
-    protected void checkBlock(Request request, ClusterState state) {
+    protected void checkBlock(Request request, String[] concreteIndices, ClusterState state) {
 
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/client/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/client/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.action.admin.indices.support.BaseIndicesRequestBuilder;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilder;
 
 /**
  * @author kimchy (shay.banon)
@@ -43,6 +44,30 @@ public class IndicesAliasesRequestBuilder extends BaseIndicesRequestBuilder<Indi
      */
     public IndicesAliasesRequestBuilder addAlias(String index, String alias) {
         request.addAlias(index, alias);
+        return this;
+    }
+
+    /**
+     * Adds an alias with filter to the index.
+     *
+     * @param index  The index
+     * @param alias  The alias
+     * @param filter The filter
+     */
+    public IndicesAliasesRequestBuilder addAlias(String index, String alias, byte[] filter) {
+        request.addAlias(index, alias, filter);
+        return this;
+    }
+
+    /**
+     * Adds an alias with filter to the index.
+     *
+     * @param index  The index
+     * @param alias  The alias
+     * @param filter The filter
+     */
+    public IndicesAliasesRequestBuilder addAlias(String index, String alias, QueryBuilder filter) {
+        request.addAlias(index, alias, filter);
         return this;
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -69,8 +69,12 @@ public class Lucene {
     }
 
     public static long count(IndexSearcher searcher, Query query, float minScore) throws IOException {
+        return count(searcher, query, null, minScore);
+    }
+
+    public static long count(IndexSearcher searcher, Query query, Filter filter, float minScore) throws IOException {
         CountCollector countCollector = new CountCollector(minScore);
-        searcher.search(query, countCollector);
+        searcher.search(query, filter, countCollector);
         return countCollector.count();
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.ExtendedIndexSearcher;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.common.Nullable;
@@ -554,12 +555,16 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         private final String queryParserName;
         private final byte[] source;
         private final String[] types;
+        private final Filter aliasFilters;
+        private byte[][] aliasFiltersSource;
 
-        public DeleteByQuery(Query query, byte[] source, @Nullable String queryParserName, String... types) {
+        public DeleteByQuery(Query query, byte[] source, @Nullable String queryParserName, @Nullable Filter aliasFilters, @Nullable byte[][] aliasFiltersSource, String... types) {
             this.query = query;
             this.source = source;
             this.queryParserName = queryParserName;
             this.types = types;
+            this.aliasFilters = aliasFilters;
+            this.aliasFiltersSource = aliasFiltersSource;
         }
 
         public String queryParserName() {
@@ -576,6 +581,14 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
 
         public String[] types() {
             return this.types;
+        }
+
+        public Filter aliasFilters() {
+            return aliasFilters;
+        }
+
+        public byte[][] aliasFiltersSource() {
+            return aliasFiltersSource;
         }
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.index.engine.robin;
 
 import org.apache.lucene.index.*;
+import org.apache.lucene.search.FilteredQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.ElasticSearchException;
@@ -568,7 +570,13 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
             if (writer == null) {
                 throw new EngineClosedException(shardId);
             }
-            writer.deleteDocuments(delete.query());
+            Query query;
+            if (delete.aliasFilters() == null) {
+                query = delete.query();
+            } else {
+                query = new FilteredQuery(delete.query(), delete.aliasFilters());
+            }
+            writer.deleteDocuments(query);
             translog.add(new Translog.DeleteByQuery(delete));
             dirty = true;
             possibleMergeNeeded = true;

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
@@ -59,13 +59,13 @@ public interface IndexShard extends IndexShardComponent {
 
     void delete(Engine.Delete delete) throws ElasticSearchException;
 
-    void deleteByQuery(byte[] querySource, @Nullable String queryParserName, String... types) throws ElasticSearchException;
+    void deleteByQuery(byte[] querySource, @Nullable String queryParserName, @Nullable byte[][] aliasFilters, String... types) throws ElasticSearchException;
 
     byte[] get(String type, String id) throws ElasticSearchException;
 
-    long count(float minScore, byte[] querySource, @Nullable String queryParserName, String... types) throws ElasticSearchException;
+    long count(float minScore, byte[] querySource, @Nullable String queryParserName, byte[][] filters, String... types) throws ElasticSearchException;
 
-    long count(float minScore, byte[] querySource, int querySourceOffset, int querySourceLength, @Nullable String queryParserName, String... types) throws ElasticSearchException;
+    long count(float minScore, byte[] querySource, int querySourceOffset, int querySourceLength, @Nullable String queryParserName, byte[][] filters, String... types) throws ElasticSearchException;
 
     void refresh(Engine.Refresh refresh) throws ElasticSearchException;
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -201,7 +201,7 @@ public class RestClusterStateAction extends BaseRestHandler {
                             builder.endObject();
 
                             builder.startArray("aliases");
-                            for (String alias : indexMetaData.aliases()) {
+                            for (String alias : indexMetaData.aliases().keySet()) {
                                 builder.value(alias);
                             }
                             builder.endArray();

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/filter/FilterFacetCollector.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/filter/FilterFacetCollector.java
@@ -56,7 +56,7 @@ public class FilterFacetCollector extends AbstractFacetCollector implements Opti
             query = new FilteredQuery(query, searchContext.filterCache().cache(searchContext.mapperService().typesFilter(searchContext.types())));
         }
         TotalHitCountCollector collector = new TotalHitCountCollector();
-        searchContext.searcher().search(query, collector);
+        searchContext.searcher().search(query, searchContext.parsedAliasFilter(), collector);
         count = collector.getTotalHits();
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/query/QueryFacetCollector.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/query/QueryFacetCollector.java
@@ -75,7 +75,7 @@ public class QueryFacetCollector extends AbstractFacetCollector implements Optim
             query = new FilteredQuery(query, searchContext.filterCache().cache(searchContext.mapperService().typesFilter(searchContext.types())));
         }
         TotalHitCountCollector collector = new TotalHitCountCollector();
-        searchContext.searcher().search(query, collector);
+        searchContext.searcher().search(query, searchContext.parsedAliasFilter(), collector);
         count = collector.getTotalHits();
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -128,6 +128,8 @@ public class SearchContext implements Releasable {
 
     private Filter filter;
 
+    private Filter aliasFilter;
+
     private int[] docIdsToLoad;
 
     private int docsIdsToLoadFrom;
@@ -341,6 +343,15 @@ public class SearchContext implements Releasable {
 
     public Filter parsedFilter() {
         return this.filter;
+    }
+
+    public SearchContext parsedAliasFilter(Filter aliasFilter) {
+        this.aliasFilter = aliasFilter;
+        return this;
+    }
+
+    public Filter parsedAliasFilter() {
+        return this.aliasFilter;
     }
 
     public String queryParserName() {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -110,7 +110,7 @@ public class QueryPhase implements SearchPhase {
                             if (topDocsPhase.scope() != null) {
                                 searchContext.searcher().processingScope(topDocsPhase.scope());
                             }
-                            TopDocs topDocs = searchContext.searcher().search(topDocsPhase.query(), numDocs);
+                            TopDocs topDocs = searchContext.searcher().search(topDocsPhase.query(), searchContext.parsedAliasFilter(), numDocs);
                             if (topDocsPhase.scope() != null) {
                                 // we mark the scope as processed, so we don't process it again, even if we need to rerun the query...
                                 searchContext.searcher().processedScope();
@@ -145,7 +145,7 @@ public class QueryPhase implements SearchPhase {
                             searchContext.searcher().processingScope(scopePhase.scope());
                         }
                         Collector collector = collectorPhase.collector();
-                        searchContext.searcher().search(collectorPhase.query(), collector);
+                        searchContext.searcher().search(collectorPhase.query(), searchContext.parsedAliasFilter(), collector);
                         collectorPhase.processCollector(collector);
                         if (collectorPhase.scope() != null) {
                             // we mark the scope as processed, so we don't process it again, even if we need to rerun the query...
@@ -192,7 +192,7 @@ public class QueryPhase implements SearchPhase {
             if (searchContext.searchType() == SearchType.COUNT) {
                 CountCollector countCollector = new CountCollector();
                 try {
-                    searchContext.searcher().search(query, countCollector);
+                    searchContext.searcher().search(query, searchContext.parsedAliasFilter(), countCollector);
                 } catch (ScanCollector.StopCollectingException e) {
                     // all is well
                 }
@@ -200,15 +200,15 @@ public class QueryPhase implements SearchPhase {
             } else if (searchContext.searchType() == SearchType.SCAN) {
                 ScanCollector scanCollector = new ScanCollector(searchContext.from(), searchContext.size());
                 try {
-                    searchContext.searcher().search(query, scanCollector);
+                    searchContext.searcher().search(query, searchContext.parsedAliasFilter(), scanCollector);
                 } catch (ScanCollector.StopCollectingException e) {
                     // all is well
                 }
                 topDocs = scanCollector.topDocs();
             } else if (sort) {
-                topDocs = searchContext.searcher().search(query, null, numDocs, searchContext.sort());
+                topDocs = searchContext.searcher().search(query, searchContext.parsedAliasFilter(), numDocs, searchContext.sort());
             } else {
-                topDocs = searchContext.searcher().search(query, numDocs);
+                topDocs = searchContext.searcher().search(query, searchContext.parsedAliasFilter(), numDocs);
             }
             searchContext.queryResult().topDocs(topDocs);
         } catch (Exception e) {

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/cluster/metadata/FilteringAliasesTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/cluster/metadata/FilteringAliasesTests.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author imotov
+ */
+public class FilteringAliasesTests {
+
+
+    @Test public void testAliasFilters() throws Exception {
+
+
+        MetaData metaData = new MetaData.Builder()
+                .put(indexMetaData("index1", "alias1,alias2", "filter1,filter2"))
+                .put(indexMetaData("index2"))
+                .put(indexMetaData("index3"))
+                .build();
+
+        byte[][] filters = metaData.aliasFilters(new String[]{"alias1", "index2"}, "index1");
+        assertThat(filters.length, equalTo(1));
+        assertThat(filters[0], equalTo("filter1".getBytes()));
+
+        // Index 1 is present unfiltered as well as filtered -> filter should have no effect
+        filters = metaData.aliasFilters(new String[]{"alias1", "index1"}, "index1");
+        assertThat(filters, nullValue());
+
+    }
+
+    private IndexMetaData indexMetaData(String name) {
+        return indexMetaData(name, null, null);
+    }
+
+    private IndexMetaData indexMetaData(String name, String aliases, String filters) {
+        IndexMetaData.Builder builder = new IndexMetaData.Builder(name);
+        if (aliases != null || filters != null) {
+            ImmutableSettings.Builder settings = ImmutableSettings.settingsBuilder();
+
+            if (aliases != null) {
+                settings.putArray("index.aliases", aliases.split(","));
+            }
+            if (filters != null) {
+                String[] filterArr = filters.split(",");
+                for (int i = 0; i < filterArr.length; i++) {
+                    filterArr[i] = Base64.encodeBytes(filterArr[i].getBytes());
+                }
+                settings.putArray("index.alias_filters", filterArr);
+            }
+            builder.settings(settings);
+        }
+        return builder.numberOfReplicas(1).numberOfShards(5).build();
+    }
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
@@ -77,7 +77,7 @@ public abstract class AbstractSimpleTranslogTests {
         assertThat(snapshot.snapshotOperations(), equalTo(3));
         snapshot.release();
 
-        translog.add(new Translog.DeleteByQuery(new byte[]{4}, null));
+        translog.add(new Translog.DeleteByQuery(new byte[]{4}, null, null));
         snapshot = translog.snapshot();
         assertThat(snapshot, translogSize(4));
         assertThat(snapshot.totalOperations(), equalTo(4));


### PR DESCRIPTION
Shay, I took a shot at adding filters to aliases. I know that you were planning to do it at some point of time, but not sure if this is what you had in mind. If it's not, please let me know. Filtering aliases are implemented for most of the methods. A couple of methods where I wasn't sure what would be a proper behavior with regard to filters are Percolator and DeleteIndex. In the first case, it seems that filters shouldn't affect the behavior at all. In the second case, perhaps, it could be appropriate to throw an Exception if a DeleteIndex is called on an alias with a filter to prevent. Could you take a look?
