### PR TITLE
fix clear for FieldLookup values

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
@@ -64,7 +64,7 @@ public class FieldLookup {
         value = null;
         valueLoaded = false;
         values.clear();
-        valuesLoaded = true;
+        valuesLoaded = false;
         doc = null;
     }
 


### PR DESCRIPTION
When using FieldLookup.getValues only the first document provides values.

This is due to wrong clear of the "valuesLoaded" flag.
