### PR TITLE
Query Parser caching does not take types into account

### DIFF
--- a/src/main/java/org/apache/lucene/queryParser/QueryParserSettings.java
+++ b/src/main/java/org/apache/lucene/queryParser/QueryParserSettings.java
@@ -24,6 +24,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -60,6 +61,7 @@ public class QueryParserSettings {
 
 
     List<String> fields = null;
+    Collection<String> queryTypes = null;
     TObjectFloatHashMap<String> boosts = null;
     float tieBreaker = 0.0f;
     boolean useDisMax = true;
@@ -256,6 +258,14 @@ public class QueryParserSettings {
         this.fields = fields;
     }
 
+    public Collection<String> queryTypes() {
+        return queryTypes;
+    }
+
+    public void queryTypes(Collection<String> queryTypes) {
+        this.queryTypes = queryTypes;
+    }
+
     public TObjectFloatHashMap<String> boosts() {
         return boosts;
     }
@@ -325,6 +335,7 @@ public class QueryParserSettings {
         if (useDisMax != that.useDisMax) return false;
         if (boosts != null ? !boosts.equals(that.boosts) : that.boosts != null) return false;
         if (fields != null ? !fields.equals(that.fields) : that.fields != null) return false;
+        if (queryTypes != null ? !queryTypes.equals(that.queryTypes) : that.queryTypes != null) return false;
 
         return true;
     }
@@ -350,6 +361,7 @@ public class QueryParserSettings {
         result = 31 * result + (analyzeWildcard ? 1 : 0);
 
         result = 31 * result + (fields != null ? fields.hashCode() : 0);
+        result = 31 * result + (queryTypes != null ? queryTypes.hashCode() : 0);
         result = 31 * result + (boosts != null ? boosts.hashCode() : 0);
         result = 31 * result + (tieBreaker != +0.0f ? Float.floatToIntBits(tieBreaker) : 0);
         result = 31 * result + (useDisMax ? 1 : 0);

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -199,6 +199,8 @@ public class QueryStringQueryParser implements QueryParser {
             qpSettings.queryString(org.apache.lucene.queryParser.QueryParser.escape(qpSettings.queryString()));
         }
 
+        qpSettings.queryTypes(parseContext.queryTypes());
+
         Query query = parseContext.indexCache().queryParserCache().get(qpSettings);
         if (query != null) {
             return query;


### PR DESCRIPTION
The QueryParserSettings class that is [used as a key](https://github.com/elasticsearch/elasticsearch/blob/3bf55a0858c17ac48208210dd71a84a6fde35dbf/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java#L202) in the parser cache doesn't contain any information about types that the cached query was parsed on. As a result some type-specific cached queries might be reused with wrong types. 

The problem can be reproduced with _id:1234 queries:  https://gist.github.com/b36137fb228eb54db8ce
