### PR TITLE
Adds a JSONQueryBuilder which allows using a JSON query string through the Java builder API.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -42,6 +42,10 @@ public class AnalyzeRequest extends SingleCustomOperationRequest {
 
     private String analyzer;
 
+    private String type;
+
+    private String field;
+
     AnalyzeRequest() {
 
     }
@@ -79,6 +83,24 @@ public class AnalyzeRequest extends SingleCustomOperationRequest {
         return this.analyzer;
     }
 
+    public AnalyzeRequest type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public String type() {
+        return this.type;
+    }
+
+    public AnalyzeRequest field(String field) {
+        this.field = field;
+        return this;
+    }
+
+    public String field() {
+        return this.field;
+    }
+
     /**
      * if this operation hits a node with a local relevant shard, should it be preferred
      * to be executed on, or just do plain round robin. Defaults to <tt>true</tt>
@@ -106,17 +128,29 @@ public class AnalyzeRequest extends SingleCustomOperationRequest {
         if (in.readBoolean()) {
             analyzer = in.readUTF();
         }
+        if (in.readBoolean()) {
+            type = in.readUTF();
+        }
+        if (in.readBoolean()) {
+            field = in.readUTF();
+        }
     }
 
     @Override public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeUTF(index);
         out.writeUTF(text);
-        if (analyzer == null) {
+        writeOption(out, analyzer);
+        writeOption(out, type);
+        writeOption(out, field);
+    }
+
+    private void writeOption(StreamOutput out, String value) throws IOException {
+        if (value==null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(analyzer);
+            out.writeUTF(value);
         }
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/client/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/client/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -56,4 +56,14 @@ public class AnalyzeRequestBuilder extends BaseIndicesRequestBuilder<AnalyzeRequ
     @Override protected void doExecute(ActionListener<AnalyzeResponse> listener) {
         client.analyze(request, listener);
     }
+
+    public AnalyzeRequestBuilder field(String field) {
+        request.field(field);
+        return this;
+    }
+
+    public AnalyzeRequestBuilder type(String type) {
+        request.type(type);
+        return this;
+    }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/JSONQueryBuilder.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/JSONQueryBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+/**
+ * Created by IntelliJ IDEA.
+ * User: cedric
+ * Date: 12/07/11
+ * Time: 11:30
+ */
+
+import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.jackson.JsonParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.common.xcontent.json.JsonXContentParser;
+
+import java.io.IOException;
+
+/**
+ * A Query builder which allows building a query thanks to a JSON string. This is useful when you want
+ * to use the Java Builder API but still have JSON query strings at hand that you want to combine with other
+ * query builders.
+ *
+ * Example usage in a boolean query :
+ * <pre>
+ * {@code
+ *      BoolQueryBuilder bool = new BoolQueryBuilder();
+ *      bool.must(new JSONQueryBuilder("{\"term\": {\"field\":\"value\"}}");
+ *      bool.must(new TermQueryBuilder("field2","value2");
+ * }
+ * </pre>
+ *
+ * @author Cedric Champeau
+ */
+public class JSONQueryBuilder extends BaseQueryBuilder {
+
+    private final String jsonQuery;
+
+    /**
+     * Builds a JSONQueryBuilder using the provided JSON query string.
+     * @param jsonQuery
+     */
+    public JSONQueryBuilder(String jsonQuery) {
+        this.jsonQuery = jsonQuery;
+    }
+
+    @Override protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(JSONQueryParser.NAME);
+        XContentParser parser = JsonXContent.jsonXContent.createParser(jsonQuery);
+        parser.nextToken();
+        builder.field("value");
+        builder.copyCurrentStructure(parser);
+        builder.endObject();
+    }
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/JSONQueryParser.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/JSONQueryParser.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+/**
+ * Query parser for JSON Queries.
+ *
+ * @author Cedric Champeau
+ */
+public class JSONQueryParser implements QueryParser {
+
+    public static final String NAME = "json";
+
+    @Inject public JSONQueryParser() {
+    }
+
+    @Override public String[] names() {
+        return new String[] {NAME};
+    }
+
+    @Override public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        System.out.println("parseContext = " + parseContext);
+        XContentParser parser = parseContext.parser();
+        XContentParser.Token token;
+        Query query = null;
+        String currentFieldName = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT && "value".equals(currentFieldName)) {
+                query = parseContext.parseInnerQuery();
+            }
+        }
+        return query;
+    }
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -611,6 +611,10 @@ public abstract class QueryBuilders {
         return new PrefixFilterBuilder(name, prefix);
     }
 
+    public static JSONQueryBuilder json(String jsonString) {
+        return new JSONQueryBuilder(jsonString);
+    }
+
     private QueryBuilders() {
 
     }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
