### PR TITLE
allow sloppy date parsing

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -86,10 +86,12 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
         @Override
         public TimestampFieldMapper build(BuilderContext context) {
             boolean parseUpperInclusive = Defaults.PARSE_UPPER_INCLUSIVE;
+            boolean parseSloppy = Defaults.PARSE_SLOPPY_DATES;
             if (context.indexSettings() != null) {
                 parseUpperInclusive = context.indexSettings().getAsBoolean("index.mapping.date.parse_upper_inclusive", Defaults.PARSE_UPPER_INCLUSIVE);
+                parseSloppy = context.indexSettings().getAsBoolean("index.mapping.date.sloppy", Defaults.PARSE_SLOPPY_DATES);
             }
-            return new TimestampFieldMapper(store, index, enabled, path, dateTimeFormatter, parseUpperInclusive);
+            return new TimestampFieldMapper(store, index, enabled, path, dateTimeFormatter, parseUpperInclusive, parseSloppy);
         }
     }
 
@@ -119,13 +121,13 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
     private final String path;
 
     public TimestampFieldMapper() {
-        this(Defaults.STORE, Defaults.INDEX, Defaults.ENABLED, Defaults.PATH, Defaults.DATE_TIME_FORMATTER, Defaults.PARSE_UPPER_INCLUSIVE);
+        this(Defaults.STORE, Defaults.INDEX, Defaults.ENABLED, Defaults.PATH, Defaults.DATE_TIME_FORMATTER, Defaults.PARSE_UPPER_INCLUSIVE, Defaults.PARSE_SLOPPY_DATES);
     }
 
-    protected TimestampFieldMapper(Field.Store store, Field.Index index, boolean enabled, String path, FormatDateTimeFormatter dateTimeFormatter, boolean parseUpperInclusive) {
+    protected TimestampFieldMapper(Field.Store store, Field.Index index, boolean enabled, String path, FormatDateTimeFormatter dateTimeFormatter, boolean parseUpperInclusive, boolean parseSloppy) {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), dateTimeFormatter,
                 Defaults.PRECISION_STEP, Defaults.FUZZY_FACTOR, index, store, Defaults.BOOST, Defaults.OMIT_NORMS,
-                Defaults.OMIT_TERM_FREQ_AND_POSITIONS, Defaults.NULL_VALUE, TimeUnit.MILLISECONDS /*always milliseconds*/, parseUpperInclusive);
+                Defaults.OMIT_TERM_FREQ_AND_POSITIONS, Defaults.NULL_VALUE, TimeUnit.MILLISECONDS /*always milliseconds*/, parseUpperInclusive, parseSloppy);
         this.enabled = enabled;
         this.path = path;
     }


### PR DESCRIPTION
This patch will allow to parse dates coming from external sources that have invalid date/time syntax.

By now, such dates will fail during mapping. For example,  MySQL may create the infamous 'null' date `0000-00-00 ...`.

```
org.joda.time.IllegalFieldValueException: Cannot parse "0000-00-00": Value 0 for monthOfYear must be in the range [1,12]
```

In some cases, it is convenient to swallow all dates in incoming data, even with invalid dates, into Elasticsearch, for example from a MySQL river.

To enable the sloppy behaviour, the configuration of the index mapping `index.mapping.date.sloppy` must be set to `true`. Default value is `false`.
