### PR TITLE
Field data caches

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/FieldDataCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/FieldDataCacheStats.java
@@ -42,7 +42,7 @@ public class FieldDataCacheStats implements ToXContent {
 		while(iterator.hasNext()) {
 			String key = iterator.next();
 			HashMap<String, Object> tmp = this.fieldCaches.get(key);
-			
+
 			//Append the map with all the fieldcaches and their size
 			builder.field(key, tmp);
 		}
@@ -50,7 +50,7 @@ public class FieldDataCacheStats implements ToXContent {
 		builder.endObject();
 		return builder;
 	}
-	
+
 	static final class Fields {
 		static final XContentBuilderString FIELDDATACACHES = new XContentBuilderString("fieldDataCaches");
 	}

--- a/src/main/java/org/elasticsearch/index/cache/FieldDataCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/FieldDataCacheStats.java
@@ -1,0 +1,48 @@
+package org.elasticsearch.index.cache;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.cache.field.data.support.AbstractConcurrentMapFieldDataCache;
+import org.elasticsearch.index.service.IndexService;
+
+public class FieldDataCacheStats implements ToXContent {
+	private Map<String, HashMap<String, Object>> fieldCaches;
+
+	public FieldDataCacheStats() {
+		fieldCaches = new HashMap<String, HashMap<String, Object>>();
+	}
+
+	public void add(IndexService indexService) {
+		HashMap<String, Object> tmp = new HashMap<String, Object>();
+
+		AbstractConcurrentMapFieldDataCache fieldCache = (AbstractConcurrentMapFieldDataCache) indexService.cache().fieldData();
+
+		for (String elem : fieldCache.getFieldNames()) {
+			long cacheSize = fieldCache.sizeInBytes(elem);
+			tmp.put(elem, cacheSize);
+		}
+
+		fieldCaches.put(indexService.index().getName(), tmp);
+	}
+
+	@Override
+	public XContentBuilder toXContent(XContentBuilder builder, Params params)
+			throws IOException {
+		builder.startObject("fieldDataCaches");
+
+		Iterator<String> iterator = this.fieldCaches.keySet().iterator();
+		while(iterator.hasNext()) {
+			String key = iterator.next();
+			HashMap<String, Object> tmp = this.fieldCaches.get(key);
+			builder.field(key, tmp);
+		}
+
+		builder.endObject();
+		return builder;
+	}
+}

--- a/src/main/java/org/elasticsearch/index/cache/FieldDataCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/FieldDataCacheStats.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.cache.field.data.support.AbstractConcurrentMapFieldDataCache;
 import org.elasticsearch.index.service.IndexService;
 
@@ -22,27 +23,35 @@ public class FieldDataCacheStats implements ToXContent {
 
 		AbstractConcurrentMapFieldDataCache fieldCache = (AbstractConcurrentMapFieldDataCache) indexService.cache().fieldData();
 
+		//Get the cache size for all fields of the given index
 		for (String elem : fieldCache.getFieldNames()) {
 			long cacheSize = fieldCache.sizeInBytes(elem);
 			tmp.put(elem, cacheSize);
 		}
 
+		//Put the whole fieldcache map into the global map
 		fieldCaches.put(indexService.index().getName(), tmp);
 	}
 
 	@Override
 	public XContentBuilder toXContent(XContentBuilder builder, Params params)
 			throws IOException {
-		builder.startObject("fieldDataCaches");
+		builder.startObject(Fields.FIELDDATACACHES);
 
 		Iterator<String> iterator = this.fieldCaches.keySet().iterator();
 		while(iterator.hasNext()) {
 			String key = iterator.next();
 			HashMap<String, Object> tmp = this.fieldCaches.get(key);
+			
+			//Append the map with all the fieldcaches and their size
 			builder.field(key, tmp);
 		}
 
 		builder.endObject();
 		return builder;
+	}
+	
+	static final class Fields {
+		static final XContentBuilderString FIELDDATACACHES = new XContentBuilderString("fieldDataCaches");
 	}
 }

--- a/src/main/java/org/elasticsearch/index/cache/field/data/support/AbstractConcurrentMapFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/field/data/support/AbstractConcurrentMapFieldDataCache.java
@@ -19,13 +19,7 @@
 
 package org.elasticsearch.index.cache.field.data.support;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.cache.Cache;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.SegmentReader;
 import org.elasticsearch.ElasticSearchException;
@@ -39,7 +33,12 @@ import org.elasticsearch.index.field.data.FieldData;
 import org.elasticsearch.index.field.data.FieldDataType;
 import org.elasticsearch.index.settings.IndexSettings;
 
-import com.google.common.cache.Cache;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -108,7 +107,7 @@ public abstract class AbstractConcurrentMapFieldDataCache extends AbstractIndexC
     			fieldNameList.add(key);
     		}
     	}
-        
+
         return fieldNameList;
     }
 

--- a/src/main/java/org/elasticsearch/index/cache/field/data/support/AbstractConcurrentMapFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/field/data/support/AbstractConcurrentMapFieldDataCache.java
@@ -19,7 +19,13 @@
 
 package org.elasticsearch.index.cache.field.data.support;
 
-import com.google.common.cache.Cache;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.SegmentReader;
 import org.elasticsearch.ElasticSearchException;
@@ -33,10 +39,7 @@ import org.elasticsearch.index.field.data.FieldData;
 import org.elasticsearch.index.field.data.FieldDataType;
 import org.elasticsearch.index.settings.IndexSettings;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
