### PR TITLE
Local node master listener

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/ClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterService.java
@@ -73,6 +73,16 @@ public interface ClusterService extends LifecycleComponent<ClusterService> {
     void remove(ClusterStateListener listener);
 
     /**
+     * Add a listener for on/off local node master events
+     */
+    void add(LocalNodeMasterListener listener);
+
+    /**
+     * Remove the given listener for on/off local master events
+     */
+    void remove(LocalNodeMasterListener listener);
+
+    /**
      * Adds a cluster state listener that will timeout after the provided timeout.
      */
     void add(TimeValue timeout, TimeoutClusterStateListener listener);

--- a/src/main/java/org/elasticsearch/cluster/LocalNodeMasterListener.java
+++ b/src/main/java/org/elasticsearch/cluster/LocalNodeMasterListener.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+/**
+ * Enables listening to master changes events of the local node (when the local node becomes the master, and when the local
+ * node cease being a master).
+ */
+public interface LocalNodeMasterListener {
+
+    /**
+     * Called when local node is elected to be the master
+     */
+    void onMaster();
+
+    /**
+     * Called when the local node used to be the master, a new master was elected and it's no longer the local node.
+     */
+    void offMaster();
+
+    /**
+     * The name of the executor that the implementation of the callbacks of this lister should be executed on. The thread
+     * that is responsible for managing instances of this lister is the same thread handling the cluster state events. If
+     * the work done is the callbacks above is inexpensive, this value may be {@link org.elasticsearch.threadpool.ThreadPool.Names#SAME SAME}
+     * (indicating that the callbaks will run on the same thread as the cluster state events are fired with). On the other hand,
+     * if the logic in the callbacks are heavier and take longer to process (or perhaps involve blocking due to IO operations),
+     * prefer to execute them on a separte more appropriate executor (eg. {@link org.elasticsearch.threadpool.ThreadPool.Names#GENERIC GENERIC}
+     * or {@link org.elasticsearch.threadpool.ThreadPool.Names#MANAGEMENT MANAGEMENT}).
+     *
+     * @return The name of the executor that will run the callbacks of this listener.
+     */
+    String executorName();
+
+}
+

--- a/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -44,11 +43,18 @@ public class ElectMasterService extends AbstractComponent {
 
     private volatile int minimumMasterNodes;
 
-    public ElectMasterService(Settings settings, NodeSettingsService nodeSettingsService) {
+    public ElectMasterService(Settings settings) {
         super(settings);
         this.minimumMasterNodes = settings.getAsInt("discovery.zen.minimum_master_nodes", -1);
         logger.debug("using minimum_master_nodes [{}]", minimumMasterNodes);
-        nodeSettingsService.addListener(new ApplySettings());
+    }
+
+    public void minimumMasterNodes(int minimumMasterNodes) {
+        this.minimumMasterNodes = minimumMasterNodes;
+    }
+
+    public int minimumMasterNodes() {
+        return minimumMasterNodes;
     }
 
     public boolean hasEnoughMasterNodes(Iterable<DiscoveryNode> nodes) {
@@ -109,17 +115,6 @@ public class ElectMasterService extends AbstractComponent {
         }
         Collections.sort(possibleNodes, nodeComparator);
         return possibleNodes;
-    }
-
-    class ApplySettings implements NodeSettingsService.Listener {
-        @Override
-        public void onRefreshSettings(Settings settings) {
-            int minimumMasterNodes = settings.getAsInt("discovery.zen.minimum_master_nodes", ElectMasterService.this.minimumMasterNodes);
-            if (minimumMasterNodes != ElectMasterService.this.minimumMasterNodes) {
-                logger.info("updating [discovery.zen.minimum_master_nodes] from [{}] to [{}]", ElectMasterService.this.minimumMasterNodes, minimumMasterNodes);
-                ElectMasterService.this.minimumMasterNodes = minimumMasterNodes;
-            }
-        }
     }
 
     private static class NodeComparator implements Comparator<DiscoveryNode> {

--- a/src/test/java/org/elasticsearch/test/integration/cluster/LocalNodeMasterListenerTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/cluster/LocalNodeMasterListenerTests.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.cluster;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.LocalNodeMasterListener;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ *
+ */
+public class LocalNodeMasterListenerTests extends AbstractZenNodesTests {
+
+    @AfterMethod
+    public void closeNodes() {
+        closeAllNodes();
+    }
+
+    @Test
+    public void testListenerCallbacks() throws Exception {
+
+        Settings settings = settingsBuilder()
+                .put("discovery.zen.minimum_master_nodes", 1)
+                .put("discovery.zen.ping_timeout", "200ms")
+                .put("discovery.initial_state_timeout", "500ms")
+                .put("plugin.types", TestPlugin.class.getName())
+                .build();
+
+        InternalNode node1 = (InternalNode) startNode("node1", settings);
+        ClusterService clusterService1 = node1.injector().getInstance(ClusterService.class);
+        MasterAwareService testService1 = node1.injector().getInstance(MasterAwareService.class);
+
+        // the first node should be a master as the minimum required is 1
+        assertThat(clusterService1.state().nodes().masterNode(), notNullValue());
+        assertThat(clusterService1.state().nodes().localNodeMaster(), is(true));
+        assertThat(testService1.master(), is(true));
+
+        InternalNode node2 = (InternalNode) startNode("node2", settings);
+        ClusterService clusterService2 = node2.injector().getInstance(ClusterService.class);
+        MasterAwareService testService2 = node2.injector().getInstance(MasterAwareService.class);
+
+        ClusterHealthResponse clusterHealth = node2.client().admin().cluster().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+
+        // the second node should not be the master as node1 is already the master.
+        assertThat(clusterService2.state().nodes().localNodeMaster(), is(false));
+        assertThat(testService2.master(), is(false));
+
+        node1.close();
+
+        clusterHealth = node2.client().admin().cluster().prepareHealth().setWaitForNodes("1").execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+
+        // now that node1 is closed, node2 should be elected as master
+        assertThat(clusterService2.state().nodes().localNodeMaster(), is(true));
+        assertThat(testService2.master(), is(true));
+
+        Settings newSettings = settingsBuilder()
+                .put("discovery.zen.minimum_master_nodes", 2)
+                .build();
+        node2.client().admin().cluster().prepareUpdateSettings().setTransientSettings(newSettings).execute().actionGet();
+        Thread.sleep(200);
+
+        // there should not be any master as the minimum number of required eligible masters is not met
+        assertThat(clusterService2.state().nodes().masterNode(), is(nullValue()));
+        assertThat(testService2.master(), is(false));
+
+
+        node1 = (InternalNode) startNode("node1", settings);
+        clusterService1 = node1.injector().getInstance(ClusterService.class);
+        testService1 = node1.injector().getInstance(MasterAwareService.class);
+
+        clusterHealth = node2.client().admin().cluster().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        assertThat(clusterHealth.timedOut(), equalTo(false));
+
+        // now that we started node1 again, a new master should be elected
+        assertThat(clusterService1.state().nodes().masterNode(), is(notNullValue()));
+        if ("node1".equals(clusterService1.state().nodes().masterNode().name())) {
+            assertThat(testService1.master(), is(true));
+            assertThat(testService2.master(), is(false));
+        } else {
+            assertThat(testService1.master(), is(false));
+            assertThat(testService2.master(), is(true));
+        }
+
+    }
+
+    public static class TestPlugin extends AbstractPlugin {
+
+        @Override
+        public String name() {
+            return "test plugin";
+        }
+
+        @Override
+        public String description() {
+            return "test plugin";
+        }
+
+        @Override
+        public Collection<Class<? extends LifecycleComponent>> services() {
+            List<Class<? extends LifecycleComponent>> services = new ArrayList<Class<? extends LifecycleComponent>>(1);
+            services.add(MasterAwareService.class);
+            return services;
+        }
+    }
+
+    @Singleton
+    public static class MasterAwareService extends AbstractLifecycleComponent<MasterAwareService> implements LocalNodeMasterListener {
+
+        private final ClusterService clusterService;
+        private volatile boolean master;
+
+        @Inject
+        public MasterAwareService(Settings settings, ClusterService clusterService) {
+            super(settings);
+            clusterService.add(this);
+            this.clusterService = clusterService;
+            logger.info("initialized test service");
+        }
+
+        @Override
+        public void onMaster() {
+            logger.info("on master [" + clusterService.state().nodes().localNode() + "]");
+            master = true;
+        }
+
+        @Override
+        public void offMaster() {
+            logger.info("off master [" + clusterService.state().nodes().localNode() + "]");
+            master = false;
+        }
+
+        public boolean master() {
+            return master;
+        }
+
+        @Override
+        protected void doStart() throws ElasticSearchException {
+        }
+
+        @Override
+        protected void doStop() throws ElasticSearchException {
+        }
+
+        @Override
+        protected void doClose() throws ElasticSearchException {
+        }
+
+        @Override
+        public String executorName() {
+            return ThreadPool.Names.SAME;
+        }
+
+    }
+}


### PR DESCRIPTION
- Fixed an issue where dynamic update to minimum_master_nodes settings would not take immediate effect
- Added LocalNodeMasterListener support to the ClusterService. Enables listening to when the local node becomes/stopped being a master
