### PR TITLE
Plugin info REST endpoint in node info

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -32,6 +32,7 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.network.NetworkInfo;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.process.ProcessInfo;
+import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.threadpool.ThreadPoolInfo;
 import org.elasticsearch.transport.TransportInfo;
 
@@ -72,13 +73,16 @@ public class NodeInfo extends NodeOperationResponse {
 
     @Nullable
     private HttpInfo http;
+    
+    @Nullable
+    private PluginInfo plugins;
 
     NodeInfo() {
     }
 
     public NodeInfo(@Nullable String hostname, DiscoveryNode node, @Nullable ImmutableMap<String, String> serviceAttributes, @Nullable Settings settings,
                     @Nullable OsInfo os, @Nullable ProcessInfo process, @Nullable JvmInfo jvm, @Nullable ThreadPoolInfo threadPool, @Nullable NetworkInfo network,
-                    @Nullable TransportInfo transport, @Nullable HttpInfo http) {
+                    @Nullable TransportInfo transport, @Nullable HttpInfo http, @Nullable PluginInfo plugins) {
         super(node);
         this.hostname = hostname;
         this.serviceAttributes = serviceAttributes;
@@ -90,6 +94,7 @@ public class NodeInfo extends NodeOperationResponse {
         this.network = network;
         this.transport = transport;
         this.http = http;
+        this.plugins = plugins;
     }
 
     /**
@@ -234,6 +239,16 @@ public class NodeInfo extends NodeOperationResponse {
         return http();
     }
 
+    @Nullable
+    public PluginInfo plugins() {
+        return plugins;
+    }
+
+    @Nullable
+    public PluginInfo getPlugins() {
+        return plugins();
+    }    
+    
     public static NodeInfo readNodeInfo(StreamInput in) throws IOException {
         NodeInfo nodeInfo = new NodeInfo();
         nodeInfo.readFrom(in);
@@ -277,6 +292,9 @@ public class NodeInfo extends NodeOperationResponse {
         }
         if (in.readBoolean()) {
             http = HttpInfo.readHttpInfo(in);
+        }
+        if (in.readBoolean()) {
+            plugins = PluginInfo.readPluginInfo(in);
         }
     }
 
@@ -346,6 +364,12 @@ public class NodeInfo extends NodeOperationResponse {
         } else {
             out.writeBoolean(true);
             http.writeTo(out);
+        }
+        if (plugins == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            plugins.writeTo(out);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -38,6 +38,7 @@ public class NodesInfoRequest extends NodesOperationRequest {
     private boolean network = false;
     private boolean transport = false;
     private boolean http = false;
+    private boolean plugins = false;
 
     public NodesInfoRequest() {
     }
@@ -62,6 +63,7 @@ public class NodesInfoRequest extends NodesOperationRequest {
         network = false;
         transport = false;
         http = false;
+        plugins = false;
         return this;
     }
 
@@ -77,6 +79,7 @@ public class NodesInfoRequest extends NodesOperationRequest {
         network = true;
         transport = true;
         http = true;
+        plugins = true;
         return this;
     }
 
@@ -200,6 +203,21 @@ public class NodesInfoRequest extends NodesOperationRequest {
         return this;
     }
 
+    /**
+     * Should the node plugin info be returned.
+     */
+    public boolean plugins() {
+        return this.plugins;
+    }
+
+    /**
+     * Should the node plugin info be returned.
+     */
+    public NodesInfoRequest plugins(boolean plugins) {
+        this.plugins = plugins;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -211,6 +229,7 @@ public class NodesInfoRequest extends NodesOperationRequest {
         network = in.readBoolean();
         transport = in.readBoolean();
         http = in.readBoolean();
+        plugins = in.readBoolean();
     }
 
     @Override
@@ -224,5 +243,6 @@ public class NodesInfoRequest extends NodesOperationRequest {
         out.writeBoolean(network);
         out.writeBoolean(transport);
         out.writeBoolean(http);
+        out.writeBoolean(plugins);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
@@ -117,6 +117,13 @@ public class NodesInfoRequestBuilder extends BaseClusterRequestBuilder<NodesInfo
         return this;
     }
 
+    /**
+     * Should the node plugin info be returned.
+     */
+    public NodesInfoRequestBuilder setPlugins(boolean plugins) {
+        request.plugins(plugins);
+        return this;
+    }
 
     @Override
     protected void doExecute(ActionListener<NodesInfoResponse> listener) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -128,6 +128,9 @@ public class NodesInfoResponse extends NodesOperationResponse<NodeInfo> implemen
             if (nodeInfo.http() != null) {
                 nodeInfo.http().toXContent(builder, params);
             }
+            if (nodeInfo.plugins() != null) {
+                nodeInfo.plugins().toXContent(builder, params);
+            }
 
             builder.endObject();
         }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -97,7 +97,7 @@ public class TransportNodesInfoAction extends TransportNodesOperationAction<Node
     @Override
     protected NodeInfo nodeOperation(NodeInfoRequest nodeRequest) throws ElasticSearchException {
         NodesInfoRequest request = nodeRequest.request;
-        return nodeService.info(request.settings(), request.os(), request.process(), request.jvm(), request.threadPool(), request.network(), request.transport(), request.http());
+        return nodeService.info(request.settings(), request.os(), request.process(), request.jvm(), request.threadPool(), request.network(), request.transport(), request.http(), request.plugins());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/node/service/NodeService.java
+++ b/src/main/java/org/elasticsearch/node/service/NodeService.java
@@ -67,20 +67,19 @@ public class NodeService extends AbstractComponent {
     private String hostname;
 
     @Inject
-    public NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService, Discovery discovery, ClusterService clusterService, TransportService transportService, IndicesService indicesService) {
+    public NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService, Discovery discovery, ClusterService clusterService, TransportService transportService, IndicesService indicesService, PluginsService pluginsService) {
         super(settings);
         this.threadPool = threadPool;
         this.monitorService = monitorService;
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.indicesService = indicesService;
+        this.pluginsService = pluginsService;
         discovery.setNodeService(this);
         InetAddress address = NetworkUtils.getLocalAddress();
         if (address != null) {
             this.hostname = address.getHostName();
-        }
-        Tuple<Settings, Environment> tuple = InternalSettingsPerparer.prepareSettings(settings, true);
-        pluginsService = new PluginsService(tuple.v1(), tuple.v2());
+        }        
     }
 
     public void setHttpServer(@Nullable HttpServer httpServer) {

--- a/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+public class PluginInfo implements Streamable, Serializable, ToXContent {
+
+    // plugin info contains name and description of all plugins installed
+    private ImmutableMap<String, String> pluginInfo;
+
+    PluginInfo() {
+    }
+    
+    public PluginInfo(ImmutableCollection<Plugin> plugins) {
+        Map<String, String> pluginInfo = Maps.newHashMap();
+        for (Plugin plugin: plugins) {
+            pluginInfo.put(plugin.name(), plugin.description());
+        }
+        this.pluginInfo = ImmutableMap.copyOf(pluginInfo);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("plugins");
+        for (Map.Entry<String,String> e : pluginInfo.entrySet()) {
+            builder.field(e.getKey(), e.getValue());
+        }
+        builder.endObject();
+        return builder;
+    }
+    
+    public static PluginInfo readPluginInfo(StreamInput in) throws IOException {
+        PluginInfo info = new PluginInfo();
+        info.readFrom(in);
+        return info;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        Map<String, String> plugins = Maps.newHashMap();
+        int n = in.readVInt();
+        for (int i = 0; i < n; i++) {
+            String name = in.readUTF();
+            String description = in.readUTF();
+            plugins.put(name, description);
+        }
+        this.pluginInfo = ImmutableMap.copyOf(plugins);
+    }
+    
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(pluginInfo.size());
+        for (Map.Entry<String,String> e : pluginInfo.entrySet()) {
+            out.writeUTF(e.getKey());
+            out.writeUTF(e.getValue());
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -204,6 +204,10 @@ public class PluginsService extends AbstractComponent {
         }
         return services;
     }
+    
+    public PluginInfo info() {
+        return new PluginInfo(plugins.values());
+    }
 
     public Collection<Class<? extends Module>> shardModules() {
         List<Class<? extends Module>> modules = Lists.newArrayList();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -73,6 +73,9 @@ public class RestNodesInfoAction extends BaseRestHandler {
         controller.registerHandler(RestRequest.Method.GET, "/_nodes/http", new RestHttpHandler());
         controller.registerHandler(RestRequest.Method.GET, "/_nodes/{nodeId}/http", new RestHttpHandler());
 
+        controller.registerHandler(RestRequest.Method.GET, "/_nodes/plugins", new RestPluginsHandler());
+        controller.registerHandler(RestRequest.Method.GET, "/_nodes/{nodeId}/plugins", new RestPluginsHandler());
+
         this.settingsFilter = settingsFilter;
     }
 
@@ -201,4 +204,14 @@ public class RestNodesInfoAction extends BaseRestHandler {
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
     }
+
+    class RestPluginsHandler implements RestHandler {
+        @Override
+        public void handleRequest(final RestRequest request, final RestChannel channel) {
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            nodesInfoRequest.clear().plugins(true);
+            executeNodeRequest(request, channel, nodesInfoRequest);
+        }
+    }
+
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -100,6 +100,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
         nodesInfoRequest.network(request.paramAsBoolean("network", nodesInfoRequest.network()));
         nodesInfoRequest.transport(request.paramAsBoolean("transport", nodesInfoRequest.transport()));
         nodesInfoRequest.http(request.paramAsBoolean("http", nodesInfoRequest.http()));
+        nodesInfoRequest.plugins(request.paramAsBoolean("plugins", nodesInfoRequest.plugins()));
 
         executeNodeRequest(request, channel, nodesInfoRequest);
     }


### PR DESCRIPTION
Another version of pull request #2007, now integrated into node info mechanism.

One minor flaw is that the "plugins" message in the logs appears twice. I am not sure how to initialize the PluginsService correctly without getting the message printed.
