### PR TITLE
Add regular expression query

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -312,6 +312,18 @@ public abstract class QueryBuilders {
     }
 
     /**
+     * Implements the regex search query. Note this query is extremely slow, as it
+     * needs to iterate over many terms. Use it only on percolation or on very small indices
+     *
+     * @param name  The field name
+     * @param query The regex query string
+     *
+    */
+    public static RegexQueryBuilder regexQuery(String name, String query) {
+      return new RegexQueryBuilder(name, query);
+    }
+
+    /**
      * A query that parses a query string and runs it. There are two modes that this operates. The first,
      * when no field is added (using {@link QueryStringQueryBuilder#field(String)}, will run the query once and non prefixed fields
      * will use the {@link QueryStringQueryBuilder#defaultField(String)} set. The second, when one or more fields are added

--- a/src/main/java/org/elasticsearch/index/query/RegexQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexQueryBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Implements the regex search query. Note this query is extremely slow, as it
+ * needs to iterate over many terms. Use it only on percolation or on very small indices
+ *
+ */
+public class RegexQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<RegexQueryBuilder> {
+
+    private final String name;
+
+    private final String regex;
+
+    private float boost = -1;
+
+    private String rewrite;
+
+    /**
+     * Implements the regex search query. Note this query is extremely slow, as it
+     * needs to iterate over many terms. Use it only on percolation or on very small indices
+     *
+     * @param name     The field name
+     * @param regex The regex query string
+     */
+    public RegexQueryBuilder(String name, String regex) {
+        this.name = name;
+        this.regex = regex;
+    }
+
+    public RegexQueryBuilder rewrite(String rewrite) {
+        this.rewrite = rewrite;
+        return this;
+    }
+
+    /**
+     * Sets the boost for this query.  Documents matching this query will (in addition to the normal
+     * weightings) have their score multiplied by the boost provided.
+     */
+    public RegexQueryBuilder boost(float boost) {
+        this.boost = boost;
+        return this;
+    }
+
+    @Override
+    public void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(RegexQueryParser.NAME);
+        if (boost == -1 && rewrite == null) {
+            builder.field(name, regex);
+        } else {
+            builder.startObject(name);
+            builder.field("wildcard", regex);
+            if (boost != -1) {
+                builder.field("boost", boost);
+            }
+            if (rewrite != null) {
+                builder.field("rewrite", rewrite);
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/RegexQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexQueryParser.java
@@ -68,7 +68,7 @@ public class RegexQueryParser implements QueryParser {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else {
-                    if ("wildcard".equals(currentFieldName)) {
+                    if ("regex".equals(currentFieldName)) {
                         value = parser.text();
                     } else if ("value".equals(currentFieldName)) {
                         value = parser.text();
@@ -77,7 +77,7 @@ public class RegexQueryParser implements QueryParser {
                     } else if ("rewrite".equals(currentFieldName)) {
                         rewriteMethod = parser.textOrNull();
                     } else {
-                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName + "]");
+                        throw new QueryParsingException(parseContext.index(), "[regex] query does not support [" + currentFieldName + "]");
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/index/query/RegexQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexQueryParser.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.search.regex.RegexQuery;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.support.QueryParsers;
+
+import java.io.IOException;
+
+import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
+
+/**
+ *
+ */
+public class RegexQueryParser implements QueryParser {
+
+    public static final String NAME = "regex";
+
+    @Inject
+    public RegexQueryParser() {
+    }
+
+    @Override
+    public String[] names() {
+        return new String[]{NAME};
+    }
+
+    @Override
+    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        XContentParser parser = parseContext.parser();
+
+        XContentParser.Token token = parser.nextToken();
+        if (token != XContentParser.Token.FIELD_NAME) {
+            throw new QueryParsingException(parseContext.index(), "[regex] query malformed, no field");
+        }
+        String fieldName = parser.currentName();
+        String rewriteMethod = null;
+
+        String value = null;
+        float boost = 1.0f;
+        token = parser.nextToken();
+        if (token == XContentParser.Token.START_OBJECT) {
+            String currentFieldName = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else {
+                    if ("wildcard".equals(currentFieldName)) {
+                        value = parser.text();
+                    } else if ("value".equals(currentFieldName)) {
+                        value = parser.text();
+                    } else if ("boost".equals(currentFieldName)) {
+                        boost = parser.floatValue();
+                    } else if ("rewrite".equals(currentFieldName)) {
+                        rewriteMethod = parser.textOrNull();
+                    } else {
+                        throw new QueryParsingException(parseContext.index(), "[wildcard] query does not support [" + currentFieldName + "]");
+                    }
+                }
+            }
+            parser.nextToken();
+        } else {
+            value = parser.text();
+            parser.nextToken();
+        }
+
+        if (value == null) {
+            throw new QueryParsingException(parseContext.index(), "No value specified for prefix query");
+        }
+
+        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
+        if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
+            fieldName = smartNameFieldMappers.mapper().names().indexName();
+            value = smartNameFieldMappers.mapper().indexedValue(value);
+        }
+
+        RegexQuery query = new RegexQuery(new Term(fieldName, value));
+        QueryParsers.setRewriteMethod(query, rewriteMethod);
+        query.setRewriteMethod(QueryParsers.parseRewriteMethod(rewriteMethod));
+        query.setBoost(boost);
+        return wrapSmartNameQuery(query, smartNameFieldMappers, parseContext);
+    }
+}

--- a/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
@@ -57,6 +57,7 @@ public class IndicesQueriesRegistry {
         addQueryParser(queryParsers, new RangeQueryParser());
         addQueryParser(queryParsers, new PrefixQueryParser());
         addQueryParser(queryParsers, new WildcardQueryParser());
+        addQueryParser(queryParsers, new RegexQueryParser());
         addQueryParser(queryParsers, new FilteredQueryParser());
         addQueryParser(queryParsers, new ConstantScoreQueryParser());
         addQueryParser(queryParsers, new CustomBoostFactorQueryParser());


### PR DESCRIPTION
Add support for Lucene's RegexQuery to ElasticSearch.

RegexQuery is really slow on Lucene 3.x, we are planning to use this query only with Percolate API
