### PR TITLE
Make it possible for the date field to accept fields that are in seconds instead of just milliseconds

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -113,7 +113,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                     builder.nullValue(propNode.toString());
                 } else if (propName.equals("format")) {
                     builder.dateTimeFormatter(parseDateTimeFormatter(propName, propNode));
-                } else if (propName.equals("numeric_precision")) {
+                } else if (propName.equals("numeric_resolution")) {
                     builder.timeUnit(TimeUnit.valueOf(propNode.toString().toUpperCase()));
                 }
             }
@@ -348,7 +348,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
             builder.field("include_in_all", includeInAll);
         }
         if (timeUnit != Defaults.TIME_UNIT) {
-            builder.field("numeric_precision", timeUnit);
+            builder.field("numeric_resolution", timeUnit);
         }
     }
 

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -357,7 +357,8 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
             return dateTimeFormatter.parser().parseMillis(value);
         } catch (RuntimeException e) {
             try {
-                return Long.parseLong(value);
+                long time = Long.parseLong(value);
+                return timeUnit.toMillis(time);
             } catch (NumberFormatException e1) {
                 throw new MapperParsingException("failed to parse date field, tried both date format [" + dateTimeFormatter.format() + "], and timestamp number", e);
             }


### PR DESCRIPTION
Not all systems have millisecond precision timestamps and would rather send their timestamp in seconds instead.

This pull request adds the following configuration option to the date field mapper: 

```
numeric_is_in_seconds: true|false
```

that tells ES which format numeric values should be treated as (seconds or milliseconds). The default value is false for backward compatability, and since this may be the most common.
