### PR TITLE
Use the java args to enable HTTP proxying etc.

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -28,4 +28,4 @@ else
     JAVA=`which java`
 fi
 
-exec $JAVA -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*
+exec $JAVA ${JAVA_ARGS} -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*


### PR DESCRIPTION
The plugin downloader uses HTTP(S) to download new plugins, but does not include support for environments where HTTP proxies are required.

This patch simply enables the use of the standard JAVA_ARGS environment variable when the java command is called in the script.

Thus you may enable HTTP proxying as so prior to running the plugin script:

export JAVA_ARGS=-Dhttp.proxyHost=host -Dhttp.proxyPort=3128 -Dhttps.proxyHost=host -Dhttps.proxyPort=3128
