### PR TITLE
Add counts of currently executing index, delete, query and fetch operations

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
@@ -40,27 +40,33 @@ public class IndexingStats implements Streamable, ToXContent {
 
         private long indexCount;
         private long indexTimeInMillis;
+        private long indexCurrent;
 
         private long deleteCount;
         private long deleteTimeInMillis;
+        private long deleteCurrent;
 
         Stats() {
 
         }
 
-        public Stats(long indexCount, long indexTimeInMillis, long deleteCount, long deleteTimeInMillis) {
+        public Stats(long indexCount, long indexTimeInMillis, long indexCurrent, long deleteCount, long deleteTimeInMillis, long deleteCurrent) {
             this.indexCount = indexCount;
             this.indexTimeInMillis = indexTimeInMillis;
+            this.indexCurrent = indexCurrent;
             this.deleteCount = deleteCount;
             this.deleteTimeInMillis = deleteTimeInMillis;
+            this.deleteCurrent = deleteCurrent;
         }
 
         public void add(Stats stats) {
             indexCount += stats.indexCount;
             indexTimeInMillis += stats.indexTimeInMillis;
+            indexCurrent += stats.indexCurrent;
 
             deleteCount += stats.deleteCount;
             deleteTimeInMillis += stats.deleteTimeInMillis;
+            deleteCurrent += stats.deleteCurrent;
         }
 
         public long indexCount() {
@@ -83,6 +89,14 @@ public class IndexingStats implements Streamable, ToXContent {
             return indexTimeInMillis;
         }
 
+        public long indexCurrent() {
+            return indexCurrent;
+        }
+
+        public long getIndexCurrent() {
+            return indexCurrent;
+        }
+
         public long deleteCount() {
             return deleteCount;
         }
@@ -103,6 +117,15 @@ public class IndexingStats implements Streamable, ToXContent {
             return deleteTimeInMillis;
         }
 
+
+        public long deleteCurrent() {
+            return deleteCurrent;
+        }
+
+        public long getDeleteCurrent() {
+            return deleteCurrent;
+        }
+
         public static Stats readStats(StreamInput in) throws IOException {
             Stats stats = new Stats();
             stats.readFrom(in);
@@ -112,27 +135,33 @@ public class IndexingStats implements Streamable, ToXContent {
         @Override public void readFrom(StreamInput in) throws IOException {
             indexCount = in.readVLong();
             indexTimeInMillis = in.readVLong();
+            indexCurrent = in.readVLong();
 
             deleteCount = in.readVLong();
             deleteTimeInMillis = in.readVLong();
+            deleteCurrent = in.readVLong();
         }
 
         @Override public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(indexCount);
             out.writeVLong(indexTimeInMillis);
+            out.writeVLong(indexCurrent);
 
             out.writeVLong(deleteCount);
             out.writeVLong(deleteTimeInMillis);
+            out.writeVLong(deleteCurrent);
         }
 
         @Override public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.INDEX_TOTAL, indexCount);
             builder.field(Fields.INDEX_TIME, indexTime().toString());
             builder.field(Fields.INDEX_TIME_IN_MILLIS, indexTimeInMillis);
+            builder.field(Fields.INDEX_CURRENT, indexCurrent);
 
             builder.field(Fields.DELETE_TOTAL, deleteCount);
             builder.field(Fields.DELETE_TIME, deleteTime().toString());
             builder.field(Fields.DELETE_TIME_IN_MILLIS, deleteTimeInMillis);
+            builder.field(Fields.DELETE_CURRENT, deleteCurrent);
 
             return builder;
         }
@@ -205,9 +234,11 @@ public class IndexingStats implements Streamable, ToXContent {
         static final XContentBuilderString INDEX_TOTAL = new XContentBuilderString("index_total");
         static final XContentBuilderString INDEX_TIME = new XContentBuilderString("index_time");
         static final XContentBuilderString INDEX_TIME_IN_MILLIS = new XContentBuilderString("index_time_in_millis");
+        static final XContentBuilderString INDEX_CURRENT = new XContentBuilderString("index_current");
         static final XContentBuilderString DELETE_TOTAL = new XContentBuilderString("delete_total");
         static final XContentBuilderString DELETE_TIME = new XContentBuilderString("delete_time");
         static final XContentBuilderString DELETE_TIME_IN_MILLIS = new XContentBuilderString("delete_time_in_millis");
+        static final XContentBuilderString DELETE_CURRENT = new XContentBuilderString("delete_current");
     }
 
     public static IndexingStats readIndexingStats(StreamInput in) throws IOException {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -40,27 +40,33 @@ public class SearchStats implements Streamable, ToXContent {
 
         private long queryCount;
         private long queryTimeInMillis;
+        private long queryCurrent;
 
         private long fetchCount;
         private long fetchTimeInMillis;
+        private long fetchCurrent;
 
         Stats() {
 
         }
 
-        public Stats(long queryCount, long queryTimeInMillis, long fetchCount, long fetchTimeInMillis) {
+        public Stats(long queryCount, long queryTimeInMillis, long queryCurrent, long fetchCount, long fetchTimeInMillis, long fetchCurrent) {
             this.queryCount = queryCount;
             this.queryTimeInMillis = queryTimeInMillis;
+            this.queryCurrent = queryCurrent;
             this.fetchCount = fetchCount;
             this.fetchTimeInMillis = fetchTimeInMillis;
+            this.fetchCurrent = fetchCurrent;
         }
 
         public void add(Stats stats) {
             queryCount += stats.queryCount;
             queryTimeInMillis += stats.queryTimeInMillis;
+            queryCurrent += stats.queryCurrent;
 
             fetchCount += stats.fetchCount;
             fetchTimeInMillis += stats.fetchTimeInMillis;
+            fetchCurrent += stats.fetchCurrent;
         }
 
         public long queryCount() {
@@ -83,6 +89,14 @@ public class SearchStats implements Streamable, ToXContent {
             return queryTimeInMillis;
         }
 
+        public long queryCurrent() {
+            return queryCurrent;
+        }
+
+        public long getQueryCurrent() {
+            return queryCurrent;
+        }
+
         public long fetchCount() {
             return fetchCount;
         }
@@ -103,6 +117,15 @@ public class SearchStats implements Streamable, ToXContent {
             return fetchTimeInMillis;
         }
 
+        public long fetchCurrent() {
+            return fetchCurrent;
+        }
+
+        public long getFetchCurrent() {
+            return fetchCurrent;
+        }
+
+
         public static Stats readStats(StreamInput in) throws IOException {
             Stats stats = new Stats();
             stats.readFrom(in);
@@ -112,27 +135,33 @@ public class SearchStats implements Streamable, ToXContent {
         @Override public void readFrom(StreamInput in) throws IOException {
             queryCount = in.readVLong();
             queryTimeInMillis = in.readVLong();
+            queryCurrent = in.readVLong();
 
             fetchCount = in.readVLong();
             fetchTimeInMillis = in.readVLong();
+            fetchCurrent = in.readVLong();
         }
 
         @Override public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(queryCount);
             out.writeVLong(queryTimeInMillis);
+            out.writeVLong(queryCurrent);
 
             out.writeVLong(fetchCount);
             out.writeVLong(fetchTimeInMillis);
+            out.writeVLong(fetchCurrent);
         }
 
         @Override public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.QUERY_TOTAL, queryCount);
             builder.field(Fields.QUERY_TIME, queryTime().toString());
             builder.field(Fields.QUERY_TIME_IN_MILLIS, queryTimeInMillis);
+            builder.field(Fields.QUERY_CURRENT, queryCurrent);
 
             builder.field(Fields.FETCH_TOTAL, fetchCount);
             builder.field(Fields.FETCH_TIME, fetchTime().toString());
             builder.field(Fields.FETCH_TIME_IN_MILLIS, fetchTimeInMillis);
+            builder.field(Fields.FETCH_CURRENT, fetchCurrent);
 
             return builder;
         }
@@ -205,9 +234,11 @@ public class SearchStats implements Streamable, ToXContent {
         static final XContentBuilderString QUERY_TOTAL = new XContentBuilderString("query_total");
         static final XContentBuilderString QUERY_TIME = new XContentBuilderString("query_time");
         static final XContentBuilderString QUERY_TIME_IN_MILLIS = new XContentBuilderString("query_time_in_millis");
+        static final XContentBuilderString QUERY_CURRENT = new XContentBuilderString("query_current");
         static final XContentBuilderString FETCH_TOTAL = new XContentBuilderString("fetch_total");
         static final XContentBuilderString FETCH_TIME = new XContentBuilderString("fetch_time");
         static final XContentBuilderString FETCH_TIME_IN_MILLIS = new XContentBuilderString("fetch_time_in_millis");
+        static final XContentBuilderString FETCH_CURRENT = new XContentBuilderString("fetch_current");
     }
 
     public static SearchStats readSearchStats(StreamInput in) throws IOException {

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.search.stats;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -72,20 +73,63 @@ public class ShardSearchService extends AbstractIndexShardComponent {
         return new SearchStats(total, groupsSt);
     }
 
-    public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
-        totalStats.queryMetric.inc(tookInNanos);
+    public void onPreQueryPhase(SearchContext searchContext) {
+        totalStats.queryCurrent.inc();
         if (searchContext.groupStats() != null) {
             for (int i = 0; i < searchContext.groupStats().size(); i++) {
-                groupStats(searchContext.groupStats().get(i)).queryMetric.inc(tookInNanos);
+                groupStats(searchContext.groupStats().get(i)).queryCurrent.inc();
             }
         }
     }
 
-    public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
-        totalStats.fetchMetric.inc(tookInNanos);
+    public void onFailedQueryPhase(SearchContext searchContext) {
+        totalStats.queryCurrent.dec();
         if (searchContext.groupStats() != null) {
             for (int i = 0; i < searchContext.groupStats().size(); i++) {
-                groupStats(searchContext.groupStats().get(i)).fetchMetric.inc(tookInNanos);
+                groupStats(searchContext.groupStats().get(i)).queryCurrent.dec();
+            }
+        }
+    }
+
+    public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
+        totalStats.queryMetric.inc(tookInNanos);
+        totalStats.queryCurrent.dec();
+        if (searchContext.groupStats() != null) {
+            for (int i = 0; i < searchContext.groupStats().size(); i++) {
+                StatsHolder statsHolder = groupStats(searchContext.groupStats().get(i));
+                statsHolder.queryMetric.inc(tookInNanos);
+                statsHolder.queryCurrent.dec();
+            }
+        }
+    }
+
+    public void onPreFetchPhase(SearchContext searchContext) {
+        totalStats.fetchCurrent.inc();
+        if (searchContext.groupStats() != null) {
+            for (int i = 0; i < searchContext.groupStats().size(); i++) {
+                groupStats(searchContext.groupStats().get(i)).fetchCurrent.inc();
+            }
+        }
+    }
+
+    public void onFailedFetchPhase(SearchContext searchContext) {
+        totalStats.fetchCurrent.dec();
+        if (searchContext.groupStats() != null) {
+            for (int i = 0; i < searchContext.groupStats().size(); i++) {
+                groupStats(searchContext.groupStats().get(i)).fetchCurrent.dec();
+            }
+        }
+    }
+
+
+    public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
+        totalStats.fetchMetric.inc(tookInNanos);
+        totalStats.fetchCurrent.dec();
+        if (searchContext.groupStats() != null) {
+            for (int i = 0; i < searchContext.groupStats().size(); i++) {
+                StatsHolder statsHolder = groupStats(searchContext.groupStats().get(i));
+                statsHolder.fetchMetric.inc(tookInNanos);
+                statsHolder.fetchCurrent.dec();
             }
         }
     }
@@ -93,7 +137,16 @@ public class ShardSearchService extends AbstractIndexShardComponent {
     public void clear() {
         totalStats.clear();
         synchronized (this) {
-            groupsStats = ImmutableMap.of();
+            if (!groupsStats.isEmpty()) {
+                MapBuilder<String, StatsHolder> typesStatsBuilder = MapBuilder.newMapBuilder();
+                for (Map.Entry<String, StatsHolder> typeStats : groupsStats.entrySet()) {
+                    if (typeStats.getValue().totalCurrent() > 0) {
+                        typeStats.getValue().clear();
+                        typesStatsBuilder.put(typeStats.getKey(), typeStats.getValue());
+                    }
+                }
+                groupsStats = typesStatsBuilder.immutableMap();
+            }
         }
     }
 
@@ -114,11 +167,17 @@ public class ShardSearchService extends AbstractIndexShardComponent {
     static class StatsHolder {
         public final MeanMetric queryMetric = new MeanMetric();
         public final MeanMetric fetchMetric = new MeanMetric();
+        public final CounterMetric queryCurrent = new CounterMetric();
+        public final CounterMetric fetchCurrent = new CounterMetric();
 
         public SearchStats.Stats stats() {
             return new SearchStats.Stats(
-                    queryMetric.count(), TimeUnit.NANOSECONDS.toMillis(queryMetric.sum()),
-                    fetchMetric.count(), TimeUnit.NANOSECONDS.toMillis(fetchMetric.sum()));
+                    queryMetric.count(), TimeUnit.NANOSECONDS.toMillis(queryMetric.sum()), queryCurrent.count(),
+                    fetchMetric.count(), TimeUnit.NANOSECONDS.toMillis(fetchMetric.sum()), fetchCurrent.count());
+        }
+
+        public long totalCurrent() {
+            return queryCurrent.count() + fetchCurrent.count();
         }
 
         public void clear() {

--- a/modules/test/integration/src/test/java/org/elasticsearch/test/integration/indices/stats/SimpleIndexStatsTests.java
+++ b/modules/test/integration/src/test/java/org/elasticsearch/test/integration/indices/stats/SimpleIndexStatsTests.java
@@ -88,6 +88,12 @@ public class SimpleIndexStatsTests extends AbstractNodesTests {
         assertThat(stats.index("test2").primaries().docs().count(), equalTo(1l));
         assertThat(stats.index("test2").total().docs().count(), equalTo(2l));
 
+        // make sure that number of requests in progress is 0
+        assertThat(stats.index("test1").total().indexing().total().indexCurrent(), equalTo(0l));
+        assertThat(stats.index("test1").total().indexing().total().deleteCurrent(), equalTo(0l));
+        assertThat(stats.index("test1").total().search().total().fetchCurrent(), equalTo(0l));
+        assertThat(stats.index("test1").total().search().total().queryCurrent(), equalTo(0l));
+
         // check flags
         stats = client.admin().indices().prepareStats()
                 .setDocs(false)
@@ -110,6 +116,8 @@ public class SimpleIndexStatsTests extends AbstractNodesTests {
         assertThat(stats.primaries().indexing().typeStats().get("type1").indexCount(), equalTo(1l));
         assertThat(stats.primaries().indexing().typeStats().get("type").indexCount(), equalTo(1l));
         assertThat(stats.primaries().indexing().typeStats().get("type2"), nullValue());
+        assertThat(stats.primaries().indexing().typeStats().get("type1").indexCurrent(), equalTo(0l));
+        assertThat(stats.primaries().indexing().typeStats().get("type1").deleteCurrent(), equalTo(0l));
 
         assertThat(stats.total().get().count(), equalTo(0l));
         // check get


### PR DESCRIPTION
Stats that were added in 0.18 are great. Sometimes, we also want to know what elasticsearch is actually doing at the moment. Could you add something like this?
