### PR TITLE
Update requirements of the deb package

### DIFF
--- a/src/deb/control/control
+++ b/src/deb/control/control
@@ -2,7 +2,7 @@ Package: elasticsearch
 Version: [[version]]
 Architecture: all
 Maintainer: Nicolas Huray <nicolas.huray@gmail.com>
-Depends: openjdk-7-jre-headless | openjdk-6-jre-headless
+Depends: java7-runtime-headless | java6-runtime-headless | java7-runtime | java6-runtime
 Section: web
 Priority: optional
 Homepage: http://www.elasticsearch.org/


### PR DESCRIPTION
Virtual packages such as java*-runtime are provided by various java/JRE implementations, which makes it more flexible to use.

Note: I can't say I tested this, but AFAIK it should help. If you can make a test build and link to it on the related ML thread I can try to install it see if it still works with my setup at least.
