### PR TITLE
adding eclipse support and an Ec2NameResolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ plugins/river/twitter/build
 plugins/river/wikipedia/build
 plugins/transport/memcached/build
 plugins/transport/thrift/build
+
+## eclipse ignores (use 'gradle eclipse' to build eclipse projects)
+.project
+.classpath
+.settings
+*/.project
+*/.classpath
+*/.settings
+*/eclipse-build

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':test-testng')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "$project.archivesBaseName"
 
@@ -124,4 +125,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> !dep.artifactId.contains('jline') }
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -70,12 +70,12 @@ public class NetworkService extends AbstractComponent {
         /**
          * Resolves the default value if possible. If not, return <tt>null</tt>.
          */
-        InetAddress resolveDefault() throws IOException;
+        InetAddress resolveDefault();
 
         /**
          * Resolves a custom value handling, return <tt>null</tt> if can't handle it.
          */
-        InetAddress resolveIfPossible(String value) throws IOException;
+        InetAddress resolveIfPossible(String value);
     }
 
     private final List<CustomNameResolver> customNameResolvers = new CopyOnWriteArrayList<CustomNameResolver>();

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -70,12 +70,12 @@ public class NetworkService extends AbstractComponent {
         /**
          * Resolves the default value if possible. If not, return <tt>null</tt>.
          */
-        InetAddress resolveDefault();
+        InetAddress resolveDefault() throws IOException;
 
         /**
          * Resolves a custom value handling, return <tt>null</tt> if can't handle it.
          */
-        InetAddress resolveIfPossible(String value);
+        InetAddress resolveIfPossible(String value) throws IOException;
     }
 
     private final List<CustomNameResolver> customNameResolvers = new CopyOnWriteArrayList<CustomNameResolver>();

--- a/modules/test/integration/build.gradle
+++ b/modules/test/integration/build.gradle
@@ -1,6 +1,7 @@
 dependsOn(':elasticsearch')
 
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
 archivesBaseName = "$rootProject.archivesBaseName-$project.archivesBaseName"
 
@@ -14,3 +15,8 @@ sourceSets.test.resources.srcDirs 'src/test/java'
 dependencies {
     compile project(':elasticsearch')
 }
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
+}
+

--- a/modules/test/testng/build.gradle
+++ b/modules/test/testng/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
 archivesBaseName = "$rootProject.archivesBaseName-$project.archivesBaseName"
 
