### PR TITLE
Fix possible race condition when routing is required but not specified f...

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -207,8 +207,9 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
                     Engine.Delete delete = indexShard.prepareDelete(deleteRequest.type(), deleteRequest.id(), deleteRequest.version()).versionType(deleteRequest.versionType()).origin(Engine.Operation.Origin.PRIMARY);
                     indexShard.delete(delete);
                     // update the request with teh version so it will go to the replicas
-                    deleteRequest.version(delete.version());
-
+                    if (!delete.notFound()) {
+                        deleteRequest.version(delete.version());
+                    }
                     // add the response
                     responses[i] = new BulkItemResponse(item.id(), "delete",
                             new DeleteResponse(deleteRequest.index(), deleteRequest.type(), deleteRequest.id(), delete.version(), delete.notFound()));


### PR DESCRIPTION
...or a delete operation

This small pull request fixes a possible race condition in the TransportShardBulkAction. This race condition can be triggered by a bulk delete operation on an index with required routing when several primary shards are located on the node that executes the operation. It sounds complicated, but it can be easily reproduced by placing content of AliasRoutingTests.testRequiredRoutingMappingWithAlias or 
SimpleRoutingTests.testRequiredRoutingMapping into an infinite loop. On my machine it typically fails after only a few iterations.

When an index is marked as routing required but routing is not specified on a delete operation, TransportBulkAction broadcasts such delete operation to all shards using [the same delete request object](https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java#L191).

When TransportShardBulkAction receives this request on a primary shard, it tries to delete the record and [updates the version field in the request](https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java#L210). The problem occurs because the version can be updated even if the record on the shard was not actually deleted. It looks like this behavior is desired and was introduced by #1341. When several primary shards are located on the same node, the DeleteRequest object is shared among all shards and the version changes on one shard affect all shards of the index on the same node. As a result the delete operation sometimes fails with VersionConflictEngineException.

While this pull request fixes the problem, it might still make sense to not share the DeleteRequest among shards. What do you think?
