### PR TITLE
setting "index.store.type: mmapfs" still uses NIOFS backend

### DIFF
--- a/src/main/java/org/apache/lucene/store/XMMapFSDirectory.java
+++ b/src/main/java/org/apache/lucene/store/XMMapFSDirectory.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 /**
  */
-public class XMMapFSDirectory extends NIOFSDirectory {
+public class XMMapFSDirectory extends MMapDirectory {
 
     private final StoreRateLimiting.Provider rateLimitingProvider;
 


### PR DESCRIPTION
XMMapFSDirectory class extends wrong directory
