### PR TITLE
config/elasticsearch.yml: add a commented out node.name with docs

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,6 +1,10 @@
 # The cluster name
 #cluster.name: elasticsearch
 
+# The node name. Used for display purposes. Will be a random Marvel
+# character name by default.
+#node.name: An Elastic Node
+
 # Path Settings
 #path.conf: /path/to/conf
 #path.data: /path/to/data


### PR DESCRIPTION
Add a commented out node.name with docs. When setting up ElasticSearch
the feature of ElasticSearch of picking random names on startup has
repeatedly confused administrators and other people looking at it.

I only found out recently that you can override this by reading the
source for InternalSettingsPerparer.java. Add it to the example
elasticsearch.yml config file to help others discover this obscure
option.
