### PR TITLE
Add an ability to define and store filter for aliases.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
@@ -62,14 +62,21 @@ public class AliasAction implements Streamable {
 
     private String alias;
 
+    private String source;
+
     private AliasAction() {
 
     }
 
     public AliasAction(Type actionType, String index, String alias) {
+        this(actionType, index, alias, "");
+    }
+
+    public AliasAction(Type actionType, String index, String alias, String source) {
         this.actionType = actionType;
         this.index = index;
         this.alias = alias;
+        this.source = source;
     }
 
     public Type actionType() {
@@ -84,6 +91,10 @@ public class AliasAction implements Streamable {
         return alias;
     }
 
+    public String source() {
+        return source;
+    }
+
     public static AliasAction readAliasAction(StreamInput in) throws IOException {
         AliasAction aliasAction = new AliasAction();
         aliasAction.readFrom(in);
@@ -94,11 +105,13 @@ public class AliasAction implements Streamable {
         actionType = Type.fromValue(in.readByte());
         index = in.readUTF();
         alias = in.readUTF();
+        source = in.readUTF();
     }
 
     @Override public void writeTo(StreamOutput out) throws IOException {
         out.writeByte(actionType.value());
         out.writeUTF(index);
         out.writeUTF(alias);
+        out.writeUTF(source);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -68,7 +68,7 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                     }
                     IndexMetaData.Builder indexMetaDataBuilder = newIndexMetaDataBuilder(indexMetaData);
                     if (aliasAction.actionType() == AliasAction.Type.ADD) {
-                        indexMetaDataBuilder.putAlias(AliasMetaData.newAliasMetaDataBuilder(aliasAction.alias()).build());
+                        indexMetaDataBuilder.putAlias(AliasMetaData.newAliasMetaDataBuilder(aliasAction.alias()).source(aliasAction.source()).build());
                     } else if (aliasAction.actionType() == AliasAction.Type.REMOVE) {
                         indexMetaDataBuilder.removerAlias(aliasAction.alias());
                     }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -31,6 +31,7 @@ import org.elasticsearch.rest.action.admin.cluster.ping.broadcast.RestBroadcastP
 import org.elasticsearch.rest.action.admin.cluster.ping.replication.RestReplicationPingAction;
 import org.elasticsearch.rest.action.admin.cluster.ping.single.RestSinglePingAction;
 import org.elasticsearch.rest.action.admin.cluster.state.RestClusterStateAction;
+import org.elasticsearch.rest.action.admin.indices.alias.RestGetIndicesAliasesAction;
 import org.elasticsearch.rest.action.admin.indices.alias.RestIndicesAliasesAction;
 import org.elasticsearch.rest.action.admin.indices.analyze.RestAnalyzeAction;
 import org.elasticsearch.rest.action.admin.indices.cache.clear.RestClearIndicesCacheAction;
@@ -94,6 +95,7 @@ public class RestActionModule extends AbstractModule {
         bind(RestReplicationPingAction.class).asEagerSingleton();
 
         bind(RestIndicesStatusAction.class).asEagerSingleton();
+        bind(RestGetIndicesAliasesAction.class).asEagerSingleton();
         bind(RestIndicesAliasesAction.class).asEagerSingleton();
         bind(RestCreateIndexAction.class).asEagerSingleton();
         bind(RestDeleteIndexAction.class).asEagerSingleton();

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestGetIndicesAliasesAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestGetIndicesAliasesAction.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices.alias;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.support.RestXContentBuilder;
+
+import java.io.IOException;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+
+/**
+ * @author imotov
+ */
+public class RestGetIndicesAliasesAction extends BaseRestHandler {
+
+    @Inject public RestGetIndicesAliasesAction(Settings settings, Client client, RestController controller) {
+        super(settings, client);
+        controller.registerHandler(GET, "/_aliases", this);
+        controller.registerHandler(GET, "/{index}/_aliases", this);
+    }
+
+    @Override public void handleRequest(final RestRequest request, final RestChannel channel) {
+        final String[] indices = splitIndices(request.param("index"));
+
+        ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
+                .filterRoutingTable(true)
+                .filterNodes(true)
+                .filteredIndices(indices);
+
+        client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
+            @Override public void onResponse(ClusterStateResponse response) {
+                try {
+                    MetaData metaData = response.state().metaData();
+                    XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
+                    builder.startObject();
+
+                    for (IndexMetaData indexMetaData : metaData) {
+                        builder.startObject(indexMetaData.index());
+
+                        builder.startObject("aliases");
+                        for (AliasMetaData alias : indexMetaData.aliases().values()) {
+                            AliasMetaData.Builder.toXContent(alias, builder, ToXContent.EMPTY_PARAMS);
+                        }
+                        builder.endObject();
+
+                        builder.endObject();
+                    }
+
+                    builder.endObject();
+
+                    channel.sendResponse(new XContentRestResponse(request, OK, builder));
+                } catch (Exception e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override public void onFailure(Throwable e) {
+                try {
+                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
+                } catch (IOException e1) {
+                    logger.error("Failed to send failure response", e1);
+                }
+            }
+        });
+    }
+}
+

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.*;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.*;
 import static org.elasticsearch.rest.RestStatus.*;
@@ -53,7 +54,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
         try {
             // {
             //     actions : [
-            //         { add : { index : "test1", alias : "alias1" } }
+            //         { add : { index : "test1", alias : "alias1", source : {"user" : "kimchy"} } }
             //         { remove : { index : "test1", alias : "alias1" } }
             //     ]
             // }
@@ -78,6 +79,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
                             }
                             String index = null;
                             String alias = null;
+                            Map<String, Object> source = null;
                             String currentFieldName = null;
                             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                                 if (token == XContentParser.Token.FIELD_NAME) {
@@ -88,6 +90,10 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
                                     } else if ("alias".equals(currentFieldName)) {
                                         alias = parser.text();
                                     }
+                                } else if (token == XContentParser.Token.START_OBJECT) {
+                                    if ("source".equals(currentFieldName)) {
+                                        source = parser.map();
+                                    }
                                 }
                             }
                             if (index == null) {
@@ -97,7 +103,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
                                 throw new ElasticSearchIllegalArgumentException("Alias action [" + action + "] requires an [alias] to be set");
                             }
                             if (type == AliasAction.Type.ADD) {
-                                indicesAliasesRequest.addAlias(index, alias);
+                                indicesAliasesRequest.addAlias(index, alias, source);
                             } else if (type == AliasAction.Type.REMOVE) {
                                 indicesAliasesRequest.removeAlias(index, alias);
                             }

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -78,6 +78,19 @@ public class ToAndFromJsonMetaDataTests {
                         .putMapping("mapping2", MAPPING_SOURCE2)
                         .putAlias(newAliasMetaDataBuilder("alias1"))
                         .putAlias(newAliasMetaDataBuilder("alias2")))
+                .put(newIndexMetaDataBuilder("test7")
+                        .settings(settingsBuilder()
+                                .put("setting1", "value1")
+                                .put("setting2", "value2")
+                                .put("index.aliases.0", "alias3")
+                                .put("index.aliases.1", "alias1"))
+                        .numberOfShards(1)
+                        .numberOfReplicas(2)
+                        .putMapping("mapping1", MAPPING_SOURCE1)
+                        .putMapping("mapping2", MAPPING_SOURCE2)
+                        .putAlias(newAliasMetaDataBuilder("alias1").source(ALIAS_SOURCE1))
+                        .putAlias(newAliasMetaDataBuilder("alias2"))
+                        .putAlias(newAliasMetaDataBuilder("alias4").source(ALIAS_SOURCE2)))
                 .build();
 
         String metaDataSource = MetaData.Builder.toXContent(metaData);
@@ -142,8 +155,29 @@ public class ToAndFromJsonMetaDataTests {
         assertThat(indexMetaData.aliases().get("alias1").alias(), equalTo("alias1"));
         assertThat(indexMetaData.aliases().get("alias2").alias(), equalTo("alias2"));
         assertThat(indexMetaData.aliases().get("alias3").alias(), equalTo("alias3"));
+
+        indexMetaData = parsedMetaData.index("test7");
+        assertThat(indexMetaData.numberOfShards(), equalTo(1));
+        assertThat(indexMetaData.numberOfReplicas(), equalTo(2));
+        assertThat(indexMetaData.settings().getAsMap().size(), equalTo(4));
+        assertThat(indexMetaData.settings().get("setting1"), equalTo("value1"));
+        assertThat(indexMetaData.settings().get("setting2"), equalTo("value2"));
+        assertThat(indexMetaData.mappings().size(), equalTo(2));
+        assertThat(indexMetaData.mappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
+        assertThat(indexMetaData.mappings().get("mapping2").source().string(), equalTo(MAPPING_SOURCE2));
+        assertThat(indexMetaData.aliases().size(), equalTo(4));
+        assertThat(indexMetaData.aliases().get("alias1").alias(), equalTo("alias1"));
+        assertThat(indexMetaData.aliases().get("alias1").source().string(), equalTo(ALIAS_SOURCE1));
+        assertThat(indexMetaData.aliases().get("alias2").alias(), equalTo("alias2"));
+        assertThat(indexMetaData.aliases().get("alias2").source(), nullValue());
+        assertThat(indexMetaData.aliases().get("alias3").alias(), equalTo("alias3"));
+        assertThat(indexMetaData.aliases().get("alias3").source(), nullValue());
+        assertThat(indexMetaData.aliases().get("alias4").alias(), equalTo("alias4"));
+        assertThat(indexMetaData.aliases().get("alias4").source().string(), equalTo(ALIAS_SOURCE2));
     }
 
     private static final String MAPPING_SOURCE1 = "{\"mapping1\":{\"text1\":{\"type\":\"string\"}}}";
     private static final String MAPPING_SOURCE2 = "{\"mapping2\":{\"text2\":{\"type\":\"string\"}}}";
+    private static final String ALIAS_SOURCE1 = "{\"field1\":\"value1\"}";
+    private static final String ALIAS_SOURCE2 = "{\"field2\":\"value2\"}";
 }


### PR DESCRIPTION
As per our discussion, this commit only adds an ability to store filter source. The stored filters are not yet used to filter search results.
