### PR TITLE
 Fix processing of regex patterns in large terms facet requests

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetCollector.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetCollector.java
@@ -211,10 +211,14 @@ public class TermsStringOrdinalsFacetCollector extends AbstractFacetCollector {
             } while (agg != null && value.equals(agg.current));
 
             if (count > minCount) {
-                if (excluded == null || !excluded.contains(value)) {
-                    InternalStringTermsFacet.StringEntry entry = new InternalStringTermsFacet.StringEntry(value, count);
-                    ordered.add(entry);
+                if (excluded != null && excluded.contains(value)) {
+                    continue;
                 }
+                if (matcher != null && !matcher.reset(value).matches()) {
+                    continue;
+                }
+                InternalStringTermsFacet.StringEntry entry = new InternalStringTermsFacet.StringEntry(value, count);
+                ordered.add(entry);
             }
         }
 


### PR DESCRIPTION
Regex patterns are ignored in large (more then 5000 facets) terms facet requests. For example:

```
curl -XGET 'http://localhost:9200/twitter/tweet/_search?pretty=true' -d '{
    "size" : 0,
    "query" : { "query_string" : {"query" : "*:*"} },
    "facets" : {
        "message" : { 
            "terms" : {
                "field" : "message",
                "regex" : "elas[a-z]*",
                "size" : "20000"
            } 
       }
    }
}'
```
