### PR TITLE
add extended validation information

### DIFF
--- a/src/main/java/org/apache/lucene/search/PublicTermsFilter.java
+++ b/src/main/java/org/apache/lucene/search/PublicTermsFilter.java
@@ -93,4 +93,17 @@ public class PublicTermsFilter extends Filter {
         }
         return result;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for(Term term: terms) {
+            if(builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(term);
+        }
+        return builder.toString();
+    }
+
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java
@@ -19,57 +19,87 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
-import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
 
 import java.io.IOException;
 
 /**
- * Internal validate response of a shard validate request executed directly against a specific shard.
- *
  *
  */
-class ShardValidateQueryResponse extends BroadcastShardOperationResponse {
+public class QueryExplanation  implements Streamable {
 
+    private String index;
+    
     private boolean valid;
     
     private String explanation;
-
-    private String error;
     
-    ShardValidateQueryResponse() {
+    private String error;
 
+    QueryExplanation() {
+        
     }
-
-    public ShardValidateQueryResponse(String index, int shardId, boolean valid, String explanation, String error) {
-        super(index, shardId);
+    
+    public QueryExplanation(String index, boolean valid, String explanation, String error) {
+        this.index = index;
         this.valid = valid;
         this.explanation = explanation;
         this.error = error;
     }
 
+    public String index() {
+        return this.index;
+    }
+
+    public String getIndex() {
+        return index();
+    }
+
     public boolean valid() {
         return this.valid;
     }
-    
-    public String explanation() {
-        return explanation;
+
+    public boolean getValid() {
+        return valid();
     }
-    
+
     public String error() {
-        return error;
+        return this.error;
+    }
+
+    public String getError() {
+        return error();
+    }
+
+    public String explanation() {
+        return this.explanation;
+    }
+
+    public String getExplanation() {
+        return explanation();
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+        index = in.readUTF();
         valid = in.readBoolean();
+        explanation = in.readOptionalUTF();
+        error = in.readOptionalUTF();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+        out.writeUTF(index);
         out.writeBoolean(valid);
+        out.writeOptionalUTF(explanation);
+        out.writeOptionalUTF(error);
+    }
+
+    public static QueryExplanation readQueryExplanation(StreamInput in)  throws IOException {
+        QueryExplanation exp = new QueryExplanation();
+        exp.readFrom(in);
+        return exp;
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -36,6 +36,8 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
     private BytesHolder querySource;
 
     private String[] types = Strings.EMPTY_ARRAY;
+    
+    private boolean explain;
 
     @Nullable
     private String[] filteringAliases;
@@ -48,6 +50,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         super(index, shardId);
         this.querySource = request.querySource();
         this.types = request.types();
+        this.explain = request.explain();
         this.filteringAliases = filteringAliases;
     }
 
@@ -57,6 +60,10 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
 
     public String[] types() {
         return this.types;
+    }
+    
+    public boolean explain() {
+        return this.explain;
     }
 
     public String[] filteringAliases() {
@@ -82,6 +89,8 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
                 filteringAliases[i] = in.readUTF();
             }
         }
+
+        explain = in.readBoolean();
     }
 
     @Override
@@ -101,5 +110,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         } else {
             out.writeVInt(0);
         }
+
+        out.writeBoolean(explain);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -55,6 +55,8 @@ public class ValidateQueryRequest extends BroadcastOperationRequest {
     private int querySourceOffset;
     private int querySourceLength;
     private boolean querySourceUnsafe;
+    
+    private boolean explain;
 
     private String[] types = Strings.EMPTY_ARRAY;
 
@@ -205,6 +207,20 @@ public class ValidateQueryRequest extends BroadcastOperationRequest {
         return this;
     }
 
+    /**
+     * Indicate if detailed information about query is requested
+     */
+    public void explain(boolean explain) {
+        this.explain = explain;
+    }
+
+    /**
+     * Indicates if detailed information about query is requested
+     */
+    public boolean explain() {
+        return explain;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -222,6 +238,9 @@ public class ValidateQueryRequest extends BroadcastOperationRequest {
                 types[i] = in.readUTF();
             }
         }
+
+        explain = in.readBoolean();
+        
     }
 
     @Override
@@ -234,10 +253,12 @@ public class ValidateQueryRequest extends BroadcastOperationRequest {
         for (String type : types) {
             out.writeUTF(type);
         }
+        
+        out.writeBoolean(explain);
     }
 
     @Override
     public String toString() {
-        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", querySource[" + Unicode.fromBytes(querySource, querySourceOffset, querySourceLength) + "]";
+        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", querySource[" + Unicode.fromBytes(querySource, querySourceOffset, querySourceLength) + "], explain:" + explain;
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
@@ -51,6 +51,16 @@ public class ValidateQueryRequestBuilder extends BaseIndicesRequestBuilder<Valid
     }
 
     /**
+     * Indicates if detailed information about the query should be returned.
+     *
+     * @see org.elasticsearch.index.query.QueryBuilders
+     */
+    public ValidateQueryRequestBuilder setExplain(boolean explain) {
+        request.explain(explain);
+        return this;
+    }
+
+    /**
      * Controls the operation threading model.
      */
     public ValidateQueryRequestBuilder setOperationThreading(BroadcastOperationThreading operationThreading) {

--- a/src/main/java/org/elasticsearch/common/lucene/search/AndFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/AndFilter.java
@@ -87,6 +87,19 @@ public class AndFilter extends Filter {
         return equalFilters(filters, other.filters);
     }
 
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for(Filter filter: filters) {
+            if(builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append('+');
+            builder.append(filter);
+        }
+        return builder.toString();
+    }
+
     private boolean equalFilters(List<? extends Filter> filters1, List<? extends Filter> filters2) {
         return (filters1 == filters2) || ((filters1 != null) && filters1.equals(filters2));
     }

--- a/src/main/java/org/elasticsearch/common/lucene/search/NotFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/NotFilter.java
@@ -66,6 +66,11 @@ public class NotFilter extends Filter {
     }
 
     @Override
+    public String toString() {
+        return "NotFilter(" + filter + ")";
+    }
+
+    @Override
     public int hashCode() {
         return filter != null ? filter.hashCode() : 0;
     }

--- a/src/main/java/org/elasticsearch/common/lucene/search/OrFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/OrFilter.java
@@ -93,6 +93,18 @@ public class OrFilter extends Filter {
         return equalFilters(filters, other.filters);
     }
 
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for(Filter filter: filters) {
+            if(builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(filter);
+        }
+        return builder.toString();
+    }
+
     private boolean equalFilters(List<? extends Filter> filters1, List<? extends Filter> filters2) {
         return (filters1 == filters2) || ((filters1 != null) && filters1.equals(filters2));
     }

--- a/src/main/java/org/elasticsearch/index/search/UidFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/UidFilter.java
@@ -33,10 +33,7 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 public class UidFilter extends Filter {
 
@@ -93,6 +90,11 @@ public class UidFilter extends Filter {
         if (o == null || getClass() != o.getClass()) return false;
         UidFilter uidFilter = (UidFilter) o;
         return !uids.equals(uidFilter.uids);
+    }
+
+    @Override
+    public String toString() {
+        return "UidFilter(" + uids + ")";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceFilter.java
@@ -138,6 +138,11 @@ public class GeoDistanceFilter extends Filter {
     }
 
     @Override
+    public String toString() {
+        return "GeoDistanceFilter(" + fieldName + ", "  + geoDistance + ", "  + distance + ", " + lat + ", " + lon + ")";
+    }
+
+    @Override
     public int hashCode() {
         int result;
         long temp;

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeFilter.java
@@ -152,6 +152,11 @@ public class GeoDistanceRangeFilter extends Filter {
     }
 
     @Override
+    public String toString() {
+        return "GeoDistanceRangeFilter(" + fieldName + ", "  + geoDistance + ", ["  + inclusiveLowerPoint + " - " + inclusiveUpperPoint + "], " + lat + ", " + lon + ")";
+    }
+
+    @Override
     public int hashCode() {
         int result;
         long temp;

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldData;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldDataType;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  *
@@ -58,6 +59,11 @@ public class GeoPolygonFilter extends Filter {
     public DocIdSet getDocIdSet(IndexReader reader) throws IOException {
         final GeoPointFieldData fieldData = (GeoPointFieldData) fieldDataCache.cache(GeoPointFieldDataType.TYPE, reader, fieldName);
         return new GeoPolygonDocSet(reader.maxDoc(), fieldData, points);
+    }
+
+    @Override
+    public String toString() {
+        return "GeoPolygonFilter(" + fieldName + ", "  + Arrays.toString(points) + ")";
     }
 
     public static class GeoPolygonDocSet extends GetDocSet {

--- a/src/main/java/org/elasticsearch/index/search/geo/InMemoryGeoBoundingBoxFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/InMemoryGeoBoundingBoxFilter.java
@@ -73,6 +73,11 @@ public class InMemoryGeoBoundingBoxFilter extends Filter {
         }
     }
 
+    @Override
+    public String toString() {
+        return "GeoBoundingBoxFilter(" + fieldName + ", "  + topLeft + ", " + bottomRight + ")";
+    }
+
     public static class Meridian180GeoBoundingBoxDocSet extends GetDocSet {
         private final GeoPointFieldData fieldData;
         private final Point topLeft;

--- a/src/test/java/org/elasticsearch/test/integration/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/validate/SimpleValidateQueryTests.java
@@ -19,11 +19,17 @@
 
 package org.elasticsearch.test.integration.validate;
 
+import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.search.geo.GeoDistance;
 import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.hamcrest.Matcher;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -81,4 +87,107 @@ public class SimpleValidateQueryTests extends AbstractNodesTests {
 
             assertThat(client.admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("foo:1 AND")).execute().actionGet().valid(), equalTo(false));
         }
+
+    @Test
+    public void explainValidateQuery() throws Exception {
+        client.admin().indices().prepareDelete().execute().actionGet();
+
+        client.admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).execute().actionGet();
+        client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        client.admin().indices().preparePutMapping("test").setType("type1")
+                .setSource(XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
+                        .startObject("foo").field("type", "string").endObject()
+                        .startObject("bar").field("type", "integer").endObject()
+                        .startObject("baz").field("type", "string").field("analyzer", "snowball").endObject()
+                        .startObject("pin").startObject("properties").startObject("location").field("type", "geo_point").endObject().endObject().endObject()
+                        .endObject().endObject().endObject())
+                .execute().actionGet();
+
+        client.admin().indices().prepareRefresh().execute().actionGet();
+
+
+        ValidateQueryResponse response;
+        response = client.admin().indices().prepareValidateQuery("test")
+                .setQuery("foo".getBytes())
+                .setExplain(true)
+                .execute().actionGet();
+        assertThat(response.valid(), equalTo(false));
+        assertThat(response.queryExplanations().size(), equalTo(1));
+        assertThat(response.queryExplanations().get(0).error(), containsString("Failed to parse"));
+        assertThat(response.queryExplanations().get(0).explanation(), nullValue());
+
+        assertExplanation(QueryBuilders.queryString("_id:1"), equalTo("ConstantScore(UidFilter([_uid:type1#1]))"));
+
+        assertExplanation(QueryBuilders.idsQuery("type1").addIds("1").addIds("2"),
+                equalTo("ConstantScore(UidFilter([_uid:type1#1, _uid:type1#2]))"));
+
+        assertExplanation(QueryBuilders.queryString("foo"), equalTo("_all:foo"));
+
+        assertExplanation(QueryBuilders.filteredQuery(
+                QueryBuilders.termQuery("foo", "1"),
+                FilterBuilders.orFilter(
+                        FilterBuilders.termFilter("bar", "2"),
+                        FilterBuilders.termFilter("baz", "3")
+                )
+        ), equalTo("filtered(foo:1)->cache(bar:[2 TO 2]) cache(baz:3)"));
+
+        assertExplanation(QueryBuilders.filteredQuery(
+                QueryBuilders.termQuery("foo", "1"),
+                FilterBuilders.orFilter(
+                        FilterBuilders.termFilter("bar", "2")
+                )
+        ), equalTo("filtered(foo:1)->cache(bar:[2 TO 2])"));
+
+        assertExplanation(QueryBuilders.filteredQuery(
+                QueryBuilders.matchAllQuery(),
+                FilterBuilders.geoPolygonFilter("pin.location")
+                        .addPoint(40, -70)
+                        .addPoint(30, -80)
+                        .addPoint(20, -90)
+        ), equalTo("ConstantScore(NotDeleted(GeoPolygonFilter(pin.location, [[40.0, -70.0], [30.0, -80.0], [20.0, -90.0]])))"));
+
+        assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.geoBoundingBoxFilter("pin.location")
+                .topLeft(40, -80)
+                .bottomRight(20, -70)
+        ), equalTo("ConstantScore(NotDeleted(GeoBoundingBoxFilter(pin.location, [40.0, -80.0], [20.0, -70.0])))"));
+
+        assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.geoDistanceFilter("pin.location")
+                .lat(10).lon(20).distance(15, DistanceUnit.MILES).geoDistance(GeoDistance.PLANE)
+        ), equalTo("ConstantScore(NotDeleted(GeoDistanceFilter(pin.location, PLANE, 15.0, 10.0, 20.0)))"));
+
+        assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.geoDistanceFilter("pin.location")
+                .lat(10).lon(20).distance(15, DistanceUnit.MILES).geoDistance(GeoDistance.PLANE)
+        ), equalTo("ConstantScore(NotDeleted(GeoDistanceFilter(pin.location, PLANE, 15.0, 10.0, 20.0)))"));
+
+        assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.geoDistanceRangeFilter("pin.location")
+                .lat(10).lon(20).from("15miles").to("25miles").geoDistance(GeoDistance.PLANE)
+        ), equalTo("ConstantScore(NotDeleted(GeoDistanceRangeFilter(pin.location, PLANE, [15.0 - 25.0], 10.0, 20.0)))"));
+
+        assertExplanation(QueryBuilders.filteredQuery(
+                QueryBuilders.termQuery("foo", "1"),
+                FilterBuilders.andFilter(
+                        FilterBuilders.termFilter("bar", "2"),
+                        FilterBuilders.termFilter("baz", "3")
+                )
+        ), equalTo("filtered(foo:1)->+cache(bar:[2 TO 2]) +cache(baz:3)"));
+
+        assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.termsFilter("foo", "1", "2", "3")),
+                equalTo("ConstantScore(NotDeleted(cache(foo:1 foo:2 foo:3)))"));
+
+        assertExplanation(QueryBuilders.constantScoreQuery(FilterBuilders.notFilter(FilterBuilders.termFilter("foo", "bar"))),
+                equalTo("ConstantScore(NotDeleted(NotFilter(cache(foo:bar))))"));
+
+    }
+
+    private void assertExplanation(QueryBuilder queryBuilder, Matcher<String> matcher) {
+        ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
+                .setQuery(queryBuilder)
+                .setExplain(true)
+                .execute().actionGet();
+        assertThat(response.queryExplanations().size(), equalTo(1));
+        assertThat(response.queryExplanations().get(0).error(), nullValue());
+        assertThat(response.queryExplanations().get(0).explanation(), matcher);
+        assertThat(response.valid(), equalTo(true));
+    }
+
 }


