### PR TITLE
No need for plenty of RAM for plugin utility

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -28,4 +28,4 @@ else
     JAVA=`which java`
 fi
 
-exec $JAVA -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*
+exec $JAVA -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*

--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -8,7 +8,7 @@ set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
 
-"%JAVA_HOME%\bin\java" -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*" "org.elasticsearch.plugins.PluginManager" %*
+"%JAVA_HOME%\bin\java" -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*" "org.elasticsearch.plugins.PluginManager" %*
 goto finally
 
 


### PR DESCRIPTION
RAM is often already taken by the elasticsearch service running beside so maybe this could be helpfull limiting its usage for the little plugin utility (usefull for puppet rules for example)

Avoiding :
Error occurred during initialization of VM
Could not reserve enough space for object heap
Could not create the Java virtual machine.
