### PR TITLE
Incorrect json for a boolean query

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -143,7 +143,7 @@ public class TransportMoreLikeThisAction extends BaseAction<MoreLikeThisRequest,
                         parseSource(getResponse, boolBuilder, docMapper, fields, request);
                     }
 
-                    if (boolBuilder.clauses().isEmpty()) {
+                    if (!boolBuilder.hasClauses()) {
                         // no field added, fail
                         listener.onFailure(new ElasticSearchException("No fields found to fetch the 'likeText' from"));
                         return;


### PR DESCRIPTION
The json generated from a boolean query can produce a map with several same keys. The keys being duplicated are "must", "must_not" and "should". I fixed this by generating arrays, as suggested by the doc: http://www.elasticsearch.org/guide/reference/query-dsl/bool-query.html

This bug had no impact on the use of the Java client per se, but has some consequence when the result of a xbuilder is manipulated in java (the Java map makes duplicated key overrides themselves).
