### PR TITLE
Added proper headers for cross-origin resource sharing (CORS) with Ajax

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -73,13 +73,13 @@ public class NettyHttpChannel implements HttpChannel {
             resp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
         }
         if (RestUtils.isBrowser(request.getHeader(HttpHeaders.Names.USER_AGENT))) {
-            // add support for cross origin
+            // Add support for cross-origin Ajax requests (CORS)
             resp.addHeader("Access-Control-Allow-Origin", "*");
             if (request.getMethod() == HttpMethod.OPTIONS) {
-                // also add more access control parameters
+                // Allow Ajax requests based on the CORS "preflight" request
                 resp.addHeader("Access-Control-Max-Age", 1728000);
-                resp.addHeader("Access-Control-Allow-Methods", "PUT, DELETE");
-                resp.addHeader("Access-Control-Allow-Headers", "X-Requested-With");
+                resp.addHeader("Access-Control-Allow-Methods", "OPTIONS, HEAD, GET, POST, PUT, DELETE");
+                resp.addHeader("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Content-Length");
             }
         }
 


### PR DESCRIPTION
Previously, when responding to Ajax requests, elasticsearch did not send proper headers for
cross-origin resource sharing (CORS) -- see issues #828, #2186.

With this commit, Ajax requests should be working. Example:

```
jQuery.ajax({
  url: "http://localhost:9200/_search",
  type: "POST",
  contentType: 'application/json; charset=UTF-8',
  success: function(data) { console.log(data) }
});
```

See:
- http://www.nczonline.net/blog/2010/05/25/cross-domain-ajax-with-cross-origin-resource-sharing/
- http://www.w3.org/TR/cors/#access-control-allow-headers-response-header

Closes #2186, fixes #828
