### PR TITLE
Don't require lowercase sort order

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -233,9 +233,9 @@ public class RestSearchAction extends BaseRestHandler {
                 if (delimiter != -1) {
                     String sortField = sort.substring(0, delimiter);
                     String reverse = sort.substring(delimiter + 1);
-                    if ("asc".equals(reverse)) {
+                    if ("asc".equals(reverse.toLowerCase())) {
                         searchSourceBuilder.sort(sortField, SortOrder.ASC);
-                    } else if ("desc".equals(reverse)) {
+                    } else if ("desc".equals(reverse.toLowerCase())) {
                         searchSourceBuilder.sort(sortField, SortOrder.DESC);
                     }
                 } else {

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -123,9 +123,9 @@ public class SortParseElement implements SearchParseElement {
                                 if ("reverse".equals(innerJsonName)) {
                                     reverse = parser.booleanValue();
                                 } else if ("order".equals(innerJsonName)) {
-                                    if ("asc".equals(parser.text())) {
+                                    if ("asc".equals(parser.text().toLowerCase())) {
                                         reverse = SCORE_FIELD_NAME.equals(fieldName);
-                                    } else if ("desc".equals(parser.text())) {
+                                    } else if ("desc".equals(parser.text().toLowerCase())) {
                                         reverse = !SCORE_FIELD_NAME.equals(fieldName);
                                     }
                                 } else if ("missing".equals(innerJsonName)) {


### PR DESCRIPTION
Currently this will not return 3... 2... 1...

```
#!/bin/sh

curl -s -XDELETE localhost:9200/test >/dev/null

curl -s -XPUT localhost:9200/test/t/uno -d '{"wat": 1}'; echo

curl -s -XPUT localhost:9200/test/t/dos -d '{"wat": 2}'; echo

curl -s -XPUT localhost:9200/test/t/tres -d '{"wat": 3}'; echo

curl -s -XPOST localhost:9200/test/_refresh\?pretty=1; echo

curl -s localhost:9200/test/_search\?pretty=1 -d '
{
    "query": {
        "match_all": {}
    }, 
    "sort": [
        {
            "wat": {
                "order": "Desc"
            }
        }
    ]
}
'; echo
```
