### PR TITLE
Local node master listener

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/ClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterService.java
@@ -73,6 +73,16 @@ public interface ClusterService extends LifecycleComponent<ClusterService> {
     void remove(ClusterStateListener listener);
 
     /**
+     * Add a listener for on/off local node master events
+     */
+    void add(LocalNodeMasterListener listener);
+
+    /**
+     * Remove the given listener for on/off local master events
+     */
+    void remove(LocalNodeMasterListener listener);
+
+    /**
      * Adds a cluster state listener that will timeout after the provided timeout.
      */
     void add(TimeValue timeout, TimeoutClusterStateListener listener);

--- a/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -44,11 +43,18 @@ public class ElectMasterService extends AbstractComponent {
 
     private volatile int minimumMasterNodes;
 
-    public ElectMasterService(Settings settings, NodeSettingsService nodeSettingsService) {
+    public ElectMasterService(Settings settings) {
         super(settings);
         this.minimumMasterNodes = settings.getAsInt("discovery.zen.minimum_master_nodes", -1);
         logger.debug("using minimum_master_nodes [{}]", minimumMasterNodes);
-        nodeSettingsService.addListener(new ApplySettings());
+    }
+
+    public void minimumMasterNodes(int minimumMasterNodes) {
+        this.minimumMasterNodes = minimumMasterNodes;
+    }
+
+    public int minimumMasterNodes() {
+        return minimumMasterNodes;
     }
 
     public boolean hasEnoughMasterNodes(Iterable<DiscoveryNode> nodes) {
@@ -109,17 +115,6 @@ public class ElectMasterService extends AbstractComponent {
         }
         Collections.sort(possibleNodes, nodeComparator);
         return possibleNodes;
-    }
-
-    class ApplySettings implements NodeSettingsService.Listener {
-        @Override
-        public void onRefreshSettings(Settings settings) {
-            int minimumMasterNodes = settings.getAsInt("discovery.zen.minimum_master_nodes", ElectMasterService.this.minimumMasterNodes);
-            if (minimumMasterNodes != ElectMasterService.this.minimumMasterNodes) {
-                logger.info("updating [discovery.zen.minimum_master_nodes] from [{}] to [{}]", ElectMasterService.this.minimumMasterNodes, minimumMasterNodes);
-                ElectMasterService.this.minimumMasterNodes = minimumMasterNodes;
-            }
-        }
     }
 
     private static class NodeComparator implements Comparator<DiscoveryNode> {


### PR DESCRIPTION
- Fixed an issue when the minimum_master_nodes is updated dynamically it takes immediate effect on the cluster state.
- Added LocalNodeMasterListener which enables listening to when the local node becomes a master or stops being one 
