### PR TITLE
Handle facet terms int overflow better

### DIFF
--- a/src/main/java/org/elasticsearch/search/facet/terms/bytes/InternalByteTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/bytes/InternalByteTermsFacet.java
@@ -224,7 +224,9 @@ public class InternalByteTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (ByteEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/doubles/InternalDoubleTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/doubles/InternalDoubleTermsFacet.java
@@ -224,7 +224,9 @@ public class InternalDoubleTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (DoubleEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/floats/InternalFloatTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/floats/InternalFloatTermsFacet.java
@@ -224,7 +224,9 @@ public class InternalFloatTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (FloatEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/ints/InternalIntTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/ints/InternalIntTermsFacet.java
@@ -221,7 +221,9 @@ public class InternalIntTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (IntEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/ip/InternalIpTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/ip/InternalIpTermsFacet.java
@@ -226,7 +226,9 @@ public class InternalIpTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (LongEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/InternalLongTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/InternalLongTermsFacet.java
@@ -224,7 +224,9 @@ public class InternalLongTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (LongEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/shorts/InternalShortTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/shorts/InternalShortTermsFacet.java
@@ -221,7 +221,9 @@ public class InternalShortTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (ShortEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/InternalStringTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/InternalStringTermsFacet.java
@@ -221,7 +221,9 @@ public class InternalStringTermsFacet extends InternalTermsFacet {
             missing += mFacet.missingCount();
             total += mFacet.totalCount();
             for (InternalStringTermsFacet.StringEntry entry : mFacet.entries) {
-                aggregated.adjustOrPutValue(entry.term(), entry.count(), entry.count());
+                if (aggregated.adjustOrPutValue(entry.term, entry.count(), entry.count()) < 0) {
+                    aggregated.put(entry.term, Integer.MAX_VALUE);
+                }
             }
         }
 


### PR DESCRIPTION
Facet terms are int based and can overflow with a large number of documents.
Instead of overflowing return Integer.MAX_VALUE.
This fix assumes overflow only happens during the reduce phase.
