### PR TITLE
Add missing testng dependencies

### DIFF
--- a/.idea/libraries/testng.xml
+++ b/.idea/libraries/testng.xml
@@ -1,6 +1,8 @@
 <component name="libraryTable">
   <library name="testng">
     <CLASSES>
+      <root url="jar://$GRADLE_REPOSITORY$/com.beust/jcommander/jars/jcommander-1.13.jar!/" />
+      <root url="jar://$GRADLE_REPOSITORY$/org.beanshell/bsh/jars/bsh-2.0b4.jar!/" />
       <root url="jar://$GRADLE_REPOSITORY$/org.testng/testng/jars/testng-6.1.1.jar!/" />
     </CLASSES>
     <JAVADOC />

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ allprojects {
                 testCompile project(':test-testng')
             }
             testCompile('org.testng:testng:6.1.1') { transitive = false }
+            testCompile('com.beust:jcommander:1.13') { transitive = false }
+            testCompile('org.beanshell:bsh:2.0b4') { transitive = false }
             testCompile('org.hamcrest:hamcrest-core:1.3.RC2') { transitive = false }
             testCompile('org.hamcrest:hamcrest-library:1.3.RC2') { transitive = false }
         }


### PR DESCRIPTION
./gradlew clean test  was returning java.lang.ClassNotFoundException without these dependencies on my machine. Not sure if they were removed intentionally or not.
