### PR TITLE
0.18 - use class-context class loader 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle/
 elasticsearch.iws
+elasticsearch.iml
 .idea/workspace.xml
 work/
 /data/

--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/Classes.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/Classes.java
@@ -46,18 +46,7 @@ public class Classes {
      * @see java.lang.Thread#getContextClassLoader()
      */
     public static ClassLoader getDefaultClassLoader() {
-        ClassLoader cl = null;
-        try {
-            cl = Thread.currentThread().getContextClassLoader();
-        }
-        catch (Throwable ex) {
-            // Cannot access thread context ClassLoader - falling back to system class loader...
-        }
-        if (cl == null) {
-            // No thread context class loader -> use class loader of this class.
-            cl = Classes.class.getClassLoader();
-        }
-        return cl;
+        return Classes.class.getClassLoader();
     }
 
     /**


### PR DESCRIPTION
I updated the default class loader logic found in Classes to use the class-context class loader, rather than the thread context.  The reason for this change is that when using elasticsearch api within an osgi container, I get exceptions similar to those found in the gist https://gist.github.com/1805733.
