### PR TITLE
use term query instead of a specialized SpanTermQuery on _all field if positions are omitted 

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -25,6 +25,7 @@ import org.apache.lucene.document.Fieldable;
 import org.apache.lucene.index.FieldInfo.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.all.AllField;
@@ -142,12 +143,16 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
 
     @Override
     public Query queryStringTermQuery(Term term) {
-        return new AllTermQuery(term);
+        if (indexOptions == IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) {
+            return new AllTermQuery(term);
+        } 
+        return new TermQuery(term);
     }
 
     @Override
     public Query fieldQuery(String value, QueryParseContext context) {
-        return new AllTermQuery(names().createIndexNameTerm(value));
+        return queryStringTermQuery(names().createIndexNameTerm(value));
+        
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/all/mapping_omit_positions_on_all.json
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/all/mapping_omit_positions_on_all.json
@@ -1,0 +1,56 @@
+{
+    "person":{
+        "_all":{
+            "enabled": true ,
+            "index_options" : "freqs"
+        },
+        "properties":{
+            "name":{
+                "type":"object",
+                "dynamic":false,
+                "properties":{
+                    "first":{
+                        "type":"string",
+                        "store":"yes",
+                        "include_in_all":false
+                    },
+                    "last":{
+                        "type":"string",
+                        "index":"not_analyzed"
+                    }
+                }
+            },
+            "address":{
+                "type":"object",
+                "include_in_all":false,
+                "properties":{
+                    "first":{
+                        "properties":{
+                            "location":{
+                                "type":"string",
+                                "store":"yes",
+                                "index_name":"firstLocation"
+                            }
+                        }
+                    },
+                    "last":{
+                        "properties":{
+                            "location":{
+                                "type":"string",
+                                "include_in_all":true
+                            }
+                        }
+                    }
+                }
+            },
+            "simple1":{
+                "type":"long",
+                "include_in_all":true
+            },
+            "simple2":{
+                "type":"long",
+                "include_in_all":false
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR uses a TermQuery instead of AllQuery if positions are omitted. See #2178 for details
