### PR TITLE
PatternReplaceFilter

### DIFF
--- a/modules/elasticsearch/src/main/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
+++ b/modules/elasticsearch/src/main/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.analysis.pattern;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.io.IOException;
+
+/**
+ * A TokenFilter which applies a Pattern to each token in the stream,
+ * replacing match occurances with the specified replacement string.
+ *
+ * <p>
+ * <b>Note:</b> Depending on the input and the pattern used and the input
+ * TokenStream, this TokenFilter may produce Tokens whose text is the empty
+ * string.
+ * </p>
+ * 
+ * @see Pattern
+ */
+public final class PatternReplaceFilter extends TokenFilter {
+  private final Pattern p;
+  private final String replacement;
+  private final boolean all;
+  private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+  private final Matcher m;
+
+  /**
+   * Constructs an instance to replace either the first, or all occurances
+   *
+   * @param in the TokenStream to process
+   * @param p the patterm to apply to each Token
+   * @param replacement the "replacement string" to substitute, if null a
+   *        blank string will be used. Note that this is not the literal
+   *        string that will be used, '$' and '\' have special meaning.
+   * @param all if true, all matches will be replaced otherwise just the first match.
+   * @see Matcher#quoteReplacement
+   */
+  public PatternReplaceFilter(TokenStream in,
+                              Pattern p,
+                              String replacement,
+                              boolean all) {
+    super(in);
+    this.p=p;
+    this.replacement = (null == replacement) ? "" : replacement;
+    this.all=all;
+    this.m = p.matcher(termAtt);
+  }
+
+  @Override
+  public boolean incrementToken() throws IOException {
+    if (!input.incrementToken()) return false;
+    
+    m.reset();
+    if (m.find()) {
+      // replaceAll/replaceFirst will reset() this previous find.
+      String transformed = all ? m.replaceAll(replacement) : m.replaceFirst(replacement);
+      termAtt.setEmpty().append(transformed);
+    }
+
+    return true;
+  }
+
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
@@ -373,6 +373,7 @@ public class AnalysisModule extends AbstractModule {
             tokenFiltersBindings.processTokenFilter("synonym", SynonymTokenFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("elision", ElisionTokenFilterFactory.class);
 
+            tokenFiltersBindings.processTokenFilter("pattern_replace", PatternReplaceTokenFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("phonetic", PhoneticTokenFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("dictionary_decompounder", DictionaryCompoundWordTokenFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("hypennation_decompounder", HyphenationCompoundWordTokenFilterFactory.class);

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/PatternReplaceTokenFilterFactory.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/analysis/PatternReplaceTokenFilterFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.pattern.PatternReplaceFilter;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.regex.Pattern;
+
+public class PatternReplaceTokenFilterFactory extends AbstractTokenFilterFactory {
+
+    private final Pattern pattern;
+    private final String replacement;
+    private final boolean all;
+
+    @Inject public PatternReplaceTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+
+        String sPattern = settings.get("pattern", "");
+        if (sPattern == null) {
+            throw new ElasticSearchIllegalArgumentException("pattern is missing for [" + name + "] token filter of type 'pattern_replace'");
+        }
+
+        this.pattern = Regex.compile(sPattern, settings.get("flags"));
+
+        String sReplacement = settings.get("replacement", "");
+        if (sReplacement == null) {
+            throw new ElasticSearchIllegalArgumentException("replacement is missing for [" + name + "] token filter of type 'pattern_replace'");
+        }
+
+        this.replacement = sReplacement;
+
+        this.all = settings.getAsBoolean("all", true);
+    }
+
+    @Override public TokenStream create(TokenStream tokenStream) {
+        return new PatternReplaceFilter(tokenStream, pattern, replacement, all);
+    }
+}


### PR DESCRIPTION
This adds the Pattern Replace Filter to Elasticsearch.

It allows to easily handle string replacement during the analysis process using the power of regular expression. 

The regular expression pattern has to be specified with the setting "pattern".

The replacement expression has to be specified with the setting "replacement".

<pre>

index:
    analysis:
        analyzer:
            default:
                tokenizer: standard
                filter: [pattern_replace]
        filter:
            pattern_replace:
                type: pattern_replace
                pattern: (?&lt;=[\d])(,)(?=[\d])

</pre>


By default the replacement expression is an empty string.
