### PR TITLE
Fix possible NPE in TransportNodesListGatewayStartedShards operation

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/gateway/local/TransportNodesListGatewayStartedShards.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/gateway/local/TransportNodesListGatewayStartedShards.java
@@ -111,10 +111,13 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
     }
 
     @Override protected NodeLocalGatewayStartedShards nodeOperation(NodeRequest request) throws ElasticSearchException {
-        for (Map.Entry<ShardId, Long> entry : gateway.currentStartedShards().shards().entrySet()) {
-            if (entry.getKey().equals(request.shardId)) {
-                assert entry.getValue() != null;
-                return new NodeLocalGatewayStartedShards(clusterService.localNode(), entry.getValue());
+        LocalGatewayStartedShards startedShards = gateway.currentStartedShards();
+        if (startedShards != null) {
+            for (Map.Entry<ShardId, Long> entry : startedShards.shards().entrySet()) {
+                if (entry.getKey().equals(request.shardId)) {
+                    assert entry.getValue() != null;
+                    return new NodeLocalGatewayStartedShards(clusterService.localNode(), entry.getValue());
+                }
             }
         }
         return new NodeLocalGatewayStartedShards(clusterService.localNode(), -1);


### PR DESCRIPTION
When recovering cluster contains data nodes with no shards on them, the TransportNodesListGatewayStartedShards fails with the following exception:

```
[2011-11-04 10:43:28,611][DEBUG][gateway.local ] [Hulk 2099] failed to execute on node [gxylYRQ-Tp-EFlRRXgOgHQ] 
org.elasticsearch.transport.RemoteTransportException: [Sandman][inet[/10.1.10.148:9301]][/gateway/local/started-shards/node] 
Caused by: java.lang.NullPointerException 
at org.elasticsearch.gateway.local.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:114) 
at org.elasticsearch.gateway.local.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:49) 
at org.elasticsearch.action.support.nodes.TransportNodesOperationAction$NodeTransportHandler.messageReceived(TransportNodesOperationAction.java:267) 
at org.elasticsearch.action.support.nodes.TransportNodesOperationAction$NodeTransportHandler.messageReceived(TransportNodesOperationAction.java:260) 
at org.elasticsearch.transport.netty.MessageChannelHandler$RequestHandler.run(MessageChannelHandler.java:238) 
at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908) 
at java.lang.Thread.run(Thread.java:680) 
```

I am not sure if it affects recovery.

To reproduce:
- delete data directory 
- start one node with default settings
- create one index with default settings
- shut down the node
- add `gateway.recover_after_nodes: 3` to elasticsearch.yml 
- add `gateway: DEBUG` to logging.yml 
- start 3 nodes 
- observe error message above in the log file
