### PR TITLE
adding wrong port exception for misguided HTTP requests

### DIFF
--- a/src/main/java/org/elasticsearch/common/transport/NetworkExceptionHelper.java
+++ b/src/main/java/org/elasticsearch/common/transport/NetworkExceptionHelper.java
@@ -58,4 +58,11 @@ public class NetworkExceptionHelper {
         }
         return false;
     }
+    
+    public static boolean isWrongPortException(Throwable e) {
+        if (e instanceof WrongPortException) {
+            return true;
+        }
+        return false;
+    }    
 }

--- a/src/main/java/org/elasticsearch/common/transport/WrongPortException.java
+++ b/src/main/java/org/elasticsearch/common/transport/WrongPortException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.transport;
+
+import java.io.IOException;
+
+
+public class WrongPortException extends IOException {
+    
+    public WrongPortException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Hi kimchy,

I think it is useful to add a special wrong port handling to netty transport, so people who accidentally connect with a HTTP client to port 9300 will receive a small diagnostic message.

Cheers,

Jörg
