### PR TITLE
fix issue 1870, clear the top docs phase before re-executing the search

### DIFF
--- a/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -19,8 +19,15 @@
 
 package org.elasticsearch.search.query;
 
-import com.google.common.collect.ImmutableMap;
-import org.apache.lucene.search.*;
+import java.util.Map;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.DeletionAwareConstantScoreQuery;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.FilteredQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHitCountCollector;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Lucene;
@@ -37,7 +44,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortParseElement;
 import org.elasticsearch.search.sort.TrackScoresParseElement;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 
 /**
  *
@@ -140,6 +147,8 @@ public class QueryPhase implements SearchPhase {
                             if (numDocs > topDocs.totalHits) {
                                 numDocs = topDocs.totalHits;
                             }
+                            
+                            topDocsPhase.clear();
                         }
                     } catch (Exception e) {
                         throw new QueryPhaseExecutionException(searchContext, "Failed to execute child query [" + scopePhase.query() + "]", e);


### PR DESCRIPTION
in 1870 i reported that when the top children query must do an incremental search, no results were being returned. I found this happened because in TopChildrenQuery.createWeight(), there is an if/else there based on if parentDocs is not null. As a fix, in QueryPhase I added a call to clear(). I also edited a test case to create a reproduction scenario.
