### PR TITLE
Add support for non-elasticsearch namespaces to Settings.getAsClass

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -213,15 +213,21 @@ public class ImmutableSettings implements Settings {
         try {
             return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
         } catch (ClassNotFoundException e) {
-            fullClassName = prefixPackage + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
+            String prefixValue = prefixPackage;
+            int packageSeparator = sValue.lastIndexOf('.');
+            if (packageSeparator > 0) {
+                prefixValue = sValue.substring(0, packageSeparator + 1);
+                sValue = sValue.substring(packageSeparator + 1);
+            }
+            fullClassName = prefixValue + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
             try {
                 return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
             } catch (ClassNotFoundException e1) {
-                fullClassName = prefixPackage + toCamelCase(sValue).toLowerCase() + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
+                fullClassName = prefixValue + toCamelCase(sValue).toLowerCase() + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
                 try {
                     return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
                 } catch (ClassNotFoundException e2) {
-                    throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + sValue + "]", e);
+                    throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + get(setting) + "]", e);
                 }
             }
         }

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/common/settings/ImmutableSettingsTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/common/settings/ImmutableSettingsTests.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.settings;
+
+import org.elasticsearch.common.settings.foo.FooTest;
+import org.testng.annotations.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author imotov
+ */
+public class ImmutableSettingsTests {
+
+    @Test public void testGetAsClass() {
+        Settings settings = settingsBuilder()
+                .put("test.class", "bar")
+                .put("test.class.package", "org.elasticsearch.common.settings.bar")
+                .build();
+
+        // Assert that defaultClazz is loaded if setting is not specified
+        assertThat(settings.getAsClass("no.settings", FooTest.class, "org.elasticsearch.common.settings.", "Test").getName(),
+                equalTo("org.elasticsearch.common.settings.foo.FooTest"));
+
+        // Assert that correct class is loaded if setting contain name without package
+        assertThat(settings.getAsClass("test.class", FooTest.class, "org.elasticsearch.common.settings.", "Test").getName(),
+                equalTo("org.elasticsearch.common.settings.bar.BarTest"));
+
+        // Assert that class cannot be loaded if wrong packagePrefix is specified
+        try {
+            settings.getAsClass("test.class", FooTest.class, "com.example.elasticsearch.common.settings.", "Test");
+            assertThat("Class with wrong package name shouldn't be loaded", false);
+        } catch (NoClassSettingsException ex) {
+            // Ignore
+        }
+
+        // Assert that package name in settings is getting correctly applied
+        assertThat(settings.getAsClass("test.class.package", FooTest.class, "com.example.elasticsearch.common.settings.", "Test").getName(),
+                equalTo("org.elasticsearch.common.settings.bar.BarTest"));
+
+    }
+
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/common/settings/bar/BarTest.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/common/settings/bar/BarTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.settings.bar;
+
+/**
+ * @author imotov
+ */
+public class BarTest {
+}

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/common/settings/foo/FooTest.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/common/settings/foo/FooTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.settings.foo;
+
+/**
+ * @author imotov
+ */
+public class FooTest {
+}


### PR DESCRIPTION
Elasticsearch provides great flexibility allowing to plug custom functionality and replace some built-in modules. However, if a plugin module is located in non org.elasticsearch namespace, it's kind of awkward to specify the plugin's module in the config file. 

For example, if I want to replace netty http transport with my own jetty-based implementation, I need to specify something like this in the config file:

`http.type: org.example.elasticsearch.http.jetty.JettyHttpServerTransportModule`

I would like to be able to simplify this to:

`http.type: org.example.elasticsearch.http.jetty`

It can be easily achieved by modifying `ImmutableSettings.getAsClass(String setting, Class<? extends T> defaultClazz, String prefixPackage, String suffixClassName)` logic a little bit. The current logic is 

1) try loading class specified in settings
2) try loading prefixPackage + Setting + suffixClassName
3) try loading prefixPackage + setting + "." + Setting + suffixClassName

I would like to add a check between 1 and 2 for the setting value. Currently it's assumed that the setting value is either resolved as a class name (1) or it doesn't contain any dots (2 and 3). I would like to add special logic that would check if a dot is present in the setting value. And if dot is present it would use the portion of the setting value before the last dot as a prefixPackage in 2) and 3). 

So, if I specify org.example.elasticsearch.http.jetty, I want it to try loading

1) org.example.elasticsearch.http.jetty
2) org.example.elasticsearch.http.JettyHttpServerTransportModule
3) org.example.elasticsearch.http.jetty.JettyHttpServerTransportModule

Since the setting value is capitalized, having a dot in the setting cannot produce an useful result right now. So the proposed solution is backward compatible with the current implementation and shouldn't break any existing functionality.

Does it make sense?