@@ -67,6 +67,7 @@ public class IndicesQueriesRegistry {
         addQueryParser(queryParsers, new MoreLikeThisFieldQueryParser());
         addQueryParser(queryParsers, new FuzzyLikeThisQueryParser());
         addQueryParser(queryParsers, new FuzzyLikeThisFieldQueryParser());
+        addQueryParser(queryParsers, new JSONQueryParser());
         this.queryParsers = ImmutableMap.copyOf(queryParsers);
 
         Map<String, FilterParser> filterParsers = Maps.newHashMap();

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -63,6 +63,8 @@ public class RestAnalyzeAction extends BaseRestHandler {
         AnalyzeRequest analyzeRequest = new AnalyzeRequest(request.param("index"), text);
         analyzeRequest.preferLocal(request.paramAsBoolean("prefer_local", analyzeRequest.preferLocalShard()));
         analyzeRequest.analyzer(request.param("analyzer"));
+        analyzeRequest.type(request.param("type"));
+        analyzeRequest.field(request.param("field"));
         client.admin().indices().analyze(analyzeRequest, new ActionListener<AnalyzeResponse>() {
             @Override public void onResponse(AnalyzeResponse response) {
                 try {

--- a/modules/test/integration/src/test/java/org/elasticsearch/test/integration/indices/analyze/AnalyzeActionTests.java
+++ b/modules/test/integration/src/test/java/org/elasticsearch/test/integration/indices/analyze/AnalyzeActionTests.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.test.integration.indices.analyze;
 
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.action.admin.indices.analyze.AnalyzeRequestBuilder;
 import org.elasticsearch.test.integration.AbstractNodesTests;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -63,6 +65,67 @@ public class AnalyzeActionTests extends AbstractNodesTests {
 
         for (int i = 0; i < 10; i++) {
             AnalyzeResponse analyzeResponse = client.admin().indices().prepareAnalyze("test", "this is a test").execute().actionGet();
+            assertThat(analyzeResponse.tokens().size(), equalTo(1));
+            AnalyzeResponse.AnalyzeToken token = analyzeResponse.tokens().get(0);
+            assertThat(token.term(), equalTo("test"));
+            assertThat(token.startOffset(), equalTo(10));
+            assertThat(token.endOffset(), equalTo(14));
+        }
+    }
+
+    @Test public void analyzerWithFieldOrTypeTests() throws Exception {
+        try {
+            client.admin().indices().prepareDelete("test").execute().actionGet();
+        } catch (Exception e) {
+            // ignore
+        }
+
+        client.admin().indices().prepareCreate("test").execute().actionGet();
+        client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+
+        client.admin().indices().preparePutMapping("test")
+                .setType("document").setSource(
+                        "{\n" +
+                                "    \"document\":{\n" +
+                                "        \"properties\":{\n" +
+                                "            \"simple\":{\n" +
+                                "                \"type\":\"string\",\n" +
+                                "                \"analyzer\": \"simple\"\n" +
+                                "            }\n" +
+                                "        }\n" +
+                                "    }\n" +
+                                "}"
+                ).execute().actionGet();
+
+        for (int i = 0; i < 10; i++) {
+            final AnalyzeRequestBuilder requestBuilder = client.admin().indices().prepareAnalyze("test", "THIS IS A TEST");
+            requestBuilder.type("document");
+            requestBuilder.field("simple");
+            AnalyzeResponse analyzeResponse = requestBuilder.execute().actionGet();
+            assertThat(analyzeResponse.tokens().size(), equalTo(4));
+            AnalyzeResponse.AnalyzeToken token = analyzeResponse.tokens().get(3);
+            assertThat(token.term(), equalTo("test"));
+            assertThat(token.startOffset(), equalTo(10));
+            assertThat(token.endOffset(), equalTo(14));
+        }
+
+        // test that using the document type only uses the default analyzer
+        for (int i = 0; i < 10; i++) {
+            final AnalyzeRequestBuilder requestBuilder = client.admin().indices().prepareAnalyze("test", "THIS IS A TEST");
+            requestBuilder.type("document");
+            AnalyzeResponse analyzeResponse = requestBuilder.execute().actionGet();
+            assertThat(analyzeResponse.tokens().size(), equalTo(1));
+            AnalyzeResponse.AnalyzeToken token = analyzeResponse.tokens().get(0);
+            assertThat(token.term(), equalTo("test"));
+            assertThat(token.startOffset(), equalTo(10));
+            assertThat(token.endOffset(), equalTo(14));
+        }
+
+        // test that using the field name only uses the default analyzer
+        for (int i = 0; i < 10; i++) {
+            final AnalyzeRequestBuilder requestBuilder = client.admin().indices().prepareAnalyze("test", "THIS IS A TEST");
+            requestBuilder.field("simple");
+            AnalyzeResponse analyzeResponse = requestBuilder.execute().actionGet();
             assertThat(analyzeResponse.tokens().size(), equalTo(1));
             AnalyzeResponse.AnalyzeToken token = analyzeResponse.tokens().get(0);
             assertThat(token.term(), equalTo("test"));


### PR DESCRIPTION
This pull request adds support for a JSONQueryBuilder. It is useful when you want to combine the Java builder API with JSON queries (strings). Example usage :

```
BoolQueryBuilder bool = new BoolQueryBuilder();
bool.must(new JSONQueryBuilder("{\"term\": {\"field\":\"value\"}}");
bool.must(new TermQueryBuilder("field2","value2");
```

In my use case, I have a custom JSON query format where I want the user to be able to put ElasticSearch "native" json queries at some points. Hence I retrieve the user query json string and use the JSON builder to let ES build the query.
