### PR TITLE
fix hightlight score ordering for a field

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -141,7 +141,7 @@ public class HighlighterParseElement implements SearchParseElement {
                                         field.fragmentOffset(parser.intValue());
                                     } else if ("highlight_filter".equals(fieldName) || "highlightFilter".equals(fieldName)) {
                                         field.highlightFilter(parser.booleanValue());
-                                    } else if ("score".equals(fieldName)) {
+                                    } else if ("order".equals(fieldName)) {
                                         field.scoreOrdered("score".equals(parser.text()));
                                     }
                                 }


### PR DESCRIPTION
Just by reading the code I noticed a issue with the parser for highlighting. Here is the fix. Not tested.
