### PR TITLE
Throw MapperParserException if trying to parse value as object.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -397,6 +397,11 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
             // the object is null ("obj1" : null), simply bail
             return;
         }
+        
+        if (token.isValue()) {
+        	// if we are parsing an object but it is just a value
+	    	throw new MapperParsingException("object mapping for [" + name + "] tried to parse as object, but found a concrete value");
+        }
 
         Document restoreDoc = null;
         if (nested.isNested()) {


### PR DESCRIPTION
When a value type is passed to the object parser it will call nextToken() until it finds an END_OBJECT token (an END_OBJECT for another object). When nested in an array the serializeArray call never exits (the extra nextToken() in parse forwards the stream out of the array).

Example:

```
{
  "object": {
    "array":[
    {
      "object": { "value": "value" }
    },
    {
      "object":"value"
    }
    ]
  },
  "value":"value"
}
```

This fix makes the object parser throw a MapperParsingException if a value type is passed to it.
