### PR TITLE
Change plugin.bat classpath to use ext.dirs

### DIFF
--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -7,10 +7,9 @@ if NOT DEFINED JAVA_HOME goto err
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
-
-"%JAVA_HOME%\bin\java" -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*" "org.elasticsearch.plugins.PluginManager" %*
+set EXT_DIR=%ES_HOME%\lib;%JAVA_HOME%\lib;%JAVA_HOME%\lib\ext;%JAVA_HOME%\jre\lib\ext
+"%JAVA_HOME%\bin\java" -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -Djava.ext.dirs="%EXT_DIR%" "org.elasticsearch.plugins.PluginManager" %*
 goto finally
-
 
 :err
 echo JAVA_HOME environment variable must be set!


### PR DESCRIPTION
The wildcarded classpath does not seem to work on Windows.  Changing
to setting the ext dirs to the lib folder does.

Fix for issue #1660
