### PR TITLE
include the path when serializing _id field mappings

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -198,7 +198,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
 
     @Override public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         // if all are defaults, no sense to write it at all
-        if (store == Defaults.STORE && index == Defaults.INDEX) {
+        if (store == Defaults.STORE && index == Defaults.INDEX && path == Defaults.PATH) {
             return builder;
         }
         builder.startObject(CONTENT_TYPE);
@@ -207,6 +207,9 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         }
         if (index != Defaults.INDEX) {
             builder.field("index", index.name().toLowerCase());
+        }
+        if (path != Defaults.PATH) {
+            builder.field("path", path);
         }
         builder.endObject();
         return builder;

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/index/mapper/id/IdMappingTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/index/mapper/id/IdMappingTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper.id;
 
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -90,5 +92,24 @@ public class IdMappingTests {
 
         assertThat(doc.rootDoc().get(UidFieldMapper.NAME), notNullValue());
         assertThat(doc.rootDoc().get(IdFieldMapper.NAME), notNullValue());
+    }
+
+    @Test public void testIdPath() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_id").field("path", "my_path").endObject()
+                .endObject().endObject().string();
+        DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
+
+        // serialize the id mapping
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder = docMapper.idFieldMapper().toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String serialized_id_mapping = builder.string();
+
+        String expected_id_mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("_id").field("path", "my_path").endObject()
+                .endObject().string();
+
+        assertThat(serialized_id_mapping, equalTo(expected_id_mapping));
     }
 }


### PR DESCRIPTION
The _id mapping supports being configured with a "path", which is where ES should find the actual id inside the document. This isn't currently returned when asking ES for the mapping. For example:

```
$ curl http://localhost:9200/test -XDELETE
{"ok":true,"acknowledged":true}

$ curl http://localhost:9200/test -XPOST
{"ok":true,"acknowledged":true}

$ curl http://localhost:9200/test/item/_mapping -XPUT -d '{
    "item" : {
        "_id": {
            "path": "foo.my_id", "store": true
        }
    }
}'
{"ok":true,"acknowledged"}

$ curl http://localhost:9200/test/item/_mapping?pretty
{
  "item" : {
    "_id" : {
      "store" : "yes"
    },
    "properties" : {
    }
  }
}

$ curl http://localhost:9200/test/item -XPOST -d '{"foo":{"my_id":"this_is_my_id"}, "bar": "bar text"}'
{"ok":true,"_index":"test","_type":"item","_id":"this_is_my_id","_version":1}

$ curl http://localhost:9200/test/item/this_is_my_id
{"_index":"test","_type":"item","_id":"this_is_my_id","_version":1,"exists":true, "_source" : {"foo":{"my_id":"this_is_my_id"}, "bar": "bar text"}}

$ curl http://localhost:9200/test/item/this_is_my_id?pretty
{
  "_index" : "test",
  "_type" : "item",
  "_id" : "this_is_my_id",
  "_version" : 1,
  "exists" : true, "_source" : {"foo":{"my_id":"this_is_my_id"}, "bar": "bar text"}
}
```

This pull request adds this variable to the outputted mapping, with an attempt at writing an unit test to prevent regressions.
