### PR TITLE
add plugin mechanism for handling source storage and retrieval - index level

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.analysis.AnalysisService;
+import org.elasticsearch.index.source.ExternalSourceProviderService;
 
 import java.io.IOException;
 import java.util.Map;
@@ -80,9 +81,12 @@ public interface Mapper extends ToXContent {
 
             private final ImmutableMap<String, TypeParser> typeParsers;
 
-            public ParserContext(AnalysisService analysisService, ImmutableMap<String, TypeParser> typeParsers) {
+            private final ExternalSourceProviderService externalSourceProviderService;
+
+            public ParserContext(AnalysisService analysisService, ImmutableMap<String, TypeParser> typeParsers, ExternalSourceProviderService externalSourceProviderService) {
                 this.analysisService = analysisService;
                 this.typeParsers = typeParsers;
+                this.externalSourceProviderService = externalSourceProviderService;
             }
 
             public AnalysisService analysisService() {
@@ -91,6 +95,10 @@ public interface Mapper extends ToXContent {
 
             public TypeParser typeParser(String type) {
                 return typeParsers.get(Strings.toUnderscoreCase(type));
+            }
+
+            public ExternalSourceProviderService sourceProviderService() {
+                return externalSourceProviderService;
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -48,6 +48,7 @@ import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.search.nested.NonNestedDocsFilter;
 import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.source.ExternalSourceProviderService;
 import org.elasticsearch.indices.InvalidTypeNameException;
 import org.elasticsearch.indices.TypeMissingException;
 
@@ -97,10 +98,11 @@ public class MapperService extends AbstractIndexComponent implements Iterable<Do
     private final SmartIndexNameSearchAnalyzer searchAnalyzer;
 
     @Inject
-    public MapperService(Index index, @IndexSettings Settings indexSettings, Environment environment, AnalysisService analysisService) {
+    public MapperService(Index index, @IndexSettings Settings indexSettings, Environment environment,
+                         AnalysisService analysisService, ExternalSourceProviderService externalSourceProviderService) {
         super(index, indexSettings);
         this.analysisService = analysisService;
-        this.documentParser = new DocumentMapperParser(index, indexSettings, analysisService);
+        this.documentParser = new DocumentMapperParser(index, indexSettings, analysisService, externalSourceProviderService);
         this.searchAnalyzer = new SmartIndexNameSearchAnalyzer(analysisService.defaultSearchAnalyzer());
 
         this.dynamic = componentSettings.getAsBoolean("dynamic", true);

--- a/src/main/java/org/elasticsearch/index/source/ExternalSourceProvider.java
+++ b/src/main/java/org/elasticsearch/index/source/ExternalSourceProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.source;
+
+import org.elasticsearch.common.BytesHolder;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public interface ExternalSourceProvider {
+
+    /**
+     * Name of the source provider
+     * @return name of the source provider
+     */
+    String name();
+
+    /**
+     * Dehydrates source
+     *
+     * Implementations of this method should remove everything from the source that is
+     * not necessary to restore the source later. If source can be restored based on type
+     * and id, this method should return emptyMap().
+     *
+     * @param type record type
+     * @param id record id
+     * @param source original source
+     * @param sourceOffset original source offset
+     * @param sourceLength original source length
+     * @return dehydrated source
+     * @throws IOException exception
+     */
+    BytesHolder dehydrateSource(String type, String id, byte[] source, int sourceOffset, int sourceLength) throws IOException;
+
+    /**
+     * Rehydrates source
+     *
+     * Implementations of this method should restore the source based on type, id and dehydrated
+     * source.
+     *
+     * @param type record type
+     * @param id record id
+     * @param source dehydrated source
+     * @param sourceOffset dehydrated source offset
+     * @param sourceLength dehydrated source length
+     * @return rehydrated source
+     */
+    BytesHolder rehydrateSource(String type, String id, byte[] source, int sourceOffset, int sourceLength);
+
+}

--- a/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderFactory.java
+++ b/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.source;
+
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ *
+ */
+public interface ExternalSourceProviderFactory {
+    ExternalSourceProvider create(String name, Settings settings);
+}

--- a/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderModule.java
+++ b/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderModule.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.source;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Scopes;
+import org.elasticsearch.common.inject.assistedinject.FactoryProvider;
+import org.elasticsearch.common.inject.multibindings.MapBinder;
+import org.elasticsearch.common.settings.NoClassSettingsException;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ *
+ */
+public class ExternalSourceProviderModule extends AbstractModule {
+
+    public static class ExternalSourceProviderBinderProcessor {
+
+        public void processSourceProviders(ExternalSourceProviderBindings externalSourceProviderBindings) {
+
+        }
+
+        public static class ExternalSourceProviderBindings {
+            private final Map<String, Class<? extends ExternalSourceProvider>> sourceProviders = Maps.newHashMap();
+
+            public ExternalSourceProviderBindings() {
+            }
+
+            public void processExternalSourceProvider(String name, Class<? extends ExternalSourceProvider> sourceProvider) {
+                sourceProviders.put(name, sourceProvider);
+            }
+        }
+    }
+
+    private final Settings settings;
+
+    private final LinkedList<ExternalSourceProviderBinderProcessor> processorExternals = Lists.newLinkedList();
+
+    public ExternalSourceProviderModule(Settings settings) {
+        this.settings = settings;
+        processorExternals.add(new DefaultProcessorExternal());
+    }
+
+    @Override
+    protected void configure() {
+        bind(ExternalSourceProviderService.class).asEagerSingleton();
+        MapBinder<String, ExternalSourceProviderFactory> providerBinder
+                = MapBinder.newMapBinder(binder(), String.class, ExternalSourceProviderFactory.class);
+
+        // initial default bindings
+        ExternalSourceProviderBinderProcessor.ExternalSourceProviderBindings externalSourceProviderBindings = new ExternalSourceProviderBinderProcessor.ExternalSourceProviderBindings();
+        for (ExternalSourceProviderBinderProcessor processorExternal : processorExternals) {
+            processorExternal.processSourceProviders(externalSourceProviderBindings);
+        }
+
+        Map<String, Settings> providersSettings = settings.getGroups(ExternalSourceProviderService.Defaults.SOURCE_PROVIDER_PREFIX);
+        for (Map.Entry<String, Settings> entry : providersSettings.entrySet()) {
+            String providerName = entry.getKey();
+            Settings providerSettings = entry.getValue();
+            Class<? extends ExternalSourceProvider> type = null;
+            try {
+                type = providerSettings.getAsClass("type", null, "org.elasticsearch.index.source.", "ExternalSourceProvider");
+            } catch (NoClassSettingsException e) {
+                // nothing found, see if its in bindings as a binding name
+                if (providerSettings.get("type") != null) {
+                    type = externalSourceProviderBindings.sourceProviders.get(Strings.toUnderscoreCase(providerSettings.get("type")));
+                    if (type == null) {
+                        type = externalSourceProviderBindings.sourceProviders.get(Strings.toCamelCase(providerSettings.get("type")));
+                    }
+                }
+            }
+            if (type == null) {
+                throw new IllegalArgumentException("External Source Provider [" + providerName + "] must be provided with a type");
+            }
+            providerBinder.addBinding(providerName).toProvider(FactoryProvider.newFactory(ExternalSourceProviderFactory.class, type)).in(Scopes.SINGLETON);
+        }
+
+        // go over the source providers in the bindings and register the ones that are not configured
+        for (Map.Entry<String, Class<? extends ExternalSourceProvider>> entry : externalSourceProviderBindings.sourceProviders.entrySet()) {
+            String providerName = entry.getKey();
+            Class<? extends ExternalSourceProvider> type = entry.getValue();
+            // we don't want to re-register one that already exists
+            if (providersSettings.containsKey(providerName)) {
+                continue;
+            }
+            // check, if it requires settings, then don't register it, we know default has no settings...
+            if (type.getAnnotation(ExternalSourceProviderSettingsRequired.class) != null) {
+                continue;
+            }
+            providerBinder.addBinding(providerName).toProvider(FactoryProvider.newFactory(ExternalSourceProviderFactory.class, type)).in(Scopes.SINGLETON);
+        }
+
+    }
+
+    public ExternalSourceProviderModule addProcessor(ExternalSourceProviderBinderProcessor processorExternal) {
+        processorExternals.addFirst(processorExternal);
+        return this;
+    }
+
+    private static class DefaultProcessorExternal extends ExternalSourceProviderBinderProcessor {
+
+        @Override public void processSourceProviders(ExternalSourceProviderBindings externalSourceProviderBindings) {
+              // No built-in providers for now
+              // externalSourceProviderBindings.processExternalSourceProvider("default", DefaultSourceFilterParser.class);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderService.java
+++ b/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderService.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.source;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.AbstractIndexComponent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+/**
+ *
+ */
+public class ExternalSourceProviderService extends AbstractIndexComponent {
+
+    public static class Defaults  {
+        public static final String SOURCE_PROVIDER_PREFIX = "index.source.provider";
+    }
+
+    private final Map<String, ExternalSourceProvider> externalSourceProviders;
+    
+    @Inject
+    public ExternalSourceProviderService(Index index, @IndexSettings Settings indexSettings,
+                                         @Nullable Map<String, ExternalSourceProviderFactory> externalSourceProviderFactories) {
+        super(index, indexSettings);
+
+        Map<String, ExternalSourceProvider> providerMap = newHashMap();
+        if (externalSourceProviderFactories != null) {
+            Map<String, Settings> providersSettings = indexSettings.getGroups(Defaults.SOURCE_PROVIDER_PREFIX);
+            for (Map.Entry<String, ExternalSourceProviderFactory> entry : externalSourceProviderFactories.entrySet()) {
+                String providerName = entry.getKey();
+                ExternalSourceProviderFactory externalSourceProviderFactory = entry.getValue();
+
+                Settings providerSettings = providersSettings.get(providerName);
+                if (providerSettings == null) {
+                    providerSettings = ImmutableSettings.Builder.EMPTY_SETTINGS;
+                }
+
+                ExternalSourceProvider provider = externalSourceProviderFactory.create(providerName, providerSettings);
+                providerMap.put(providerName, provider);
+                providerMap.put(Strings.toCamelCase(providerName), provider);
+            }
+        }
+        this.externalSourceProviders = ImmutableMap.copyOf(providerMap);
+    }
+
+    
+    public ExternalSourceProvider externalSourceProvider(String name) {
+        return externalSourceProviders.get(name);
+    }
+    
+}

--- a/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderSettingsRequired.java
+++ b/src/main/java/org/elasticsearch/index/source/ExternalSourceProviderSettingsRequired.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ *
+ */
+package org.elasticsearch.index.source;
+
+import java.lang.annotation.*;
+
+/**
+ * A marker annotation on {@link ExternalSourceProvider} which will cause the provider to only be created
+ * when explicit settings are provided.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ExternalSourceProviderSettingsRequired {
+}

--- a/src/main/java/org/elasticsearch/index/source/ParsingExternalSourceProvider.java
+++ b/src/main/java/org/elasticsearch/index/source/ParsingExternalSourceProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.source;
+
+import org.elasticsearch.common.BytesHolder;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.stream.CachedStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ *
+ */
+public abstract class ParsingExternalSourceProvider implements ExternalSourceProvider {
+    
+    private String name;
+
+    protected ParsingExternalSourceProvider(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public BytesHolder dehydrateSource(String type, String id, byte[] source, int sourceOffset, int sourceLength) throws IOException {
+        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(source, sourceOffset, sourceLength, true);
+        Map<String, Object> parsedSource = dehydrateSource(type, id, mapTuple.v2());
+        if(parsedSource != null) {
+            CachedStreamOutput.Entry cachedEntry = CachedStreamOutput.popEntry();
+            try {
+                StreamOutput streamOutput = cachedEntry.cachedBytes();
+                XContentBuilder builder = XContentFactory.contentBuilder(mapTuple.v1(), streamOutput).map(parsedSource);
+                builder.close();
+                return new BytesHolder(cachedEntry.bytes().copiedByteArray());
+            } finally {
+                CachedStreamOutput.pushEntry(cachedEntry);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    protected abstract Map<String, Object> dehydrateSource(String type, String id, Map<String, Object> source) throws IOException;
+
+}

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
@@ -62,6 +62,7 @@ import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.index.store.IndexStoreModule;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
@@ -280,6 +281,7 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
         modules.add(new IndexGatewayModule(indexSettings, injector.getInstance(Gateway.class)));
         modules.add(new IndexModule(indexSettings));
         modules.add(new PercolatorModule());
+        modules.add(new ExternalSourceProviderModule(indexSettings));
 
         Injector indexInjector;
         try {

--- a/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -89,10 +89,14 @@ public class InternalSearchHit implements SearchHit {
     }
 
     public InternalSearchHit(int docId, String id, String type, byte[] source, Map<String, SearchHitField> fields) {
+        this(docId, id, type, source == null ? null : new BytesHolder(source), fields);
+    }
+
+    public InternalSearchHit(int docId, String id, String type, BytesHolder source, Map<String, SearchHitField> fields) {
         this.docId = docId;
         this.id = id;
         this.type = type;
-        this.source = source == null ? null : new BytesHolder(source);
+        this.source = source;
         this.fields = fields;
     }
 

--- a/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
+++ b/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
@@ -40,7 +40,7 @@ public class SearchLookup {
 
     public SearchLookup(MapperService mapperService, FieldDataCache fieldDataCache) {
         docMap = new DocLookup(mapperService, fieldDataCache);
-        sourceLookup = new SourceLookup();
+        sourceLookup = new SourceLookup(mapperService);
         fieldsLookup = new FieldsLookup(mapperService);
         asMap = ImmutableMap.<String, Object>of("doc", docMap, "_doc", docMap, "_source", sourceLookup, "_fields", fieldsLookup);
     }

--- a/src/test/java/org/elasticsearch/test/integration/indices/source/CustomSourceMappingIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/source/CustomSourceMappingIntegrationTests.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.indices.source;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.elasticsearch.test.unit.index.mapper.source.TestExternalSourceProvider;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.client.Requests.createIndexRequest;
+import static org.elasticsearch.client.Requests.deleteIndexRequest;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.queryString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ *
+ */
+public class CustomSourceMappingIntegrationTests extends AbstractNodesTests {
+
+
+    protected Settings indexSettings(int numOfReplicas, int numOfShards) {
+        return settingsBuilder()
+                .put("index.number_of_replicas", numOfReplicas)
+                .put("index.number_of_shards", numOfShards)
+                .build();
+
+    }
+
+    protected void deleteIndex(String index) {
+        try {
+            client("node1").admin().indices().delete(deleteIndexRequest(index)).actionGet();
+        } catch (ElasticSearchException ex) {
+            // Ignore
+        }
+    }
+
+
+    protected void createIndex(String index, Settings indexSettings) throws IOException {
+
+        logger.info("Creating index test");
+        client("node1").admin().indices().create(createIndexRequest(index)
+                .settings(
+                        settingsBuilder()
+                                .put(indexSettings)
+                                .put("index.source.provider.test.type", TestExternalSourceProvider.class.getName())
+                )
+                .mapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("_source")
+                        .field("provider", "test")
+                        .endObject()
+                        .endObject().endObject().string())).actionGet();
+    }
+
+    @AfterMethod
+    public void closeNodes() {
+        closeAllNodes();
+    }
+
+    @Test
+    public void testSearchWithCustomSource() throws Exception {
+        startNode("node1");
+        deleteIndex("test");
+        createIndex("test", indexSettings(0, 1));
+
+        for (int i = 0; i < 10; i++) {
+            client("node1").prepareIndex("test", "type1", Integer.toString(i)).setSource(jsonBuilder().startObject()
+                    .field("value", "test" + i)
+                    .endObject()).execute().actionGet();
+        }
+
+        ClusterHealthResponse clusterHealth = client("node1").admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+        client("node1").admin().indices().prepareRefresh().execute().actionGet();
+
+        SearchResponse searchResponse = client("node1").prepareSearch().setQuery(matchAllQuery()).execute().actionGet();
+        SearchHits hits = searchResponse.hits();
+        assertThat(hits.totalHits(), equalTo(10l));
+        for (int i = 0; i < 10; i++) {
+            assertThat(hits.getAt(i).sourceAsString(), equalTo("--type1--" + hits.getAt(i).id() + "--{\"dehydrated\":true}--"));
+        }
+    }
+
+    @Test
+    public void testGetWithCustomSource() throws Exception {
+        startNode("node1");
+        deleteIndex("test");
+        createIndex("test", indexSettings(0, 1));
+
+        for (int i = 0; i < 10; i++) {
+            client("node1").prepareIndex("test", "type1", Integer.toString(i)).setSource(jsonBuilder().startObject()
+                    .field("value", "test" + i)
+                    .endObject()).execute().actionGet();
+        }
+
+        ClusterHealthResponse clusterHealth = client("node1").admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+        client("node1").admin().indices().prepareFlush().execute().actionGet();
+
+        for (int i = 0; i < 10; i++) {
+            GetResponse getResponse = client("node1").prepareGet("test", "type1", Integer.toString(i)).execute().actionGet();
+            assertThat(getResponse.sourceAsString(), equalTo("--type1--" + getResponse.id() + "--{\"dehydrated\":true}--"));
+        }
+    }
+
+    @Test
+    public void testReplication() throws Exception {
+        startNode("node1");
+        startNode("node2");
+        deleteIndex("test");
+        createIndex("test", indexSettings(1, 4));
+
+        client("node1").prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
+                .field("value", "test1")
+                .endObject()).execute().actionGet();
+
+        ClusterHealthResponse clusterHealth = client("node1").admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+        client("node1").admin().indices().prepareFlush().execute().actionGet();
+        for (int i = 0; i < 10; i++) {
+            GetResponse getResponse = client("node2").prepareGet("test", "type1", "1").execute().actionGet();
+            assertThat(getResponse.sourceAsString(), equalTo("--type1--1--{\"dehydrated\":true}--"));
+        }
+    }
+
+    @Test
+    public void testMappingSettings() throws Exception {
+        startNode("node1");
+        startNode("node2");
+        deleteIndex("test");
+        createIndex("test", indexSettings(1, 4));
+
+        ClusterStateResponse clusterStateResponse = client("node2").admin().cluster().prepareState()
+                .setFilterAll().setFilterIndices("test").setFilterMetaData(false)
+                .execute().actionGet();
+
+        MetaData metaData = clusterStateResponse.state().metaData();
+        MappingMetaData mappingMetaData = metaData.getIndices().get("test").getMappings().get("type1");
+        String mapping = mappingMetaData.source().string();
+        assertThat(mapping, containsString("\"provider\":\"test\""));
+
+    }
+
+    @Test
+    public void testIdBasedSourceProvider() throws Exception {
+        startNode("node1");
+        try {
+            client("node1").admin().indices().delete(deleteIndexRequest("test")).actionGet();
+        } catch (ElasticSearchException ex) {
+            // Ignore
+        }
+        logger.info("Creating index test");
+        client("node1").admin().indices().create(createIndexRequest("test")
+                .settings(
+                        settingsBuilder()
+                                .put("index.number_of_replicas", 0)
+                                .put("index.number_of_shards", 1)
+                                .put("index.source.provider.idbased.type", IdBasedExternalSourceProvider.class.getName())
+                                .put("index.source.provider.idbased.source_pattern", "{\"_id\":\"%2$s\", \"_type\":\"%1$s\", "
+                                        + "\"body\":\"This record has id %2$s and type %1$s\", \"generated\":true}")
+                )
+                .mapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("_source")
+                        .field("provider", "idbased")
+                        .endObject()
+                        .startObject("properties")
+
+                        .startObject("body")
+                        .field("type", "string")
+                        .field("store", "no")
+                        .endObject()
+
+                        .endObject()
+                        .endObject().endObject().string())).actionGet();
+
+        ClusterHealthResponse clusterHealth = client("node1").admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+
+        for (int i = 0; i < 10; i++) {
+            client("node1").prepareIndex("test", "type1", Integer.toString(i)).setSource(jsonBuilder().startObject()
+                    .field("_id", i)
+                    .field("body", "This record has id " + i + " and type type1")
+                    .endObject()).execute().actionGet();
+        }
+
+        // Test get before flush
+        GetResponse getResponse = client("node1").prepareGet("test", "type1", "1")
+                .setFields("body", "_source")
+                .setRealtime(true)
+                .execute().actionGet();
+        assertThat(getResponse.sourceAsString(), containsString("This record has id 1 and type type1"));
+        assertThat((String) getResponse.field("body").value(), equalTo("This record has id 1 and type type1"));
+
+        client("node1").admin().indices().prepareFlush().execute().actionGet();
+
+        SearchResponse searchResponse = client("node1").prepareSearch()
+                .setQuery(queryString("body:\"has id 3\""))
+                .addField("generated")
+                .addField("body")
+                .addHighlightedField("body", 100, 1)
+                .setHighlighterPreTags("!--")
+                .setHighlighterPostTags("--!")
+                .addScriptField("script_body", "'(' + _source.body + ')'")
+                .execute().actionGet();
+        SearchHits hits = searchResponse.hits();
+        // Check that body field was indexed
+        assertThat(hits.totalHits(), equalTo(1l));
+        // Check that generated sources is accessible
+        assertThat(hits.getAt(0).field("generated").<Boolean>value(), equalTo(true));
+        String[] fragments = hits.getAt(0).highlightFields().get("body").fragments();
+        assertThat(fragments.length, equalTo(1));
+        assertThat(fragments[0], containsString("!--has--! !--id--! !--3--!"));
+        assertThat(hits.getAt(0).field("script_body").<String>value(), equalTo("(This record has id 3 and type type1)"));
+
+        // Test get after flush
+        getResponse = client("node1").prepareGet("test", "type1", "2")
+                .setFields("body", "_source", "generated", "'[' + _source.body + ']'")
+                .execute().actionGet();
+        assertThat(getResponse.sourceAsString(), containsString("This record has id 2 and type type1"));
+        assertThat((String) getResponse.field("body").value(), equalTo("This record has id 2 and type type1"));
+        assertThat((String) getResponse.field("'[' + _source.body + ']'").value(), equalTo("[This record has id 2 and type type1]"));
+        assertThat((Boolean) getResponse.field("generated").value(), equalTo(true));
+    }
+
+    @Test
+    public void testTransformingSourceProvider() throws Exception {
+        startNode("node1");
+        try {
+            client("node1").admin().indices().delete(deleteIndexRequest("test")).actionGet();
+        } catch (ElasticSearchException ex) {
+            // Ignore
+        }
+        logger.info("Creating index test");
+        client("node1").admin().indices().create(createIndexRequest("test")
+                .settings(
+                        settingsBuilder()
+                                .put("index.number_of_replicas", 0)
+                                .put("index.number_of_shards", 1)
+                                .put("index.source.provider.transforming.type", TransformingExternalSourceProviderParser.class.getName())
+                )
+                .mapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type")
+                        .startObject("_source")
+                        .field("provider", "transforming")
+                        .endObject()
+                        .startObject("properties")
+
+                        .startObject("body")
+                        .field("type", "string")
+                        .field("store", "no")
+                        .endObject()
+
+                        .endObject()
+                        .endObject().endObject().string())).actionGet();
+
+        ClusterHealthResponse clusterHealth = client("node1").admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+
+        for (int i = 0; i < 10; i++) {
+            client("node1").prepareIndex("test", "type1", Integer.toString(i)).setSource(jsonBuilder().startObject()
+                    .field("_id", i)
+                    .field("body", "Content of a file file" + i + ".txt")
+                    .field("file", "file" + i + ".txt")
+                    .endObject()).execute().actionGet();
+        }
+
+        // Test get before flush
+        GetResponse getResponse = client("node1").prepareGet("test", "type1", "1")
+                .setFields("body", "_source")
+                .setRealtime(true)
+                .execute().actionGet();
+        assertThat(getResponse.sourceAsString(), containsString("Content of a file file1.txt"));
+        assertThat((String) getResponse.field("body").value(), equalTo("Content of a file file1.txt"));
+
+        client("node1").admin().indices().prepareFlush().execute().actionGet();
+
+        SearchResponse searchResponse = client("node1").prepareSearch()
+                .setQuery(queryString("body:\"file file3.txt\""))
+                .addField("generated")
+                .addHighlightedField("body", 100, 1)
+                .setHighlighterPreTags("!--")
+                .setHighlighterPostTags("--!")
+                .addScriptField("script_body", "'(' + _source.body + ')'")
+                .execute().actionGet();
+        SearchHits hits = searchResponse.hits();
+        // Check that body field was indexed
+        assertThat(hits.totalHits(), equalTo(1l));
+        // Check that generated sources is accessible
+        assertThat(hits.getAt(0).field("generated").<Boolean>value(), equalTo(true));
+        String[] fragments = hits.getAt(0).highlightFields().get("body").fragments();
+        assertThat(fragments.length, equalTo(1));
+        assertThat(fragments[0], containsString("!--file--! !--file3--!.!--txt--!"));
+        assertThat(hits.getAt(0).field("script_body").<String>value(), equalTo("(Content of a file file3.txt)"));
+
+        // Test get after flush
+        getResponse = client("node1").prepareGet("test", "type1", "2")
+                .setFields("body", "_source", "generated", "'[' + _source.body + ']'")
+                .execute().actionGet();
+        assertThat(getResponse.sourceAsString(), containsString("Content of a file file2.txt"));
+        assertThat((String) getResponse.field("body").value(), equalTo("Content of a file file2.txt"));
+        assertThat((String) getResponse.field("'[' + _source.body + ']'").value(), equalTo("[Content of a file file2.txt]"));
+        assertThat((Boolean) getResponse.field("generated").value(), equalTo(true));
+
+        // Test get after flush without requesting source
+        getResponse = client("node1").prepareGet("test", "type1", "2")
+                .setFields("body", "generated", "'[' + _source.body + ']'")
+                .execute().actionGet();
+        assertThat((String) getResponse.field("body").value(), equalTo("Content of a file file2.txt"));
+        assertThat((String) getResponse.field("'[' + _source.body + ']'").value(), equalTo("[Content of a file file2.txt]"));
+        assertThat((Boolean) getResponse.field("generated").value(), equalTo(true));
+
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/indices/source/IdBasedExternalSourceProvider.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/source/IdBasedExternalSourceProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.indices.source;
+
+import org.elasticsearch.common.BytesHolder;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.source.ParsingExternalSourceProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Emulates a source provider that can rehydrate source based on type and id
+ */
+public class IdBasedExternalSourceProvider extends ParsingExternalSourceProvider {
+
+    public static class Defaults {
+        public static String NAME = "idbased";
+        public static String SOURCE_PATTERN = "{\"_id\":\"%2$s\", \"_type\":\"%1$s\", \"body\":\"This record has id %2$s and type %1$s\"}";
+    }
+
+    private final String sourcePattern;
+
+    @Inject
+    public IdBasedExternalSourceProvider(@Assisted String name, @Assisted Settings settings) {
+        super(name);
+        this.sourcePattern = settings.get("source_pattern", Defaults.SOURCE_PATTERN);
+    }
+
+    @Override
+    public Map<String, Object> dehydrateSource(String type, String id, Map<String, Object> source) throws IOException {
+        return emptyMap();
+    }
+
+    @Override
+    public BytesHolder rehydrateSource(String type, String id, byte[] source, int sourceOffset, int sourceLength) {
+        byte[] buffer = String.format(sourcePattern, type, id).getBytes();
+        return new BytesHolder(buffer);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/indices/source/TransformingExternalSourceProviderParser.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/source/TransformingExternalSourceProviderParser.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.indices.source;
+
+import com.google.common.collect.Maps;
+import org.elasticsearch.common.BytesHolder;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.source.ParsingExternalSourceProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Emulates source provider that needs a content of a field in order to restore source
+ */
+public class TransformingExternalSourceProviderParser extends ParsingExternalSourceProvider {
+
+    public static class Defaults {
+        public static String NAME = "transform";
+        public static String SOURCE_PATTERN = "{\"_id\":\"%1$s\", \"_type\":\"%2$s\", \"body\":\"Content of a file %3$s\", " +
+                "\"file\":\"%3$s\", \"generated\":true}";
+        public static String PATH_FIELD = "file";
+    }
+
+    private final String sourcePattern;
+
+    private final String pathField;
+
+
+    @Inject
+    public TransformingExternalSourceProviderParser(@Assisted String name, @Assisted Settings settings) {
+        super(name);
+        this.sourcePattern = settings.get("source_pattern", Defaults.SOURCE_PATTERN);
+        this.pathField = settings.get("path_field", Defaults.PATH_FIELD);
+    }
+
+    @Override
+    public Map<String, Object> dehydrateSource(String type, String id, Map<String, Object> source) throws IOException {
+        Object pathFieldObject = source.get(pathField);
+        if (pathFieldObject != null && pathFieldObject instanceof String) {
+            // Replace path with just the portion that is needed to restore source in the future
+            Map<String, Object> dehydratedMap = Maps.newHashMap();
+            dehydratedMap.put(pathField, pathFieldObject);
+            return dehydratedMap;
+        } else {
+            // Path field is not found - don't store source at all
+            return emptyMap();
+        }
+    }
+
+    @Override
+    public BytesHolder rehydrateSource(String type, String id, byte[] source, int sourceOffset, int sourceLength) {
+        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(source, sourceOffset, sourceLength, true);
+        Map<String, Object> sourceMap = mapTuple.v2();
+        Object pathFieldObject = sourceMap.get(pathField);
+        if (pathFieldObject != null && pathFieldObject instanceof String) {
+            // Load source from the path
+            return loadFile(id, type, (String) pathFieldObject);
+        } else {
+            // Path field is not found - don't load source
+            return null;
+        }
+    }
+
+    private BytesHolder loadFile(String id, String type, String path) {
+        // Emulate loading source from the path
+        byte[] buffer = String.format(sourcePattern, id, type, path).getBytes();
+        return new BytesHolder(buffer);
+    }
+
+}
+

--- a/src/test/java/org/elasticsearch/test/unit/index/aliases/IndexAliasesServiceTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/aliases/IndexAliasesServiceTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.InvalidAliasNameException;
 import org.elasticsearch.script.ScriptModule;
 import org.testng.annotations.Test;
@@ -71,6 +72,7 @@ public class IndexAliasesServiceTests {
                 new SettingsModule(ImmutableSettings.Builder.EMPTY_SETTINGS),
                 new IndexEngineModule(ImmutableSettings.Builder.EMPTY_SETTINGS),
                 new IndexCacheModule(ImmutableSettings.Builder.EMPTY_SETTINGS),
+                new ExternalSourceProviderModule(ImmutableSettings.Builder.EMPTY_SETTINGS),
                 new AbstractModule() {
                     @Override
                     protected void configure() {

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/MapperTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/MapperTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.test.unit.index.mapper;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.EnvironmentModule;
@@ -32,6 +33,8 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.index.source.ExternalSourceProviderService;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.analysis.IndicesAnalysisModule;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 
@@ -41,20 +44,44 @@ import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 public class MapperTests {
 
     public static DocumentMapperParser newParser() {
-        return new DocumentMapperParser(new Index("test"), newAnalysisService());
+        return new DocumentMapperParser(new Index("test"), newAnalysisService(), newSourceProviderService());
+    }
+
+    public static DocumentMapperParser newParser(Settings indexSettings) {
+        return new DocumentMapperParser(new Index("test"), indexSettings, newAnalysisService(indexSettings), newSourceProviderService(indexSettings));
     }
 
     public static MapperService newMapperService() {
-        return new MapperService(new Index("test"), ImmutableSettings.Builder.EMPTY_SETTINGS, new Environment(), newAnalysisService());
+        return new MapperService(new Index("test"), ImmutableSettings.Builder.EMPTY_SETTINGS, new Environment(),
+                newAnalysisService(), newSourceProviderService());
     }
 
+
     public static AnalysisService newAnalysisService() {
+        return newAnalysisService(ImmutableSettings.Builder.EMPTY_SETTINGS);
+    }
+
+    public static AnalysisService newAnalysisService(Settings indexSettings) {
         Injector parentInjector = new ModulesBuilder().add(new SettingsModule(ImmutableSettings.Builder.EMPTY_SETTINGS), new EnvironmentModule(new Environment(ImmutableSettings.Builder.EMPTY_SETTINGS)), new IndicesAnalysisModule()).createInjector();
         Injector injector = new ModulesBuilder().add(
-                new IndexSettingsModule(new Index("test"), ImmutableSettings.Builder.EMPTY_SETTINGS),
+                new IndexSettingsModule(new Index("test"), indexSettings),
                 new IndexNameModule(new Index("test")),
-                new AnalysisModule(ImmutableSettings.Builder.EMPTY_SETTINGS, parentInjector.getInstance(IndicesAnalysisService.class))).createChildInjector(parentInjector);
+                new AnalysisModule(indexSettings, parentInjector.getInstance(IndicesAnalysisService.class))).createChildInjector(parentInjector);
 
         return injector.getInstance(AnalysisService.class);
+    }
+
+    public static ExternalSourceProviderService newSourceProviderService() {
+        return newSourceProviderService(ImmutableSettings.Builder.EMPTY_SETTINGS);
+    }
+
+    public static ExternalSourceProviderService newSourceProviderService(Settings indexSettings) {
+        Injector parentInjector = new ModulesBuilder().add(new SettingsModule(ImmutableSettings.Builder.EMPTY_SETTINGS), new EnvironmentModule(new Environment(ImmutableSettings.Builder.EMPTY_SETTINGS))).createInjector();
+        Injector injector = new ModulesBuilder().add(
+                new IndexSettingsModule(new Index("test"), indexSettings),
+                new IndexNameModule(new Index("test")),
+                new ExternalSourceProviderModule(indexSettings)).createChildInjector(parentInjector);
+
+        return injector.getInstance(ExternalSourceProviderService.class);
     }
 }

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/source/CustomSourceMappingTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/source/CustomSourceMappingTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.index.mapper.source;
+
+import org.apache.lucene.document.Document;
+import org.elasticsearch.common.BytesHolder;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.test.unit.index.mapper.MapperTests;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ *
+ */
+public class CustomSourceMappingTests {
+    
+    private Settings defaultSettings() {
+        return ImmutableSettings.settingsBuilder().put("index.source.provider.test.type", TestExternalSourceProvider.class.getName()).build();
+    }
+
+    @Test
+    public void testNoFormat() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_source")
+                .field("provider", "test")
+                .endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper documentMapper = MapperTests.newParser(defaultSettings()).parse(mapping);
+        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+                .field("field", "value")
+                .endObject().copiedBytes());
+        
+        assertThat(doc.docs().size(), equalTo(1));
+        Document document = doc.docs().get(0);
+        assertThat(new String(document.getBinaryValue("_source")), equalTo("{\"dehydrated\":true}"));
+        BytesHolder rehydratedSource = documentMapper.sourceMapper().extractSource("type", "1", document.getFieldable("_source"));
+        String rehydratedSourceString = new String(rehydratedSource.bytes(), rehydratedSource.offset(), rehydratedSource.length());
+        assertThat(rehydratedSourceString, equalTo("--type--1--{\"dehydrated\":true}--"));
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/source/TestExternalSourceProvider.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/source/TestExternalSourceProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.index.mapper.source;
+
+import org.elasticsearch.common.BytesHolder;
+import org.elasticsearch.common.io.stream.CachedStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.source.ExternalSourceProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+/**
+ *
+ */
+public class TestExternalSourceProvider implements ExternalSourceProvider {
+
+    @Override
+    public String name() {
+        return "test";
+    }
+
+    @Override
+    public BytesHolder dehydrateSource(String type, String id,  byte[] source, int sourceOffset, int sourceLength) throws IOException {
+        Map<String, Object> dehydratedSource = newHashMap();
+        dehydratedSource.put("dehydrated", true);
+        CachedStreamOutput.Entry cachedEntry = CachedStreamOutput.popEntry();
+        try {
+            StreamOutput streamOutput = cachedEntry.cachedBytes();
+            XContentBuilder builder = XContentFactory.jsonBuilder(streamOutput).map(dehydratedSource);
+            builder.close();
+            return new BytesHolder(cachedEntry.bytes().copiedByteArray());
+        } finally {
+            CachedStreamOutput.pushEntry(cachedEntry);
+        }
+    }
+
+    @Override public BytesHolder rehydrateSource(String type, String id, byte[] source, int sourceOffset, int sourceLength) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("--");
+        builder.append(type);
+        builder.append("--");
+        builder.append(id);
+        builder.append("--");
+        builder.append(new String(source, sourceOffset, sourceLength));
+        builder.append("--");
+        return new BytesHolder(builder.toString().getBytes());
+    }
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/percolator/PercolatorExecutorTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/percolator/PercolatorExecutorTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.threadpool.ThreadPoolModule;
@@ -76,6 +77,7 @@ public class PercolatorExecutorTests {
                 new SimilarityModule(settings),
                 new IndexQueryParserModule(settings),
                 new IndexNameModule(index),
+                new ExternalSourceProviderModule(settings),
                 new AbstractModule() {
                     @Override
                     protected void configure() {

--- a/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.search.geo.GeoPolygonFilter;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxFilter;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.threadpool.ThreadPoolModule;
@@ -94,6 +95,7 @@ public class SimpleIndexQueryParserTests {
                 new SimilarityModule(settings),
                 new IndexQueryParserModule(settings),
                 new IndexNameModule(index),
+                new ExternalSourceProviderModule(settings),
                 new AbstractModule() {
                     @Override
                     protected void configure() {

--- a/src/test/java/org/elasticsearch/test/unit/index/query/guice/IndexQueryParserModuleTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/guice/IndexQueryParserModuleTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.threadpool.ThreadPoolModule;
@@ -72,6 +73,7 @@ public class IndexQueryParserModuleTests {
                 new SimilarityModule(settings),
                 new IndexQueryParserModule(settings),
                 new IndexNameModule(index),
+                new ExternalSourceProviderModule(settings),
                 new AbstractModule() {
                     @Override
                     protected void configure() {

--- a/src/test/java/org/elasticsearch/test/unit/index/query/plugin/IndexQueryParserPlugin2Tests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/plugin/IndexQueryParserPlugin2Tests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.threadpool.ThreadPoolModule;
@@ -70,6 +71,7 @@ public class IndexQueryParserPlugin2Tests {
                 new SimilarityModule(settings),
                 queryParserModule,
                 new IndexNameModule(index),
+                new ExternalSourceProviderModule(settings),
                 new AbstractModule() {
                     @Override
                     protected void configure() {

--- a/src/test/java/org/elasticsearch/test/unit/index/query/plugin/IndexQueryParserPluginTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/plugin/IndexQueryParserPluginTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.settings.IndexSettingsModule;
 import org.elasticsearch.index.similarity.SimilarityModule;
+import org.elasticsearch.index.source.ExternalSourceProviderModule;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.threadpool.ThreadPoolModule;
@@ -79,6 +80,7 @@ public class IndexQueryParserPluginTests {
                 new SimilarityModule(settings),
                 queryParserModule,
                 new IndexNameModule(index),
+                new ExternalSourceProviderModule(settings),
                 new AbstractModule() {
                     @Override
                     protected void configure() {


### PR DESCRIPTION
Here is another version to compare. I moved configuration completely to the index level and kept compression and include/exclude functionality in the SourceFieldMapper. I think it looks much simpler and doesn't loose any functionality.
