### PR TITLE
Add constructor IndexRequest(String index, String type) and fix javadoc

### DIFF
--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -136,12 +136,21 @@ public class IndexRequest extends ShardReplicationOperationRequest {
     }
 
     /**
-     * Constructs a new index request against the specific index. The {@link #type(String)},
-     * {@link #id(String)} and {@link #source(byte[])} must be set.
+     * Constructs a new index request against the specific index. The {@link #type(String)}
+     * {@link #source(byte[])} must be set. 
      */
     public IndexRequest(String index) {
         this.index = index;
     }
+
+    /**
+     * Constructs a new index request against the specific index and type. The 
+     * {@link #source(byte[])} must be set.
+     */
+    public IndexRequest(String index, String type) {
+        this.index = index;
+        this.type = type;
+   }
 
     /**
      * Constructs a new index request against the index, type, id and using the source.


### PR DESCRIPTION
When using Bulk insertion, we need to add IndexRequest to the bulk.
But, constructors does not allow not to provide the id.

``` java
IndexRequest irq = new IndexRequest("index", "type", "id");
```

But, as we can do it for prepareIndex(), it could be nice to have a constructor without the id:

``` java
// PrepareIndex
client.prepareIndex("index", "type").setSource("{}")
  .execute().actionGet();

// Bulk
client.prepareBulk()
  .add(new IndexRequest("index", "type").source("{}"))
  .execute().actionGet();
```

Prior to this pull request, if we don't want to set the ID and let Elasticsearch generate it, we have to use one of these forms:

``` java
new IndexRequest().index("index").type("type");
new IndexRequest("index").type("type");
```

BTW, I fixed the javadoc documentation for `IndexRequest(String index)` as ID is not mandatory.
