### PR TITLE
Add 1ms sleep after update to prevent test from failing

### DIFF
--- a/src/test/java/org/elasticsearch/test/integration/update/UpdateTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/update/UpdateTests.java
@@ -264,6 +264,7 @@ public class UpdateTests extends AbstractNodesTests {
 
         // check TTL update
         client.prepareUpdate("test", "type1", "2").setScript("ctx._ttl = 3600000").execute().actionGet();
+        Thread.sleep(1);
         getResponse = client.prepareGet("test", "type1", "2").setFields("_ttl").execute().actionGet();
         ttl = ((Number) getResponse.field("_ttl").value()).longValue();
         assertThat(ttl, greaterThan(0L));


### PR DESCRIPTION
This test fails half of the time on my laptop with _ttl still equal to 3600000 during get. This sleep ensures that ttl is reduced by at least 1ms. 
