### PR TITLE
implement external_relaxed versioning type - (Doesn't throw VersionConfl...

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/VersionType.java
@@ -26,7 +26,7 @@ import org.elasticsearch.ElasticSearchIllegalArgumentException;
 public enum VersionType {
     INTERNAL((byte) 0),
     EXTERNAL((byte) 1),
-    EXTERNAL_RELAXED((byte) 2);
+    EXTERNAL_QUIET((byte) 2);
 
     private final byte value;
 
@@ -43,8 +43,8 @@ public enum VersionType {
             return INTERNAL;
         } else if ("external".equals(versionType)) {
             return EXTERNAL;
-        } else if ("external_relaxed".equals(versionType)) {
-            return EXTERNAL_RELAXED;
+        } else if ("external_quiet".equals(versionType)) {
+            return EXTERNAL_QUIET;
         }
         throw new ElasticSearchIllegalArgumentException("No version type match [" + versionType + "]");
     }
@@ -57,8 +57,8 @@ public enum VersionType {
             return INTERNAL;
         } else if ("external".equals(versionType)) {
             return EXTERNAL;
-        } else if ("external_relaxed".equals(versionType)) {
-            return EXTERNAL_RELAXED;
+        } else if ("external_quiet".equals(versionType)) {
+            return EXTERNAL_QUIET;
         }
         throw new ElasticSearchIllegalArgumentException("No version type match [" + versionType + "]");
     }
@@ -69,7 +69,7 @@ public enum VersionType {
         } else if (value == 1) {
             return EXTERNAL;
         } else if (value == 2) {
-            return EXTERNAL_RELAXED;
+            return EXTERNAL_QUIET;
         }
         throw new ElasticSearchIllegalArgumentException("No version type match [" + value + "]");
     }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/VersionType.java
@@ -25,7 +25,8 @@ import org.elasticsearch.ElasticSearchIllegalArgumentException;
  */
 public enum VersionType {
     INTERNAL((byte) 0),
-    EXTERNAL((byte) 1);
+    EXTERNAL((byte) 1),
+    EXTERNAL_RELAXED((byte) 2);
 
     private final byte value;
 
@@ -42,6 +43,8 @@ public enum VersionType {
             return INTERNAL;
         } else if ("external".equals(versionType)) {
             return EXTERNAL;
+        } else if ("external_relaxed".equals(versionType)) {
+            return EXTERNAL_RELAXED;
         }
         throw new ElasticSearchIllegalArgumentException("No version type match [" + versionType + "]");
     }
@@ -54,6 +57,8 @@ public enum VersionType {
             return INTERNAL;
         } else if ("external".equals(versionType)) {
             return EXTERNAL;
+        } else if ("external_relaxed".equals(versionType)) {
+            return EXTERNAL_RELAXED;
         }
         throw new ElasticSearchIllegalArgumentException("No version type match [" + versionType + "]");
     }
