### PR TITLE
Fix reporting of total indexing stats

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStats.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStats.java
@@ -159,7 +159,7 @@ public class IndicesStats extends BroadcastOperationResponse implements ToXConte
         builder.endObject();
 
         builder.startObject("total");
-        primaries().toXContent(builder, params);
+        total().toXContent(builder, params);
         builder.endObject();
 
         builder.startObject(Fields.INDICES);


### PR DESCRIPTION
It looks like there is a typo in the toXContent method that causes /_stats REST action to return primary stats instead of total stats.

On a relevant note, I have upgraded my notebook and now SearchStatsTests are failing almost every time. Fetches are occurring too fast and as a result fetchTimeInMillis() is almost always 0. Sometimes I am even getting 0 in queryTimeInMillis().