+import com.google.common.cache.Cache;
 
 /**
  *
@@ -93,9 +96,26 @@ public abstract class AbstractConcurrentMapFieldDataCache extends AbstractIndexC
         return sizeInBytes;
     }
 
+    /**
+     * Returns all field names a cache exists for
+     * @return List of field names, which have a cache
+     */
+    public Set<String> getFieldNames() {
+    	Set<String> fieldNameList = new HashSet<String>();
+
+        for (Cache<String, FieldData> map : cache.values()) {
+    		for(String key : map.asMap().keySet()) {
+    			fieldNameList.add(key);
+    		}
+    	}
+        
+        return fieldNameList;
+    }
+
     @Override
     public long sizeInBytes(String fieldName) {
         long sizeInBytes = 0;
+
         for (Cache<String, FieldData> map : cache.values()) {
             FieldData fieldData = map.getIfPresent(fieldName);
             if (fieldData != null) {

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
@@ -19,43 +19,20 @@
 
 package org.elasticsearch.indices;
 
-import static com.google.common.collect.Maps.newHashMap;
-import static com.google.common.collect.Sets.newHashSet;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
-import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.ElasticSearchIllegalStateException;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.inject.CreationException;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Injector;
-import org.elasticsearch.common.inject.Injectors;
-import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.inject.*;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.Gateway;
-import org.elasticsearch.index.CloseableIndexComponent;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexModule;
-import org.elasticsearch.index.IndexNameModule;
-import org.elasticsearch.index.IndexServiceManagement;
-import org.elasticsearch.index.LocalNodeIdModule;
+import org.elasticsearch.index.*;
 import org.elasticsearch.index.aliases.IndexAliasesServiceModule;
 import org.elasticsearch.index.analysis.AnalysisModule;
 import org.elasticsearch.index.analysis.AnalysisService;
@@ -96,9 +73,20 @@ import org.elasticsearch.plugins.IndexPluginsModule;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.UnmodifiableIterator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 /**
  *
@@ -106,7 +94,7 @@ import com.google.common.collect.UnmodifiableIterator;
 public class InternalIndicesService extends AbstractLifecycleComponent<IndicesService> implements IndicesService {
 
     private final NodeEnvironment nodeEnv;
-    
+
     private final ThreadPool threadPool;
 
     private final InternalIndicesLifecycle indicesLifecycle;
@@ -221,7 +209,7 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
                 refreshStats.add(indexShard.refreshStats());
                 flushStats.add(indexShard.flushStats());
             }
-            
+
             fieldCacheStats.add(indexService);
             cacheStats.add(indexService.cache().stats());
         }

--- a/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.indices;
 
+import java.io.IOException;
+import java.io.Serializable;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -26,6 +29,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.cache.CacheStats;
+import org.elasticsearch.index.cache.FieldDataCacheStats;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.get.GetStats;
 import org.elasticsearch.index.indexing.IndexingStats;
@@ -34,9 +38,6 @@ import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.store.StoreStats;
-
-import java.io.IOException;
-import java.io.Serializable;
 
 /**
  * Global information on indices stats running on a specific node.
@@ -62,11 +63,13 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
     private RefreshStats refreshStats;
 
     private FlushStats flushStats;
+    
+    private FieldDataCacheStats fieldCacheStats;
 
     NodeIndicesStats() {
     }
 
-    public NodeIndicesStats(StoreStats storeStats, DocsStats docsStats, IndexingStats indexingStats, GetStats getStats, SearchStats searchStats, CacheStats cacheStats, MergeStats mergeStats, RefreshStats refreshStats, FlushStats flushStats) {
+    public NodeIndicesStats(StoreStats storeStats, DocsStats docsStats, IndexingStats indexingStats, GetStats getStats, SearchStats searchStats, CacheStats cacheStats, FieldDataCacheStats fieldCacheStats, MergeStats mergeStats, RefreshStats refreshStats, FlushStats flushStats) {
         this.storeStats = storeStats;
         this.docsStats = docsStats;
         this.indexingStats = indexingStats;
@@ -76,6 +79,7 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
         this.mergeStats = mergeStats;
         this.refreshStats = refreshStats;
         this.flushStats = flushStats;
+        this.fieldCacheStats = fieldCacheStats;
     }
 
     public StoreStats store() {
@@ -127,6 +131,14 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
 
     public CacheStats getCache() {
         return this.cache();
+    }
+    
+    public FieldDataCacheStats fieldDataCache() {
+        return this.fieldCacheStats;
+    }
+
+    public FieldDataCacheStats getFieldDataCache() {
+        return this.fieldDataCache();
     }
 
     public MergeStats merge() {
@@ -199,6 +211,7 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
         refreshStats.toXContent(builder, params);
         flushStats.toXContent(builder, params);
 
+        fieldCacheStats.toXContent(builder, params);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.indices;
 
-import java.io.IOException;
-import java.io.Serializable;
-
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -38,6 +35,9 @@ import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.store.StoreStats;
+
+import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * Global information on indices stats running on a specific node.
@@ -63,7 +63,7 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
     private RefreshStats refreshStats;
 
     private FlushStats flushStats;
-    
+
     private FieldDataCacheStats fieldCacheStats;
 
     NodeIndicesStats() {
@@ -132,7 +132,7 @@ public class NodeIndicesStats implements Streamable, Serializable, ToXContent {
     public CacheStats getCache() {
         return this.cache();
     }
-    
+
     public FieldDataCacheStats fieldDataCache() {
         return this.fieldCacheStats;
     }


### PR DESCRIPTION
The sizes of the field caches per index are exported with the node stats
