### PR TITLE
Verify that source object is ended properly and does not contain any trailing tokens

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -497,6 +497,12 @@ public class DocumentMapper implements ToXContent {
             for (int i = 0; i < countDownTokens; i++) {
                 parser.nextToken();
             }
+            
+            // try to parse the next token, this should be null if the object is ended properly (might throw a JSON exception if the extra tokens is not valid JSON, this will be handled by the catch)
+            if(parser.nextToken() != null) {
+            	// this source object contains more tokens than expected...
+            	 throw new MapperParsingException("Malformed content, object is not ended properly");
+            }
 
             for (RootMapper rootMapper : rootMappersOrdered) {
                 rootMapper.postParse(context);

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/source/DefaultSourceMappingTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/source/DefaultSourceMappingTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test.unit.index.mapper.source;
 
 import org.apache.lucene.document.Fieldable;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -192,5 +193,15 @@ public class DefaultSourceMappingTests {
         DocumentMapper mapper = mapperService.documentMapper("my_type");
         assertThat(mapper.type(), equalTo("my_type"));
         assertThat(mapper.sourceMapper().enabled(), equalTo(true));
+    }
+    
+    @Test(expectedExceptions = MapperParsingException.class)
+    public void testSourceObjectContainsExtraTokens() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_source").endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper documentMapper = MapperTests.newParser().parse(mapping);
+        ParsedDocument doc = documentMapper.parse("type", "1", new BytesArray("{}}")); // extra end object (invalid JSON)
     }
 }


### PR DESCRIPTION
...iling tokens (this might corrupt client result parsing).

Invalidate document when the source containins trailing tokens:

Example (indexing):

'{}}' => invalid sice it contains an extra '}' after the source object is exited.
