### PR TITLE
added include_lower and include_upper properties to RangeFilter

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacet.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacet.java
@@ -52,7 +52,9 @@ public interface RangeFacet extends Facet, Iterable<RangeFacet.Entry> {
         String fromAsString;
 
         String toAsString;
-
+        boolean includeLower = true;
+        boolean includeUpper = false;
+        
         long count;
         long totalCount;
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacetBuilder.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacetBuilder.java
@@ -89,8 +89,34 @@ public class RangeFacetBuilder extends AbstractFacetBuilder {
         return this;
     }
 
+    /**
+     * Adds a range entry with explicit from, to, includeLower and includeUpper.
+     *
+     * @param from The from range limit
+     * @param to   The to range limit
+     * @param includeLower Should the lower bound be included
+     * @param includeUpper Should the upper bound be included
+     */
+    public RangeFacetBuilder addRange(double from, double to, boolean includeLower, boolean includeUpper) {
+        entries.add(new Entry(from, to, includeLower, includeUpper));
+        return this;
+    }
+
     public RangeFacetBuilder addRange(String from, String to) {
         entries.add(new Entry(from, to));
+        return this;
+    }
+
+    /**
+     * Adds a range entry with explicit from, to, includeLower and includeUpper.
+     *
+     * @param from The from range limit
+     * @param to   The to range limit
+     * @param includeLower Should the lower bound be included
+     * @param includeUpper Should the upper bound be included
+     */
+    public RangeFacetBuilder addRange(String from, String to, boolean includeLower, boolean includeUpper) {
+        entries.add(new Entry(from, to, includeLower, includeUpper));
         return this;
     }
 
@@ -181,6 +207,12 @@ public class RangeFacetBuilder extends AbstractFacetBuilder {
             } else if (!Double.isInfinite(entry.to)) {
                 builder.field("to", entry.to);
             }
+            if (entry.includeLower!=null) {
+            	builder.field("include_lower", entry.includeLower);
+            }
+            if (entry.includeUpper!=null) {
+            	builder.field("include_upper", entry.includeUpper);
+            }
             builder.endObject();
         }
         builder.endArray();
@@ -196,18 +228,35 @@ public class RangeFacetBuilder extends AbstractFacetBuilder {
     static class Entry {
         double from = Double.NEGATIVE_INFINITY;
         double to = Double.POSITIVE_INFINITY;
-
+        
         String fromAsString;
         String toAsString;
 
+        Boolean includeLower = null;
+        Boolean includeUpper = null;
+        
         Entry(String fromAsString, String toAsString) {
             this.fromAsString = fromAsString;
             this.toAsString = toAsString;
         }
 
+        Entry(String fromAsString, String toAsString, boolean includeLower, boolean includeUpper) {
+            this.fromAsString = fromAsString;
+            this.toAsString = toAsString;
+            this.includeLower = includeLower;
+            this.includeUpper = includeUpper;
+        }
+
         Entry(double from, double to) {
             this.from = from;
             this.to = to;
+        }
+
+        Entry(double from, double to, boolean includeLower, boolean includeUpper) {
+            this.from = from;
+            this.to = to;
+            this.includeLower = includeLower;
+            this.includeUpper = includeUpper;
         }
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacetCollector.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacetCollector.java
@@ -97,7 +97,7 @@ public class RangeFacetCollector extends AbstractFacetCollector {
                 if (entry.foundInDoc) {
                     continue;
                 }
-                if (value >= entry.getFrom() && value < entry.getTo()) {
+                if (isMatchingValue(entry, value)) {
                     entry.foundInDoc = true;
                     entry.count++;
                     entry.totalCount++;
@@ -110,6 +110,20 @@ public class RangeFacetCollector extends AbstractFacetCollector {
                     }
                 }
             }
+        }
+        
+        private boolean isMatchingValue(RangeFacet.Entry entry, double value) {
+        	boolean result = false;
+        	if (entry.includeLower && entry.includeUpper) {
+        		result = (value >= entry.getFrom() && value <= entry.getTo());
+        	} else if (entry.includeLower && !entry.includeUpper) {
+        		result = (value >= entry.getFrom() && value < entry.getTo());        		
+        	} else if (!entry.includeLower && entry.includeUpper) {
+        		result = (value > entry.getFrom() && value <= entry.getTo());
+	    	} else if (!entry.includeLower && !entry.includeUpper) {
+        		result = (value > entry.getFrom() && value < entry.getTo());
+	    	}
+        	return result;
         }
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacetProcessor.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/range/RangeFacetProcessor.java
@@ -73,17 +73,26 @@ public class RangeFacetProcessor extends AbstractComponent implements FacetProce
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {
                             fieldName = parser.currentName();
-                        } else if (token == XContentParser.Token.VALUE_STRING) {
+                        } 
+                        else {
                             if ("from".equals(fieldName)) {
-                                entry.fromAsString = parser.text();
+                            	if (token == XContentParser.Token.VALUE_STRING) {
+                            		entry.fromAsString = parser.text();
+                            	}
+                            	else if (token.isValue()) {
+                            		entry.from = parser.doubleValue();
+                            	}
                             } else if ("to".equals(fieldName)) {
-                                entry.toAsString = parser.text();
-                            }
-                        } else if (token.isValue()) {
-                            if ("from".equals(fieldName)) {
-                                entry.from = parser.doubleValue();
-                            } else if ("to".equals(fieldName)) {
-                                entry.to = parser.doubleValue();
+                            	if (token == XContentParser.Token.VALUE_STRING) {
+                            		entry.toAsString = parser.text();
+                            	}
+                            	else if (token.isValue()) {
+                            		entry.to = parser.doubleValue();
+                            	}
+                            } else if ("include_lower".equals(fieldName)) {
+                            	entry.includeLower = parser.booleanValue();
+                            } else if ("include_upper".equals(fieldName)) {
+                            	entry.includeUpper = parser.booleanValue();
                             }
                         }
                     }


### PR DESCRIPTION
Hi Shay,

based on the conversation we had on the mailing list, I field the following issue:
https://github.com/elasticsearch/elasticsearch/issues/1092) 
and provided a patch for it. 

The difficult part was to get eclipse configured correctly with gradle. I basically ended up using the eclipse plugin from gradle that generated config files and it worked like a charm! 

When I get a change I will add a section to the doc for those who want to use Eclipse with ES source code
