### PR TITLE
Add support for a _timestamp field

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -123,16 +123,16 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
                     }
 
                     SourceToParse sourceToParse = SourceToParse.source(indexRequest.source()).type(indexRequest.type()).id(indexRequest.id())
-                            .routing(indexRequest.routing()).parent(indexRequest.parent());
+                            .routing(indexRequest.routing()).parent(indexRequest.parent()).timestamp(indexRequest.timestamp());
                     long version;
                     Engine.IndexingOperation op;
                     if (indexRequest.opType() == IndexRequest.OpType.INDEX) {
-                        Engine.Index index = indexShard.prepareIndex(sourceToParse).version(indexRequest.version()).versionType(indexRequest.versionType()).origin(Engine.Operation.Origin.PRIMARY);
+                        Engine.Index index = indexShard.prepareIndex(sourceToParse).version(indexRequest.version()).versionType(indexRequest.versionType()).timestamp(indexRequest.timestamp()).origin(Engine.Operation.Origin.PRIMARY);
                         indexShard.index(index);
                         version = index.version();
                         op = index;
                     } else {
-                        Engine.Create create = indexShard.prepareCreate(sourceToParse).version(indexRequest.version()).versionType(indexRequest.versionType()).origin(Engine.Operation.Origin.PRIMARY);
+                        Engine.Create create = indexShard.prepareCreate(sourceToParse).version(indexRequest.version()).versionType(indexRequest.versionType()).timestamp(indexRequest.timestamp()).origin(Engine.Operation.Origin.PRIMARY);
                         indexShard.create(create);
                         version = create.version();
                         op = create;
@@ -236,12 +236,12 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
                 IndexRequest indexRequest = (IndexRequest) item.request();
                 try {
                     SourceToParse sourceToParse = SourceToParse.source(indexRequest.source()).type(indexRequest.type()).id(indexRequest.id())
-                            .routing(indexRequest.routing()).parent(indexRequest.parent());
+                            .routing(indexRequest.routing()).parent(indexRequest.parent()).timestamp(indexRequest.timestamp());
                     if (indexRequest.opType() == IndexRequest.OpType.INDEX) {
-                        Engine.Index index = indexShard.prepareIndex(sourceToParse).version(indexRequest.version()).origin(Engine.Operation.Origin.REPLICA);
+                        Engine.Index index = indexShard.prepareIndex(sourceToParse).version(indexRequest.version()).timestamp(indexRequest.timestamp()).origin(Engine.Operation.Origin.REPLICA);
                         indexShard.index(index);
                     } else {
-                        Engine.Create create = indexShard.prepareCreate(sourceToParse).version(indexRequest.version()).origin(Engine.Operation.Origin.REPLICA);
+                        Engine.Create create = indexShard.prepareCreate(sourceToParse).version(indexRequest.version()).timestamp(indexRequest.timestamp()).origin(Engine.Operation.Origin.REPLICA);
                         indexShard.create(create);
                     }
                 } catch (Exception e) {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.VersionType;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Map;
 
 import static org.elasticsearch.action.Actions.*;
@@ -128,6 +129,8 @@ public class IndexRequest extends ShardReplicationOperationRequest {
     private long version = 0;
     private VersionType versionType = VersionType.INTERNAL;
     private String percolate;
+
+    private long timestamp = new Date().getTime();
 
     private XContentType contentType = Requests.INDEX_CONTENT_TYPE;
 
@@ -548,6 +551,15 @@ public class IndexRequest extends ShardReplicationOperationRequest {
         return this.versionType;
     }
 
+    public IndexRequest timestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public long timestamp() {
+        return this.timestamp;
+    }
+
     /**
      * Causes the index request document to be percolated. The parameter is the percolate query
      * to use to reduce the percolated queries that are going to run against this doc. Can be
@@ -609,6 +621,7 @@ public class IndexRequest extends ShardReplicationOperationRequest {
             percolate = in.readUTF();
         }
         versionType = VersionType.fromValue(in.readByte());
+        timestamp = in.readLong();
     }
 
     @Override public void writeTo(StreamOutput out) throws IOException {
@@ -644,6 +657,7 @@ public class IndexRequest extends ShardReplicationOperationRequest {
             out.writeUTF(percolate);
         }
         out.writeByte(versionType.getValue());
+        out.writeLong(timestamp);
     }
 
     @Override public String toString() {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -178,13 +178,14 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
 
         IndexShard indexShard = indexShard(shardRequest);
         SourceToParse sourceToParse = SourceToParse.source(request.source()).type(request.type()).id(request.id())
-                .routing(request.routing()).parent(request.parent());
+                .routing(request.routing()).parent(request.parent()).timestamp(request.timestamp());
         long version;
         Engine.IndexingOperation op;
         if (request.opType() == IndexRequest.OpType.INDEX) {
             Engine.Index index = indexShard.prepareIndex(sourceToParse)
                     .version(request.version())
                     .versionType(request.versionType())
+                    .timestamp(request.timestamp())
                     .origin(Engine.Operation.Origin.PRIMARY);
             indexShard.index(index);
             version = index.version();
@@ -193,6 +194,7 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
             Engine.Create create = indexShard.prepareCreate(sourceToParse)
                     .version(request.version())
                     .versionType(request.versionType())
+                    .timestamp(request.timestamp())
                     .origin(Engine.Operation.Origin.PRIMARY);
             indexShard.create(create);
             version = create.version();
@@ -233,15 +235,17 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
         IndexShard indexShard = indexShard(shardRequest);
         IndexRequest request = shardRequest.request;
         SourceToParse sourceToParse = SourceToParse.source(request.source()).type(request.type()).id(request.id())
-                .routing(request.routing()).parent(request.parent());
+                .routing(request.routing()).parent(request.parent()).timestamp(request.timestamp());
         if (request.opType() == IndexRequest.OpType.INDEX) {
             Engine.Index index = indexShard.prepareIndex(sourceToParse)
                     .version(request.version())
+                    .timestamp(request.timestamp())
                     .origin(Engine.Operation.Origin.REPLICA);
             indexShard.index(index);
         } else {
             Engine.Create create = indexShard.prepareCreate(sourceToParse)
                     .version(request.version())
+                    .timestamp(request.timestamp())
                     .origin(Engine.Operation.Origin.REPLICA);
             indexShard.create(create);
         }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -314,6 +314,7 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         private final Term uid;
         private final ParsedDocument doc;
         private long version;
+        private long timestamp;
         private VersionType versionType = VersionType.INTERNAL;
         private Origin origin = Origin.PRIMARY;
 
@@ -378,6 +379,15 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
             return this;
         }
 
+        public Create timestamp(long timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public long timestamp() {
+            return this.timestamp;
+        }
+
         public String parent() {
             return this.doc.parent();
         }
@@ -404,6 +414,7 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         private final Term uid;
         private final ParsedDocument doc;
         private long version;
+        private long timestamp;
         private VersionType versionType = VersionType.INTERNAL;
         private Origin origin = Origin.PRIMARY;
 
@@ -454,6 +465,15 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
 
         public VersionType versionType() {
             return this.versionType;
+        }
+
+        public Index timestamp(long timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public long timestamp() {
+            return this.timestamp;
         }
 
         public List<Document> docs() {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -145,6 +145,8 @@ public class DocumentMapperParser extends AbstractIndexComponent {
                 docBuilder.sourceField(parseSourceField((Map<String, Object>) fieldNode, parserContext));
             } else if (SizeFieldMapper.CONTENT_TYPE.equals(fieldName)) {
                 docBuilder.sizeField(parseSizeField((Map<String, Object>) fieldNode, parserContext));
+            } else if (TimestampFieldMapper.CONTENT_TYPE.equals(fieldName)) {
+                docBuilder.timestampField(parseTimestampField((Map<String, Object>) fieldNode, parserContext));
             } else if (IdFieldMapper.CONTENT_TYPE.equals(fieldName) || "idField".equals(fieldName)) {
                 docBuilder.idField(parseIdField((Map<String, Object>) fieldNode, parserContext));
             } else if (IndexFieldMapper.CONTENT_TYPE.equals(fieldName) || "indexField".equals(fieldName)) {
@@ -287,6 +289,21 @@ public class DocumentMapperParser extends AbstractIndexComponent {
                 builder.enabled(nodeBooleanValue(fieldNode));
             } else if (fieldName.equals("store")) {
                 builder.store(parseStore(fieldName, fieldNode.toString()));
+            }
+        }
+        return builder;
+    }
+
+    private TimestampFieldMapper.Builder parseTimestampField(Map<String, Object> timestampNode, Mapper.TypeParser.ParserContext parserContext) {
+        TimestampFieldMapper.Builder builder = timestamp();
+        parseField(builder, builder.name, timestampNode, parserContext);
+        for (Map.Entry<String, Object> entry : timestampNode.entrySet()) {
+            String fieldName = Strings.toUnderscoreCase(entry.getKey());
+            Object fieldNode = entry.getValue();
+            if (fieldName.equals("enabled")) {
+                builder.enabled(nodeBooleanValue(fieldNode));
+            } else if (fieldName.equals("format")) {
+                builder.dateTimeFormatter(parseDateTimeFormatter(builder.name(), fieldNode.toString()));
             }
         }
         return builder;

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
@@ -22,15 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.core.*;
-import org.elasticsearch.index.mapper.internal.AllFieldMapper;
-import org.elasticsearch.index.mapper.internal.AnalyzerMapper;
-import org.elasticsearch.index.mapper.internal.BoostFieldMapper;
-import org.elasticsearch.index.mapper.internal.IdFieldMapper;
-import org.elasticsearch.index.mapper.internal.IndexFieldMapper;
-import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
-import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
-import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
-import org.elasticsearch.index.mapper.internal.UidFieldMapper;
+import org.elasticsearch.index.mapper.internal.*;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.index.mapper.multifield.MultiFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
@@ -59,6 +51,10 @@ public final class MapperBuilders {
 
     public static IdFieldMapper.Builder id() {
         return new IdFieldMapper.Builder();
+    }
+
+    public static TimestampFieldMapper.Builder timestamp() {
+        return new TimestampFieldMapper.Builder();
     }
 
     public static RoutingFieldMapper.Builder routing() {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -71,6 +71,7 @@ public class ParseContext {
     private Map<String, String> ignoredValues = new HashMap<String, String>();
 
     private ParsedIdState parsedIdState;
+    private ParsedTimestampState parsedTimestampState;
 
     private boolean mappersAdded = false;
 
@@ -104,6 +105,7 @@ public class ParseContext {
         this.flyweight = flyweight;
         this.path.reset();
         this.parsedIdState = ParsedIdState.NO;
+        this.parsedTimestampState = ParsedTimestampState.NO;
         this.mappersAdded = false;
         this.listener = listener == null ? DocumentMapper.ParseListener.EMPTY : listener;
         this.allEntries = new AllEntries();
@@ -201,6 +203,15 @@ public class ParseContext {
         return this.parsedIdState;
     }
 
+    public void parsedTimestamp(ParsedTimestampState parsedTimestampState) {
+        this.parsedTimestampState = parsedTimestampState;
+    }
+
+    public ParsedTimestampState parsedTimestampState() {
+        return this.parsedTimestampState;
+    }
+
+
     public void ignoredValue(String indexName, String value) {
         ignoredValues.put(indexName, value);
     }
@@ -278,5 +289,11 @@ public class ParseContext {
         NO,
         PARSED,
         EXTERNAL
+    }
+
+    public static enum ParsedTimestampState {
+        NO,
+        PARSED,
+        GENERATED
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.xcontent.XContentParser;
 
+import java.util.Date;
+
 /**
  * @author kimchy (shay.banon)
  */
@@ -47,6 +49,8 @@ public class SourceToParse {
     private String routing;
 
     private String parentId;
+
+    private long timestamp;
 
     public SourceToParse(XContentParser parser) {
         this.parser = parser;
@@ -108,6 +112,15 @@ public class SourceToParse {
 
     public SourceToParse routing(String routing) {
         this.routing = routing;
+        return this;
+    }
+
+    public long timestamp() {
+        return this.timestamp;
+    }
+
+    public SourceToParse timestamp(long timestamp) {
+        this.timestamp = timestamp;
         return this;
     }
 }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -333,7 +333,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
         }
     }
 
-    private long parseStringValue(String value) {
+    protected long parseStringValue(String value) {
         try {
             return dateTimeFormatter.parser().parseMillis(value);
         } catch (RuntimeException e) {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.internal;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.Fieldable;
+import org.elasticsearch.common.joda.FormatDateTimeFormatter;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.InternalMapper;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MergeContext;
+import org.elasticsearch.index.mapper.MergeMappingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.LongFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * @author paikan (benjamin.deveze)
+ */
+public class TimestampFieldMapper extends DateFieldMapper implements InternalMapper {
+
+    public static final String CONTENT_TYPE = "_timestamp";
+
+    public static class Defaults extends DateFieldMapper.Defaults {
+        public static final boolean ENABLED = false;
+        public static final String NAME = CONTENT_TYPE;
+        public static final Field.Index INDEX = Field.Index.NOT_ANALYZED;
+        public static final Field.Store STORE = Field.Store.NO;
+        public static final boolean OMIT_NORMS = true;
+        public static final boolean OMIT_TERM_FREQ_AND_POSITIONS = true;
+    }
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, TimestampFieldMapper> {
+
+        protected boolean enabled = Defaults.ENABLED;
+
+        protected FormatDateTimeFormatter dateTimeFormatter = Defaults.DATE_TIME_FORMATTER;
+
+        public Builder() {
+            super(Defaults.NAME);
+            index = Defaults.INDEX;
+            store = Defaults.STORE;
+            omitNorms = Defaults.OMIT_NORMS;
+            omitTermFreqAndPositions = Defaults.OMIT_TERM_FREQ_AND_POSITIONS;
+            builder = this;
+        }
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return builder;
+        }
+
+        public Builder dateTimeFormatter(FormatDateTimeFormatter dateTimeFormatter) {
+            this.dateTimeFormatter = dateTimeFormatter;
+            return this;
+        }
+
+        @Override public TimestampFieldMapper build(BuilderContext context) {
+            TimestampFieldMapper fieldMapper = new TimestampFieldMapper(enabled, dateTimeFormatter, buildNames(context),
+                    precisionStep, fuzzyFactor, index, store, boost, omitNorms, omitTermFreqAndPositions);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    private final boolean enabled;
+
+    private final FormatDateTimeFormatter dateTimeFormatter;
+
+    public TimestampFieldMapper() {
+        this(Defaults.NAME);
+    }
+
+    public TimestampFieldMapper(String name) {
+        this(Defaults.ENABLED, Defaults.DATE_TIME_FORMATTER, new Names(name), Defaults.PRECISION_STEP,
+                Defaults.FUZZY_FACTOR, Defaults.INDEX, Defaults.STORE, Defaults.BOOST, Defaults.OMIT_NORMS,
+                Defaults.OMIT_TERM_FREQ_AND_POSITIONS);
+    }
+
+    public TimestampFieldMapper(boolean enabled, FormatDateTimeFormatter dateTimeFormatter, Names names,
+                                int precisionStep, String fuzzyFactor, Field.Index index, Field.Store store,
+                                float boost, boolean omitNorms, boolean omitTermFreqAndPositions) {
+        super(names, dateTimeFormatter, precisionStep, fuzzyFactor, index, store, boost, omitNorms, omitTermFreqAndPositions, null);
+        this.enabled = enabled;
+        this.dateTimeFormatter = dateTimeFormatter;
+    }
+
+    @Override protected String contentType() {
+        return Defaults.NAME;
+    }
+
+    public boolean enabled() {
+        return this.enabled;
+    }
+
+    public FormatDateTimeFormatter dateTimeFormatter() {
+        return this.dateTimeFormatter;
+    }
+
+    /**
+     * Override the default behavior (to return the string, and return the actual Number instance).
+     */
+    @Override public Object valueForSearch(Fieldable field) {
+        return value(field);
+    }
+
+    @Override public String valueAsString(Fieldable field) {
+        Long value = value(field);
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    @Override protected Fieldable parseCreateField(ParseContext context) throws IOException {
+        if (!enabled) {
+            return null;
+        }
+
+        if (context.parsedTimestampState() == ParseContext.ParsedTimestampState.NO) {
+            String dateAsString = null;
+            Long value = null;
+            float boost = this.boost;
+            XContentParser parser = context.parser();
+            XContentParser.Token token = parser.currentToken();
+            if (token == XContentParser.Token.VALUE_NULL) {
+                // In case of null value, the _timestamp will be generated
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                value = parser.longValue();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                String currentFieldName = null;
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        currentFieldName = parser.currentName();
+                    } else {
+                        if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
+                            if (token == XContentParser.Token.VALUE_NULL) {
+                                // In case of null value, the _timestamp will be generated
+                            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                                value = parser.longValue();
+                            } else {
+                                dateAsString = parser.text();
+                            }
+                        } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
+                            boost = parser.floatValue();
+                        }
+                    }
+                }
+            } else {
+                dateAsString = parser.text();
+            }
+
+            if (value == null && dateAsString == null) {
+                return null;
+            }
+
+            if (value == null) {
+                try {
+                value = parseStringValue(dateAsString);
+                } catch (Exception e) {
+                    return null;
+                }
+            }
+            System.out.println("Setting timestamp to: " + value + " [" + new Date(value).toString() + "]");
+            context.parsedTimestamp(ParseContext.ParsedTimestampState.PARSED);
+            LongFieldMapper.CustomLongNumericField field = new LongFieldMapper.CustomLongNumericField(this, value);
+            field.setBoost(boost);
+            return field;
+        } else if (context.parsedTimestampState() == ParseContext.ParsedTimestampState.GENERATED) {
+            long value = ((Number) context.externalValue()).longValue();
+            System.out.println("Setting timestamp to: " + value + " [" + new Date(value).toString() + "]");
+            return new LongFieldMapper.CustomLongNumericField(this, value);
+        } else {
+            throw new MapperParsingException("Illegal parsed timestamp state");
+        }
+    }
+
+    @Override public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // all are defaults, don't write it at all
+        if (enabled == Defaults.ENABLED
+                && store == Defaults.STORE
+                && dateTimeFormatter.format() == Defaults.DATE_TIME_FORMATTER.format()) {
+            return builder;
+        }
+        builder.startObject(contentType());
+        if (enabled != Defaults.ENABLED) {
+            builder.field("enabled", enabled);
+        }
+        if (store != Defaults.STORE) {
+            builder.field("store", store.name().toLowerCase());
+        }
+        if (dateTimeFormatter.format() != Defaults.DATE_TIME_FORMATTER.format()) {
+            builder.field("format", dateTimeFormatter().format());
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
+        // maybe allow to change enabled? But then we need to figure out null for default value
+    }
+}

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -136,10 +136,6 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
     }
 
     @Override protected Fieldable parseCreateField(ParseContext context) throws IOException {
-        if (!enabled) {
-            return null;
-        }
-
         if (context.parsedTimestampState() == ParseContext.ParsedTimestampState.NO) {
             String dateAsString = null;
             Long value = null;
@@ -184,14 +180,17 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
                     return null;
                 }
             }
-            System.out.println("Setting timestamp to: " + value + " [" + new Date(value).toString() + "]");
+
             context.parsedTimestamp(ParseContext.ParsedTimestampState.PARSED);
             LongFieldMapper.CustomLongNumericField field = new LongFieldMapper.CustomLongNumericField(this, value);
             field.setBoost(boost);
             return field;
         } else if (context.parsedTimestampState() == ParseContext.ParsedTimestampState.GENERATED) {
+            // If it is not enabled in mapping no timestamp is generated
+            if (!enabled) {
+                return null;
+            }
             long value = ((Number) context.externalValue()).longValue();
-            System.out.println("Setting timestamp to: " + value + " [" + new Date(value).toString() + "]");
             return new LongFieldMapper.CustomLongNumericField(this, value);
         } else {
             throw new MapperParsingException("Illegal parsed timestamp state");

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -496,13 +496,13 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
             case CREATE:
                 Translog.Create create = (Translog.Create) operation;
                 engine.create(prepareCreate(source(create.source()).type(create.type()).id(create.id())
-                        .routing(create.routing()).parent(create.parent())).version(create.version())
+                        .routing(create.routing()).parent(create.parent()).timestamp(create.timestamp())).version(create.version()).timestamp(create.timestamp())
                         .origin(Engine.Operation.Origin.RECOVERY));
                 break;
             case SAVE:
                 Translog.Index index = (Translog.Index) operation;
                 engine.index(prepareIndex(source(index.source()).type(index.type()).id(index.id())
-                        .routing(index.routing()).parent(index.parent())).version(index.version())
+                        .routing(index.routing()).parent(index.parent()).timestamp(index.timestamp())).version(index.version()).timestamp(index.timestamp())
                         .origin(Engine.Operation.Origin.RECOVERY));
                 break;
             case DELETE:

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -228,6 +228,7 @@ public interface Translog extends IndexShardComponent {
         private String routing;
         private String parent;
         private long version;
+        private long timestamp;
 
         public Create() {
         }
@@ -237,6 +238,7 @@ public interface Translog extends IndexShardComponent {
             this.routing = create.routing();
             this.parent = create.parent();
             this.version = create.version();
+            this.timestamp = create.timestamp();
         }
 
         public Create(String type, String id, byte[] source) {
@@ -277,6 +279,10 @@ public interface Translog extends IndexShardComponent {
             return this.version;
         }
 
+        public long timestamp() {
+            return this.timestamp;
+        }
+
         @Override public BytesHolder readSource(BytesStreamInput in) throws IOException {
             int version = in.readVInt(); // version
             id = in.readUTF();
@@ -306,6 +312,7 @@ public interface Translog extends IndexShardComponent {
             if (version >= 3) {
                 this.version = in.readLong();
             }
+            this.timestamp = in.readLong();
         }
 
         @Override public void writeTo(StreamOutput out) throws IOException {
@@ -327,6 +334,7 @@ public interface Translog extends IndexShardComponent {
                 out.writeUTF(parent);
             }
             out.writeLong(version);
+            out.writeLong(timestamp);
         }
     }
 
@@ -337,6 +345,7 @@ public interface Translog extends IndexShardComponent {
         private byte[] source;
         private String routing;
         private String parent;
+        private long timestamp;
 
         public Index() {
         }
@@ -346,6 +355,7 @@ public interface Translog extends IndexShardComponent {
             this.routing = index.routing();
             this.parent = index.parent();
             this.version = index.version();
+            this.timestamp = index.timestamp();
         }
 
         public Index(String type, String id, byte[] source) {
@@ -386,6 +396,10 @@ public interface Translog extends IndexShardComponent {
             return this.version;
         }
 
+        public long timestamp() {
+            return this.timestamp;
+        }
+
         @Override public BytesHolder readSource(BytesStreamInput in) throws IOException {
             int version = in.readVInt(); // version
             id = in.readUTF();
@@ -415,6 +429,7 @@ public interface Translog extends IndexShardComponent {
             if (version >= 3) {
                 this.version = in.readLong();
             }
+            this.timestamp = in.readLong();
         }
 
         @Override public void writeTo(StreamOutput out) throws IOException {
@@ -436,6 +451,7 @@ public interface Translog extends IndexShardComponent {
                 out.writeUTF(parent);
             }
             out.writeLong(version);
+            out.writeLong(timestamp);
         }
     }
 

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.timestamp;
+
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperTests;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+@Test
+public class TimestampMappingTests {
+
+    @Test public void testTimestampEnabled() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_timestamp").field("enabled", true).endObject()
+                .endObject().endObject().string();
+        DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
+
+        byte[] source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "value")
+                .endObject()
+                .copiedBytes();
+        ParsedDocument doc = docMapper.parse(SourceToParse.source(source).type("type").id("1"));
+
+        assertThat(doc.rootDoc().getFieldable("_timestamp").isStored(), equalTo(false));
+        assertThat(doc.rootDoc().getFieldable("_timestamp").tokenStreamValue(), notNullValue());
+    }
+
+    @Test public void testTimestampEnabledAndStored() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_timestamp").field("enabled", true).field("store", "yes").endObject()
+                .endObject().endObject().string();
+        DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
+
+        byte[] source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "value")
+                .endObject()
+                .copiedBytes();
+        ParsedDocument doc = docMapper.parse(SourceToParse.source(source).type("type").id("1"));
+
+        assertThat(doc.rootDoc().getFieldable("_timestamp").isStored(), equalTo(true));
+        assertThat(doc.rootDoc().getFieldable("_timestamp").tokenStreamValue(), notNullValue());
+    }
+
+    @Test public void testTimestampDisabled() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_timestamp").field("enabled", false).endObject()
+                .endObject().endObject().string();
+        DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
+
+        byte[] source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "value")
+                .endObject()
+                .copiedBytes();
+        ParsedDocument doc = docMapper.parse(SourceToParse.source(source).type("type").id("1"));
+
+        assertThat(doc.rootDoc().getFieldable("_timestamp"), nullValue());
+    }
+
+    @Test public void testTimestampNotSet() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .endObject().endObject().string();
+        DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
+
+        byte[] source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "value")
+                .endObject()
+                .copiedBytes();
+        ParsedDocument doc = docMapper.parse(SourceToParse.source(source).type("type").id("1"));
+
+        assertThat(doc.rootDoc().getFieldable("_timestamp"), nullValue());
+    }
+}


### PR DESCRIPTION
This patch add support for a _timestamp field (issue #491).

The _timestamp can be provided in the _source field or its value is automatically set. It is a classical date field with customizable format.  The timestamp value can be given using the following values:
- a number
- a number inside string
- a string conformed with the defined format

If the provided timestamp cannot be parsed or is null the _timestamp will be automatically generated.

By default the _timestamp field is disabled and not stored.

When the _timestamp is automatically generated it is set with the current time when the index query was received.

This patch should work properly with transactions log and replicates.

It will hopefully serve as a basis for the per doc TTL feature I am working on.
