### PR TITLE
Support files with no extension in config mappings

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -415,7 +415,8 @@ public class MetaDataCreateIndexService extends AbstractComponent {
             if (mappingFile.isHidden()) {
                 continue;
             }
-            String mappingType = mappingFile.getName().substring(0, mappingFile.getName().lastIndexOf('.'));
+            int lastDotIndex = mappingFile.getName().lastIndexOf('.');
+            String mappingType = lastDotIndex != -1 ? mappingFile.getName().substring(0, lastDotIndex) : mappingFile.getName();
             try {
                 String mappingSource = Streams.copyToString(new FileReader(mappingFile));
                 if (mappings.containsKey(mappingType)) {


### PR DESCRIPTION
When config mappings directory contains a file without an extension, index creation fails with 

java.lang.StringIndexOutOfBoundsException: String index out of range: -1

To reproduce:
- create file test (with no extension) in directory config/mappings/_default
- create a new index
- index creation fails

Since an extension doesn't play any role in the mapping parsing, it might make sense to support files with no extensions or provide a better error message.

Found in https://groups.google.com/d/topic/elasticsearch/tcfhIpxaRKQ/discussion
