### PR TITLE
Permit full accuracy of results when limiting the size of a facet query

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -114,13 +114,14 @@ public class IndexMetaData {
             .add(IndexMetaData.SETTING_BLOCKS_READ)
             .add(IndexMetaData.SETTING_BLOCKS_WRITE)
             .add(IndexMetaData.SETTING_BLOCKS_METADATA)
+            .add(IndexMetaData.SETTING_NEED_ACCURACY)
             .build();
 
     public static final ClusterBlock INDEX_READ_ONLY_BLOCK = new ClusterBlock(5, "index read-only (api)", false, false, RestStatus.FORBIDDEN, ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA);
     public static final ClusterBlock INDEX_READ_BLOCK = new ClusterBlock(7, "index read (api)", false, false, RestStatus.FORBIDDEN, ClusterBlockLevel.READ);
     public static final ClusterBlock INDEX_WRITE_BLOCK = new ClusterBlock(8, "index write (api)", false, false, RestStatus.FORBIDDEN, ClusterBlockLevel.WRITE);
     public static final ClusterBlock INDEX_METADATA_BLOCK = new ClusterBlock(9, "index metadata (api)", false, false, RestStatus.FORBIDDEN, ClusterBlockLevel.METADATA);
-
+    
     public static ImmutableSet<String> dynamicSettings() {
         return dynamicSettings;
     }
@@ -181,7 +182,8 @@ public class IndexMetaData {
     public static final String SETTING_BLOCKS_WRITE = "index.blocks.write";
     public static final String SETTING_BLOCKS_METADATA = "index.blocks.metadata";
     public static final String SETTING_VERSION_CREATED = "index.version.created";
-
+    public static final String SETTING_NEED_ACCURACY = "index.need_accuracy";
+    
     private final String index;
     private final long version;
 


### PR DESCRIPTION
Fixed issue #1832

The current method used to implement a size limit on a facet query favors performance over accuracy. This is a result of the size limit being applied per shard before aggregation of the results.

I modified class org.elasticsearch.search.facet.terms.strings.TermsStringOrdinalsFacetCollector to check for a new configuration parameter and if enabled, override this behavior to return all of the facets in the sorted order on a per shard basis. The merge facet process will still apply the size limit to return the top N facets based on the counts.

The result of this is that the client receives full accuracy with a size limited facet query.
