### PR TITLE
Better ExplainableSearchScript interface

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/CustomScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CustomScoreQueryParser.java
@@ -146,12 +146,12 @@ public class CustomScoreQueryParser implements QueryParser {
             if (script instanceof ExplainableSearchScript) {
                 script.setNextDocId(docId);
                 script.setNextScore(subQueryExpl.getValue());
-                exp = ((ExplainableSearchScript) script).explain();
+                exp = ((ExplainableSearchScript) script).explain(subQueryExpl);
             } else {
                 float score = score(docId, subQueryExpl.getValue());
-                exp = new Explanation(score, "script score function: product of:");
+                exp = new Explanation(score, "script score function: composed of:");
+                exp.addDetail(subQueryExpl);
             }
-            exp.addDetail(subQueryExpl);
             return exp;
         }
 

--- a/src/main/java/org/elasticsearch/script/ExplainableSearchScript.java
+++ b/src/main/java/org/elasticsearch/script/ExplainableSearchScript.java
@@ -27,7 +27,9 @@ public interface ExplainableSearchScript extends SearchScript {
 
     /**
      * Build the explanation of the current document being scored
+     * 
+     * @param subQueryExpl the explanation of the subQuery 
      */
-    Explanation explain();
+    Explanation explain(Explanation subQueryExpl);
 
 }


### PR DESCRIPTION
ExplainableSearchScript is a life saver to debug native script, but it doesn't display accurately the explanation of the computation. The explanation of the sub query of the custom scorer should be placed in the hierarchy by the custom scorer, since it is the one using it, or not. Hence the suggested patch.
