### PR TITLE
Hidden files indexed in mappings

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -367,6 +367,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
     private void addMappings(Map<String, Map<String, Object>> mappings, File mappingsDir) {
         File[] mappingsFiles = mappingsDir.listFiles();
         for (File mappingFile : mappingsFiles) {
+            if (mappingFile.isHidden()) {
+                continue;
+            }
             String mappingType = mappingFile.getName().substring(0, mappingFile.getName().lastIndexOf('.'));
             try {
                 String mappingSource = Streams.copyToString(new FileReader(mappingFile));


### PR DESCRIPTION
Found issue with hidden files attempting to be indexed when mappings being loaded. This allows mappings to skip hidden files.

failed to read / parse mapping [] from location [/opt/elastic/current/config/mappings/n233/.svn], ignoring...
java.io.FileNotFoundException: /opt/elastic/current/config/mappings/n233/.svn (Is a directory)
        at java.io.FileInputStream.open(Native Method)
