### PR TITLE
Add an interface about "boost settable" query builders

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  *
  */
-public class BoolQueryBuilder extends BaseQueryBuilder {
+public class BoolQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<BoolQueryBuilder> {
 
     private ArrayList<QueryBuilder> mustClauses = new ArrayList<QueryBuilder>();
 

--- a/src/main/java/org/elasticsearch/index/query/BoostableQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostableQueryBuilder.java
@@ -1,0 +1,14 @@
+package org.elasticsearch.index.query;
+
+/**
+ * Query builder which allow setting some boost
+ */
+public interface BoostableQueryBuilder<B extends BoostableQueryBuilder<B>> {
+
+    /**
+     * Sets the boost for this query.  Documents matching this query will (in addition to the normal
+     * weightings) have their score multiplied by the boost provided.
+     */
+    public B boost(float boost);
+
+}

--- a/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * multiplied by the supplied "boost" parameter, so this should be less than 1 to achieve a
  * demoting effect
  */
-public class BoostingQueryBuilder extends BaseQueryBuilder {
+public class BoostingQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<BoostingQueryBuilder> {
 
     private QueryBuilder positiveQuery;
 

--- a/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  *
  *
  */
-public class ConstantScoreQueryBuilder extends BaseQueryBuilder {
+public class ConstantScoreQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<ConstantScoreQueryBuilder> {
 
     private final FilterBuilder filterBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/CustomFiltersScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/CustomFiltersScoreQueryBuilder.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * A query that uses a filters with a script associated with them to compute the score.
  */
-public class CustomFiltersScoreQueryBuilder extends BaseQueryBuilder {
+public class CustomFiltersScoreQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<CustomFiltersScoreQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/CustomScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/CustomScoreQueryBuilder.java
@@ -30,7 +30,7 @@ import java.util.Map;
  *
  *
  */
-public class CustomScoreQueryBuilder extends BaseQueryBuilder {
+public class CustomScoreQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<CustomScoreQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -33,7 +33,7 @@ import static com.google.common.collect.Lists.newArrayList;
  *
  *
  */
-public class DisMaxQueryBuilder extends BaseQueryBuilder {
+public class DisMaxQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<DisMaxQueryBuilder> {
 
     private ArrayList<QueryBuilder> queries = newArrayList();
 

--- a/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FieldMaskingSpanQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder {
+public class FieldMaskingSpanQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<FieldMaskingSpanQueryBuilder> {
 
     private final SpanQueryBuilder queryBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/FieldQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FieldQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * version of {@link QueryStringQueryBuilder} that simply runs against
  * a single field.
  */
-public class FieldQueryBuilder extends BaseQueryBuilder {
+public class FieldQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<FieldQueryBuilder> {
 
     public static enum Operator {
         OR,

--- a/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * A query that applies a filter to the results of another query.
  */
-public class FilteredQueryBuilder extends BaseQueryBuilder {
+public class FilteredQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<FilteredQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisFieldQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisFieldQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FuzzyLikeThisFieldQueryBuilder extends BaseQueryBuilder {
+public class FuzzyLikeThisFieldQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<FuzzyLikeThisFieldQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class FuzzyLikeThisQueryBuilder extends BaseQueryBuilder {
+public class FuzzyLikeThisQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<FuzzyLikeThisQueryBuilder> {
 
     private final String[] fields;
 

--- a/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class FuzzyQueryBuilder extends BaseQueryBuilder {
+public class FuzzyQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<FuzzyQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class HasChildQueryBuilder extends BaseQueryBuilder {
+public class HasChildQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<HasChildQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * A query that will return only documents matching specific ids (and a type).
  */
-public class IdsQueryBuilder extends BaseQueryBuilder {
+public class IdsQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<IdsQueryBuilder> {
 
     private final List<String> types;
 

--- a/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class MatchAllQueryBuilder extends BaseQueryBuilder {
+public class MatchAllQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<MatchAllQueryBuilder> {
 
     private String normsField;
 

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class MoreLikeThisFieldQueryBuilder extends BaseQueryBuilder {
+public class MoreLikeThisFieldQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<MoreLikeThisFieldQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  *
  *
  */
-public class MoreLikeThisQueryBuilder extends BaseQueryBuilder {
+public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<MoreLikeThisQueryBuilder> {
 
     private final String[] fields;
 

--- a/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class NestedQueryBuilder extends BaseQueryBuilder {
+public class NestedQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<NestedQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
     private final FilterBuilder filterBuilder;

--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class PrefixQueryBuilder extends BaseQueryBuilder {
+public class PrefixQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<PrefixQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -37,7 +37,7 @@ import static com.google.common.collect.Lists.newArrayList;
  * <p/>
  * (shay.baon)
  */
-public class QueryStringQueryBuilder extends BaseQueryBuilder {
+public class QueryStringQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<QueryStringQueryBuilder> {
 
     public static enum Operator {
         OR,

--- a/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class RangeQueryBuilder extends BaseQueryBuilder {
+public class RangeQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<RangeQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanFirstQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder {
+public class SpanFirstQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanFirstQueryBuilder> {
 
     private final SpanQueryBuilder matchBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 /**
  *
  */
-public class SpanNearQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder {
+public class SpanNearQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanNearQueryBuilder> {
 
     private ArrayList<SpanQueryBuilder> clauses = new ArrayList<SpanQueryBuilder>();
 

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder {
+public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanNotQueryBuilder> {
 
     private SpanQueryBuilder include;
 

--- a/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 /**
  *
  */
-public class SpanOrQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder {
+public class SpanOrQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanOrQueryBuilder> {
 
     private ArrayList<SpanQueryBuilder> clauses = new ArrayList<SpanQueryBuilder>();
 

--- a/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SpanTermQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder {
+public class SpanTermQueryBuilder extends BaseQueryBuilder implements SpanQueryBuilder, BoostableQueryBuilder<SpanTermQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class TermQueryBuilder extends BaseQueryBuilder {
+public class TermQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<TermQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class TermsQueryBuilder extends BaseQueryBuilder {
+public class TermsQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<TermsQueryBuilder> {
 
     private final String name;
 

--- a/src/main/java/org/elasticsearch/index/query/TextQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TextQueryBuilder.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Text query is a query that analyzes the text and constructs a query as the result of the analysis. It
  * can construct different queries based on the type provided.
  */
-public class TextQueryBuilder extends BaseQueryBuilder {
+public class TextQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<TextQueryBuilder> {
 
     public static enum Operator {
         OR,

--- a/src/main/java/org/elasticsearch/index/query/TopChildrenQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TopChildrenQueryBuilder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  *
  */
-public class TopChildrenQueryBuilder extends BaseQueryBuilder {
+public class TopChildrenQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<TopChildrenQueryBuilder> {
 
     private final QueryBuilder queryBuilder;
 

--- a/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  *
  *
  */
-public class WildcardQueryBuilder extends BaseQueryBuilder {
+public class WildcardQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<WildcardQueryBuilder> {
 
     private final String name;
 


### PR DESCRIPTION
I have some generic code that build my queries. At some point I want to apply some boost. The suggested interface would make my code cleaner.
