### PR TITLE
Problem Parents & Children

### DIFF
--- a/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -132,8 +132,14 @@ public class QueryPhase implements SearchPhase {
                                 break;
                             }
                             // if we did not find enough docs, check if it make sense to search further
-                            if (topDocs.totalHits <= numDocs) {
+                            if(topDocsPhase instanceof TopChildrenQuery){
+                              if (topDocsPhase.numHits() <= numDocs) {
                                 break;
+                              }
+                            }else{
+                              if (topDocs.totalHits <= numDocs) {
+                                  break;
+                              }
                             }
                             // if not, update numDocs, and search again
                             numDocs *= topDocsPhase.incrementalFactor();


### PR DESCRIPTION
I had one small problem when doing a search using TopChildrenQuery and realized that when I have more than 51 children to the same document, my search has not returned any results. Digging deeper I found comparison what might be wrong in class QueryPhase.

I posted a code to simulate this problem in gist.

https://gist.github.com/3140681
