### PR TITLE
fixed TermsFacet.Entry ordering

### DIFF
--- a/src/main/java/org/elasticsearch/search/facet/terms/TermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/TermsFacet.java
@@ -68,7 +68,7 @@ public interface TermsFacet extends Facet, Iterable<TermsFacet.Entry> {
             public int compare(Entry o1, Entry o2) {
                 int i = o2.count() - o1.count();
                 if (i == 0) {
-                    i = o2.compareTo(o1);
+                    i = o1.compareTo(o2);
                     if (i == 0) {
                         i = System.identityHashCode(o2) - System.identityHashCode(o1);
                     }

--- a/src/test/java/org/elasticsearch/test/integration/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/facet/SimpleFacetsTests.java
@@ -674,6 +674,36 @@ public class SimpleFacetsTests extends AbstractNodesTests {
             assertThat(facet.entries().get(0).term().string(), equalTo("zzz"));
             assertThat(facet.entries().get(0).count(), equalTo(1));
 
+            searchResponse = client.prepareSearch()
+                    .setQuery(matchAllQuery())
+                    .addFacet(termsFacet("facet1").field("tag").size(10).order(TermsFacet.ComparatorType.COUNT).executionHint(executionHint))
+                    .execute().actionGet();
+
+            facet = searchResponse.facets().facet("facet1");
+            assertThat(facet.name(), equalTo("facet1"));
+            assertThat(facet.entries().size(), equalTo(3));
+            assertThat(facet.entries().get(0).term(), equalTo("yyy"));
+            assertThat(facet.entries().get(0).count(), equalTo(2));
+            assertThat(facet.entries().get(1).term(), equalTo("xxx"));
+            assertThat(facet.entries().get(1).count(), equalTo(1));
+            assertThat(facet.entries().get(2).term(), equalTo("zzz"));
+            assertThat(facet.entries().get(2).count(), equalTo(1));
+
+            searchResponse = client.prepareSearch()
+                    .setQuery(matchAllQuery())
+                    .addFacet(termsFacet("facet1").field("tag").size(10).order(TermsFacet.ComparatorType.REVERSE_COUNT).executionHint(executionHint))
+                    .execute().actionGet();
+
+            facet = searchResponse.facets().facet("facet1");
+            assertThat(facet.name(), equalTo("facet1"));
+            assertThat(facet.entries().size(), equalTo(3));
+            assertThat(facet.entries().get(2).term(), equalTo("yyy"));
+            assertThat(facet.entries().get(2).count(), equalTo(2));
+            assertThat(facet.entries().get(1).term(), equalTo("xxx"));
+            assertThat(facet.entries().get(1).count(), equalTo(1));
+            assertThat(facet.entries().get(0).term(), equalTo("zzz"));
+            assertThat(facet.entries().get(0).count(), equalTo(1));
+
             // Script
 
             searchResponse = client.prepareSearch()


### PR DESCRIPTION
If ComparatorType.COUNT is used Entries with same count will now be sorted ascending and not descending.
