### PR TITLE
Fix reversed ShingleFilter constructor arguments

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/ShingleTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ShingleTokenFilterFactory.java
@@ -54,7 +54,7 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
 
     @Override
     public TokenStream create(TokenStream tokenStream) {
-        ShingleFilter filter = new ShingleFilter(tokenStream, maxShingleSize, minShingleSize);
+        ShingleFilter filter = new ShingleFilter(tokenStream, minShingleSize, maxShingleSize);
         filter.setOutputUnigrams(outputUnigrams);
         filter.setOutputUnigramsIfNoShingles(outputUnigramsIfNoShingles);
         filter.setTokenSeparator(tokenSeparator);


### PR DESCRIPTION
The `ShingleTokenFilterFactory` in ElasticSearch reverses the `minShingleSize` and `maxShingleSize` arguments to the underlying Lucene `ShingleFilter`

For reference, here is a script that reproduces the issue clearly (tested against 0.19.9): https://gist.github.com/3558149
