### PR TITLE
Avoid NPE when passing a bool filter with should, must or not keys omitted.

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -117,7 +117,9 @@ public class BoolFilterParser implements FilterParser {
             }
         }
 
-        if (boolFilter.getMustFilters().isEmpty() && boolFilter.getNotFilters().isEmpty() && boolFilter.getShouldFilters().isEmpty()) {
+        if ((boolFilter.getMustFilters() != null && boolFilter.getMustFilters().isEmpty())
+                && (boolFilter.getNotFilters() != null && boolFilter.getNotFilters().isEmpty())
+                && (boolFilter.getShouldFilters() != null && boolFilter.getShouldFilters().isEmpty())) {
             return null;
         }
 

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -117,9 +117,9 @@ public class BoolFilterParser implements FilterParser {
             }
         }
 
-        if ((boolFilter.getMustFilters() != null && boolFilter.getMustFilters().isEmpty())
-                && (boolFilter.getNotFilters() != null && boolFilter.getNotFilters().isEmpty())
-                && (boolFilter.getShouldFilters() != null && boolFilter.getShouldFilters().isEmpty())) {
+        if ((boolFilter.getMustFilters() == null || boolFilter.getMustFilters().isEmpty())
+                && (boolFilter.getNotFilters() == null || boolFilter.getNotFilters().isEmpty())
+                && (boolFilter.getShouldFilters() == null || boolFilter.getShouldFilters().isEmpty())) {
             return null;
         }
 


### PR DESCRIPTION
I was getting NPEs on a seemingly valid JSON:
"filtered":{
        "query":{
            "match_all":{}
        },
        "filter":{
            "and":{
                "filters":[
                    {
                            "should":{
                                "term":{
                                    "category":"Laptops"
                                }
                            }
                    }
                ]
            }
        }
