### PR TITLE
Add mean ordering for terms stats

### DIFF
--- a/src/main/java/org/elasticsearch/search/facet/termsstats/TermsStatsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/TermsStatsFacet.java
@@ -143,6 +143,9 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
             }
         }),
 
+        /**
+         * Order by the (higher) total of each term.
+         */
         TOTAL((byte) 4, new Comparator<Entry>() {
             @Override
             public int compare(Entry o1, Entry o2) {
@@ -156,16 +159,17 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                 if (o2 == null) {
                     return -1;
                 }
-                if (o2.total() < o1.total()) {
-                    return -1;
-                } else if (o2.total() == o1.total()) {
-                    return COUNT.comparator().compare(o1, o2);
-                } else {
-                    return 1;
+                int i = -Double.compare(o1.total(), o2.total());
+                if (i == 0) {
+                    i = COUNT.comparator().compare(o1, o2);
                 }
+                return i;
             }
         }),
 
+        /**
+         * Order by the (lower) total of each term.
+         */
         REVERSE_TOTAL((byte) 5, new Comparator<Entry>() {
             @Override
             public int compare(Entry o1, Entry o2) {
@@ -183,6 +187,9 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
             }
         }),
 
+        /**
+         * Order by the (lower) min of each term.
+         */
         MIN((byte) 6, new Comparator<Entry>() {
             @Override
             public int compare(Entry o1, Entry o2) {
@@ -196,15 +203,16 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                 if (o2 == null) {
                     return -1;
                 }
-                if (o1.min() < o2.min()) {
-                    return -1;
-                } else if (o1.min() == o2.min()) {
-                    return COUNT.comparator().compare(o1, o2);
-                } else {
-                    return 1;
+                int i = Double.compare(o1.min(), o2.min());
+                if (i == 0) {
+                    i = COUNT.comparator().compare(o1, o2);
                 }
+                return i;
             }
         }),
+        /**
+         * Order by the (higher) min of each term.
+         */
         REVERSE_MIN((byte) 7, new Comparator<Entry>() {
             @Override
             public int compare(Entry o1, Entry o2) {
@@ -221,6 +229,9 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                 return -MIN.comparator().compare(o1, o2);
             }
         }),
+        /**
+         * Order by the (higher) max of each term.
+         */
         MAX((byte) 8, new Comparator<Entry>() {
             @Override
             public int compare(Entry o1, Entry o2) {
@@ -234,15 +245,16 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                 if (o2 == null) {
                     return -1;
                 }
-                if (o2.max() < o1.max()) {
-                    return -1;
-                } else if (o1.max() == o2.max()) {
-                    return COUNT.comparator().compare(o1, o2);
-                } else {
-                    return 1;
+                int i =  -Double.compare(o1.max(), o2.max());
+                if (i == 0) {
+                    i = COUNT.comparator().compare(o1, o2);
                 }
+                return i;
             }
         }),
+        /**
+         * Order by the (lower) max of each term.
+         */
         REVERSE_MAX((byte) 9, new Comparator<Entry>() {
             @Override
             public int compare(Entry o1, Entry o2) {
@@ -257,6 +269,48 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                     return -1;
                 }
                 return -MAX.comparator().compare(o1, o2);
+            }
+        }),
+        /**
+         * Order by the (higher) mean of each term.
+         */
+        MEAN((byte) 10, new Comparator<Entry>() {
+            @Override
+            public int compare(Entry o1, Entry o2) {
+                // push nulls to the end
+                if (o1 == null) {
+                    if (o2 == null) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                if (o2 == null) {
+                    return -1;
+                }
+                int i =  -Double.compare(o1.mean(), o2.mean());
+                if (i == 0) {
+                    i = COUNT.comparator().compare(o1, o2);
+                }
+                return i;
+            }
+        }),
+        /**
+         * Order by the (lower) mean of each term.
+         */
+        REVERSE_MEAN((byte) 11, new Comparator<Entry>() {
+            @Override
+            public int compare(Entry o1, Entry o2) {
+                // push nulls to the end
+                if (o1 == null) {
+                    if (o2 == null) {
+                        return 0;
+                    }
+                    return 1;
+                }
+                if (o2 == null) {
+                    return -1;
+                }
+                return -MEAN.comparator().compare(o1, o2);
             }
         }),;
 
@@ -298,6 +352,10 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                 return MAX;
             } else if (id == REVERSE_MAX.id()) {
                 return REVERSE_MAX;
+            } else if (id == MEAN.id()) {
+                return MEAN;
+            } else if (id == REVERSE_MEAN.id()) {
+                return  REVERSE_MEAN;
             }
             throw new ElasticSearchIllegalArgumentException("No type argument match for terms facet comparator [" + id + "]");
         }
@@ -323,6 +381,10 @@ public interface TermsStatsFacet extends Facet, Iterable<TermsStatsFacet.Entry> 
                 return MAX;
             } else if ("reverse_max".equals(type) || "reverseMax".equals(type)) {
                 return REVERSE_MAX;
+            } else if ("mean".equals(type)) {
+                return MEAN;
+            } else if ("reverse_mean".equals(type) || "reverseMean".equals(type)) {
+                return REVERSE_MEAN;
             }
             throw new ElasticSearchIllegalArgumentException("No type argument match for terms stats facet comparator [" + type + "]");
         }


### PR DESCRIPTION
Added mean and reverse_mean order options to terms stats.  Also made
ordering based on double values more robust by using Double.compare().
