### PR TITLE
Fix NullPointerException when search request partially fails on one or mo

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -68,6 +68,7 @@ public class ShardSearchFailure implements ShardOperationFailedException {
     public ShardSearchFailure(String reason, SearchShardTarget shardTarget) {
         this.shardTarget = shardTarget;
         this.reason = reason;
+        this.status = RestStatus.INTERNAL_SERVER_ERROR;
     }
 
     /**


### PR DESCRIPTION
I had one shard missing and kept getting NPEs on master instead of a partially failed response because rest status in ShardSearchFailure wasn't initialized. The issue seems to be related to #1035.