### PR DESCRIPTION
This pull request is adding an extended validation information option to the _validate/query request. By adding **explain=true** to the URL it's now possible to get text of the error message if validation fails or translated query if validation succeeds. Such information is very useful when debugging queries that return unexpected results. 

Example of a valid query:

```
$ curl 'localhost:9200/twitter/_validate/query?pretty=true&explain=true' -d '{
  "query_string" : {
    "query" : "some query string here"
  }
}'
```

```
{
  "valid" : true,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "explanations" : [ {
    "index" : "twitter",
    "valid" : true,
    "explanation" : "_all:some _all:query _all:string _all:here"
  } ]
} 
```

Example if an invalid query

```
$ curl 'localhost:9200/twitter/_validate/query?pretty=true&explain=true' -d '{
  "query_string" : {
    "query" : "missing ("
  }
}'
```

```
{
  "valid" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "explanations" : [ {
    "index" : "twitter",
    "valid" : false,
    "error" : "org.elasticsearch.index.query.QueryParsingException: [twitter] Failed to parse query [missing (]; org.apache.lucene.queryParser.ParseException: Cannot parse 'missing (': Encountered \"<EOF>\" at line 1, column 9.\nWas expecting one of:\n    <NOT> ...\n    \"+\" ...\n    \"-\" ...\n    \"(\" ...\n    \"*\" ...\n    <QUOTED> ...\n    <TERM> ...\n    <PREFIXTERM> ...\n    <WILDTERM> ...\n    \"[\" ...\n    \"{\" ...\n    <NUMBER> ...\n    <TERM> ...\n    \"*\" ...\n    "
  } ]
}
```
