### PR TITLE
Fixes plugin install failure on Windows 7 / JDK 7u3

### DIFF
--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -8,7 +8,7 @@ set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
 
-"%JAVA_HOME%\bin\java" -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*" "org.elasticsearch.plugins.PluginManager" %*
+"%JAVA_HOME%\bin\java" -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginManager" %*
 goto finally
 
 


### PR DESCRIPTION
Without the fix installation of plugins fails with this error message (sorry for my swedish locale :-)):

C:\java\elasticsearch-0.19.2\bin>plugin.bat -install mobz/elasticsearch-head
Fel: Hittar inte eller kan inte ladda huvudklassen C:\java\elasticsearch-0.19.2.
lib.jna-3.3.0.jar