@@ -12,4 +13,8 @@ sourceSets.test.resources.srcDirs 'src/test/java'
 dependencies {
     compile('org.testng:testng:5.10:jdk15') { transitive = false }
     compile('log4j:log4j:1.2.15') { transitive = false }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/analysis/icu/build.gradle
+++ b/plugins/analysis/icu/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-analysis-icu"
 
@@ -126,4 +127,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/cloud/aws/build.gradle
+++ b/plugins/cloud/aws/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-cloud-aws"
 
@@ -130,4 +131,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -1,0 +1,96 @@
+package org.elasticsearch.cloud.aws.network;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.elasticsearch.common.network.NetworkService.CustomNameResolver;
+
+/**
+ * Resolves certain ec2 related 'meta' hostnames into an actual hostname
+ * obtained from ec2 meta-data.
+ * <p /> 
+ * Valid config values for {@link Ec2HostnameType}s are -
+ * <ul>
+ *     <li>_ec2 - maps to privateIpv4</li>
+ *     <li>_ec2:privateIp_ - maps to privateIpv4</li>
+ *     <li>_ec2:privateIpv4_</li>
+ *     <li>_ec2:privateDns_</li>
+ *     <li>_ec2:publicIp_ - maps to publicIpv4</li>
+ *     <li>_ec2:publicIpv4_</li>
+ *     <li>_ec2:publicDns_</li>
+ * </ul>
+ * @author Paul_Loy (keteracel)
+ */
+public class Ec2NameResolver implements CustomNameResolver {
+
+	// enum that can be added to over time with more meta-data types (such as ipv6 when this is available)
+	private static enum Ec2HostnameType {
+
+		PRIVATE_IPv4("_ec2:privateIpv4_", "local-ipv4"),
+		PRIVATE_DNS ("_ec2:privateDns_",  "local-hostname"),
+		PUBLIC_IPv4 ("_ec2:publicIpv4_",  "public-ipv4"),
+		PUBLIC_DNS  ("_ec2:publicDns_",   "public-hostname"),
+
+		PUBLIC_IP   ("_ec2:publicIp_",    PUBLIC_IPv4.ec2Name),
+		PRIVATE_IP  ("_ec2:privateIp_",   PRIVATE_IPv4.ec2Name),
+		DEFAULT     ("_ec2",              PRIVATE_IPv4.ec2Name);
+
+		final String configName;
+		final String ec2Name;
+
+		private Ec2HostnameType(String configName, String ec2Name) {
+			this.configName = configName;
+			this.ec2Name = ec2Name;
+		}
+
+	}
+
+	private static final String EC2_METADATA_URL = "http://169.254.169.254/latest/meta-data/";
+
+	private final Ec2HostnameType type;
+
+	/**
+	 * Construct a {@link CustomNameResolver} with the given {@link Ec2HostnameType}
+	 * address type.
+	 * 
+	 * @param addressType the type of ec2 host to bind to.
+	 */
+	public Ec2NameResolver(Ec2HostnameType addressType) {
+		this.type = addressType;
+	}
+
+	/**
+	 * @return the appropriate host resolved from ec2 meta-data.
+	 * @throws IOException if ec2 meta-data cannot be obtained.
+	 * 
+	 * @see CustomNameResolver#resolve()
+	 */
+	@Override
+	public InetAddress resolve() throws IOException {
+		String ec2Url = EC2_METADATA_URL + this.type.ec2Name;
+		GetMethod ec2MetadataRequest = new GetMethod(ec2Url);
+
+		int status = new HttpClient().executeMethod(ec2MetadataRequest);
+		if (status != 200) {	
+			throw new HttpException(MessageFormat.format("unable to retrieve ec2 metadata from {0}. Response: {1} {2}", ec2Url, status, HttpStatus.getStatusText(status)));
+		}
+		String metadataResult = ec2MetadataRequest.getResponseBodyAsString();
+		return InetAddress.getByName(metadataResult);
+	}
+
+	public static Map<String, CustomNameResolver> resolvers() {
+		Map<String, CustomNameResolver> resolvers = new HashMap<String, CustomNameResolver>();
+		for (Ec2HostnameType type : Ec2HostnameType.values()) {
+			resolvers.put(type.configName, new Ec2NameResolver(type));
+		}
+		return resolvers;
+	}
+
+}

--- a/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -1,15 +1,30 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.cloud.aws.network;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
-import java.text.MessageFormat;
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URL;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 import org.elasticsearch.common.network.NetworkService.CustomNameResolver;
 
 /**
@@ -30,7 +45,11 @@ import org.elasticsearch.common.network.NetworkService.CustomNameResolver;
  */
 public class Ec2NameResolver implements CustomNameResolver {
 
-	// enum that can be added to over time with more meta-data types (such as ipv6 when this is available)
+	/**
+	 *  enum that can be added to over time with more meta-data types (such as ipv6 when this is available)
+	 *  
+	 * @author Paul_Loy
+	 */
 	private static enum Ec2HostnameType {
 
 		PRIVATE_IPv4("_ec2:privateIpv4_", "local-ipv4"),
@@ -38,6 +57,7 @@ public class Ec2NameResolver implements CustomNameResolver {
 		PUBLIC_IPv4 ("_ec2:publicIpv4_",  "public-ipv4"),
 		PUBLIC_DNS  ("_ec2:publicDns_",   "public-hostname"),
 
+		// some less verbose defaults
 		PUBLIC_IP   ("_ec2:publicIp_",    PUBLIC_IPv4.ec2Name),
 		PRIVATE_IP  ("_ec2:privateIp_",   PRIVATE_IPv4.ec2Name),
 		DEFAULT     ("_ec2",              PRIVATE_IPv4.ec2Name);
@@ -54,43 +74,54 @@ public class Ec2NameResolver implements CustomNameResolver {
 
 	private static final String EC2_METADATA_URL = "http://169.254.169.254/latest/meta-data/";
 
-	private final Ec2HostnameType type;
-
 	/**
 	 * Construct a {@link CustomNameResolver} with the given {@link Ec2HostnameType}
 	 * address type.
 	 * 
 	 * @param addressType the type of ec2 host to bind to.
 	 */
-	public Ec2NameResolver(Ec2HostnameType addressType) {
-		this.type = addressType;
+	public Ec2NameResolver() {
 	}
 
 	/**
 	 * @return the appropriate host resolved from ec2 meta-data.
 	 * @throws IOException if ec2 meta-data cannot be obtained.
 	 * 
-	 * @see CustomNameResolver#resolve()
+	 * @see CustomNameResolver#resolveIfPossible(String)
 	 */
-	@Override
-	public InetAddress resolve() throws IOException {
-		String ec2Url = EC2_METADATA_URL + this.type.ec2Name;
-		GetMethod ec2MetadataRequest = new GetMethod(ec2Url);
+	public InetAddress resolve(Ec2HostnameType type) throws IOException {
+		
+		URL url = new URL(EC2_METADATA_URL + type.ec2Name);
+		BufferedReader urlReader = new BufferedReader(new InputStreamReader(url.openStream()));
 
-		int status = new HttpClient().executeMethod(ec2MetadataRequest);
-		if (status != 200) {	
-			throw new HttpException(MessageFormat.format("unable to retrieve ec2 metadata from {0}. Response: {1} {2}", ec2Url, status, HttpStatus.getStatusText(status)));
+		String metadataResult = urlReader.readLine();
+		if (metadataResult == null || metadataResult.length() == 0) {
+			throw new IOException("no ec2 metadata returned from :" + url);
 		}
-		String metadataResult = ec2MetadataRequest.getResponseBodyAsString();
 		return InetAddress.getByName(metadataResult);
 	}
 
-	public static Map<String, CustomNameResolver> resolvers() {
-		Map<String, CustomNameResolver> resolvers = new HashMap<String, CustomNameResolver>();
+	/*
+	 * (non-Javadoc)
+	 * @see org.elasticsearch.common.network.NetworkService.CustomNameResolver#resolveDefault()
+	 */
+	@Override
+	public InetAddress resolveDefault() throws IOException {
+		return resolve(Ec2HostnameType.DEFAULT);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.elasticsearch.common.network.NetworkService.CustomNameResolver#resolveIfPossible(java.lang.String)
+	 */
+	@Override
+	public InetAddress resolveIfPossible(String value) throws IOException {
 		for (Ec2HostnameType type : Ec2HostnameType.values()) {
-			resolvers.put(type.configName, new Ec2NameResolver(type));
+			if (type.configName.equals(value)) {
+				return resolve(type);
+			}
 		}
-		return resolvers;
+		return null;
 	}
 
 }

--- a/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/plugins/cloud/aws/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -52,15 +52,15 @@ public class Ec2NameResolver implements CustomNameResolver {
 	 */
 	private static enum Ec2HostnameType {
 
-		PRIVATE_IPv4("_ec2:privateIpv4_", "local-ipv4"),
-		PRIVATE_DNS ("_ec2:privateDns_",  "local-hostname"),
-		PUBLIC_IPv4 ("_ec2:publicIpv4_",  "public-ipv4"),
-		PUBLIC_DNS  ("_ec2:publicDns_",   "public-hostname"),
+		PRIVATE_IPv4("ec2:privateIpv4", "local-ipv4"),
+		PRIVATE_DNS ("ec2:privateDns",  "local-hostname"),
+		PUBLIC_IPv4 ("ec2:publicIpv4",  "public-ipv4"),
+		PUBLIC_DNS  ("ec2:publicDns",   "public-hostname"),
 
 		// some less verbose defaults
-		PUBLIC_IP   ("_ec2:publicIp_",    PUBLIC_IPv4.ec2Name),
-		PRIVATE_IP  ("_ec2:privateIp_",   PRIVATE_IPv4.ec2Name),
-		DEFAULT     ("_ec2",              PRIVATE_IPv4.ec2Name);
+		PUBLIC_IP   ("ec2:publicIp",    PUBLIC_IPv4.ec2Name),
+		PRIVATE_IP  ("ec2:privateIp",   PRIVATE_IPv4.ec2Name),
+		DEFAULT     ("ec2",             PRIVATE_IPv4.ec2Name);
 
 		final String configName;
 		final String ec2Name;

--- a/plugins/cloud/aws/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
+++ b/plugins/cloud/aws/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.discovery.ec2;
 
 import org.elasticsearch.cloud.aws.AwsEc2Service;
+import org.elasticsearch.cloud.aws.network.Ec2NameResolver;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.discovery.zen.ping.ZenPing;
@@ -37,26 +39,31 @@ import org.elasticsearch.transport.TransportService;
  */
 public class Ec2Discovery extends ZenDiscovery {
 
-    @Inject public Ec2Discovery(Settings settings, ClusterName clusterName, ThreadPool threadPool, TransportService transportService,
-                                ClusterService clusterService, ZenPingService pingService, AwsEc2Service ec2Service) {
-        super(settings, clusterName, threadPool, transportService, clusterService, pingService);
-        if (settings.getAsBoolean("cloud.enabled", true)) {
-            ImmutableList<? extends ZenPing> zenPings = pingService.zenPings();
-            UnicastZenPing unicastZenPing = null;
-            for (ZenPing zenPing : zenPings) {
-                if (zenPing instanceof UnicastZenPing) {
-                    unicastZenPing = (UnicastZenPing) zenPing;
-                    break;
-                }
-            }
-            if (unicastZenPing != null) {
-                // update the unicast zen ping to add cloud hosts provider
-                // and, while we are at it, use only it and not the multicast for example
-                unicastZenPing.addHostsProvider(new AwsEc2UnicastHostsProvider(settings, transportService, ec2Service.client()));
-                pingService.zenPings(ImmutableList.of(unicastZenPing));
-            } else {
-                logger.warn("failed to apply ec2 unicast discovery, no unicast ping found");
-            }
-        }
-    }
+	@Inject public Ec2Discovery(Settings settings, ClusterName clusterName, ThreadPool threadPool, TransportService transportService,
+			ClusterService clusterService, ZenPingService pingService, AwsEc2Service ec2Service, NetworkService networkService) {
+		super(settings, clusterName, threadPool, transportService, clusterService, pingService);
+		if (settings.getAsBoolean("cloud.enabled", true)) {
+
+			// add ec2 hostname resolvers to NetworkService issue#940
+			networkService.addCustomNameResolver(new Ec2NameResolver());
+
+			ImmutableList<? extends ZenPing> zenPings = pingService.zenPings();
+			UnicastZenPing unicastZenPing = null;
+			for (ZenPing zenPing : zenPings) {
+				if (zenPing instanceof UnicastZenPing) {
+					unicastZenPing = (UnicastZenPing) zenPing;
+					break;
+				}
+			}
+
+			if (unicastZenPing != null) {
+				// update the unicast zen ping to add cloud hosts provider
+				// and, while we are at it, use only it and not the multicast for example
+				unicastZenPing.addHostsProvider(new AwsEc2UnicastHostsProvider(settings, transportService, ec2Service.client()));
+				pingService.zenPings(ImmutableList.of(unicastZenPing));
+			} else {
+				logger.warn("failed to apply ec2 unicast discovery, no unicast ping found");
+			}
+		}
+	}
 }

--- a/plugins/hadoop/build.gradle
+++ b/plugins/hadoop/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-hadoop"
 
@@ -130,4 +131,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/lang/javascript/build.gradle
+++ b/plugins/lang/javascript/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-lang-javascript"
 
@@ -130,4 +131,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/lang/python/build.gradle
+++ b/plugins/lang/python/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-lang-python"
 
@@ -130,4 +131,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/mapper/attachments/build.gradle
+++ b/plugins/mapper/attachments/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-mapper-attachments"
 
@@ -124,4 +125,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/river/couchdb/build.gradle
+++ b/plugins/river/couchdb/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-river-couchdb"
 
@@ -121,4 +122,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/river/rabbitmq/build.gradle
+++ b/plugins/river/rabbitmq/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-river-rabbitmq"
 
@@ -126,4 +127,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/river/twitter/build.gradle
+++ b/plugins/river/twitter/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-river-twitter"
 
@@ -124,4 +125,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/river/wikipedia/build.gradle
+++ b/plugins/river/wikipedia/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-river-wikipedia"
 
@@ -121,4 +122,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/transport/memcached/build.gradle
+++ b/plugins/transport/memcached/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-transport-memcached"
 
@@ -129,4 +130,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }

--- a/plugins/transport/thrift/build.gradle
+++ b/plugins/transport/thrift/build.gradle
@@ -2,6 +2,7 @@ dependsOn(':elasticsearch')
 
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'eclipse'
 
 archivesBaseName = "elasticsearch-transport-thrift"
 
@@ -132,4 +133,8 @@ uploadArchives {
             pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
         }
     }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
 }


### PR DESCRIPTION
- adds a little bit to gradle.build files that allows someone to simple use 'gradle eclipse' to generate eclipse project and classpath files.
- also adds the Ec2NameResolver which is part 1 of https://github.com/elasticsearch/elasticsearch/issues/940

(unfortunately my commit went a little awry and added the Ec2NameResolver to what was supposed to just be eclipse support)
