### PR TITLE
Allow control over if we load settings from System Properties when using TransportClient.

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -143,12 +143,28 @@ public class TransportClient extends AbstractClient {
      * be loaded from the classpath / file system (the <tt>elasticsearch.(yml|json)</tt> files optionally prefixed with
      * <tt>config/</tt>).
      *
-     * @param pSettings          The explicit settings.
+     * @param settings           The explicit settings.
      * @param loadConfigSettings <tt>true</tt> if settings should be loaded from the classpath/file system.
      * @throws ElasticSearchException
      */
     public TransportClient(Settings pSettings, boolean loadConfigSettings) throws ElasticSearchException {
-        Tuple<Settings, Environment> tuple = InternalSettingsPerparer.prepareSettings(pSettings, loadConfigSettings);
+    	this(pSettings, loadConfigSettings, true);
+    }
+
+    /**
+     * Constructs a new transport client with the provided settings and the ability to control if settings will
+     * be loaded from the classpath / file system (the <tt>elasticsearch.(yml|json)</tt> files optionally prefixed with
+     * <tt>config/</tt>).
+     * 
+     * Also, we allow the ability to control if settings will be loaded from the System Properties. 
+     *
+     * @param pSettings          The explicit settings.
+     * @param loadConfigSettings <tt>true</tt> if settings should be loaded from the classpath/file system.
+     * @param loadSystemProperties <tt>true</tt> if settings should be loaded from the System properties.
+     * @throws ElasticSearchException
+     */
+    public TransportClient(Settings pSettings, boolean loadConfigSettings, boolean loadSystemProperties) throws ElasticSearchException {
+        Tuple<Settings, Environment> tuple = InternalSettingsPerparer.prepareSettings(pSettings, loadConfigSettings, loadSystemProperties);
         Settings settings = settingsBuilder().put(tuple.v1())
                 .put("network.server", false)
                 .put("node.client", true)

--- a/src/main/java/org/elasticsearch/node/internal/InternalSettingsPerparer.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalSettingsPerparer.java
@@ -36,16 +36,24 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 public class InternalSettingsPerparer {
 
     public static Tuple<Settings, Environment> prepareSettings(Settings pSettings, boolean loadConfigSettings) {
+    	return prepareSettings(pSettings, loadConfigSettings, true);
+    }
+
+    public static Tuple<Settings, Environment> prepareSettings(Settings pSettings, boolean loadConfigSettings, boolean loadSystemProperties) {
         // ignore this prefixes when getting properties from es. and elasticsearch.
         String[] ignorePrefixes = new String[]{"es.default.", "elasticsearch.default."};
         // just create enough settings to build the environment
         ImmutableSettings.Builder settingsBuilder = settingsBuilder()
-                .put(pSettings)
-                .putProperties("elasticsearch.default.", System.getProperties())
+                .put(pSettings);
+        
+        if(loadSystemProperties){
+        	settingsBuilder.putProperties("elasticsearch.default.", System.getProperties())
                 .putProperties("es.default.", System.getProperties())
                 .putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
-                .putProperties("es.", System.getProperties(), ignorePrefixes)
-                .replacePropertyPlaceholders();
+                .putProperties("es.", System.getProperties(), ignorePrefixes);
+        }
+        
+        settingsBuilder.replacePropertyPlaceholders();
 
         Environment environment = new Environment(settingsBuilder.build());
 
@@ -86,10 +94,12 @@ public class InternalSettingsPerparer {
             }
         }
 
-        settingsBuilder.put(pSettings)
-                .putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
-                .putProperties("es.", System.getProperties(), ignorePrefixes)
-                .replacePropertyPlaceholders();
+        settingsBuilder.put(pSettings);
+        if(loadSystemProperties){
+        	settingsBuilder.putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
+                .putProperties("es.", System.getProperties(), ignorePrefixes);
+        }
+        settingsBuilder.replacePropertyPlaceholders();
 
         // generate the name
         if (settingsBuilder.get("name") == null) {


### PR DESCRIPTION
I had problems when trying to use the TransportClient inside a java application plugin - that now uses an internal ES node.  They are setting all the ES settings via the System Properties, so my settings get overridden.  I am now just allowing a bit more control over how the settings get loaded.
