### PR TITLE
When creating an index, fail properly on classpath error

### DIFF
--- a/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
@@ -284,6 +284,8 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
         Injector indexInjector;
         try {
             indexInjector = modules.createChildInjector(injector);
+        } catch (NoClassDefFoundError e) {
+            throw new IndexCreationException(index, e);
         } catch (CreationException e) {
             throw new IndexCreationException(index, Injectors.getFirstErrorFailure(e));
         }


### PR DESCRIPTION
I was struggling with an elasticsearch which was not responding at all to my "create index" request. I was able to find out the error until I had the idea of starting in foreground, so I could get the stdout. There was some thread dying because of a NoClassDefFoundError. One of my plugin was not properly setup.

The suggested patch catch the NoClassDefFoundError and throws a proper IndexCreationException, which in the end produce an error on the client side rather than having it hang.

Probably RiversService#createRiver suffer from the same issue.
