### PR TITLE
ElisionFilter

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -118,6 +118,29 @@ public class Analysis {
             .put("_turkish_", TurkishAnalyzer.getDefaultStopSet())
             .immutableMap();
 
+    public static Set<?> parseArticles(Environment env, Settings settings) {
+        String value = settings.get("articles");
+        if (value != null) {
+            if ("_none_".equals(value)) {
+                return ImmutableSet.of();
+            } else {
+                return ImmutableSet.copyOf(Strings.commaDelimitedListToSet(value));
+            }
+        }
+        String[] articles = settings.getAsArray("articles", null);
+        if (articles != null) {
+            Set setArticles = new HashSet<String>(Arrays.asList(articles));
+            return setArticles;
+        }
+        Set<String> pathLoadedArticles = getWordSet(env, settings, "articles");
+        if (pathLoadedArticles != null) {
+            Set setArticles = new HashSet<String>(pathLoadedArticles);
+            return setArticles;
+        }
+
+        return null;
+    }
+
     public static Set<?> parseStopWords(Environment env, Settings settings, Set<?> defaultStopWords) {
         String value = settings.get("stopwords");
         if (value != null) {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/ElisionTokenFilterFactory.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/ElisionTokenFilterFactory.java
@@ -39,14 +39,14 @@ public class ElisionTokenFilterFactory extends AbstractTokenFilterFactory {
 
     @Inject public ElisionTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, Environment env, @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
-	this.articles = Analysis.parseArticles(env, settings);
+        this.articles = Analysis.parseArticles(env, settings);
     }
 
     @Override public TokenStream create(TokenStream tokenStream) {
-	if (articles == null) {
-	    return new ElisionFilter(version, tokenStream);
-	} else {
-	    return new ElisionFilter(version, tokenStream, articles);
-	}
+        if (articles == null) {
+            return new ElisionFilter(version, tokenStream);
+        } else {
+            return new ElisionFilter(version, tokenStream, articles);
+        }
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/ElisionTokenFilterFactory.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/ElisionTokenFilterFactory.java
@@ -24,20 +24,29 @@ import org.apache.lucene.analysis.fr.ElisionFilter;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.settings.IndexSettings;
 
+import java.util.Set;
 
 /**
  * @author kimchy (Shay Banon)
  */
 public class ElisionTokenFilterFactory extends AbstractTokenFilterFactory {
 
-    @Inject public ElisionTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+    private final Set<?> articles;
+
+    @Inject public ElisionTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, Environment env, @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
+	this.articles = Analysis.parseArticles(env, settings);
     }
 
     @Override public TokenStream create(TokenStream tokenStream) {
-        return new ElisionFilter(version, tokenStream);
+	if (articles == null) {
+	    return new ElisionFilter(version, tokenStream);
+	} else {
+	    return new ElisionFilter(version, tokenStream, articles);
+	}
     }
 }


### PR DESCRIPTION
This adds the ability to specify a list of stopword articles with the setting "articles".

<pre>
index:
    analysis:
        analyzer:
            default:
                tokenizer: standard
                filter: [elision]
        filter:
            elision:
                type: elision
                articles: [l, m, t, qu, n, s, j] 
</pre>


By default the standart stop words are used.
