### PR TITLE
Fix incorrect key in config sample

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -200,7 +200,7 @@
 
 # Set a custom port for the node to node communication (9300 by default):
 #
-# transport.port: 9300
+# transport.tcp.port: 9300
 
 # Enable compression for all communication between nodes (disabled by default):
 #


### PR DESCRIPTION
Just a small one:

"transport.tcp.port" is used to configure netty, not "transport.port"
