### PR TITLE
multi get ids shortcut should grab custom fields.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -282,7 +282,7 @@ public class MultiGetRequest implements ActionRequest {
                             if (!token.isValue()) {
                                 throw new ElasticSearchIllegalArgumentException("ids array element should only contain ids");
                             }
-                            add(new Item(defaultIndex, defaultType, parser.text()));
+                            add(new Item(defaultIndex, defaultType, parser.text()).fields(defaultFields));
                         }
                     }
                 }


### PR DESCRIPTION
This patch lets the `{"ids": ["..."]}` form of a multi get use the url parameter "fields" like the longer form does.
