### PR TITLE
[FIX] Added checking for Java on the system in `bin/elasticsearch`

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -92,6 +92,11 @@ else
     JAVA=`which java`
 fi
 
+if [ -z $JAVA ] || [ ! -x $JAVA ]; then
+  echo "[!] Cannot find Java -- is it installed?"
+  exit 1
+fi
+
 if [ -z "$ES_CLASSPATH" ]; then
     echo "You must set the ES_CLASSPATH var" >&2
     exit 1


### PR DESCRIPTION
When Java wasn't installed/available in the system, a confusing "permission denied" error
was diplayed to users:

```
user@server:/home/ubuntu/elasticsearch-0.19.9# ./bin/elasticsearch -f
./bin/elasticsearch: 122: exec: : Permission denied
```

This patch fixes the issue by checking for:

a) Java script existence based on the $JAVA environment variable,
b) executability of the Java script

The following [Vagrant](http://vagrantup.com) configuration was used to set up a clean Linux environment:

``` ruby
Vagrant::Config.run do |config|
  config.vm.box = "precise64"

  config.vm.provision :shell, :inline => <<-BOOTSTRAP
    sudo apt-get install unzip -y
    sudo apt-get install vim -y
    sudo apt-get install curl -y

    wget https://github.com/downloads/elasticsearch/elasticsearch/elasticsearch-0.19.9.zip
    unzip elasticsearch-0.19.9.zip
  BOOTSTRAP
end
```
