### PR TITLE
Add Maven javadoc jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,19 @@
                 </configuration>
             </plugin>
             <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.1.2</version>


### PR DESCRIPTION
As seen here : https://groups.google.com/forum/?hl=fr&fromgroups#!topic/elasticsearch/m0RjOrnwUB0

We can add javadoc to be deployed as a jar in maven repositories.

HTH
David.
