### PR TITLE
Corrected erroneous stem filter (loads the Spanish, not the Swedish ligh...

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
@@ -43,6 +43,7 @@ import org.apache.lucene.analysis.pt.PortugueseMinimalStemFilter;
 import org.apache.lucene.analysis.pt.PortugueseStemFilter;
 import org.apache.lucene.analysis.ru.RussianLightStemFilter;
 import org.apache.lucene.analysis.snowball.SnowballFilter;
+import org.apache.lucene.analysis.sv.SwedishLightStemFilter;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
@@ -152,7 +153,7 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
         } else if ("light_spanish".equalsIgnoreCase(language) || "lightSpanish".equalsIgnoreCase(language)) {
             return new SpanishLightStemFilter(tokenStream);
         } else if ("light_swedish".equalsIgnoreCase(language) || "lightSwedish".equalsIgnoreCase(language)) {
-            return new SpanishLightStemFilter(tokenStream);
+            return new SwedishLightStemFilter(tokenStream);
         } else if ("greek".equalsIgnoreCase(language)) {
             return new GreekStemFilter(tokenStream);
         }


### PR DESCRIPTION
...t stemmer):

} else if ("light_swedish".equalsIgnoreCase(language) || "lightSwedish".equalsIgnoreCase(language)) {
            return new SpanishLightStemFilter(tokenStream);
}
to "return new SwedishLightStemFilter(tokenStream);"
