### PR TITLE
Partial update without using a script

### DIFF
--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
 
@@ -333,6 +334,10 @@ public class IndexRequest extends ShardReplicationOperationRequest {
         return new BytesHolder(underlyingSource(), underlyingSourceOffset(), underlyingSourceLength());
     }
 
+    public Map<String, Object> underlyingSourceAsMap() {
+        return XContentHelper.convertToMap(underlyingSource(), underlyingSourceOffset(), underlyingSourceLength(), false).v2();
+    }
+    
     public byte[] underlyingSource() {
         if (sourceUnsafe) {
             source();

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -184,6 +184,62 @@ public class UpdateRequestBuilder extends BaseRequestBuilder<UpdateRequest, Upda
     }
 
     /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(IndexRequest indexRequest) {
+        request.doc(indexRequest);
+        return this;
+    }
+
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(XContentBuilder source) {
+        request.doc(source);
+        return this;
+    }
+
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(Map source) {
+        request.doc(source);
+        return this;
+    }
+
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(Map source, XContentType contentType) {
+        request.doc(source, contentType);
+        return this;
+    }
+
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(String source) {
+        request.doc(source);
+        return this;
+    }
+
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(byte[] source) {
+        request.doc(source);
+        return this;
+    }
+
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(byte[] source, int offset, int length) {
+        request.doc(source, offset, length);
+        return this;
+    }
+    
+    /**
      * Sets the index request to be used if the document does not exists. Otherwise, a {@link org.elasticsearch.index.engine.DocumentMissingException}
      * is thrown.
      */

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -101,6 +101,17 @@ public class RestUpdateAction extends BaseRestHandler {
                     upsertRequest.version(RestActions.parseVersion(request));
                     upsertRequest.versionType(VersionType.fromString(request.param("version_type"), upsertRequest.versionType()));
                 }
+                IndexRequest doc = updateRequest.doc();
+                if (doc != null) {
+                    doc.routing(request.param("routing"));
+                    doc.parent(request.param("parent")); // order is important, set it after routing, so it will set the routing
+                    doc.timestamp(request.param("timestamp"));
+                    if (request.hasParam("ttl")) {
+                        doc.ttl(request.paramAsTime("ttl", null).millis());
+                    }
+                    doc.version(RestActions.parseVersion(request));
+                    doc.versionType(VersionType.fromString(request.param("version_type"), doc.versionType()));
+                }
             } catch (Exception e) {
                 try {
                     channel.sendResponse(new XContentThrowableRestResponse(request, e));


### PR DESCRIPTION
Basic support for performing partial updates from the specified "doc" vs. needing to use a script.  Currently only supports adding new fields or changing existing fields (no deletes).

See comments in #2008 for more information.
