### PR TITLE
Allow limiting the number of concurrent ES nodes

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -60,7 +60,8 @@ public class NodeEnvironment extends AbstractComponent {
         Lock[] locks = new Lock[environment.dataWithClusterFiles().length];
         int localNodeId = -1;
         IOException lastException = null;
-        for (int possibleLockId = 0; possibleLockId < 50; possibleLockId++) {
+        int maxLocalStorageNodes = settings.getAsInt("node.max_local_storage_nodes", 50);
+        for (int possibleLockId = 0; possibleLockId < maxLocalStorageNodes; possibleLockId++) {
             for (int dirIndex = 0; dirIndex < environment.dataWithClusterFiles().length; dirIndex++) {
                 File dir = new File(new File(environment.dataWithClusterFiles()[dirIndex], "nodes"), Integer.toString(possibleLockId));
                 if (!dir.exists()) {


### PR DESCRIPTION
In many deployment scenarios it might be useful to limit the number of ES nodes that can run simultaneously on the same machine. For example, if a machine was configured to run a single ES node, the consequences of accidental start of the second ES node can be quite severe.

Usage: Adding the following line to elasticsearch.yml file will not allow more then one ES node to be started using the same data directory.

```node.max_local_storage_nodes: 1 

```
```
