### PR TITLE
Aliases should be processed when index routing changes

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -406,7 +406,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
     }
 
     private boolean aliasesChanged(ClusterChangedEvent event) {
-        return !event.state().metaData().aliases().equals(event.previousState().metaData().aliases());
+        return !event.state().metaData().aliases().equals(event.previousState().metaData().aliases()) ||
+                !event.state().routingTable().equals(event.previousState().routingTable());
     }
 
     private void applyAliases(ClusterChangedEvent event) {


### PR DESCRIPTION
Found a bug in filtering aliases code. During initial recovery or shard relocations, IndicesClusterStateService doesn't process filtering aliases during cluster state update if metadata didn't change, even when an index with such aliases is allocated on the node. It manifests itself through InvalidAliasNameException when an unprocessed filtering alias is used in search queries.
