### PR TITLE
Build ElasticSearch as Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,13 @@ plugins/river/twitter/build
 plugins/river/wikipedia/build
 plugins/transport/memcached/build
 plugins/transport/thrift/build
+.idea/gradle.xml
+.idea/misc.xml
+.idea/modules/elasticsearch-root.iml
+.idea/modules/plugin-river-rabbitmq.iml
+.idea/projectCodeStyle.xml
+
+
 
 ## eclipse ignores (use 'gradle eclipse' to build eclipse projects)
 .project

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,11 @@ configurations {
     distLib {
         visible = false
     }
+    jdeb
+}
+
+dependencies {
+    jdeb group: 'org.vafer', name: 'jdeb', version: '0.8'
 }
 
 //task run(dependsOn: [configurations.distLib], description: 'Runs') << {
@@ -182,7 +187,28 @@ task tar(type: Tar, dependsOn: ['explodedDist']) {
     }
 }
 
-task release(dependsOn: [zip, tar]) << {
+
+task deb(dependsOn: ['explodedDist']) << {
+    ant.taskdef(name: "deb", classname: "org.vafer.jdeb.ant.DebAntTask", classpath: configurations.jdeb.asPath )
+    ant.copy(todir: "${distsDir}/debian") { 
+        fileset(dir: "pkg/debian/control")
+        filterset(begintoken: "[[", endtoken: "]]"){
+                filter(token: "version", value: "${version}")
+        }
+    }
+    ant.deb(destfile: "${distsDir}/${archivesBaseName}-${version}-1_all.deb", control: "${distsDir}/debian", verbose: "true"){
+        tarfileset(dir: explodedDistDir, prefix: "/usr/share/elasticsearch", includes: "*.txt, *.textile", username: "root", group: "root")
+        tarfileset(dir: explodedDistBinDir, prefix: "/usr/share/elasticsearch/bin", excludes: "*.bat", filemode: "755", username: "root", group: "root")
+        tarfileset(dir: explodedDistLibDir, prefix: "/usr/share/elasticsearch/lib", includes: "*.jar, sigar/*", username: "root", group: "root")
+        tarfileset(dir: explodedDistConfigDir, prefix: "/etc/elasticsearch", username: "root", group: "root")
+        tarfileset(dir: "pkg/debian/init.d", includes: "elasticsearch", prefix: "/etc/init.d", filemode: "755", username: "root", group: "root")
+        tarfileset(dir: "pkg/debian/default", includes: "elasticsearch", prefix: "/etc/default", username: "root", group: "root")
+    }
+    ant.delete(dir: "${distsDir}/debian")
+}
+
+
+task release(dependsOn: [zip, tar, deb]) << {
     ant.delete(dir: explodedDistDir)
 }
 

--- a/pkg/debian/control/conffiles
+++ b/pkg/debian/control/conffiles
@@ -1,0 +1,4 @@
+/etc/init.d/elasticsearch
+/etc/default/elasticsearch
+/etc/elasticsearch/logging.yml
+/etc/elasticsearch/elasticsearch.yml

--- a/pkg/debian/control/control
+++ b/pkg/debian/control/control
@@ -1,0 +1,36 @@
+Package: elasticsearch
+Version: [[version]]
+Architecture: all
+Maintainer: Nicolas Huray <nicolas.huray@gmail.com>
+Depends: openjdk-6-jre-headless | sun-java6-jre
+Section: web
+Priority: optional
+Homepage: http://www.elasticsearch.org/
+Description: Open Source, Distributed, RESTful Search Engine
+ ElasticSearch is a distributed RESTful search engine built for the cloud. 
+ .
+ Features include:
+ .
+ * Distributed and Highly Available Search Engine.
+   - Each index is fully sharded with a configurable number of shards.
+   - Each shard can have one or more replicas.
+   - Read / Search operations performed on either one of the replica shard.
+ * Multi Tenant with Multi Types.
+   - Support for more than one index.
+   - Support for more than one type per index.
+   - Index level configuration (number of shards, index storage, ...).
+ * Various set of APIs
+   - HTTP RESTful API
+   - Native Java API.
+   - All APIs perform automatic node operation rerouting.
+ * Document oriented
+   - No need for upfront schema definition.
+   - Schema can be defined per type for customization of the indexing process.
+ * Reliable, Asynchronous Write Behind for long term persistency.
+ * (Near) Real Time Search.
+ * Built on top of Lucene
+   - Each shard is a fully functional Lucene index
+   - All the power of Lucene easily exposed through simple configuration / plugins.
+ * Per operation consistency
+   - Single document level operations are atomic, consistent, isolated and durable.
+ * Open Source under Apache 2 License.

--- a/pkg/debian/control/postinst
+++ b/pkg/debian/control/postinst
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+	[ -f /etc/default/elasticsearch ] && . /etc/default/elasticsearch
+	[ -z "$ES_USER" ] && ES_USER="elasticsearch"
+	[ -z "$ES_GROUP" ] && ES_GROUP="elasticsearch"
+	if ! getent group "$ES_GROUP" > /dev/null 2>&1 ; then
+	    addgroup --system "$ES_GROUP" --quiet
+	fi
+	if ! id $ES_USER > /dev/null 2>&1 ; then
+	    adduser --system --home /usr/share/elasticsearch --no-create-home \
+		--ingroup "$ES_GROUP" --disabled-password --shell /bin/false \
+		"$ES_USER"
+	fi
+
+	# Set user permissions on /var/log/elasticsearch and /var/lib/elasticsearch
+	mkdir -p /var/log/elasticsearch /var/lib/elasticsearch
+	chown -R $ES_USER:$ES_GROUP /var/log/elasticsearch /var/lib/elasticsearch
+	chmod 755 /var/log/elasticsearch /var/lib/elasticsearch
+	
+	# configuration files should not be modifiable by elasticsearch user, as this can be a security issue
+	chown -Rh root:root /etc/elasticsearch/*
+	chmod 755 /etc/elasticsearch
+	chmod 644 /etc/elasticsearch/*
+    ;;
+esac
+
+
+if [ -x "/etc/init.d/elasticsearch" ]; then
+	update-rc.d elasticsearch defaults 95 10 >/dev/null
+	if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+		invoke-rc.d elasticsearch start || true
+	else
+		/etc/init.d/elasticsearch start || true
+	fi
+fi
+

--- a/pkg/debian/control/postrm
+++ b/pkg/debian/control/postrm
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove)
+        # Remove logs and data
+        rm -rf /var/log/elasticsearch /var/lib/elasticsearch
+    ;;
+
+    purge)
+    	# Remove service
+        update-rc.d elasticsearch remove >/dev/null || true
+    
+        # Remove logs and data
+        rm -rf /var/log/elasticsearch /var/lib/elasticsearch
+
+        # Remove user/group
+        deluser elasticsearch || true
+        delgroup elasticsearch || true
+    ;;
+
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        # Nothing to do here
+    ;;
+
+    *)
+        echo "$0 called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac

--- a/pkg/debian/control/prerm
+++ b/pkg/debian/control/prerm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ -x "/etc/init.d/elasticsearch" ]; then
+	if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+		invoke-rc.d elasticsearch stop || true
+	else
+		/etc/init.d/elasticsearch stop || true
+	fi
+fi

--- a/pkg/debian/default/elasticsearch
+++ b/pkg/debian/default/elasticsearch
@@ -1,0 +1,24 @@
+# Run ElasticSearch as this user ID and group ID
+ES_USER=elasticsearch
+ES_GROUP=elasticsearch
+
+# Minimum Heap memory to run ElasticSearch
+ES_MIN_MEM=256m
+
+# Maximum Heap memory to run ElasticSearch
+ES_MAX_MEM=1g
+
+# ElasticSearch log directory
+LOG_DIR=/var/log/elasticsearch
+
+# ElasticSearch data directory
+DATA_DIR=/var/lib/elasticsearch
+
+# ElasticSearch work directory
+WORK_DIR=/tmp/elasticsearch
+
+# ElasticSearch configuration directory
+CONF_DIR=/etc/elasticsearch
+
+# ElasticSearch configuration file (elasticsearch.yml)
+CONF_FILE=/etc/elasticsearch/elasticsearch.yml

--- a/pkg/debian/init.d/elasticsearch
+++ b/pkg/debian/init.d/elasticsearch
@@ -1,0 +1,192 @@
+#!/bin/sh
+#
+# /etc/init.d/elasticsearch -- startup script for Elasticsearch
+#
+# Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+# Modified for Debian GNU/Linux	by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+# Modified for Tomcat by Stefan Gybas <sgybas@debian.org>.
+# Modified for Tomcat6 by Thierry Carrez <thierry.carrez@ubuntu.com>.
+# Additional improvements by Jason Brittain <jason.brittain@mulesoft.com>.
+# Modified by Nicolas Huray for ElasticSearch <nicolas.huray@gmail.com>.
+#
+### BEGIN INIT INFO
+# Provides:          elasticsearch
+# Required-Start:    $all
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts elasticsearch
+# Description:       Starts elasticsearch using start-stop-daemon
+### END INIT INFO
+
+set -e
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+NAME=elasticsearch
+DESC="ElasticSearch Server"
+DEFAULT=/etc/default/$NAME
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+	. /etc/default/rcS
+fi
+
+
+# The following variables can be overwritten in $DEFAULT
+
+# Run ElasticSearch as this user ID and group ID
+ES_USER=elasticsearch
+ES_GROUP=elasticsearch
+
+# The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
+JDK_DIRS="/usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-sun"
+
+# Look for the right JVM to use
+for jdir in $JDK_DIRS; do
+    if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
+	JAVA_HOME="$jdir"
+    fi
+done
+export JAVA_HOME
+
+# Directory where the ElasticSearch binary distribution resides
+ES_HOME=/usr/share/$NAME
+
+# Minimum Heap memory to run ElasticSearch
+ES_MIN_MEM=256m
+
+# Maximum Heap memory to run ElasticSearch
+ES_MAX_MEM=1g
+
+# ElasticSearch log directory
+LOG_DIR=/var/log/$NAME
+
+# ElasticSearch data directory
+DATA_DIR=/var/lib/$NAME
+
+# ElasticSearch work directory
+WORK_DIR=/tmp/$NAME
+
+# ElasticSearch configuration directory
+CONF_DIR=/etc/$NAME
+
+# ElasticSearch configuration file (elasticsearch.yml)
+CONF_FILE=$CONF_DIR/elasticsearch.yml
+
+# End of variables that can be overwritten in $DEFAULT
+
+# overwrite settings from default file
+if [ -f "$DEFAULT" ]; then
+	. "$DEFAULT"
+fi
+
+# Define other required variables
+PID_FILE=/var/run/$NAME.pid
+DAEMON=$ES_HOME/bin/elasticsearch
+DAEMON_OPTS="-p $PID_FILE -Des.config=$CONF_FILE -Des.path.home=$ES_HOME -Des.path.logs=$LOG_DIR -Des.path.data=$DATA_DIR -Des.path.work=$WORK_DIR -Des.path.conf=$CONF_DIR"
+
+export ES_MIN_MEM ES_MAX_MEM
+
+# Check DAEMON exists
+test -x $DAEMON || exit 0
+
+case "$1" in
+  start)
+	if [ -z "$JAVA_HOME" ]; then
+		log_failure_msg "no JDK found - please set JAVA_HOME"
+		exit 1
+	fi
+
+	log_daemon_msg "Starting $DESC"
+	
+	if start-stop-daemon --test --start --pidfile "$PID_FILE" \
+		--user "$ES_USER" --exec "$JAVA_HOME/bin/java" \
+		>/dev/null; then
+		
+		# Prepare environment
+		mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
+		touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
+		ulimit -n 65535
+
+		# Start Daemon
+		start-stop-daemon --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec /bin/bash -- -c "$DAEMON $DAEMON_OPTS"
+
+		sleep 1
+		if start-stop-daemon --test --start --pidfile "$PID_FILE" \
+			--user "$ES_USER" --exec "$JAVA_HOME/bin/java" \
+			>/dev/null; then
+			if [ -f "$PID_FILE" ]; then
+				rm -f "$PID_FILE"
+			fi
+			log_end_msg 1
+		else
+			log_end_msg 0
+		fi
+		
+	else
+	    log_progress_msg "(already running)"
+	    log_end_msg 0
+	fi
+	;;		
+  stop)
+	log_daemon_msg "Stopping $DESC"
+
+	set +e
+	if [ -f "$PID_FILE" ]; then 
+		start-stop-daemon --stop --pidfile "$PID_FILE" \
+			--user "$ES_USER" \
+			--retry=TERM/20/KILL/5 >/dev/null
+		if [ $? -eq 1 ]; then
+			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+		elif [ $? -eq 3 ]; then
+			PID="`cat $PID_FILE`"
+			log_failure_msg "Failed to stop $DESC (pid $PID)"
+			exit 1
+		fi
+		rm -f "$PID_FILE"
+	else
+		log_progress_msg "(not running)"
+	fi
+	log_end_msg 0
+	set -e
+	;;
+  status)
+	set +e
+	start-stop-daemon --test --start --pidfile "$PID_FILE" \
+		--user "$ES_USER" --exec "$JAVA_HOME/bin/java" \
+		>/dev/null 2>&1
+	if [ "$?" = "0" ]; then
+
+		if [ -f "$PID_FILE" ]; then
+		    log_success_msg "$DESC is not running, but pid file exists."
+			exit 1
+		else
+		    log_success_msg "$DESC is not running."
+			exit 3
+		fi
+	else
+		log_success_msg "$DESC is running with pid `cat $PID_FILE`"
+	fi
+	set -e
+    ;;
+  restart|force-reload)
+	if [ -f "$PID_FILE" ]; then
+		$0 stop
+		sleep 1
+	fi
+	$0 start
+	;;
+  *)
+	log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
+	exit 1
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
Hi Shay,

I'd like to submit a patch to the elascticsearch project for building elasticsearch as a debian package.

The debian package is built with jdeb (https://github.com/tcurdt/jdeb) and is integrated with the gradle script (task named "deb").

The debian package installation has the following structure : 

/usr/share/elasticsearch         : elasticsearch home directory
/etc/elasticsearch                  : elasticsearch configuration directory
/etc/default/elasticsearch       : default service configuration file
/etc/init.d/elasticsearch          : service file (sysvinit)
/var/lib/elasticsearch              : elasticsearch data directory (for indices)
/var/log/elasctisearch             : elasticsearch logs directory

Regards,

Nicolas
