### PR TITLE
Manipulatable pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -377,6 +377,17 @@
                                 <exclude>/*.txt</exclude>
                                 <exclude>build.properties</exclude>
                             </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>io.netty:netty</artifact>
+                            <includes>
+                                <include>**</include>
+                                <exclude>META-INF/**</exclude>
+                                <exclude>LICENSE</exclude>
+                                <exclude>NOTICE</exclude>
+                                <exclude>/*.txt</exclude>
+                                <exclude>build.properties</exclude>
+                            </includes>
                         </filter>
                     </filters>
                 </configuration>

--- a/src/main/java/org/elasticsearch/common/netty/PipelineFactories.java
+++ b/src/main/java/org/elasticsearch/common/netty/PipelineFactories.java
@@ -1,0 +1,40 @@
+package org.elasticsearch.common.netty;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.transport.netty.NettyTransport;
+import org.elasticsearch.transport.netty.MessageChannelHandler;
+import org.elasticsearch.common.netty.OpenChannelsHandler;
+import org.elasticsearch.common.inject.Inject;
+import org.jboss.netty.channel.ChannelPipelineFactory;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.Channels;
+
+public class PipelineFactories {
+
+    @Inject()
+    public PipelineFactories() {
+    }
+
+    public ChannelPipelineFactory serverPipelineFactory(final NettyTransport transport, final OpenChannelsHandler serverOpenChannels, final ESLogger logger) throws ElasticSearchException {
+        return new ChannelPipelineFactory() {
+            @Override
+            public ChannelPipeline getPipeline() throws Exception {
+                ChannelPipeline pipeline = Channels.pipeline();
+                pipeline.addLast("openChannels", serverOpenChannels);
+                pipeline.addLast("dispatcher", new MessageChannelHandler(transport, logger));
+                return pipeline;
+            }
+        };
+    }
+
+    public ChannelPipelineFactory clientPipelineFactory(final NettyTransport transport, final ESLogger logger) throws ElasticSearchException {
+        return new ChannelPipelineFactory() {
+            @Override
+            public ChannelPipeline getPipeline() throws Exception {
+                ChannelPipeline pipeline = Channels.pipeline();
+                pipeline.addLast("dispatcher", new MessageChannelHandler(transport, logger));
+                return pipeline;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This concerns #664 . This pull request enables a plugin to implement any additional functionality on the transport handlers by itself by providing a different PipelineFactories.

A proof-of-concept plugin can be found here:
https://github.com/Asquera/elasticsearch-ssl-transport-plugin

The plugin is much lighter on the side of configurability, where #2105 does a much better job.

As a side-effect of the change, I also had to un-minify netty, because it was a huge pain to compile the plugin properly with SslHandler etc. living in a different (non-relocated) package.

Implementing SSL as a plugin would allow the plugin to be iterated independently of elasticsearch master, which, after thinking alot about what you can do after enabling SSL (different authentication strategies, etc).
