### PR TITLE
Get _mapping on a empty index with no mappings passed when created returns 404

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -116,6 +116,11 @@ public class RestGetMappingAction extends BaseRestHandler {
                                 builder.field(mappingMd.type());
                                 builder.map(mappingMd.sourceAsMap());
                             }
+                            
+                            if (indexMetaData.mappings().values().isEmpty() && types.isEmpty()) {
+                                // if no types are specified and no mappings are set for the index, consider this an empty mapping
+                            	foundAny = true;
+                            }
 
                             builder.endObject();
                         }


### PR DESCRIPTION
Given an empty index with no mappings passed when created returns 404 when requesting _mapping. Should the "empty" mapping be considered "empty" or "non existant"?

PUT localhost:9200/myindex

GET localhost:9200/myindex/_mapping 
=> returns the empty mapping:
{
    "myindex": {}
}
with status 404.

Should this be considered as a bug or by design? 

This pull request resolves the issue by returning 200 if the index has no mappings and no types passed to the _mapping-call. 
