### PR TITLE
Move alias metadata from settings to a separate data structure

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.Immutable;
+import org.elasticsearch.common.xcontent.*;
+
+import java.io.IOException;
+
+/**
+ * @author imotov
+ */
+@Immutable
+public class AliasMetaData {
+
+    private final String alias;
+
+    private AliasMetaData(String alias) {
+        this.alias = alias;
+    }
+
+    public String alias() {
+        return alias;
+    }
+
+    public String getAlias() {
+        return alias();
+    }
+
+    public static Builder newAliasMetaDataBuilder(String alias) {
+        return new Builder(alias);
+    }
+
+    public static class Builder {
+
+        private String alias;
+
+        public Builder(String alias) {
+            this.alias = alias;
+        }
+
+        public Builder(AliasMetaData aliasMetaData) {
+            this(aliasMetaData.alias());
+        }
+
+        public String alias() {
+            return alias;
+        }
+
+        public AliasMetaData build() {
+            return new AliasMetaData(alias);
+        }
+
+        public static void toXContent(AliasMetaData aliasMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startObject(aliasMetaData.alias(), XContentBuilder.FieldCaseConversion.NONE);
+            // Filters will go here
+            builder.endObject();
+        }
+
+        public static AliasMetaData fromXContent(XContentParser parser) throws IOException {
+            Builder builder = new Builder(parser.currentName());
+            XContentParser.Token token = parser.nextToken();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                // Skip the content for now, filter and other settings will go here
+            }
+            return builder.build();
+        }
+
+        public static void writeTo(AliasMetaData aliasMetaData, StreamOutput out) throws IOException {
+            out.writeUTF(aliasMetaData.alias());
+        }
+
+        public static AliasMetaData readFrom(StreamInput in) throws IOException {
+            String alias = in.readUTF();
+            return new AliasMetaData(alias);
+        }
+    }
+
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -75,7 +75,7 @@ public class MetaData implements Iterable<IndexMetaData> {
         // build aliases set
         Set<String> aliases = newHashSet();
         for (IndexMetaData indexMetaData : indices.values()) {
-            aliases.addAll(indexMetaData.aliases());
+            aliases.addAll(indexMetaData.aliases().keySet());
         }
         this.aliases = ImmutableSet.copyOf(aliases);
 
@@ -89,7 +89,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             }
             lst.add(indexMetaData.index());
 
