### PR TITLE
Move all generated files during tests to maven target dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
                 <includes>
                     <include>**/*.*</include>
                 </includes>
+                <filtering>true</filtering>
             </testResource>
         </testResources>
 

--- a/src/test/java/org/elasticsearch/test/integration/AbstractNodesTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/AbstractNodesTests.java
@@ -93,6 +93,14 @@ public abstract class AbstractNodesTests {
             finalSettings = settingsBuilder().put(finalSettings).put("cluster.routing.schedule", "50ms").build();
         }
 
+    	// If we did not set path.data before, we move data dir to target dir es/data
+        if (finalSettings.get("path.data") == null) {
+            Settings pathdatasettings = settingsBuilder()
+                    .loadFromClasspath("es-test.properties")
+                    .build();
+            finalSettings = settingsBuilder().put(finalSettings).put(pathdatasettings).build();
+        }
+
         Node node = nodeBuilder()
                 .settings(finalSettings)
                 .build();

--- a/src/test/java/org/elasticsearch/test/stress/fullrestart/FullRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/test/stress/fullrestart/FullRestartStressTest.java
@@ -42,6 +42,7 @@ import org.elasticsearch.node.internal.InternalNode;
 import java.io.File;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
 /**
@@ -216,12 +217,18 @@ public class FullRestartStressTest {
         System.setProperty("es.logger.prefix", "");
 
         int numberOfNodes = 2;
+	    Settings pathdatasettings = settingsBuilder()
+	            .loadFromClasspath("es-test.properties")
+	            .build();
+	    String datadir = pathdatasettings.get("path.data");
+	    String pathData = datadir + "/data1," + datadir + "/data2";
+
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("index.shard.check_on_startup", true)
                 .put("gateway.type", "local")
                 .put("gateway.recover_after_nodes", numberOfNodes)
                 .put("index.number_of_shards", 1)
-                .put("path.data", "data/data1,data/data2")
+                .put("path.data", pathData)
                 .build();
 
         FullRestartStressTest test = new FullRestartStressTest()

--- a/src/test/java/org/elasticsearch/test/stress/rollingrestart/RollingRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/test/stress/rollingrestart/RollingRestartStressTest.java
@@ -339,10 +339,16 @@ public class RollingRestartStressTest {
     public static void main(String[] args) throws Exception {
         System.setProperty("es.logger.prefix", "");
 
+	    Settings pathdatasettings = settingsBuilder()
+	            .loadFromClasspath("es-test.properties")
+	            .build();
+	    String datadir = pathdatasettings.get("path.data");
+	    String pathData = datadir + "/data1," + datadir + "/data2";
+
         Settings settings = settingsBuilder()
                 .put("index.shard.check_on_startup", true)
                 .put("gateway.type", "none")
-                .put("path.data", "data/data1,data/data2")
+                .put("path.data", pathData)
                 .build();
 
         RollingRestartStressTest test = new RollingRestartStressTest()

--- a/src/test/java/org/elasticsearch/test/unit/index/engine/AbstractSimpleEngineTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/engine/AbstractSimpleEngineTests.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.deletionpolicy.KeepOnlyLastDeletionPolicy;
@@ -61,6 +62,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.elasticsearch.common.lucene.DocumentBuilder.*;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.REPLICA;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -116,11 +118,21 @@ public abstract class AbstractSimpleEngineTests {
     }
 
     protected Translog createTranslog() {
-        return new FsTranslog(shardId, EMPTY_SETTINGS, new File("work/fs-translog/primary"));
+	    Settings pathdatasettings = settingsBuilder()
+	            .loadFromClasspath("es-test.properties")
+	            .build();
+	    String workdir = pathdatasettings.get("path.work");
+    	
+        return new FsTranslog(shardId, EMPTY_SETTINGS, new File(workdir + "/fs-translog/primary"));
     }
 
     protected Translog createTranslogReplica() {
-        return new FsTranslog(shardId, EMPTY_SETTINGS, new File("work/fs-translog/replica"));
+	    Settings pathdatasettings = settingsBuilder()
+	            .loadFromClasspath("es-test.properties")
+	            .build();
+	    String workdir = pathdatasettings.get("path.work");
+    	
+        return new FsTranslog(shardId, EMPTY_SETTINGS, new File(workdir + "/fs-translog/replica"));
     }
 
     protected IndexDeletionPolicy createIndexDeletionPolicy() {

--- a/src/test/java/org/elasticsearch/test/unit/index/translog/fs/FsBufferedTranslogTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/translog/fs/FsBufferedTranslogTests.java
@@ -19,15 +19,13 @@
 
 package org.elasticsearch.test.unit.index.translog.fs;
 
-import org.elasticsearch.common.io.FileSystemUtils;
+import java.io.File;
+
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.fs.FsTranslog;
 import org.elasticsearch.index.translog.fs.FsTranslogFile;
 import org.elasticsearch.test.unit.index.translog.AbstractSimpleTranslogTests;
-import org.testng.annotations.AfterClass;
-
-import java.io.File;
 
 /**
  *
@@ -35,14 +33,9 @@ import java.io.File;
 public class FsBufferedTranslogTests extends AbstractSimpleTranslogTests {
 
     @Override
-    protected Translog create() {
+    protected Translog create(String testdir) {
         return new FsTranslog(shardId,
                 ImmutableSettings.settingsBuilder().put("index.translog.fs.type", FsTranslogFile.Type.BUFFERED.name()).build(),
-                new File("data/fs-translog"));
-    }
-
-    @AfterClass
-    public void cleanup() {
-        FileSystemUtils.deleteRecursively(new File("data/fs-translog"), true);
+                new File(testdir));
     }
 }

--- a/src/test/java/org/elasticsearch/test/unit/index/translog/fs/FsSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/translog/fs/FsSimpleTranslogTests.java
@@ -19,15 +19,13 @@
 
 package org.elasticsearch.test.unit.index.translog.fs;
 
-import org.elasticsearch.common.io.FileSystemUtils;
+import java.io.File;
+
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.fs.FsTranslog;
 import org.elasticsearch.index.translog.fs.FsTranslogFile;
 import org.elasticsearch.test.unit.index.translog.AbstractSimpleTranslogTests;
-import org.testng.annotations.AfterClass;
-
-import java.io.File;
 
 /**
  *
@@ -35,14 +33,9 @@ import java.io.File;
 public class FsSimpleTranslogTests extends AbstractSimpleTranslogTests {
 
     @Override
-    protected Translog create() {
+    protected Translog create(String testdir) {
         return new FsTranslog(shardId,
                 ImmutableSettings.settingsBuilder().put("index.translog.fs.type", FsTranslogFile.Type.SIMPLE.name()).build(),
-                new File("data/fs-translog"));
-    }
-
-    @AfterClass
-    public void cleanup() {
-        FileSystemUtils.deleteRecursively(new File("data/fs-translog"), true);
+                new File(testdir));
     }
 }

--- a/src/test/resources/es-test.properties
+++ b/src/test/resources/es-test.properties
@@ -1,0 +1,3 @@
+# If ES needs to write something, it's here
+path.data=${project.build.directory}/es/data
+path.work=${project.build.directory}/es/work


### PR DESCRIPTION
Hi there,

By now when launching tests, some dir are created under `/data` or `/work` dirs.
IMHO, it's best to use `/target` dir to hold test dirs.

So, here a proposal for change:
- all tests creates data files under `/target/es/data` and work files under `/target/es/work`
- `src/test/resources/es-test.properties` is created and contain `path.data` and `path.work` settings
- `pom.xml` is modified to parse test resources and modify `${project.build.directory}` to maven target dir
- some TestNG tests are modified to use theses settings
- some _main()_ tests (stress tests) are modified to use theses settings

HTH
David.
