### PR TITLE
Validate query bug fixes

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
@@ -65,11 +65,15 @@ class ShardValidateQueryResponse extends BroadcastShardOperationResponse {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         valid = in.readBoolean();
+        explanation = in.readOptionalUTF();
+        error = in.readOptionalUTF();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(valid);
+        out.writeOptionalUTF(explanation);
+        out.writeOptionalUTF(error);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -36,7 +36,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.internal.InternalSearchRequest;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -54,10 +59,13 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
 
     private final IndicesService indicesService;
 
+    private final ScriptService scriptService;
+
     @Inject
-    public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService) {
+    public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ScriptService scriptService) {
         super(settings, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
+        this.scriptService = scriptService;
     }
 
     @Override
@@ -148,12 +156,19 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
     @Override
     protected ShardValidateQueryResponse shardOperation(ShardValidateQueryRequest request) throws ElasticSearchException {
         IndexQueryParserService queryParserService = indicesService.indexServiceSafe(request.index()).queryParserService();
+        IndexService indexService = indicesService.indexServiceSafe(request.index());
+        IndexShard indexShard = indexService.shardSafe(request.shardId());
+
         boolean valid;
         String explanation = null;
         String error = null;
         if (request.querySource().length() == 0) {
             valid = true;
         } else {
+            SearchContext.setCurrent(new SearchContext(0,
+                    new InternalSearchRequest().types(request.types()),
+                    null, indexShard.searcher(), indexService, indexShard,
+                    scriptService));
             try {
                 ParsedQuery parsedQuery = queryParserService.parse(request.querySource().bytes(), request.querySource().offset(), request.querySource().length());
                 valid = true;
@@ -166,6 +181,9 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
             } catch (AssertionError e) {
                 valid = false;
                 error = e.getMessage();
+            } finally {
+                SearchContext.current().release();
+                SearchContext.removeCurrent();
             }
         }
         return new ShardValidateQueryResponse(request.index(), request.shardId(), valid, explanation, error);


### PR DESCRIPTION
Found a couple of bugs in the /validate/query request. The query explanations were not propagated between shards (fixed in de52f91) and because current SearchContext wasn't set, some query parsers were failing while trying to access SearchContext (fixed in be74b31).
