### PR TITLE
Fix escaping of arguments with paths in the bash script

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -121,11 +121,11 @@ launch_service()
     # but it's up to us not to background.
     if [ "x$foreground" != "x" ]; then
         es_parms="$es_parms -Des-foreground=yes"
-        exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -cp $ES_CLASSPATH $props \
+        exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS "$es_parms" -cp "$ES_CLASSPATH" $props \
                 org.elasticsearch.bootstrap.ElasticSearch
     else
         # Startup ElasticSearch, background it, and write the pid.
-        exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -cp $ES_CLASSPATH $props \
+        exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS "$es_parms" -cp "$ES_CLASSPATH" $props \
                     org.elasticsearch.bootstrap.ElasticSearch <&- &
         [ ! -z "$pidpath" ] && printf '%d' $! > "$pidpath"
     fi
@@ -140,7 +140,7 @@ eval set -- "$args"
 while true; do
     case $1 in
         -v)
-            "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -cp $ES_CLASSPATH $props \
+            "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS "$es_parms" -cp "$ES_CLASSPATH" $props \
                     org.elasticsearch.Version
             exit 0
         ;;


### PR DESCRIPTION
The bash script does not currently escape the paths it passes to the Java executable. This causes unexpected results when the path contains special characters (e.g. whitespace). This patch quotes `$es_parms` and `$ES_CLASSPATH` to pass the paths properly.

For example, if the path to the directory where we've extracted elasticsearch is `/some path/leading to/elasticsearch`, we get an error like this (note how the path gets split up at the spaces):

```
Exception in thread "main" java.lang.NoClassDefFoundError: path/leading
Caused by: java.lang.ClassNotFoundException: path.leading
    at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
Could not find the main class: path/leading.  Program will exit.
```
