### PR TITLE
Query DSL: custom_filters_score allow score_mode ... closes #1560

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/CustomFiltersScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CustomFiltersScoreQueryParser.java
@@ -120,8 +120,12 @@ public class CustomFiltersScoreQueryParser implements QueryParser {
                         scoreMode = FiltersFunctionScoreQuery.ScoreMode.Avg;
                     } else if ("max".equals(sScoreMode)) {
                         scoreMode = FiltersFunctionScoreQuery.ScoreMode.Max;
+                    } else if ("min".equals(sScoreMode)) {
+                        scoreMode = FiltersFunctionScoreQuery.ScoreMode.Min;
                     } else if ("total".equals(sScoreMode)) {
                         scoreMode = FiltersFunctionScoreQuery.ScoreMode.Total;
+                    } else if ("multiply".equals(sScoreMode)) {
+                        scoreMode = FiltersFunctionScoreQuery.ScoreMode.Multiply;
                     } else if ("first".equals(sScoreMode)) {
                         scoreMode = FiltersFunctionScoreQuery.ScoreMode.First;
                     } else {


### PR DESCRIPTION
Added both "min" and "multiply" modes
