### PR TITLE
Allow custom type_table to be passed to Lucene's WordDelimiterFilter() constructor, instead of just the default

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/WordDelimiterTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/WordDelimiterTokenFilterFactory.java
@@ -92,7 +92,7 @@ public class WordDelimiterTokenFilterFactory extends AbstractTokenFilterFactory 
     @Override
     public TokenStream create(TokenStream tokenStream) {
         return new WordDelimiterFilter(tokenStream,
-                WordDelimiterIterator.DEFAULT_WORD_DELIM_TABLE,
+                charTypeTable,
                 generateWordParts ? 1 : 0,
                 generateNumberParts ? 1 : 0,
                 catenateWords ? 1 : 0,


### PR DESCRIPTION
fixes #2145
