### PR TITLE
TR locale problem on Rest 

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -234,7 +234,7 @@ public class TransportBulkAction extends TransportAction<BulkRequest, BulkRespon
                         for (BulkItemRequest request : requests) {
                             if (request.request() instanceof IndexRequest) {
                                 IndexRequest indexRequest = (IndexRequest) request.request();
-                                responses[request.id()] = new BulkItemResponse(request.id(), indexRequest.opType().toString().toLowerCase(),
+                                responses[request.id()] = new BulkItemResponse(request.id(), indexRequest.opType().toString().toLowerCase(Locale.ENGLISH),
                                         new BulkItemResponse.Failure(indexRequest.index(), indexRequest.type(), indexRequest.id(), message));
                             } else if (request.request() instanceof DeleteRequest) {
                                 DeleteRequest deleteRequest = (DeleteRequest) request.request();

--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -183,7 +183,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
                     }
 
                     // add the response
-                    responses[i] = new BulkItemResponse(item.id(), indexRequest.opType().toString().toLowerCase(),
+                    responses[i] = new BulkItemResponse(item.id(), indexRequest.opType().toString().toLowerCase(Locale.ENGLISH),
                             new IndexResponse(indexRequest.index(), indexRequest.type(), indexRequest.id(), version));
                 } catch (Exception e) {
                     // rethrow the failure if we are going to retry on primary and let parent failure to handle it
@@ -195,7 +195,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
                     } else {
                         logger.debug("[{}][{}] failed to bulk item (index) {}", e, shardRequest.request.index(), shardRequest.shardId, indexRequest);
                     }
-                    responses[i] = new BulkItemResponse(item.id(), indexRequest.opType().toString().toLowerCase(),
+                    responses[i] = new BulkItemResponse(item.id(), indexRequest.opType().toString().toLowerCase(Locale.ENGLISH),
                             new BulkItemResponse.Failure(indexRequest.index(), indexRequest.type(), indexRequest.id(), ExceptionsHelper.detailedMessage(e)));
                     // nullify the request so it won't execute on the replicas
                     request.items()[i] = null;

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -536,7 +536,7 @@ public class IndexMetaData {
             builder.startObject(indexMetaData.index(), XContentBuilder.FieldCaseConversion.NONE);
 
             builder.field("version", indexMetaData.version());
-            builder.field("state", indexMetaData.state().toString().toLowerCase());
+            builder.field("state", indexMetaData.state().toString().toLowerCase(Locale.ENGLISH));
 
             boolean binary = params.paramAsBoolean("binary", false);
 

--- a/src/main/java/org/elasticsearch/index/query/TextQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TextQueryBuilder.java
@@ -167,7 +167,7 @@ public class TextQueryBuilder extends BaseQueryBuilder implements BoostableQuery
 
         builder.field("query", text);
         if (type != null) {
-            builder.field("type", type.toString().toLowerCase());
+            builder.field("type", type.toString().toLowerCase(Locale.ENGLISH));
         }
         if (operator != null) {
             builder.field("operator", operator.toString());

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -182,7 +182,7 @@ public class RestClusterStateAction extends BaseRestHandler {
                         for (IndexMetaData indexMetaData : state.metaData()) {
                             builder.startObject(indexMetaData.index(), XContentBuilder.FieldCaseConversion.NONE);
 
-                            builder.field("state", indexMetaData.state().toString().toLowerCase());
+                            builder.field("state", indexMetaData.state().toString().toLowerCase(Locale.ENGLISH));
 
                             builder.startObject("settings");
                             Settings settings = settingsFilter.filterSettings(indexMetaData.settings());


### PR DESCRIPTION
Enum -> toString -> toLowerCase used for some Rest Responses. They fail when containing "I" (like OpType.INDEX). TR locale servers convert these enums to "ındex" instead of "index". (I discover this behavior when a TR locale server joined my cluster)
