### PR TITLE
Log4j River

### DIFF
--- a/plugins/river/log4j/build.gradle
+++ b/plugins/river/log4j/build.gradle
@@ -1,0 +1,130 @@
+dependsOn(':elasticsearch')
+
+apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'eclipse'
+
+archivesBaseName = "elasticsearch-river-log4j"
+
+explodedDistDir = new File(distsDir, 'exploded')
+
+manifest.mainAttributes("Implementation-Title": "ElasticSearch::Plugins::River::Log4j", "Implementation-Version": rootProject.version, "Implementation-Date": buildTimeStr)
+
+configurations.compile.transitive = true
+configurations.testCompile.transitive = true
+
+// no need to use the resource dir
+sourceSets.main.resources.srcDirs 'src/main/java'
+sourceSets.test.resources.srcDirs 'src/test/java'
+
+// add the source files to the dist jar
+//jar {
+//    from sourceSets.main.allJava
+//}
+
+configurations {
+    dists
+    distLib {
+        visible = false
+        transitive = false
+    }
+}
+
+dependencies {
+    compile project(':elasticsearch')
+
+}
+
+task explodedDist(dependsOn: [jar], description: 'Builds the plugin zip file') << {
+    [explodedDistDir]*.mkdirs()
+
+    copy {
+        from configurations.distLib
+        into explodedDistDir
+    }
+
+    // remove elasticsearch files (compile above adds the elasticsearch one)
+    ant.delete { fileset(dir: explodedDistDir, includes: "elasticsearch-*.jar") }
+
+    copy {
+        from libsDir
+        into explodedDistDir
+    }
+
+    ant.delete { fileset(dir: explodedDistDir, includes: "elasticsearch-*-javadoc.jar") }
+    ant.delete { fileset(dir: explodedDistDir, includes: "elasticsearch-*-sources.jar") }
+}
+
+task zip(type: Zip, dependsOn: ['explodedDist']) {
+    from(explodedDistDir) {
+    }
+}
+
+task release(dependsOn: [zip]) << {
+    ant.delete(dir: explodedDistDir)
+    copy {
+        from distsDir
+        into(new File(rootProject.distsDir, "plugins"))
+    }
+}
+
+configurations {
+    deployerJars
+}
+
+dependencies {
+    deployerJars "org.apache.maven.wagon:wagon-http:1.0-beta-2"
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+uploadArchives {
+    repositories.mavenDeployer {
+        configuration = configurations.deployerJars
+        repository(url: rootProject.mavenRepoUrl) {
+            authentication(userName: rootProject.mavenRepoUser, password: rootProject.mavenRepoPass)
+        }
+        snapshotRepository(url: rootProject.mavenSnapshotRepoUrl) {
+            authentication(userName: rootProject.mavenRepoUser, password: rootProject.mavenRepoPass)
+        }
+
+        pom.project {
+            inceptionYear '2011'
+            name 'elasticsearch-plugins-river-log4j'
+            description 'Log4j River Plugin for ElasticSearch'
+            licenses {
+                license {
+                    name 'The Apache Software License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution 'repo'
+                }
+            }
+            scm {
+                connection 'git://github.com/elasticsearch/elasticsearch.git'
+                developerConnection 'git@github.com:elasticsearch/elasticsearch.git'
+                url 'http://github.com/elasticsearch/elasticsearch'
+            }
+        }
+
+        pom.whenConfigured {pom ->
+            pom.dependencies = pom.dependencies.findAll {dep -> dep.scope != 'test' } // removes the test scoped ones
+        }
+    }
+}
+
+eclipseClasspath {
+    defaultOutputDir = file('build/eclipse-build')
+}

--- a/plugins/river/log4j/src/main/java/es-plugin.properties
+++ b/plugins/river/log4j/src/main/java/es-plugin.properties
@@ -1,0 +1,1 @@
+plugin=org.elasticsearch.plugin.river.log4j.Log4JRiverPlugin

--- a/plugins/river/log4j/src/main/java/org/elasticsearch/plugin/river/log4j/Log4JRiverPlugin.java
+++ b/plugins/river/log4j/src/main/java/org/elasticsearch/plugin/river/log4j/Log4JRiverPlugin.java
@@ -1,0 +1,29 @@
+package org.elasticsearch.plugin.river.log4j;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.river.RiversModule;
+import org.elasticsearch.river.log4j.Log4JRiverModule;
+
+public class Log4JRiverPlugin extends AbstractPlugin {
+
+	@Inject public Log4JRiverPlugin() {}
+	
+	@Override
+	public String description() {
+		return "Log4j River Plugin";
+	}
+
+	@Override
+	public String name() {
+		return "river-log4j";
+	}
+	
+	@Override public void processModule(Module module) {
+        if (module instanceof RiversModule) {
+            ((RiversModule) module).registerRiver("log4j", Log4JRiverModule.class);
+        }
+    }
+
+}

--- a/plugins/river/log4j/src/main/java/org/elasticsearch/river/log4j/Log4JRiver.java
+++ b/plugins/river/log4j/src/main/java/org/elasticsearch/river/log4j/Log4JRiver.java
@@ -1,0 +1,277 @@
+package org.elasticsearch.river.log4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Hierarchy;
+import org.apache.log4j.Level;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.net.SocketNode;
+import org.apache.log4j.spi.LoggerRepository;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.spi.RootLogger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.indices.IndexAlreadyExistsException;
+import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.river.AbstractRiverComponent;
+import org.elasticsearch.river.River;
+import org.elasticsearch.river.RiverName;
+import org.elasticsearch.river.RiverSettings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+public class Log4JRiver extends AbstractRiverComponent implements River {
+
+	private final ThreadPool threadPool;
+
+    private final Client client;
+
+    private final String indexName;
+
+    private final String typeName;
+
+    private final String logConfigFilePath;
+   
+    private HashMap<InetAddress, LoggerRepository> loggerHierarchyMap;
+    
+    private LoggerRepository genericHierarchy;
+    
+    private final int socketPort;
+    
+    public static String GENERIC = "generic";
+
+    public static String CONFIG_FILE_EXT = ".lcf";
+    
+    public static final String MSG_PROP_DATE = "date";
+    public static final String MSG_PROP_LOGGER = "server";
+    public static final String MSG_PROP_THREAD = "thread";
+    public static final String MSG_PROP_LEVEL = "level";
+    public static final String MSG_PROP_MESSAGE = "message";
+    
+	@Inject public Log4JRiver(RiverName riverName, RiverSettings settings, Client client, ThreadPool threadPool) {
+		super(riverName, settings);
+		this.threadPool = threadPool;
+		this.client = client;
+		
+		if (settings.settings().containsKey("index")) {
+            Map<String, Object> indexSettings = (Map<String, Object>) settings.settings().get("index");
+            indexName = XContentMapValues.nodeStringValue(indexSettings.get("index"), riverName.name());
+            typeName = XContentMapValues.nodeStringValue(indexSettings.get("type"), "log-message");
+        } else {
+            indexName = riverName.name();
+            typeName = "log-message";
+        }
+		
+		if(settings.settings().containsKey("log-config")) {
+			Map<String, Object> logConfigSettings = (Map<String, Object>) settings.settings().get("log-config");
+			logConfigFilePath = XContentMapValues.nodeStringValue(logConfigSettings.get("config-file-path"), ".");
+			socketPort = XContentMapValues.nodeIntegerValue(logConfigSettings.get("listen-port"), 2020);
+		} else {
+			logConfigFilePath = ".";
+			socketPort = 2020;
+		}
+		
+		this.loggerHierarchyMap = new HashMap<InetAddress, LoggerRepository>();
+	}
+	
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void start() {
+        logger.info("starting log4j stream");
+        try {
+        	String mapping = XContentFactory.jsonBuilder()
+        		.startObject()
+	        		.startObject(typeName)
+	        			.startObject("properties")
+	        				.startObject(MSG_PROP_DATE)
+	        					.field("type", "date")
+	        					.field("format", "MM-dd-YYYY HH:mm:ss.SSS")
+	        				.endObject()
+	        				.startObject(MSG_PROP_LOGGER)
+	        					.field("type", "string")
+	        				.endObject()
+	        				.startObject(MSG_PROP_THREAD)
+	        					.field("type", "string")
+	        				.endObject()
+	        				.startObject(MSG_PROP_LEVEL)
+	        					.field("type", "string")
+	        				.endObject()
+	        				.startObject(MSG_PROP_MESSAGE)
+	        					.field("type", "string")
+	        				.endObject()
+	        			.endObject()
+	        		.endObject()
+	        	.endObject()
+	        	.string();
+        	
+            client.admin().indices().prepareCreate(indexName).addMapping(typeName, mapping).execute().actionGet();
+        } catch (Exception e) {
+            if (ExceptionsHelper.unwrapCause(e) instanceof IndexAlreadyExistsException) {
+                // that's fine
+            } else if (ExceptionsHelper.unwrapCause(e) instanceof ClusterBlockException) {
+                // ok, not recovered yet..., lets start indexing and hope we recover by the first bulk
+                // TODO: a smarter logic can be to register for cluster event listener here, and only start sampling when the block is removed...
+            } else {
+                logger.warn("failed to create index [{}], disabling river...", e, indexName);
+                return;
+            }
+        }
+        
+        try {
+        	SocketAcceptor acceptor = new SocketAcceptor();
+        	threadPool.cached().execute(acceptor);
+        } catch (IOException ioe) {
+        	
+        }
+	}
+	
+	private LoggerRepository configureHierarchy(InetAddress inetAddress) {
+		String s = inetAddress.toString();
+		int i = s.indexOf("/");
+		if (i == -1) {
+			logger.info("Could not parse the inetAddress [" + inetAddress + "]. Using default hierarchy.");
+			return genericHierarchy();
+		}
+		String key = s.substring(0, i);
+
+		File configFile = new File(logConfigFilePath, key + CONFIG_FILE_EXT);
+		if (configFile.exists()) {
+			RootLogger rootLogger = new RootLogger(Level.ALL);
+					
+			Hierarchy h = new Hierarchy(rootLogger);
+			rootLogger.addAppender(new ESAppender());
+			
+			this.loggerHierarchyMap.put(inetAddress, h);
+
+			new PropertyConfigurator().doConfigure(configFile.getAbsolutePath(), h);
+			return h;
+		}
+		logger.info("Could not find config file [" + configFile + "].");
+		return genericHierarchy();
+	}
+
+	private LoggerRepository genericHierarchy() {
+		if (this.genericHierarchy == null) {
+			RootLogger rootLogger = new RootLogger(Level.ALL);
+			this.genericHierarchy = new Hierarchy(rootLogger);
+			rootLogger.addAppender(new ESAppender());
+			
+			File f = new File(logConfigFilePath, GENERIC + CONFIG_FILE_EXT);
+			if (f.exists()) {
+				new PropertyConfigurator().doConfigure(f.getAbsolutePath(), this.genericHierarchy);
+			} else {
+				logger.info("Could not find config file [" + f + "]. All received log events will be indexed.");
+			}
+		}
+		return this.genericHierarchy;
+	}
+	
+	private class SocketAcceptor implements Runnable {
+
+		private ServerSocket serverSocket;
+		
+		public SocketAcceptor() throws IOException {
+			serverSocket = new ServerSocket(Log4JRiver.this.socketPort);
+		}
+		
+		@Override
+		public void run() {
+			try {
+				Socket socket = serverSocket.accept();
+				
+				InetAddress inetAddress = socket.getInetAddress();
+				
+				LoggerRepository h = (LoggerRepository)loggerHierarchyMap.get(inetAddress);
+				if (h == null) {
+					h = configureHierarchy(inetAddress);
+				}
+				SocketNode socketNode = new SocketNode(socket, h);
+				
+				Log4JRiver.this.threadPool.cached().execute(socketNode);
+			} catch (IOException ioe) {
+				logger.error("Erroring connecting remote logger", ioe);
+			}
+		}
+	}
+	
+	private class ESAppender extends AppenderSkeleton implements Appender {
+		
+		@Override
+		protected void append(LoggingEvent loggingEvent) {
+			if (logger.isTraceEnabled()) {
+                logger.trace("logmessage {} : {}", loggingEvent.getLoggerName(), loggingEvent.getRenderedMessage());
+            }
+            
+			try {
+                XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+                builder.field(MSG_PROP_DATE, loggingEvent.getTimeStamp());
+                builder.field(MSG_PROP_LOGGER, loggingEvent.getLoggerName());
+                builder.field(MSG_PROP_THREAD, loggingEvent.getThreadName());
+                builder.field(MSG_PROP_LEVEL, loggingEvent.getLevel());
+                builder.field(MSG_PROP_MESSAGE, loggingEvent.getRenderedMessage());
+                builder.endObject();
+                
+                IndexRequest request = 
+                	Requests.indexRequest(indexName).type(typeName)
+                		.create(true).source(builder);
+                
+                client.index(request, new ActionListener<IndexResponse>() {
+					
+					@Override
+					public void onResponse(IndexResponse response) {
+						logger.trace("logmessage indexed");
+					}
+					
+					@Override
+					public void onFailure(Throwable throwable) {
+						if (ExceptionsHelper.unwrapCause(throwable) instanceof RejectedExecutionException ||
+							ExceptionsHelper.unwrapCause(throwable) instanceof NodeClosedException) {
+			                // probably the index cluster is shutting down or otherwise not ready
+							// so log as debug
+							logger.debug("failed to index logmessage since node is unavailable - you can probably ignore this if it occurs during node shutdown or startup", throwable);
+			            } else {
+			            	// something else is happening, logs as error
+			            	logger.error("failed to index logmessage", throwable);
+			            }
+					}
+				});
+                		
+            } catch (Exception e) {
+                logger.warn("failed to construct index request", e);
+            }
+            
+            
+		}
+		
+		@Override
+		public boolean requiresLayout() {
+			return false;
+		}
+		
+		@Override
+		public void close() {
+			// TODO Auto-generated method stub
+			
+		}
+	}
+}

--- a/plugins/river/log4j/src/main/java/org/elasticsearch/river/log4j/Log4JRiverModule.java
+++ b/plugins/river/log4j/src/main/java/org/elasticsearch/river/log4j/Log4JRiverModule.java
@@ -1,0 +1,13 @@
+package org.elasticsearch.river.log4j;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.river.River;
+
+public class Log4JRiverModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		bind(River.class).to(Log4JRiver.class).asEagerSingleton();
+	}
+
+}


### PR DESCRIPTION
A river that listens for Log4j LoggingEvents on a socket. Works with the out-of-the-box Log4j SocketAppender, so no changes to logging source applications is required.  Borrows heavily (entirely?) from OOTB Log4j SocketServer class - notably, per-host configuration files enable ES-side filtering of received log events.
