### PR TITLE
Skip non-persisted indices during recovery from gateway

### DIFF
--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -173,8 +173,12 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                 recoveryStatus.updateStage(RecoveryStatus.Stage.INIT);
 
                 try {
-                    logger.debug("starting recovery from {} ...", shardGateway);
-                    shardGateway.recover(indexShouldExists, recoveryStatus);
+                    if (indexShard.store().indexStore().persistent()) {
+                        logger.debug("starting recovery from {} ...", shardGateway);
+                        shardGateway.recover(indexShouldExists, recoveryStatus);
+                    } else {
+                        logger.debug("skipping recovery from {}, non-persisted index ... ", shardGateway);
+                    }
 
                     lastIndexVersion = recoveryStatus.index().version();
                     lastTranslogId = -1;

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -124,6 +124,10 @@ public class Store extends AbstractIndexShardComponent {
         indexSettingsService.addListener(applySettings);
     }
 
+    public IndexStore indexStore() {
+        return indexStore;
+    }
+
     public Directory directory() {
         return directory;
     }


### PR DESCRIPTION
Proof of concept thus no tests yet.

Observed behavior with a memory index and local gateway is that on a full cluster restart (try 1 shard, 0 replicas, restart the node) the recovery fails.
It will not even correctly restore the index structure, because loading the shard(s) fails.

This patch does not attempt to load the shards for non-persistent index stores.
