### PR TITLE
Better print error message on native script error

### DIFF
--- a/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -61,13 +61,14 @@ public final class ExceptionsHelper {
         if (t.getCause() != null) {
             StringBuilder sb = new StringBuilder();
             while (t != null) {
+                sb.append(t.getClass().getSimpleName());
                 if (t.getMessage() != null) {
-                    sb.append(t.getClass().getSimpleName()).append("[");
+                    sb.append("[");
                     sb.append(t.getMessage());
                     sb.append("]");
-                    if (!newLines) {
-                        sb.append("; ");
-                    }
+                }
+                if (!newLines) {
+                    sb.append("; ");
                 }
                 t = t.getCause();
                 if (t != null) {

--- a/src/main/java/org/elasticsearch/index/query/CustomScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CustomScoreQueryParser.java
@@ -95,7 +95,12 @@ public class CustomScoreQueryParser implements QueryParser {
             return null;
         }
 
-        SearchScript searchScript = parseContext.scriptService().search(parseContext.lookup(), scriptLang, script, vars);
+        SearchScript searchScript;
+        try {
+            searchScript = parseContext.scriptService().search(parseContext.lookup(), scriptLang, script, vars);
+        } catch (Exception e) {
+            throw new QueryParsingException(parseContext.index(), "[custom_score] the script could not be loaded", e);
+        }
         FunctionScoreQuery functionScoreQuery = new FunctionScoreQuery(query, new ScriptScoreFunction(script, vars, searchScript));
         functionScoreQuery.setBoost(boost);
         return functionScoreQuery;


### PR DESCRIPTION
When there's an error on elasticsearch side, in some native script for instance, there is no explanation at all of the error, there is just an empty "nested: ".
I patched ExceptionsHelper so at least a classname is printed, so "nested: " won't be empty.
I patched CustomScoreQueryParser so it can state that the culprit of the error is the load of the script.
