### PR TITLE
Allow fuzzy ip queries to accept long typed min_similarity values

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -178,7 +178,16 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
 
     @Override public Query fuzzyQuery(String value, String minSim, int prefixLength, int maxExpansions) {
         long iValue = ipToLong(value);
-        long iSim = ipToLong(minSim);
+        long iSim;
+        try {
+          iSim = ipToLong(minSim);
+        } catch (ElasticSearchIllegalArgumentException e) {
+          try {
+            iSim = Long.parseLong(minSim);
+          } catch (NumberFormatException e1) {
+            iSim = (long) Double.parseDouble(minSim);
+          }
+        }
         return NumericRangeQuery.newLongRange(names.indexName(), precisionStep,
                 iValue - iSim,
                 iValue + iSim,

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -76,7 +76,7 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
         try {
             String[] octets = pattern.split(ip);
             if (octets.length != 4) {
-                throw new ElasticSearchIllegalArgumentException("failed ot parse ip [" + ip + "], not full ip address (4 dots)");
+                throw new ElasticSearchIllegalArgumentException("failed to parse ip [" + ip + "], not full ip address (4 dots)");
             }
             return (Long.parseLong(octets[0]) << 24) + (Integer.parseInt(octets[1]) << 16) +
                     (Integer.parseInt(octets[2]) << 8) + Integer.parseInt(octets[3]);
@@ -158,7 +158,7 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
     }
 
     /**
-     * Dates should return as a string, delegates to {@link #valueAsString(org.apache.lucene.document.Fieldable)}.
+     * IPs should return as a string, delegates to {@link #valueAsString(org.apache.lucene.document.Fieldable)}.
      */
     @Override public Object valueForSearch(Fieldable field) {
         return valueAsString(field);


### PR DESCRIPTION
Thought this would be useful since I didn't expect to have to pass ip addresses for the min_similarity.
