### PR TITLE
Upgraded to Spatial4j 0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>com.spatial4j</groupId>
             <artifactId>spatial4j</artifactId>
-            <version>0.2</version>
+            <version>0.3</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
@@ -20,9 +20,9 @@
 package org.elasticsearch.common.geo;
 
 import com.spatial4j.core.shape.Shape;
+import com.spatial4j.core.shape.impl.RectangleImpl;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
-import com.spatial4j.core.shape.simple.RectangleImpl;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LinearRing;
@@ -138,9 +138,9 @@ public class GeoJSONShapeParser {
      */
     private static Shape buildShape(String shapeType, CoordinateNode node) {
         if ("point".equals(shapeType)) {
-            return new JtsPoint(GEOMETRY_FACTORY.createPoint(node.coordinate));
+            return new JtsPoint(GEOMETRY_FACTORY.createPoint(node.coordinate), GeoShapeConstants.SPATIAL_CONTEXT);
         } else if ("linestring".equals(shapeType)) {
-            return new JtsGeometry(GEOMETRY_FACTORY.createLineString(toCoordinates(node)));
+            return new JtsGeometry(GEOMETRY_FACTORY.createLineString(toCoordinates(node)), GeoShapeConstants.SPATIAL_CONTEXT, true);
         } else if ("polygon".equals(shapeType)) {
             LinearRing shell = GEOMETRY_FACTORY.createLinearRing(toCoordinates(node.children.get(0)));
             LinearRing[] holes = null;
@@ -150,12 +150,12 @@ public class GeoJSONShapeParser {
                     holes[i] = GEOMETRY_FACTORY.createLinearRing(toCoordinates(node.children.get(i + 1)));
                 }
             }
-            return new JtsGeometry(GEOMETRY_FACTORY.createPolygon(shell, holes));
+            return new JtsGeometry(GEOMETRY_FACTORY.createPolygon(shell, holes), GeoShapeConstants.SPATIAL_CONTEXT, true);
         } else if ("multipoint".equals(shapeType)) {
-            return new JtsGeometry(GEOMETRY_FACTORY.createMultiPoint(toCoordinates(node)));
+            return new JtsGeometry(GEOMETRY_FACTORY.createMultiPoint(toCoordinates(node)), GeoShapeConstants.SPATIAL_CONTEXT, true);
         } else if ("envelope".equals(shapeType)) {
             Coordinate[] coordinates = toCoordinates(node);
-            return new RectangleImpl(coordinates[0].x, coordinates[1].x, coordinates[1].y, coordinates[0].y);
+            return new RectangleImpl(coordinates[0].x, coordinates[1].x, coordinates[1].y, coordinates[0].y, GeoShapeConstants.SPATIAL_CONTEXT);
         }
 
         throw new UnsupportedOperationException("ShapeType [" + shapeType + "] not supported");

--- a/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeSerializer.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeSerializer.java
@@ -50,7 +50,7 @@ public class GeoJSONShapeSerializer {
      */
     public static void serialize(Shape shape, XContentBuilder builder) throws IOException {
         if (shape instanceof JtsGeometry) {
-            Geometry geometry = ((JtsGeometry) shape).geo;
+            Geometry geometry = ((JtsGeometry) shape).getGeom();
             if (geometry instanceof Point) {
                 serializePoint((Point) geometry, builder);
             } else if (geometry instanceof LineString) {

--- a/src/main/java/org/elasticsearch/common/geo/GeoShapeConstants.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoShapeConstants.java
@@ -19,38 +19,12 @@
 
 package org.elasticsearch.common.geo;
 
-import com.spatial4j.core.shape.impl.PointImpl;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import com.spatial4j.core.context.jts.JtsSpatialContext;
 
 /**
+ * Common constants through the GeoShape codebase
  */
-public class ShapesAvailability {
+public interface GeoShapeConstants {
 
-    public static final boolean SPATIAL4J_AVAILABLE;
-    public static final boolean JTS_AVAILABLE;
-
-    static {
-        boolean xSPATIAL4J_AVAILABLE;
-        try {
-            new PointImpl(0, 0, GeoShapeConstants.SPATIAL_CONTEXT);
-            xSPATIAL4J_AVAILABLE = true;
-        } catch (Throwable t) {
-            xSPATIAL4J_AVAILABLE = false;
-        }
-        SPATIAL4J_AVAILABLE = xSPATIAL4J_AVAILABLE;
-
-        boolean xJTS_AVAILABLE;
-        try {
-            new GeometryFactory();
-            xJTS_AVAILABLE = true;
-        } catch (Throwable t) {
-            xJTS_AVAILABLE = false;
-        }
-        JTS_AVAILABLE = xJTS_AVAILABLE;
-    }
-
-
-    private ShapesAvailability() {
-
-    }
+    public static final JtsSpatialContext SPATIAL_CONTEXT = new JtsSpatialContext(true);
 }

--- a/src/main/java/org/elasticsearch/common/geo/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/ShapeBuilder.java
@@ -22,10 +22,10 @@ package org.elasticsearch.common.geo;
 import com.spatial4j.core.shape.Point;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
+import com.spatial4j.core.shape.impl.PointImpl;
+import com.spatial4j.core.shape.impl.RectangleImpl;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
-import com.spatial4j.core.shape.simple.PointImpl;
-import com.spatial4j.core.shape.simple.RectangleImpl;
 import com.vividsolutions.jts.geom.*;
 
 import java.util.ArrayList;
@@ -50,7 +50,7 @@ public class ShapeBuilder {
      * @return Point with the latitude and longitude
      */
     public static Point newPoint(double lon, double lat) {
-        return new PointImpl(lon, lat);
+        return new PointImpl(lon, lat, GeoShapeConstants.SPATIAL_CONTEXT);
     }
 
     /**
@@ -80,9 +80,9 @@ public class ShapeBuilder {
      */
     public static Geometry toJTSGeometry(Shape shape) {
         if (shape instanceof JtsGeometry) {
-            return ((JtsGeometry) shape).geo;
+            return ((JtsGeometry) shape).getGeom();
         } else if (shape instanceof JtsPoint) {
-            return ((JtsPoint) shape).getJtsPoint();
+            return ((JtsPoint) shape).getGeom();
         } else if (shape instanceof Rectangle) {
             Rectangle rectangle = (Rectangle) shape;
 
@@ -119,7 +119,7 @@ public class ShapeBuilder {
          * @return this
          */
         public RectangleBuilder topLeft(double lon, double lat) {
-            this.topLeft = new PointImpl(lon, lat);
+            this.topLeft = new PointImpl(lon, lat, GeoShapeConstants.SPATIAL_CONTEXT);
             return this;
         }
 
@@ -131,7 +131,7 @@ public class ShapeBuilder {
          * @return this
          */
         public RectangleBuilder bottomRight(double lon, double lat) {
-            this.bottomRight = new PointImpl(lon, lat);
+            this.bottomRight = new PointImpl(lon, lat, GeoShapeConstants.SPATIAL_CONTEXT);
             return this;
         }
 
@@ -141,7 +141,7 @@ public class ShapeBuilder {
          * @return Built Rectangle
          */
         public Rectangle build() {
-            return new RectangleImpl(topLeft.getX(), bottomRight.getX(), bottomRight.getY(), topLeft.getY());
+            return new RectangleImpl(topLeft.getX(), bottomRight.getX(), bottomRight.getY(), topLeft.getY(), GeoShapeConstants.SPATIAL_CONTEXT);
         }
     }
 
@@ -160,7 +160,7 @@ public class ShapeBuilder {
          * @return this
          */
         public PolygonBuilder point(double lon, double lat) {
-            points.add(new PointImpl(lon, lat));
+            points.add(new PointImpl(lon, lat, GeoShapeConstants.SPATIAL_CONTEXT));
             return this;
         }
 
@@ -170,7 +170,7 @@ public class ShapeBuilder {
          * @return Built polygon
          */
         public Shape build() {
-            return new JtsGeometry(toPolygon());
+            return new JtsGeometry(toPolygon(), GeoShapeConstants.SPATIAL_CONTEXT, true);
         }
 
         /**

--- a/src/main/java/org/elasticsearch/common/lucene/spatial/prefix/tree/Node.java
+++ b/src/main/java/org/elasticsearch/common/lucene/spatial/prefix/tree/Node.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 /**
  * Represents a grid cell. These are not necessarily threadsafe, although new Cell("") (world cell) must be.
+ *
+ * @lucene.experimental
  */
 public abstract class Node implements Comparable<Node> {
   public static final byte LEAF_BYTE = '+';//NOTE: must sort before letters & numbers
@@ -150,7 +152,7 @@ public abstract class Node implements Comparable<Node> {
     }
     List<Node> copy = new ArrayList<Node>(cells.size());//copy since cells contractually isn't modifiable
     for (Node cell : cells) {
-      SpatialRelation rel = cell.getShape().relate(shapeFilter, spatialPrefixTree.ctx);
+      SpatialRelation rel = cell.getShape().relate(shapeFilter);
       if (rel == SpatialRelation.DISJOINT)
         continue;
       cell.shapeRel = rel;

--- a/src/main/java/org/elasticsearch/common/lucene/spatial/prefix/tree/SpatialPrefixTree.java
+++ b/src/main/java/org/elasticsearch/common/lucene/spatial/prefix/tree/SpatialPrefixTree.java
@@ -28,10 +28,12 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A Spatial Prefix Tree, or Trie, which decomposes shapes into prefixed strings at variable lengths corresponding to
+ * A spatial Prefix Tree, or Trie, which decomposes shapes into prefixed strings at variable lengths corresponding to
  * variable precision.  Each string corresponds to a spatial region.
- *
+ * <p/>
  * Implementations of this class should be thread-safe and immutable once initialized.
+ *
+ * @lucene.experimental
  */
 public abstract class SpatialPrefixTree {
 
@@ -61,34 +63,14 @@ public abstract class SpatialPrefixTree {
   }
 
   /**
-   * See {@link com.spatial4j.core.query.SpatialArgs#getDistPrecision()}.
-   * A grid level looked up via {@link #getLevelForDistance(double)} is returned.
-   *
-   * @param shape
-   * @param precision 0-0.5
-   * @return 1-maxLevels
-   */
-  public int getMaxLevelForPrecision(Shape shape, double precision) {
-    if (precision < 0 || precision > 0.5) {
-      throw new IllegalArgumentException("Precision " + precision + " must be between [0-0.5]");
-    }
-    if (precision == 0 || shape instanceof Point) {
-      return maxLevels;
-    }
-    double bboxArea = shape.getBoundingBox().getArea();
-    if (bboxArea == 0) {
-      return maxLevels;
-    }
-    double avgSideLenFromCenter = Math.sqrt(bboxArea) / 2;
-    return getLevelForDistance(avgSideLenFromCenter * precision);
-  }
-
-  /**
-   * Returns the level of the smallest grid size with a side length that is greater or equal to the provided
-   * distance.
+   * Returns the level of the largest grid in which its longest side is less
+   * than or equal to the provided distance (in degrees). Consequently {@code
+   * dist} acts as an error epsilon declaring the amount of detail needed in the
+   * grid, such that you can get a grid with just the right amount of
+   * precision.
    *
    * @param dist >= 0
-   * @return level [1-maxLevels]
+   * @return level [1 to maxLevels]
    */
   public abstract int getLevelForDistance(double dist);
 

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -1,14 +1,12 @@
 package org.elasticsearch.index.mapper.geo;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.jts.JtsSpatialContext;
-import com.spatial4j.core.distance.DistanceUnits;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Fieldable;
 import org.apache.lucene.index.FieldInfo;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJSONShapeParser;
+import org.elasticsearch.common.geo.GeoShapeConstants;
 import org.elasticsearch.common.lucene.spatial.SpatialStrategy;
 import org.elasticsearch.common.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.GeohashPrefixTree;
@@ -43,9 +41,6 @@ import java.util.Map;
 public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
 
     public static final String CONTENT_TYPE = "geo_shape";
-
-    // TODO: Unsure if the units actually matter since we dont do distance calculations
-    public static final SpatialContext SPATIAL_CONTEXT = new JtsSpatialContext(DistanceUnits.KILOMETERS);
 
     public static class Names {
         public static final String TREE = "tree";
@@ -93,10 +88,10 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
         public GeoShapeFieldMapper build(BuilderContext context) {
             if (tree.equals(Names.GEOHASH)) {
                 int levels = treeLevels != 0 ? treeLevels : Defaults.GEOHASH_LEVELS;
-                prefixTree = new GeohashPrefixTree(SPATIAL_CONTEXT, levels);
+                prefixTree = new GeohashPrefixTree(GeoShapeConstants.SPATIAL_CONTEXT, levels);
             } else if (tree.equals(Names.QUADTREE)) {
                 int levels = treeLevels != 0 ? treeLevels : Defaults.QUADTREE_LEVELS;
-                prefixTree = new QuadPrefixTree(SPATIAL_CONTEXT, levels);
+                prefixTree = new QuadPrefixTree(GeoShapeConstants.SPATIAL_CONTEXT, levels);
             } else {
                 throw new ElasticSearchIllegalArgumentException("Unknown prefix tree type [" + tree + "]");
             }

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
@@ -5,6 +5,7 @@ import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
 import com.vividsolutions.jts.geom.*;
 import org.elasticsearch.common.geo.GeoJSONShapeParser;
+import org.elasticsearch.common.geo.GeoShapeConstants;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -30,7 +31,7 @@ public class GeoJSONShapeParserTests {
                 .endObject().string();
 
         Point expected = GEOMETRY_FACTORY.createPoint(new Coordinate(100.0, 0.0));
-        assertGeometryEquals(new JtsPoint(expected), pointGeoJson);
+        assertGeometryEquals(new JtsPoint(expected, GeoShapeConstants.SPATIAL_CONTEXT), pointGeoJson);
     }
 
     @Test
@@ -48,7 +49,7 @@ public class GeoJSONShapeParserTests {
 
         LineString expected = GEOMETRY_FACTORY.createLineString(
                 lineCoordinates.toArray(new Coordinate[lineCoordinates.size()]));
-        assertGeometryEquals(new JtsGeometry(expected), lineGeoJson);
+        assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), lineGeoJson);
     }
 
     @Test
@@ -75,7 +76,7 @@ public class GeoJSONShapeParserTests {
         LinearRing shell = GEOMETRY_FACTORY.createLinearRing(
                 shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
-        assertGeometryEquals(new JtsGeometry(expected), polygonGeoJson);
+        assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), polygonGeoJson);
     }
 
     @Test
@@ -119,7 +120,7 @@ public class GeoJSONShapeParserTests {
         holes[0] = GEOMETRY_FACTORY.createLinearRing(
                 holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, holes);
-        assertGeometryEquals(new JtsGeometry(expected), polygonGeoJson);
+        assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), polygonGeoJson);
     }
 
     @Test
@@ -137,7 +138,7 @@ public class GeoJSONShapeParserTests {
 
         MultiPoint expected = GEOMETRY_FACTORY.createMultiPoint(
                 multiPointCoordinates.toArray(new Coordinate[multiPointCoordinates.size()]));
-        assertGeometryEquals(new JtsGeometry(expected), multiPointGeoJson);
+        assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), multiPointGeoJson);
     }
 
     private void assertGeometryEquals(Shape expected, String geoJson) throws IOException {

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeSerializerTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeSerializerTests.java
@@ -5,6 +5,7 @@ import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
 import com.vividsolutions.jts.geom.*;
 import org.elasticsearch.common.geo.GeoJSONShapeSerializer;
+import org.elasticsearch.common.geo.GeoShapeConstants;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.testng.annotations.Test;
@@ -29,7 +30,7 @@ public class GeoJSONShapeSerializerTests {
                 .endObject();
 
         Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(100.0, 0.0));
-        assertSerializationEquals(expected, new JtsPoint(point));
+        assertSerializationEquals(expected, new JtsPoint(point, GeoShapeConstants.SPATIAL_CONTEXT));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class GeoJSONShapeSerializerTests {
         LineString lineString = GEOMETRY_FACTORY.createLineString(
                 lineCoordinates.toArray(new Coordinate[lineCoordinates.size()]));
 
-        assertSerializationEquals(expected, new JtsGeometry(lineString));
+        assertSerializationEquals(expected, new JtsGeometry(lineString, GeoShapeConstants.SPATIAL_CONTEXT, false));
     }
 
     @Test
@@ -76,7 +77,7 @@ public class GeoJSONShapeSerializerTests {
                 shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
         Polygon polygon = GEOMETRY_FACTORY.createPolygon(shell, null);
 
-        assertSerializationEquals(expected, new JtsGeometry(polygon));
+        assertSerializationEquals(expected, new JtsGeometry(polygon, GeoShapeConstants.SPATIAL_CONTEXT, false));
     }
 
     @Test
@@ -121,7 +122,7 @@ public class GeoJSONShapeSerializerTests {
                 holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
         Polygon polygon = GEOMETRY_FACTORY.createPolygon(shell, holes);
 
-        assertSerializationEquals(expected, new JtsGeometry(polygon));
+        assertSerializationEquals(expected, new JtsGeometry(polygon, GeoShapeConstants.SPATIAL_CONTEXT, false));
     }
 
     @Test
@@ -140,7 +141,7 @@ public class GeoJSONShapeSerializerTests {
         MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(
                 multiPointCoordinates.toArray(new Coordinate[multiPointCoordinates.size()]));
 
-        assertSerializationEquals(expected, new JtsGeometry(multiPoint));
+        assertSerializationEquals(expected, new JtsGeometry(multiPoint, GeoShapeConstants.SPATIAL_CONTEXT, false));
     }
 
     private void assertSerializationEquals(XContentBuilder expected, Shape shape) throws IOException {

--- a/src/test/java/org/elasticsearch/test/unit/common/lucene/spatial/prefix/TermQueryPrefixTreeStrategyTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/lucene/spatial/prefix/TermQueryPrefixTreeStrategyTests.java
@@ -1,8 +1,5 @@
 package org.elasticsearch.test.unit.common.lucene.spatial.prefix;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.jts.JtsSpatialContext;
-import com.spatial4j.core.distance.DistanceUnits;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
 import org.apache.lucene.analysis.KeywordAnalyzer;
@@ -16,6 +13,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.Version;
+import org.elasticsearch.common.geo.GeoShapeConstants;
 import org.elasticsearch.common.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.QuadPrefixTree;
@@ -37,13 +35,12 @@ import static org.testng.Assert.assertTrue;
  */
 public class TermQueryPrefixTreeStrategyTests {
 
-    private static final SpatialContext SPATIAL_CONTEXT = new JtsSpatialContext(DistanceUnits.KILOMETERS);
 
     // TODO: Randomize the implementation choice
     private static final SpatialPrefixTree QUAD_PREFIX_TREE =
-            new QuadPrefixTree(SPATIAL_CONTEXT, QuadPrefixTree.DEFAULT_MAX_LEVELS);
+            new QuadPrefixTree(GeoShapeConstants.SPATIAL_CONTEXT, QuadPrefixTree.DEFAULT_MAX_LEVELS);
     private static final SpatialPrefixTree GEOHASH_PREFIX_TREE
-            = new GeohashPrefixTree(SPATIAL_CONTEXT, GeohashPrefixTree.getMaxLevelsPossible());
+            = new GeohashPrefixTree(GeoShapeConstants.SPATIAL_CONTEXT, GeohashPrefixTree.getMaxLevelsPossible());
 
     private static final TermQueryPrefixTreeStrategy STRATEGY = new TermQueryPrefixTreeStrategy(new FieldMapper.Names("shape"), GEOHASH_PREFIX_TREE, 0.025);
 


### PR DESCRIPTION
Upgrade to Spatial4j 0.3.  

The predominant changes are in two places: 
- All Shapes in Spatial4j now require a SpatialContext during construction, so the single instance used has been isolated for reuse.  
- The SpatialPrefixTree API has changed a little as part of new interaction with Spatial4j and as part of some bugs that were identified during the Spatial4j testing.
