### PR TITLE
Allow passing additional parameters with query request.

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -825,4 +825,9 @@ public class SearchRequestBuilder extends BaseRequestBuilder<SearchRequest, Sear
     private HighlightBuilder highlightBuilder() {
         return sourceBuilder().highlighter();
     }
+    
+    public SearchRequestBuilder addAdditionalParameter(String name, String value) {
+      sourceBuilder.additionalParameters().addParam(name, value);
+      return this;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.search;
 
+import static org.elasticsearch.common.unit.TimeValue.timeValueMinutes;
+
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.search.SearchType;
@@ -46,14 +49,23 @@ import org.elasticsearch.indices.IndicesLifecycle;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.warmer.IndicesWarmer;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.additional.AdditionalParametersParser;
 import org.elasticsearch.search.dfs.CachedDfSource;
 import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.dfs.DfsSearchResult;
-import org.elasticsearch.search.fetch.*;
+import org.elasticsearch.search.fetch.FetchPhase;
+import org.elasticsearch.search.fetch.FetchSearchRequest;
+import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.QueryFetchSearchResult;
+import org.elasticsearch.search.fetch.ScrollQueryFetchSearchResult;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
 import org.elasticsearch.search.internal.InternalSearchRequest;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.query.*;
+import org.elasticsearch.search.query.QueryPhase;
+import org.elasticsearch.search.query.QueryPhaseExecutionException;
+import org.elasticsearch.search.query.QuerySearchRequest;
+import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.search.query.ScrollQuerySearchResult;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -62,8 +74,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
-
-import static org.elasticsearch.common.unit.TimeValue.timeValueMinutes;
 
 /**
  *
@@ -122,6 +132,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         elementParsers.putAll(queryPhase.parseElements());
         elementParsers.putAll(fetchPhase.parseElements());
         elementParsers.put("stats", new StatsGroupsParseElement());
+        elementParsers.put("additional", new AdditionalParametersParser());
         this.elementParsers = ImmutableMap.copyOf(elementParsers);
         indicesLifecycle.addListener(indicesLifecycleListener);
 

--- a/src/main/java/org/elasticsearch/search/additional/AdditionalParametersBuilder.java
+++ b/src/main/java/org/elasticsearch/search/additional/AdditionalParametersBuilder.java
@@ -1,0 +1,39 @@
+package org.elasticsearch.search.additional;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** 
+ * Builder for additional parameters query section. 
+ */
+public class AdditionalParametersBuilder implements ToXContent {
+  private Map<String, String> parameters;
+  
+  public AdditionalParametersBuilder() {
+    parameters = new HashMap<String, String>();
+  }
+  
+  public AdditionalParametersBuilder addParam(String name, String value) {
+    parameters.put(name, value);
+    return this;
+  }
+  
+  @Override
+  public XContentBuilder toXContent(XContentBuilder builder, Params params)
+      throws IOException {
+    builder.startObject("additional");
+    if (!parameters.isEmpty()) {
+      for (Map.Entry<String, String> entry : parameters.entrySet()) {
+        if (entry.getKey() != null && !entry.getKey().isEmpty() && entry.getValue() != null && !entry.getValue().isEmpty()) {
+          builder.field(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+    builder.endObject();
+    return builder;
+  }
+}

--- a/src/main/java/org/elasticsearch/search/additional/AdditionalParametersParser.java
+++ b/src/main/java/org/elasticsearch/search/additional/AdditionalParametersParser.java
@@ -1,0 +1,30 @@
+package org.elasticsearch.search.additional;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ * Parser for additional parameters section.
+ */
+public class AdditionalParametersParser implements SearchParseElement {
+  @Override
+  public void parse(XContentParser parser, SearchContext context)
+      throws Exception {
+    XContentParser.Token token;
+    String name = null, value = null;
+    
+    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+      if (token == XContentParser.Token.FIELD_NAME) {
+        name = parser.text();
+      } else if (token == XContentParser.Token.VALUE_STRING) {
+        value = parser.text();
+      } 
+      if (name != null && value != null) {
+        context.addAdditionalParameter(name, value);
+        name = null;
+        value = null;
+      }
+    }
+  }
+}

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -21,8 +21,7 @@ package org.elasticsearch.search.builder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import gnu.trove.iterator.TObjectFloatIterator;
-import gnu.trove.map.hash.TObjectFloatHashMap;
+
 import org.elasticsearch.ElasticSearchGenerationException;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
@@ -36,12 +35,15 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.additional.AdditionalParametersBuilder;
 import org.elasticsearch.search.facet.AbstractFacetBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 
+import gnu.trove.iterator.TObjectFloatIterator;
+import gnu.trove.map.hash.TObjectFloatHashMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,6 +69,13 @@ public class SearchSourceBuilder implements ToXContent {
      */
     public static HighlightBuilder highlight() {
         return new HighlightBuilder();
+    }
+    
+    /** 
+     * A static factory method to construct new additional parameters builder. 
+     */
+    public static AdditionalParametersBuilder additionalParams() {
+      return new AdditionalParametersBuilder();
     }
 
     private QueryBuilder queryBuilder;
@@ -106,6 +115,8 @@ public class SearchSourceBuilder implements ToXContent {
     private TObjectFloatHashMap<String> indexBoost = null;
 
     private String[] stats;
+    
+    private AdditionalParametersBuilder additionalParameters;
 
 
     /**
@@ -534,6 +545,13 @@ public class SearchSourceBuilder implements ToXContent {
         this.stats = statsGroups;
         return this;
     }
+    
+    public AdditionalParametersBuilder additionalParameters() {
+      if (this.additionalParameters == null) {
+        this.additionalParameters = additionalParams();
+      }
+      return this.additionalParameters;
+    }
 
     @Override
     public String toString() {
@@ -717,6 +735,10 @@ public class SearchSourceBuilder implements ToXContent {
             builder.endArray();
         }
 
+        if (additionalParameters != null) {
+            additionalParameters.toXContent(builder, params);
+        }
+        
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -167,6 +167,8 @@ public class SearchContext implements Releasable {
     private List<ScopePhase> scopePhases = null;
 
     private Map<String, BlockJoinQuery> nestedQueries;
+    
+    private Map<String, String> additionalParameters;
 
     public SearchContext(long id, InternalSearchRequest request, SearchShardTarget shardTarget,
                          Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard, ScriptService scriptService) {
@@ -603,5 +605,16 @@ public class SearchContext implements Releasable {
 
     public MapperService.SmartNameObjectMapper smartNameObjectMapper(String name) {
         return mapperService().smartNameObjectMapper(name, request.types());
+    }
+    
+    public Map<String, String> additionalParameters() {
+      return additionalParameters;
+    }
+
+    public void addAdditionalParameter(String name, String value) {
+      if (additionalParameters == null) {
+        additionalParameters = new HashMap<String, String>();
+      }
+      additionalParameters.put(name, value);
     }
 }

--- a/src/test/java/org/elasticsearch/test/integration/search/additional/AdditionalParametersTest.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/additional/AdditionalParametersTest.java
@@ -1,0 +1,55 @@
+package org.elasticsearch.test.integration.search.additional;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AdditionalParametersTest extends AbstractNodesTests {
+  private Client client;
+
+  @BeforeClass
+  public void createNodes() throws Exception {
+      startNode("server1");
+      client = client("server1");
+  }
+
+  @AfterClass
+  public void closeNodes() {
+      client.close();
+      closeAllNodes();
+  }
+  
+  @Test
+  public void testPassAdditionalParameters() throws Exception {
+      try {
+          client.admin().indices().prepareDelete("test").execute().actionGet();
+      } catch (Exception e) {
+          // ignore
+      }
+      client.admin().indices().prepareCreate("test").execute().actionGet();
+      client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+
+      client.prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
+              .field("id", "1")
+              .field("name", "aaa")
+              .endObject()).execute().actionGet();
+
+      client.admin().indices().prepareFlush().setRefresh(true).execute().actionGet();
+
+      SearchResponse searchResponse = client.prepareSearch()
+              .setQuery(matchAllQuery())
+              .addAdditionalParameter("userId", "12345")
+              .addAdditionalParameter("token", "dksajas812enxaskhas")
+              .execute().actionGet();
+
+      assertThat(searchResponse.hits().getTotalHits(), equalTo(1l));
+  }
+}


### PR DESCRIPTION
A small addition to ElasticSearch allowing to pass additional, not parsed parameters along with the query, for example like the following:

```
{
 "from" : 0,
 "size" : 60,
 "query" : {
  "term" : { 
   "name" : "value" 
  }
 },
 "additional" : { 
  "token" : "nabsy26dsqnbu1276", 
  "userId" : "12345" 
 }
}
```
