### PR TITLE
Test that verifies behavior of GeoDistance.ARC and GeoDistance.PLANE distance calculation

### DIFF
--- a/src/test/java/org/elasticsearch/test/unit/index/search/geo/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/search/geo/GeoDistanceTests.java
@@ -21,10 +21,13 @@ package org.elasticsearch.test.unit.index.search.geo;
 
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.search.geo.GeoDistance;
+import org.elasticsearch.index.search.geo.Point;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  */
@@ -35,18 +38,33 @@ public class GeoDistanceTests {
     public void testDistanceCheck() {
         // Note, is within is an approximation, so, even though 0.52 is outside 50mi, we still get "true"
         GeoDistance.DistanceBoundingCheck check = GeoDistance.distanceBoundingCheck(0, 0, 50, DistanceUnit.MILES);
-        //System.out.println("Dist: " + GeoDistance.ARC.calculate(0, 0, 0.5, 0.5, DistanceUnit.MILES));
         assertThat(check.isWithin(0.5, 0.5), equalTo(true));
-        //System.out.println("Dist: " + GeoDistance.ARC.calculate(0, 0, 0.52, 0.52, DistanceUnit.MILES));
         assertThat(check.isWithin(0.52, 0.52), equalTo(true));
-        //System.out.println("Dist: " + GeoDistance.ARC.calculate(0, 0, 1, 1, DistanceUnit.MILES));
         assertThat(check.isWithin(1, 1), equalTo(false));
 
-
         check = GeoDistance.distanceBoundingCheck(0, 179, 200, DistanceUnit.MILES);
-        //System.out.println("Dist: " + GeoDistance.ARC.calculate(0, 179, 0, -179, DistanceUnit.MILES));
         assertThat(check.isWithin(0, -179), equalTo(true));
-        //System.out.println("Dist: " + GeoDistance.ARC.calculate(0, 179, 0, -178, DistanceUnit.MILES));
         assertThat(check.isWithin(0, -178), equalTo(false));
+    }
+
+    @Test
+    public void testArcDistanceVsPlaneInEllipsis() {
+        Point centre = new Point(48.8534100, 2.3488000);
+        Point northernPoint = new Point(48.8801108681, 2.35152032666);
+        Point westernPoint = new Point(48.85265, 2.308896);
+
+        // With GeoDistance.ARC both the northern and western points are within the 4km range
+        assertThat(GeoDistance.ARC.calculate(centre.lat, centre.lon, northernPoint.lat,
+                northernPoint.lon, DistanceUnit.KILOMETERS), lessThan(4D));
+        assertThat(GeoDistance.ARC.calculate(centre.lat, centre.lon, westernPoint.lat,
+                westernPoint.lon, DistanceUnit.KILOMETERS), lessThan(4D));
+
+        // With GeoDistance.PLANE, only the northern point is within the 4km range,
+        // the western point is outside of the range due to the simple math it employs,
+        // meaning results will appear elliptical
+        assertThat(GeoDistance.PLANE.calculate(centre.lat, centre.lon, northernPoint.lat,
+                northernPoint.lon, DistanceUnit.KILOMETERS), lessThan(4D));
+        assertThat(GeoDistance.PLANE.calculate(centre.lat, centre.lon, westernPoint.lat,
+                westernPoint.lon, DistanceUnit.KILOMETERS), greaterThan(4D));
     }
 }


### PR DESCRIPTION
Included test which verifies the differences in the distance calculations of GeoDistance.ARC and GeoDistance.PLANE, showing why this could cause elliptical results.  Some small tidy up of the test class too.