-            for (String alias : indexMetaData.aliases()) {
+            for (String alias : indexMetaData.aliases().keySet()) {
                 lst = tmpAliasAndIndexToIndexBuilder.get(alias);
                 if (lst == null) {
                     lst = newHashSet();

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -29,13 +29,9 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.InvalidAliasNameException;
 
-import java.util.Set;
-
 import static org.elasticsearch.cluster.ClusterState.*;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
 import static org.elasticsearch.cluster.metadata.MetaData.*;
-import static org.elasticsearch.common.collect.Sets.*;
-import static org.elasticsearch.common.settings.ImmutableSettings.*;
 
 /**
  * @author kimchy (shay.banon)
@@ -70,18 +66,14 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                     if (indexMetaData == null) {
                         throw new IndexMissingException(new Index(aliasAction.index()));
                     }
-                    Set<String> indexAliases = newHashSet(indexMetaData.settings().getAsArray("index.aliases"));
+                    IndexMetaData.Builder indexMetaDataBuilder = newIndexMetaDataBuilder(indexMetaData);
                     if (aliasAction.actionType() == AliasAction.Type.ADD) {
-                        indexAliases.add(aliasAction.alias());
+                        indexMetaDataBuilder.putAlias(AliasMetaData.newAliasMetaDataBuilder(aliasAction.alias()).build());
                     } else if (aliasAction.actionType() == AliasAction.Type.REMOVE) {
-                        indexAliases.remove(aliasAction.alias());
+                        indexMetaDataBuilder.removerAlias(aliasAction.alias());
                     }
 
-                    Settings settings = settingsBuilder().put(indexMetaData.settings())
-                            .putArray("index.aliases", indexAliases.toArray(new String[indexAliases.size()]))
-                            .build();
-
-                    builder.put(newIndexMetaDataBuilder(indexMetaData).settings(settings));
+                    builder.put(indexMetaDataBuilder);
                 }
                 return newClusterStateBuilder().state(currentState).metaData(builder).build();
             }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -201,7 +201,7 @@ public class RestClusterStateAction extends BaseRestHandler {
                             builder.endObject();
 
                             builder.startArray("aliases");
-                            for (String alias : indexMetaData.aliases()) {
+                            for (String alias : indexMetaData.aliases().keySet()) {
                                 builder.value(alias);
                             }
                             builder.endArray();

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static org.elasticsearch.cluster.metadata.AliasMetaData.newAliasMetaDataBuilder;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
 import static org.elasticsearch.cluster.metadata.MetaData.*;
 import static org.elasticsearch.common.settings.ImmutableSettings.*;
@@ -57,6 +58,26 @@ public class ToAndFromJsonMetaDataTests {
                         .numberOfReplicas(2)
                         .putMapping("mapping1", MAPPING_SOURCE1)
                         .putMapping("mapping2", MAPPING_SOURCE2))
+                .put(newIndexMetaDataBuilder("test5")
+                        .settings(settingsBuilder().put("setting1", "value1").put("setting2", "value2"))
+                        .numberOfShards(1)
+                        .numberOfReplicas(2)
+                        .putMapping("mapping1", MAPPING_SOURCE1)
+                        .putMapping("mapping2", MAPPING_SOURCE2)
+                        .putAlias(newAliasMetaDataBuilder("alias1"))
+                        .putAlias(newAliasMetaDataBuilder("alias2")))
+                .put(newIndexMetaDataBuilder("test6")
+                        .settings(settingsBuilder()
+                                .put("setting1", "value1")
+                                .put("setting2", "value2")
+                                .put("index.aliases.0", "alias3")
+                                .put("index.aliases.1", "alias1"))
+                        .numberOfShards(1)
+                        .numberOfReplicas(2)
+                        .putMapping("mapping1", MAPPING_SOURCE1)
+                        .putMapping("mapping2", MAPPING_SOURCE2)
+                        .putAlias(newAliasMetaDataBuilder("alias1"))
+                        .putAlias(newAliasMetaDataBuilder("alias2")))
                 .build();
 
         String metaDataSource = MetaData.Builder.toXContent(metaData);
@@ -94,6 +115,33 @@ public class ToAndFromJsonMetaDataTests {
         assertThat(indexMetaData.mappings().size(), equalTo(2));
         assertThat(indexMetaData.mappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
         assertThat(indexMetaData.mappings().get("mapping2").source().string(), equalTo(MAPPING_SOURCE2));
+
+        indexMetaData = parsedMetaData.index("test5");
+        assertThat(indexMetaData.numberOfShards(), equalTo(1));
+        assertThat(indexMetaData.numberOfReplicas(), equalTo(2));
+        assertThat(indexMetaData.settings().getAsMap().size(), equalTo(4));
+        assertThat(indexMetaData.settings().get("setting1"), equalTo("value1"));
+        assertThat(indexMetaData.settings().get("setting2"), equalTo("value2"));
+        assertThat(indexMetaData.mappings().size(), equalTo(2));
+        assertThat(indexMetaData.mappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
+        assertThat(indexMetaData.mappings().get("mapping2").source().string(), equalTo(MAPPING_SOURCE2));
+        assertThat(indexMetaData.aliases().size(), equalTo(2));
+        assertThat(indexMetaData.aliases().get("alias1").alias(), equalTo("alias1"));
+        assertThat(indexMetaData.aliases().get("alias2").alias(), equalTo("alias2"));
+
+        indexMetaData = parsedMetaData.index("test6");
+        assertThat(indexMetaData.numberOfShards(), equalTo(1));
+        assertThat(indexMetaData.numberOfReplicas(), equalTo(2));
+        assertThat(indexMetaData.settings().getAsMap().size(), equalTo(4));
+        assertThat(indexMetaData.settings().get("setting1"), equalTo("value1"));
+        assertThat(indexMetaData.settings().get("setting2"), equalTo("value2"));
+        assertThat(indexMetaData.mappings().size(), equalTo(2));
+        assertThat(indexMetaData.mappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
+        assertThat(indexMetaData.mappings().get("mapping2").source().string(), equalTo(MAPPING_SOURCE2));
+        assertThat(indexMetaData.aliases().size(), equalTo(3));
+        assertThat(indexMetaData.aliases().get("alias1").alias(), equalTo("alias1"));
+        assertThat(indexMetaData.aliases().get("alias2").alias(), equalTo("alias2"));
+        assertThat(indexMetaData.aliases().get("alias3").alias(), equalTo("alias3"));
     }
 
     private static final String MAPPING_SOURCE1 = "{\"mapping1\":{\"text1\":{\"type\":\"string\"}}}";


### PR DESCRIPTION
Not sure what to do with RestClusterStateAction to make response backward compatible in the future.
