### PR TITLE
Fix failed test ClusterAndIndexReaderOnlyTests

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -54,7 +54,7 @@ public class MetaData implements Iterable<IndexMetaData> {
     public static final ClusterBlock CLUSTER_READ_ONLY_BLOCK = new ClusterBlock(6, "cluster read-only (api)", false, false, ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA);
 
     private static ImmutableSet<String> dynamicSettings = ImmutableSet.<String>builder()
-            .add("cluster.read_only")
+            .add(SETTING_READ_ONLY)
             .build();
 
     public static ImmutableSet<String> dynamicSettings() {


### PR DESCRIPTION
The fix passes all tests in test suite, except QuorumLocalGatewayTests and BlobStoreSmallBufferSizeFsIndexGatewayTests, which should be unrelated.

Please review the code.