@@ -63,6 +68,8 @@ public enum VersionType {
             return INTERNAL;
         } else if (value == 1) {
             return EXTERNAL;
+        } else if (value == 2) {
+            return EXTERNAL_RELAXED;
         }
         throw new ElasticSearchIllegalArgumentException("No version type match [" + value + "]");
     }

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
@@ -420,7 +420,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
                         // the actual version checking is one in an external system, and we just want to not index older versions
                         if (currentVersion >= 0) { // we can check!, its there
                             if (currentVersion >= create.version()) {
-                                if(create.versionType() != VersionType.EXTERNAL_RELAXED) {
+                                if(create.versionType() != VersionType.EXTERNAL_QUIET) {
                                     throw new VersionConflictEngineException(shardId, create.type(), create.id(), currentVersion, create.version());
                                 } else {
                                     create.version(currentVersion); //update the request version to reflect the current index version
@@ -548,7 +548,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
                         // the actual version checking is one in an external system, and we just want to not index older versions
                         if (currentVersion >= 0) { // we can check!, its there
                             if (currentVersion >= index.version()) {
-                                if(index.versionType() != VersionType.EXTERNAL_RELAXED) {
+                                if(index.versionType() != VersionType.EXTERNAL_QUIET) {
                                     throw new VersionConflictEngineException(shardId, index.type(), index.id(), currentVersion, index.version());
                                 } else {
                                     index.version(currentVersion); //update the request version to reflect the current index version
@@ -666,7 +666,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
                             // its an external version, that's fine, we allow it to be set
                             //throw new VersionConflictEngineException(shardId, delete.type(), delete.id(), -1, delete.version());
                         } else if (currentVersion >= delete.version()) {
-                            if(delete.versionType() != VersionType.EXTERNAL_RELAXED) {
+                            if(delete.versionType() != VersionType.EXTERNAL_QUIET) {
                                 throw new VersionConflictEngineException(shardId, delete.type(), delete.id(), currentVersion, delete.version());
                             } else {
                                 delete.version(currentVersion); //update the request version to reflect the current index version

--- a/modules/test/integration/src/test/java/org/elasticsearch/test/integration/versioning/SimpleVersioningTests.java
+++ b/modules/test/integration/src/test/java/org/elasticsearch/test/integration/versioning/SimpleVersioningTests.java
@@ -285,7 +285,7 @@ public class SimpleVersioningTests extends AbstractNodesTests {
         assertThat(indexResponse.version(), equalTo(1l));
     }
 
-    @Test public void testRelaxedExternalVersioning() throws Exception {
+    @Test public void testQuietExternalVersioning() throws Exception {
         try {
             client.admin().indices().prepareDelete("test").execute().actionGet();
         } catch (IndexMissingException e) {
@@ -294,21 +294,21 @@ public class SimpleVersioningTests extends AbstractNodesTests {
         client.admin().indices().prepareCreate("test").execute().actionGet();
         client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
 
-        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value12").setVersion(12).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value12").setVersion(12).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(indexResponse.version(), equalTo(12l));
 
-        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value14").setVersion(14).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value14").setVersion(14).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(indexResponse.version(), equalTo(14l));
 
 
         //it's ok, but the version returned is 14 - nothing happened
-        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value13").setVersion(13).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value13").setVersion(13).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(indexResponse.version(), equalTo(14l));
         assertThat((String) client.prepareGet("test", "type", "1").execute().actionGet().sourceAsMap().get("field1"), equalTo("value14"));
 
 
         //it's ok, but the version returned is 14 - nothing happened
-        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value14-secondattempt").setVersion(14).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value14-secondattempt").setVersion(14).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(indexResponse.version(), equalTo(14l));
         assertThat((String) client.prepareGet("test", "type", "1").execute().actionGet().sourceAsMap().get("field1"), equalTo("value14"));
 
@@ -317,15 +317,15 @@ public class SimpleVersioningTests extends AbstractNodesTests {
             assertThat(client.prepareGet("test", "type", "1").execute().actionGet().version(), equalTo(14l));
         }
 
-        DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(deleteResponse.notFound(), equalTo(false));
         assertThat(deleteResponse.version(), equalTo(17l));
 
-        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(2).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(2).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(deleteResponse.notFound(), equalTo(false));
         assertThat(deleteResponse.version(), equalTo(17l));
 
-        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_QUIET).execute().actionGet();
         assertThat(deleteResponse.notFound(), equalTo(true));
         assertThat(deleteResponse.version(), equalTo(18l));
     }

--- a/modules/test/integration/src/test/java/org/elasticsearch/test/integration/versioning/SimpleVersioningTests.java
+++ b/modules/test/integration/src/test/java/org/elasticsearch/test/integration/versioning/SimpleVersioningTests.java
@@ -284,4 +284,50 @@ public class SimpleVersioningTests extends AbstractNodesTests {
         IndexResponse indexResponse = bulkResponse.items()[0].response();
         assertThat(indexResponse.version(), equalTo(1l));
     }
+
+    @Test public void testRelaxedExternalVersioning() throws Exception {
+        try {
+            client.admin().indices().prepareDelete("test").execute().actionGet();
+        } catch (IndexMissingException e) {
+            // its ok
+        }
+        client.admin().indices().prepareCreate("test").execute().actionGet();
+        client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+
+        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value12").setVersion(12).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(indexResponse.version(), equalTo(12l));
+
+        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value14").setVersion(14).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(indexResponse.version(), equalTo(14l));
+
+
+        //it's ok, but the version returned is 14 - nothing happened
+        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value13").setVersion(13).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(indexResponse.version(), equalTo(14l));
+        assertThat((String) client.prepareGet("test", "type", "1").execute().actionGet().sourceAsMap().get("field1"), equalTo("value14"));
+
+
+        //it's ok, but the version returned is 14 - nothing happened
+        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value14-secondattempt").setVersion(14).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(indexResponse.version(), equalTo(14l));
+        assertThat((String) client.prepareGet("test", "type", "1").execute().actionGet().sourceAsMap().get("field1"), equalTo("value14"));
+
+        client.admin().indices().prepareRefresh().execute().actionGet();
+        for (int i = 0; i < 10; i++) {
+            assertThat(client.prepareGet("test", "type", "1").execute().actionGet().version(), equalTo(14l));
+        }
+
+        DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(deleteResponse.notFound(), equalTo(false));
+        assertThat(deleteResponse.version(), equalTo(17l));
+
+        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(2).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(deleteResponse.notFound(), equalTo(false));
+        assertThat(deleteResponse.version(), equalTo(17l));
+
+        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_RELAXED).execute().actionGet();
+        assertThat(deleteResponse.notFound(), equalTo(true));
+        assertThat(deleteResponse.version(), equalTo(18l));
+    }
+
 }


### PR DESCRIPTION
...ictExceptions)

I wanted to change elasticsearch so it didn't throw a VersionConflictException if it received a create/index/delete request for a version less than the current index version. It returns the normal 'ok' response but the version number returned is the latest index version.

The reasoning behind this is; I am writing a very thin wrapper to elasticsearch, and any request into the wrapper after elasticsearch is put onto a messagequeue, if putting on that queue fails I return a specific 'temporary' error and the client is supposed to resend the request. When they resend the request, I didn't want it to fail at elasticsearch, hence this version type of external_relaxed....

feedback appreciated.
