### PR TITLE
Updated JAVA_HOME directories for Ubuntu 12.04 x86_64

### DIFF
--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -46,7 +46,7 @@ ES_USER=elasticsearch
 ES_GROUP=elasticsearch
 
 # The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
-JDK_DIRS="/usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-6-sun /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-6-openjdk"
+JDK_DIRS="/usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-6-sun /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-7-openjdk-amd64/ /usr/lib/jvm/java-6-openjdk-amd64/"
 
 # Look for the right JVM to use
 for jdir in $JDK_DIRS; do


### PR DESCRIPTION
Hi,

Following this thread:
http://groups.google.com/group/elasticsearch/browse_thread/thread/669c7487354500a1

I've added the JAVA_HOME paths to match the packages openjdk-7-jre-headless and openjdk-6-jre-headless from Ubuntu 12.04. Tested on my test machine and it works as expected.

Best regards,
Radu
