### PR TITLE
Wait for alias operations to be propagated to all nodes before returning 

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesResponse.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesResponse.java
@@ -27,18 +27,36 @@ import org.elasticsearch.common.io.stream.Streamable;
 import java.io.IOException;
 
 /**
- * A response for a create index action.
+ * A response for a add/remove alias action.
  *
  * @author kimchy (shay.banon)
  */
 public class IndicesAliasesResponse implements ActionResponse, Streamable {
 
+    private boolean acknowledged;
+
     IndicesAliasesResponse() {
+
     }
 
+    IndicesAliasesResponse(boolean acknowledged) {
+        this.acknowledged = acknowledged;
+    }
+
+    public boolean acknowledged() {
+        return acknowledged;
+    }
+
+    public boolean getAcknowledged() {
+        return acknowledged();
+    }
+
+
     @Override public void readFrom(StreamInput in) throws IOException {
+        acknowledged = in.readBoolean();
     }
 
     @Override public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(acknowledged);
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -79,9 +79,9 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
         final AtomicReference<IndicesAliasesResponse> responseRef = new AtomicReference<IndicesAliasesResponse>();
         final AtomicReference<Throwable> failureRef = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(1);
-        indexAliasesService.indicesAliases(new MetaDataIndexAliasesService.Request(request.aliasActions().toArray(new AliasAction[request.aliasActions().size()])), new MetaDataIndexAliasesService.Listener() {
+        indexAliasesService.indicesAliases(new MetaDataIndexAliasesService.Request(request.aliasActions().toArray(new AliasAction[request.aliasActions().size()]), request.timeout()), new MetaDataIndexAliasesService.Listener() {
             @Override public void onResponse(MetaDataIndexAliasesService.Response response) {
-                responseRef.set(new IndicesAliasesResponse());
+                responseRef.set(new IndicesAliasesResponse(response.acknowledged()));
                 latch.countDown();
             }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/client/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/client/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
@@ -115,6 +115,16 @@ public class IndicesAliasesRequestBuilder extends BaseIndicesRequestBuilder<Indi
         return this;
     }
 
+    /**
+     * Sets operation timeout.
+     *
+     * @param timeout
+     */
+    public IndicesAliasesRequestBuilder setTimeout(TimeValue timeout) {
+        request.timeout(timeout);
+        return this;
+    }
+
     @Override protected void doExecute(ActionListener<IndicesAliasesResponse> listener) {
         client.aliases(request, listener);
     }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -66,5 +66,6 @@ public class ClusterModule extends AbstractModule implements SpawnModules {
         bind(NodeMappingCreatedAction.class).asEagerSingleton();
         bind(NodeMappingRefreshAction.class).asEagerSingleton();
         bind(MappingUpdatedAction.class).asEagerSingleton();
+        bind(NodeAliasesUpdatedAction.class).asEagerSingleton();
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/action/index/NodeAliasesUpdatedAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/action/index/NodeAliasesUpdatedAction.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.action.index;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.VoidStreamable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.BaseTransportRequestHandler;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.VoidTransportResponseHandler;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * @author imotov
+ */
+public class NodeAliasesUpdatedAction extends AbstractComponent {
+
+    private final ThreadPool threadPool;
+
+    private final TransportService transportService;
+
+    private final ClusterService clusterService;
+
+    private final List<Listener> listeners = new CopyOnWriteArrayList<Listener>();
+
+    @Inject public NodeAliasesUpdatedAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService) {
+        super(settings);
+        this.threadPool = threadPool;
+        this.transportService = transportService;
+        this.clusterService = clusterService;
+        transportService.registerHandler(NodeAliasesUpdatedTransportHandler.ACTION, new NodeAliasesUpdatedTransportHandler());
+    }
+
+    public void add(final Listener listener, TimeValue timeout) {
+        listeners.add(listener);
+        threadPool.schedule(timeout, ThreadPool.Names.CACHED, new Runnable() {
+            @Override public void run() {
+                boolean removed = listeners.remove(listener);
+                if (removed) {
+                    listener.onTimeout();
+                }
+            }
+        });
+    }
+
+    public void remove(Listener listener) {
+        listeners.remove(listener);
+    }
+
+    public void nodeAliasesUpdated(final NodeAliasesUpdatedResponse response) throws ElasticSearchException {
+        DiscoveryNodes nodes = clusterService.state().nodes();
+        if (nodes.localNodeMaster()) {
+            threadPool.cached().execute(new Runnable() {
+                @Override public void run() {
+                    innerNodeAliasesUpdated(response);
+                }
+            });
+        } else {
+            transportService.sendRequest(clusterService.state().nodes().masterNode(),
+                    NodeAliasesUpdatedTransportHandler.ACTION, response, VoidTransportResponseHandler.INSTANCE_SAME);
+        }
+    }
+
+    private void innerNodeAliasesUpdated(NodeAliasesUpdatedResponse response) {
+        for (Listener listener : listeners) {
+            listener.onAliasesUpdated(response);
+        }
+    }
+
+
+    public static interface Listener {
+        void onAliasesUpdated(NodeAliasesUpdatedResponse response);
+
+        void onTimeout();
+    }
+
+    private class NodeAliasesUpdatedTransportHandler extends BaseTransportRequestHandler<NodeAliasesUpdatedResponse> {
+
+        static final String ACTION = "cluster/nodeAliasesUpdated";
+
+        @Override public NodeAliasesUpdatedResponse newInstance() {
+            return new NodeAliasesUpdatedResponse();
+        }
+
+        @Override public void messageReceived(NodeAliasesUpdatedResponse response, TransportChannel channel) throws Exception {
+            innerNodeAliasesUpdated(response);
+            channel.sendResponse(VoidStreamable.INSTANCE);
+        }
+
+        @Override public String executor() {
+            return ThreadPool.Names.SAME;
+        }
+    }
+
+    public static class NodeAliasesUpdatedResponse implements Streamable {
+
+        private String nodeId;
+
+        private long version;
+
+        private NodeAliasesUpdatedResponse() {
+        }
+
+        public NodeAliasesUpdatedResponse(String nodeId, long version) {
+            this.nodeId = nodeId;
+            this.version = version;
+        }
+
+        public String nodeId() {
+            return nodeId;
+        }
+
+        public long version() {
+            return version;
+        }
+
+        @Override public void writeTo(StreamOutput out) throws IOException {
+            out.writeUTF(nodeId);
+            out.writeLong(version);
+        }
+
+        @Override public void readFrom(StreamInput in) throws IOException {
+            nodeId = in.readUTF();
+            version = in.readLong();
+        }
+    }
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -87,6 +87,31 @@ public class AliasMetaData {
         return new Builder(alias);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AliasMetaData that = (AliasMetaData) o;
+
+        if (alias != null ? !alias.equals(that.alias) : that.alias != null) return false;
+        if (filter != null ? !filter.equals(that.filter) : that.filter != null) return false;
+        if (indexRouting != null ? !indexRouting.equals(that.indexRouting) : that.indexRouting != null) return false;
+        if (searchRouting != null ? !searchRouting.equals(that.searchRouting) : that.searchRouting != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = alias != null ? alias.hashCode() : 0;
+        result = 31 * result + (filter != null ? filter.hashCode() : 0);
+        result = 31 * result + (indexRouting != null ? indexRouting.hashCode() : 0);
+        result = 31 * result + (searchRouting != null ? searchRouting.hashCode() : 0);
+        return result;
+    }
+
     public static class Builder {
 
         private String alias;

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -188,11 +188,11 @@ public class MetaData implements Iterable<IndexMetaData> {
         return this.version;
     }
 
-    public ImmutableSet<String> aliases() {
-        return this.aliases.keySet();
+    public ImmutableMap<String, ImmutableMap<String, AliasMetaData>> aliases() {
+        return this.aliases;
     }
 
-    public ImmutableSet<String> getAliases() {
+    public ImmutableMap<String, ImmutableMap<String, AliasMetaData>> getAliases() {
         return aliases();
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -424,7 +424,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         if (!Strings.validFileName(request.index)) {
             throw new InvalidIndexNameException(new Index(request.index), request.index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
-        if (state.metaData().aliases().contains(request.index)) {
+        if (state.metaData().aliases().containsKey(request.index)) {
             throw new InvalidIndexNameException(new Index(request.index), request.index, "an alias with the same name already exists");
         }
     }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.action.index.NodeAliasesUpdatedAction;
 import org.elasticsearch.cluster.action.index.NodeIndexCreatedAction;
 import org.elasticsearch.cluster.action.index.NodeIndexDeletedAction;
 import org.elasticsearch.cluster.action.index.NodeMappingCreatedAction;
@@ -97,6 +98,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
 
     private final NodeMappingRefreshAction nodeMappingRefreshAction;
 
+    private final NodeAliasesUpdatedAction nodeAliasesUpdatedAction;
+
     // a map of mappings type we have seen per index due to cluster state
     // we need this so we won't remove types automatically created as part of the indexing process
     private final ConcurrentMap<Tuple<String, String>, Boolean> seenMappings = ConcurrentCollections.newConcurrentMap();
@@ -109,7 +112,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                                               ThreadPool threadPool, RecoveryTarget recoveryTarget, RecoverySource recoverySource,
                                               ShardStateAction shardStateAction,
                                               NodeIndexCreatedAction nodeIndexCreatedAction, NodeIndexDeletedAction nodeIndexDeletedAction,
-                                              NodeMappingCreatedAction nodeMappingCreatedAction, NodeMappingRefreshAction nodeMappingRefreshAction) {
+                                              NodeMappingCreatedAction nodeMappingCreatedAction, NodeMappingRefreshAction nodeMappingRefreshAction,
+                                              NodeAliasesUpdatedAction nodeAliasesUpdatedAction) {
         super(settings);
         this.indicesService = indicesService;
         this.clusterService = clusterService;
@@ -121,6 +125,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         this.nodeIndexDeletedAction = nodeIndexDeletedAction;
         this.nodeMappingCreatedAction = nodeMappingCreatedAction;
         this.nodeMappingRefreshAction = nodeMappingRefreshAction;
+        this.nodeAliasesUpdatedAction = nodeAliasesUpdatedAction;
     }
 
     @Override protected void doStart() throws ElasticSearchException {
@@ -372,26 +377,36 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         return requiresRefresh;
     }
 
+    private boolean aliasesChanged(ClusterChangedEvent event) {
+        return !event.state().metaData().aliases().equals(event.previousState().metaData().aliases());
+    }
+
     private void applyAliases(ClusterChangedEvent event) {
-        // go over and update aliases
-        for (IndexMetaData indexMetaData : event.state().metaData()) {
-            if (!indicesService.hasIndex(indexMetaData.index())) {
-                // we only create / update here
-                continue;
-            }
-            String index = indexMetaData.index();
-            IndexService indexService = indicesService.indexService(index);
-            IndexAliasesService indexAliasesService = indexService.aliasesService();
-            for (AliasMetaData aliasesMd : indexMetaData.aliases().values()) {
-                processAlias(index, aliasesMd.alias(), aliasesMd.filter(), indexAliasesService);
-            }
-            // go over and remove aliases
-            for (IndexAlias indexAlias : indexAliasesService) {
-                if (!indexMetaData.aliases().containsKey(indexAlias.alias())) {
-                    // we have it in our aliases, but not in the metadata, remove it
-                    indexAliasesService.remove(indexAlias.alias());
+        // check if aliases changed
+        if (aliasesChanged(event)) {
+            // go over and update aliases
+            for (IndexMetaData indexMetaData : event.state().metaData()) {
+                if (!indicesService.hasIndex(indexMetaData.index())) {
+                    // we only create / update here
+                    continue;
+                }
+                String index = indexMetaData.index();
+                IndexService indexService = indicesService.indexService(index);
+                IndexAliasesService indexAliasesService = indexService.aliasesService();
+                for (AliasMetaData aliasesMd : indexMetaData.aliases().values()) {
+                    processAlias(index, aliasesMd.alias(), aliasesMd.filter(), indexAliasesService);
+                }
+                // go over and remove aliases
+                for (IndexAlias indexAlias : indexAliasesService) {
+                    if (!indexMetaData.aliases().containsKey(indexAlias.alias())) {
+                        // we have it in our aliases, but not in the metadata, remove it
+                        indexAliasesService.remove(indexAlias.alias());
+                    }
                 }
             }
+            // Notify client that alias changes were applied
+            nodeAliasesUpdatedAction.nodeAliasesUpdated(
+                    new NodeAliasesUpdatedAction.NodeAliasesUpdatedResponse(event.state().nodes().localNodeId(), event.state().version()));
         }
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.AliasAction.*;
+import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 import static org.elasticsearch.rest.RestRequest.Method.*;
 import static org.elasticsearch.rest.RestStatus.*;
 import static org.elasticsearch.rest.action.support.RestXContentBuilder.*;
@@ -64,6 +65,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
             //         { remove : { index : "test1", alias : "alias1" } }
             //     ]
             // }
+            indicesAliasesRequest.timeout(request.paramAsTime("timeout", timeValueSeconds(10)));
             XContentParser parser = XContentFactory.xContent(request.contentByteArray(), request.contentByteArrayOffset(), request.contentLength())
                     .createParser(request.contentByteArray(), request.contentByteArrayOffset(), request.contentLength());
             XContentParser.Token token = parser.nextToken();
@@ -156,6 +158,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
                     XContentBuilder builder = restContentBuilder(request);
                     builder.startObject()
                             .field("ok", true)
+                            .field("acknowledged", response.acknowledged())
                             .endObject();
                     channel.sendResponse(new XContentRestResponse(request, OK, builder));
                 } catch (Exception e) {


### PR DESCRIPTION
Fixed logging level, renamed NodeAliasUpdatedTransportHandler, and move version check to the CountDownListener.  
