### PR TITLE
A content decompressor that throws a human readable message when compression is disabled and the user sends compressed content

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/ESHttpContentDecompressor.java
+++ b/src/main/java/org/elasticsearch/http/netty/ESHttpContentDecompressor.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.http.netty;
+
+import org.elasticsearch.transport.TransportException;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.embedder.DecoderEmbedder;
+import org.jboss.netty.handler.codec.http.HttpContentDecompressor;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+
+public class ESHttpContentDecompressor extends HttpContentDecompressor {
+	private final boolean compression;
+	
+	public ESHttpContentDecompressor(boolean compression) {
+		super();
+		this.compression = compression;
+	}
+
+	@Override
+	protected DecoderEmbedder<ChannelBuffer> newContentDecoder(
+			String contentEncoding) throws Exception {
+		if (compression) {
+			return super.newContentDecoder(contentEncoding);
+		} else {
+			if (HttpHeaders.Values.IDENTITY.equals(contentEncoding)) {
+				return null;
+			} else {
+				throw new TransportException("Support for compressed content is disabled. You can enable it with http.compression=true");
+			}
+		}
+	}
+}

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -300,9 +300,7 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
                     (int) transport.maxHeaderSize.bytes(),
                     (int) transport.maxChunkSize.bytes()
             ));
-            if (transport.compression) {
-                pipeline.addLast("decoder_compress", new HttpContentDecompressor());
-            }
+            pipeline.addLast("decoder_compress", new ESHttpContentDecompressor(transport.compression));
             pipeline.addLast("aggregator", new HttpChunkAggregator((int) transport.maxContentLength.bytes()));
             pipeline.addLast("encoder", new HttpResponseEncoder());
             if (transport.compression) {


### PR DESCRIPTION
Currently the user gets an obscure error message about content that cannot be decoded because ES handles the compressed content as uncompressed content.
I personally think that we should not care about broken clients and respond to requests according to the HTTP specs.
Compression is very useful when you use the bulk-API btw....
