### PR TITLE
Fix WildcardQueryBuilder when only rewrite is changed

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -76,7 +76,7 @@ public class WildcardQueryBuilder extends BaseQueryBuilder {
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(WildcardQueryParser.NAME);
-        if (boost == -1 && rewrite != null) {
+        if (boost == -1 && rewrite == null) {
             builder.field(name, wildcard);
         } else {
             builder.startObject(name);


### PR DESCRIPTION
If only the rewrite field is changed, and not the boost one,
the serilization did not write the rewrite field.
