### PR TITLE
Fix copy-pasted javadoc error

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/selector/AllButSourceFieldSelector.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/selector/AllButSourceFieldSelector.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.lucene.document.ResetFieldSelector;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 
 /**
- * An optimized field selector that loads just the uid and the source.
+ * A field selector that loads all fields except the source field.
  *
  * @author kimchy (shay.banon)
  */


### PR DESCRIPTION
Not a big deal of course but still an improvement ;)
