### PR TITLE
Backport for 0.18: Fix for XContentMapConverter with nulls in arrays

### DIFF
--- a/modules/elasticsearch/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapConverter.java
+++ b/modules/elasticsearch/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapConverter.java
@@ -133,7 +133,11 @@ public class XContentMapConverter {
     private static void writeIterable(XContentGenerator gen, Iterable iterable) throws IOException {
         gen.writeStartArray();
         for (Object value : iterable) {
-            writeValue(gen, value);
+	    if (value == null) {
+		gen.writeNull();
+	    } else {
+		writeValue(gen, value);
+	    }
         }
         gen.writeEndArray();
     }

--- a/modules/elasticsearch/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/modules/elasticsearch/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentGenerator;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.testng.annotations.Test;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.*;
 import static org.hamcrest.MatcherAssert.*;
@@ -66,6 +68,17 @@ public class XContentBuilderTests {
         builder = XContentFactory.contentBuilder(XContentType.JSON);
         builder.startObject().field("test", "value").endObject();
         assertThat(builder.string(), equalTo("{\"test\":\"value\"}"));
+    }
+
+    @Test
+    public void testMapArraysWithNull() throws Exception {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        HashMap m = new HashMap();
+        ArrayList li = new ArrayList();
+        li.add(null);
+        m.put("map", li);
+        builder.startObject().field("test", m).endObject();
+        assertThat(builder.string(), equalTo("{\"test\":{\"map\":[null]}}"));
     }
 
     @Test public void testOverloadedList() throws Exception {


### PR DESCRIPTION
(sorry fluffed that last one!)
