### PR TITLE
Adding collator-based sorting for terms facet entries

### DIFF
--- a/src/main/java/org/elasticsearch/search/facet/terms/TermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/TermsFacet.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.search.facet.terms;
 
-import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.search.facet.Facet;
 
-import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -50,102 +48,6 @@ public interface TermsFacet extends Facet, Iterable<TermsFacet.Entry> {
         int count();
 
         int getCount();
-    }
-
-    /**
-     * Controls how the terms facets are ordered.
-     */
-    public static enum ComparatorType {
-        /**
-         * Order by the (higher) count of each term.
-         */
-        COUNT((byte) 0, new Comparator<Entry>() {
-
-            @Override
-            public int compare(Entry o1, Entry o2) {
-                int i = o2.count() - o1.count();
-                if (i == 0) {
-                    i = o2.compareTo(o1);
-                    if (i == 0) {
-                        i = System.identityHashCode(o2) - System.identityHashCode(o1);
-                    }
-                }
-                return i;
-            }
-        }),
-        /**
-         * Order by the (lower) count of each term.
-         */
-        REVERSE_COUNT((byte) 1, new Comparator<Entry>() {
-
-            @Override
-            public int compare(Entry o1, Entry o2) {
-                return -COUNT.comparator().compare(o1, o2);
-            }
-        }),
-        /**
-         * Order by the terms.
-         */
-        TERM((byte) 2, new Comparator<Entry>() {
-
-            @Override
-            public int compare(Entry o1, Entry o2) {
-                return o1.compareTo(o2);
-            }
-        }),
-        /**
-         * Order by the terms.
-         */
-        REVERSE_TERM((byte) 3, new Comparator<Entry>() {
-
-            @Override
-            public int compare(Entry o1, Entry o2) {
-                return -TERM.comparator().compare(o1, o2);
-            }
-        });
-
-        private final byte id;
-
-        private final Comparator<Entry> comparator;
-
-        ComparatorType(byte id, Comparator<Entry> comparator) {
-            this.id = id;
-            this.comparator = comparator;
-        }
-
-        public byte id() {
-            return this.id;
-        }
-
-        public Comparator<Entry> comparator() {
-            return comparator;
-        }
-
-        public static ComparatorType fromId(byte id) {
-            if (id == COUNT.id()) {
-                return COUNT;
-            } else if (id == REVERSE_COUNT.id()) {
-                return REVERSE_COUNT;
-            } else if (id == TERM.id()) {
-                return TERM;
-            } else if (id == REVERSE_TERM.id()) {
-                return REVERSE_TERM;
-            }
-            throw new ElasticSearchIllegalArgumentException("No type argument match for terms facet comparator [" + id + "]");
-        }
-
-        public static ComparatorType fromString(String type) {
-            if ("count".equals(type)) {
-                return COUNT;
-            } else if ("term".equals(type)) {
-                return TERM;
-            } else if ("reverse_count".equals(type) || "reverseCount".equals(type)) {
-                return REVERSE_COUNT;
-            } else if ("reverse_term".equals(type) || "reverseTerm".equals(type)) {
-                return REVERSE_TERM;
-            }
-            throw new ElasticSearchIllegalArgumentException("No type argument match for terms facet comparator [" + type + "]");
-        }
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/facet/terms/TermsFacetBuilder.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/TermsFacetBuilder.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.search.facet.terms;
 
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import com.google.common.collect.Maps;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -27,6 +29,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilderException;
 import org.elasticsearch.search.facet.AbstractFacetBuilder;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -42,7 +45,8 @@ public class TermsFacetBuilder extends AbstractFacetBuilder {
     private Object[] exclude;
     private String regex;
     private int regexFlags = 0;
-    private TermsFacet.ComparatorType comparatorType;
+    private Locale locale;
+    private TermsFacetComparator comparator;
     private String script;
     private String lang;
     private Map<String, Object> params;
@@ -151,10 +155,10 @@ public class TermsFacetBuilder extends AbstractFacetBuilder {
     }
 
     /**
-     * The order by which to return the facets by. Defaults to {@link TermsFacet.ComparatorType#COUNT}.
+     * The order by which to return the facets by. Defaults to {@link TermsFacetCountComparator}.
      */
-    public TermsFacetBuilder order(TermsFacet.ComparatorType comparatorType) {
-        this.comparatorType = comparatorType;
+    public TermsFacetBuilder order(AbstractTermsFacetComparator comparator) {
+        this.comparator = comparator;
         return this;
     }
 
@@ -236,8 +240,9 @@ public class TermsFacetBuilder extends AbstractFacetBuilder {
                 builder.field("regex_flags", Regex.flagsToString(regexFlags));
             }
         }
-        if (comparatorType != null) {
-            builder.field("order", comparatorType.name().toLowerCase());
+        if (comparator != null) {
+            builder.field("locale", comparator.getLocale());
+            builder.field("order", comparator.getType());
         }
         if (allTerms != null) {
             builder.field("all_terms", allTerms);

--- a/src/main/java/org/elasticsearch/search/facet/terms/bytes/InternalByteTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/bytes/InternalByteTermsFacet.java
@@ -31,12 +31,15 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.InternalTermsFacet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -120,14 +123,14 @@ public class InternalByteTermsFacet extends InternalTermsFacet {
 
     Collection<ByteEntry> entries = ImmutableList.of();
 
-    ComparatorType comparatorType;
+    TermsFacetComparator comparator;
 
     InternalByteTermsFacet() {
     }
 
-    public InternalByteTermsFacet(String name, ComparatorType comparatorType, int requiredSize, Collection<ByteEntry> entries, long missing, long total) {
+    public InternalByteTermsFacet(String name, TermsFacetComparator comparator, int requiredSize, Collection<ByteEntry> entries, long missing, long total) {
         this.name = name;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.requiredSize = requiredSize;
         this.entries = entries;
         this.missing = missing;
@@ -228,7 +231,7 @@ public class InternalByteTermsFacet extends InternalTermsFacet {
             }
         }
 
-        BoundedTreeSet<ByteEntry> ordered = new BoundedTreeSet<ByteEntry>(first.comparatorType.comparator(), first.requiredSize);
+        BoundedTreeSet<ByteEntry> ordered = new BoundedTreeSet<ByteEntry>(first.comparator, first.requiredSize);
         for (TByteIntIterator it = aggregated.iterator(); it.hasNext(); ) {
             it.advance();
             ordered.add(new ByteEntry(it.key(), it.value()));
@@ -280,7 +283,13 @@ public class InternalByteTermsFacet extends InternalTermsFacet {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
-        comparatorType = ComparatorType.fromId(in.readByte());
+        String type = in.readUTF();
+        boolean reverse = in.readBoolean();
+        Locale locale =  new Locale(in.readUTF());
+        String rules = in.readOptionalUTF();
+        int decomp = in.readInt();
+        int strength = in.readInt();
+        comparator = AbstractTermsFacetComparator.getInstance(type, reverse, locale, rules, decomp, strength);
         requiredSize = in.readVInt();
         missing = in.readVLong();
         total = in.readVLong();
@@ -295,8 +304,12 @@ public class InternalByteTermsFacet extends InternalTermsFacet {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeByte(comparatorType.id());
-
+        out.writeUTF(comparator.getType());
+        out.writeBoolean(comparator.getReverse());
+        out.writeUTF(comparator.getLocale().toString());
+        out.writeOptionalUTF(comparator.getRules());
+        out.writeInt(comparator.getDecomposition());
+        out.writeInt(comparator.getStrength());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);
         out.writeVLong(total);

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/AbstractTermsFacetComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/AbstractTermsFacetComparator.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.facet.terms.comparator;
+
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+
+import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
+import java.util.Locale;
+
+/**
+ * Abstract terms facet comparator, also serving as a factory
+ * for TermsFacetComparator classes.
+ * 
+ * @author joerg
+ */
+public abstract class AbstractTermsFacetComparator implements TermsFacetComparator {
+
+    private final String type;
+    protected final boolean reverse;
+    private Locale locale;
+
+    public AbstractTermsFacetComparator(String type, boolean reverse) {
+        this.type = type;
+        this.reverse = reverse;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+    
+    @Override
+    public boolean getReverse() {
+        return reverse;
+    }
+
+    public AbstractTermsFacetComparator setLocale(Locale locale) {
+        this.locale = locale;
+        return this;
+    }
+
+    @Override
+    public Locale getLocale() {
+        return locale;
+    }
+
+    /**
+     * Must override if own collator is used, otherwise always
+     * the default collator of the given locale is used
+     */
+    @Override
+    public int getDecomposition() {
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        return Collator.getInstance(locale).getDecomposition();
+    }
+
+    /**
+     * Must override if own collator is used, otherwise always
+     * the default collator of the given locale is used
+     */
+    @Override
+    public int getStrength() {
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        return Collator.getInstance(locale).getStrength();
+    }
+
+    @Override
+    public String getRules() {
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        return ((RuleBasedCollator) Collator.getInstance(locale)).getRules();
+    }
+
+    public static TermsFacetComparator getInstance(String type, boolean reverse, Locale locale, String rules, int decomp, int strength) {
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        if ("count".equals(type) || "reverse_count".equals(type) || "reverseCount".equals(type)) {
+            if (type.startsWith("reverse")) {
+                reverse = true; // compatibility mode
+            }
+            return new TermsFacetCountComparator("count", reverse);
+        } else if ("term".equals(type) || "reverse_term".equals(type) || "reverseTerm".equals(type)) {
+            if (type.startsWith("reverse")) {
+                reverse = true; // compatibility mode
+            }
+            TermsFacetCollationComparator comparator = new TermsFacetCollationComparator("term", reverse);
+            comparator.setLocale(locale);
+            Collator collator = Collator.getInstance(locale);
+            if (rules == null) {
+                if (strength != -1) {
+                    collator.setStrength(strength);
+                }
+                if (decomp != -1) {
+                    collator.setDecomposition(decomp);
+                }
+                comparator.setCollator(collator);
+            } else {
+                try {
+                    comparator.setRules(rules);
+                    RuleBasedCollator rc = (RuleBasedCollator) collator;
+                    comparator.setCollator(new RuleBasedCollator(rc.getRules() + rules));
+                } catch (ParseException e) {
+                    comparator.setCollator(Collator.getInstance(locale));
+                }
+            }
+            return comparator;
+        }
+        throw new ElasticSearchIllegalArgumentException("No type argument match for terms facet comparator [" + type + "]");
+    }
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/CollatorTermsFacetComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/CollatorTermsFacetComparator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.facet.terms.comparator;
+
+import java.text.Collator;
+import java.util.Locale;
+
+/**
+ * A collator based terms facet entry comparator.
+ * For convenience usage from API.
+ * 
+ * @author joerg
+ */
+public class CollatorTermsFacetComparator extends LocalizedTermsFacetComparator {
+    
+    public CollatorTermsFacetComparator(Locale locale, Collator collator, boolean reverse) {
+        super(locale, reverse);
+        setCollator(collator);
+    }
+   
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/LocalizedTermsFacetComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/LocalizedTermsFacetComparator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.facet.terms.comparator;
+
+import java.text.Collator;
+import java.util.Locale;
+
+/**
+ * A localized terms facet entry comparator.
+ * For convenience usage from API.
+ * 
+ * @author joerg
+ */
+public class LocalizedTermsFacetComparator extends TermsFacetCollationComparator {
+    
+    public LocalizedTermsFacetComparator(Locale locale, boolean reverse) {
+        super(reverse ? "reverse_term" : "term", reverse);
+        setLocale(locale);
+        setCollator(Collator.getInstance(locale));
+    }
+   
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/SimpleTermsFacetComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/SimpleTermsFacetComparator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.facet.terms.comparator;
+
+import org.elasticsearch.search.facet.terms.TermsFacet.Entry;
+
+/**
+ * Collation-unaware terms facet entry comparator.
+ * Deprecated. Use it just for compatibility reasons.
+ * 
+ * @author joerg
+ */
+@Deprecated
+public class SimpleTermsFacetComparator extends AbstractTermsFacetComparator {
+
+    public SimpleTermsFacetComparator(String type, boolean reverse) {
+        super(type, reverse);
+    }
+    
+    @Override
+    public int compare(Entry o1, Entry o2) {
+        return reverse ? o2.compareTo(o1) :  o1.compareTo(o2);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/TermsFacetCollationComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/TermsFacetCollationComparator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.facet.terms.comparator;
+
+import org.elasticsearch.search.facet.terms.TermsFacet.Entry;
+
+import java.text.Collator;
+
+/**
+ * Collation-aware terms facet comparator
+ * 
+ * @author joerg
+ */
+public class TermsFacetCollationComparator extends AbstractTermsFacetComparator {
+
+    private Collator collator;
+    private int decomp;
+    private int strength;
+    private String rules;
+
+    public TermsFacetCollationComparator(String type, boolean reverse) {
+        super(type, reverse);
+    }
+
+    public void setStrength(int strength) {
+        this.strength = strength;
+    }
+    
+    public void setDecomposition(int decomp) {
+        this.decomp = decomp;
+    }
+    
+    public void setRules(String rules) {
+        this.rules = rules;
+    }
+    
+    @Override
+    public int getDecomposition() {
+        return decomp;
+    }
+    
+    @Override
+    public String getRules() {
+        return rules;
+    }
+    @Override
+    public int getStrength() {
+        return strength;
+    }
+ 
+    public TermsFacetCollationComparator setCollator(Collator collator) {
+        this.collator = collator;
+        return this;
+    }
+
+    public Collator getCollator() {
+        return collator;
+    }
+
+    @Override
+    public int compare(Entry o1, Entry o2) {
+        return reverse ? collator.compare(o2.getTerm(), o1.getTerm()) : collator.compare(o1.getTerm(), o2.getTerm());
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/TermsFacetComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/TermsFacetComparator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.facet.terms.comparator;
+
+import org.elasticsearch.search.facet.terms.TermsFacet.Entry;
+
+import java.util.Comparator;
+import java.util.Locale;
+
+/**
+ * A terms facet comparator interface that provides collation attributes
+ * 
+ * @author joerg
+ */
+public interface TermsFacetComparator extends Comparator<Entry>{
+    
+    String getType();
+    
+    boolean getReverse();
+    
+    Locale getLocale();
+    
+    String getRules();
+    
+    int getDecomposition();
+    
+    int getStrength();
+    
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/comparator/TermsFacetCountComparator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/comparator/TermsFacetCountComparator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.facet.terms.comparator;
+
+import org.elasticsearch.search.facet.terms.TermsFacet.Entry;
+
+/**
+ * A comparator for terms facet counts
+ */
+public class TermsFacetCountComparator extends AbstractTermsFacetComparator {
+
+    public TermsFacetCountComparator(String type, boolean reverse) {
+        super(type, reverse);
+    }
+    
+    @Override
+    public int compare(Entry o1, Entry o2) {
+        int i = o2.count() - o1.count();
+        if (i == 0) {
+            i = o2.compareTo(o1);
+            if (i == 0) {
+                i = System.identityHashCode(o2) - System.identityHashCode(o1);
+            }
+        }
+        return reverse ? -i : i;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleOrdinalsFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleOrdinalsFacetCollector.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.support.EntryPriorityQueue;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -51,7 +52,7 @@ public class TermsDoubleOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final String indexFieldName;
 
-    private final TermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
@@ -72,12 +73,12 @@ public class TermsDoubleOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final TDoubleHashSet excluded;
 
-    public TermsDoubleOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacet.ComparatorType comparatorType, boolean allTerms, SearchContext context,
+    public TermsDoubleOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacetComparator comparator, boolean allTerms, SearchContext context,
                                              ImmutableSet<String> excluded) {
         super(facetName);
         this.fieldDataCache = context.fieldDataCache();
         this.size = size;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.numberOfShards = context.numberOfShards();
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
@@ -155,7 +156,7 @@ public class TermsDoubleOrdinalsFacetCollector extends AbstractFacetCollector {
         // YACK, we repeat the same logic, but once with an optimizer priority queue for smaller sizes
         if (size < EntryPriorityQueue.LIMIT) {
             // optimize to use priority size
-            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparatorType.comparator());
+            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparator);
 
             while (queue.size() > 0) {
                 ReaderAggregator agg = queue.top();
@@ -188,10 +189,10 @@ public class TermsDoubleOrdinalsFacetCollector extends AbstractFacetCollector {
                 CacheRecycler.pushIntArray(aggregator.counts);
             }
 
-            return new InternalDoubleTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
+            return new InternalDoubleTermsFacet(facetName, comparator, size, Arrays.asList(list), missing, total);
         }
 
-        BoundedTreeSet<InternalDoubleTermsFacet.DoubleEntry> ordered = new BoundedTreeSet<InternalDoubleTermsFacet.DoubleEntry>(comparatorType.comparator(), size);
+        BoundedTreeSet<InternalDoubleTermsFacet.DoubleEntry> ordered = new BoundedTreeSet<InternalDoubleTermsFacet.DoubleEntry>(comparator, size);
 
         while (queue.size() > 0) {
             ReaderAggregator agg = queue.top();
@@ -220,7 +221,7 @@ public class TermsDoubleOrdinalsFacetCollector extends AbstractFacetCollector {
             CacheRecycler.pushIntArray(aggregator.counts);
         }
 
-        return new InternalDoubleTermsFacet(facetName, comparatorType, size, ordered, missing, total);
+        return new InternalDoubleTermsFacet(facetName, comparator, size, ordered, missing, total);
     }
 
     public static class ReaderAggregator implements FieldData.OrdinalInDocProc {

--- a/src/main/java/org/elasticsearch/search/facet/terms/floats/InternalFloatTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/floats/InternalFloatTermsFacet.java
@@ -31,12 +31,15 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.InternalTermsFacet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -123,14 +126,14 @@ public class InternalFloatTermsFacet extends InternalTermsFacet {
 
     Collection<FloatEntry> entries = ImmutableList.of();
 
-    ComparatorType comparatorType;
+    TermsFacetComparator comparator;
 
     InternalFloatTermsFacet() {
     }
 
-    public InternalFloatTermsFacet(String name, ComparatorType comparatorType, int requiredSize, Collection<FloatEntry> entries, long missing, long total) {
+    public InternalFloatTermsFacet(String name, TermsFacetComparator comparator, int requiredSize, Collection<FloatEntry> entries, long missing, long total) {
         this.name = name;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.requiredSize = requiredSize;
         this.entries = entries;
         this.missing = missing;
@@ -228,7 +231,7 @@ public class InternalFloatTermsFacet extends InternalTermsFacet {
             }
         }
 
-        BoundedTreeSet<FloatEntry> ordered = new BoundedTreeSet<FloatEntry>(first.comparatorType.comparator(), first.requiredSize);
+        BoundedTreeSet<FloatEntry> ordered = new BoundedTreeSet<FloatEntry>(first.comparator, first.requiredSize);
         for (TFloatIntIterator it = aggregated.iterator(); it.hasNext(); ) {
             it.advance();
             ordered.add(new FloatEntry(it.key(), it.value()));
@@ -280,7 +283,13 @@ public class InternalFloatTermsFacet extends InternalTermsFacet {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
-        comparatorType = ComparatorType.fromId(in.readByte());
+        String type = in.readUTF();
+        boolean reverse = in.readBoolean();
+        Locale locale =  new Locale(in.readUTF());
+        String rules = in.readOptionalUTF();
+        int decomp = in.readInt();
+        int strength = in.readInt();
+        comparator = AbstractTermsFacetComparator.getInstance(type, reverse, locale, rules, decomp, strength);
         requiredSize = in.readVInt();
         missing = in.readVLong();
         total = in.readVLong();
@@ -295,7 +304,12 @@ public class InternalFloatTermsFacet extends InternalTermsFacet {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeByte(comparatorType.id());
+        out.writeUTF(comparator.getType());
+        out.writeBoolean(comparator.getReverse());
+        out.writeUTF(comparator.getLocale().toString());
+        out.writeOptionalUTF(comparator.getRules());
+        out.writeInt(comparator.getDecomposition());
+        out.writeInt(comparator.getStrength());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);
         out.writeVLong(total);

--- a/src/main/java/org/elasticsearch/search/facet/terms/index/IndexNameFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/index/IndexNameFacetCollector.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.IndexReader;
 import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.strings.InternalStringTermsFacet;
 
 import java.io.IOException;
@@ -35,16 +36,16 @@ public class IndexNameFacetCollector extends AbstractFacetCollector {
 
     private final String indexName;
 
-    private final InternalStringTermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
     private int count = 0;
 
-    public IndexNameFacetCollector(String facetName, String indexName, TermsFacet.ComparatorType comparatorType, int size) {
+    public IndexNameFacetCollector(String facetName, String indexName, TermsFacetComparator comparator, int size) {
         super(facetName);
         this.indexName = indexName;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.size = size;
     }
 
@@ -59,6 +60,6 @@ public class IndexNameFacetCollector extends AbstractFacetCollector {
 
     @Override
     public Facet facet() {
-        return new InternalStringTermsFacet(facetName, comparatorType, size, Sets.newHashSet(new InternalStringTermsFacet.StringEntry(indexName, count)), 0, count);
+        return new InternalStringTermsFacet(facetName, comparator, size, Sets.newHashSet(new InternalStringTermsFacet.StringEntry(indexName, count)), 0, count);
     }
 }

--- a/src/main/java/org/elasticsearch/search/facet/terms/ints/InternalIntTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/ints/InternalIntTermsFacet.java
@@ -31,12 +31,15 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.InternalTermsFacet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -120,14 +123,14 @@ public class InternalIntTermsFacet extends InternalTermsFacet {
 
     Collection<IntEntry> entries = ImmutableList.of();
 
-    ComparatorType comparatorType;
+    TermsFacetComparator comparator;
 
     InternalIntTermsFacet() {
     }
 
-    public InternalIntTermsFacet(String name, ComparatorType comparatorType, int requiredSize, Collection<IntEntry> entries, long missing, long total) {
+    public InternalIntTermsFacet(String name, TermsFacetComparator comparator, int requiredSize, Collection<IntEntry> entries, long missing, long total) {
         this.name = name;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.requiredSize = requiredSize;
         this.entries = entries;
         this.missing = missing;
@@ -225,7 +228,7 @@ public class InternalIntTermsFacet extends InternalTermsFacet {
             }
         }
 
-        BoundedTreeSet<IntEntry> ordered = new BoundedTreeSet<IntEntry>(first.comparatorType.comparator(), first.requiredSize);
+        BoundedTreeSet<IntEntry> ordered = new BoundedTreeSet<IntEntry>(first.comparator, first.requiredSize);
         for (TIntIntIterator it = aggregated.iterator(); it.hasNext(); ) {
             it.advance();
             ordered.add(new IntEntry(it.key(), it.value()));
@@ -277,7 +280,13 @@ public class InternalIntTermsFacet extends InternalTermsFacet {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
-        comparatorType = ComparatorType.fromId(in.readByte());
+        String type = in.readUTF();
+        boolean reverse = in.readBoolean();
+        Locale locale =  new Locale(in.readUTF());
+        String rules = in.readOptionalUTF();
+        int decomp = in.readInt();
+        int strength = in.readInt();
+        comparator = AbstractTermsFacetComparator.getInstance(type, reverse, locale, rules, decomp, strength);
         requiredSize = in.readVInt();
         missing = in.readVLong();
         total = in.readVLong();
@@ -292,7 +301,12 @@ public class InternalIntTermsFacet extends InternalTermsFacet {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeByte(comparatorType.id());
+        out.writeUTF(comparator.getType());
+        out.writeBoolean(comparator.getReverse());
+        out.writeUTF(comparator.getLocale().toString());
+        out.writeOptionalUTF(comparator.getRules());
+        out.writeInt(comparator.getDecomposition());
+        out.writeInt(comparator.getStrength());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);
         out.writeVLong(total);

--- a/src/main/java/org/elasticsearch/search/facet/terms/ip/TermsIpOrdinalsFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/ip/TermsIpOrdinalsFacetCollector.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.support.EntryPriorityQueue;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -51,7 +52,7 @@ public class TermsIpOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final String indexFieldName;
 
-    private final TermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
@@ -72,12 +73,12 @@ public class TermsIpOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final TLongHashSet excluded;
 
-    public TermsIpOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacet.ComparatorType comparatorType, boolean allTerms, SearchContext context,
+    public TermsIpOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacetComparator comparator, boolean allTerms, SearchContext context,
                                          ImmutableSet<String> excluded) {
         super(facetName);
         this.fieldDataCache = context.fieldDataCache();
         this.size = size;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.numberOfShards = context.numberOfShards();
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
@@ -155,7 +156,7 @@ public class TermsIpOrdinalsFacetCollector extends AbstractFacetCollector {
         // YACK, we repeat the same logic, but once with an optimizer priority queue for smaller sizes
         if (size < EntryPriorityQueue.LIMIT) {
             // optimize to use priority size
-            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparatorType.comparator());
+            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparator);
 
             while (queue.size() > 0) {
                 ReaderAggregator agg = queue.top();
@@ -188,10 +189,10 @@ public class TermsIpOrdinalsFacetCollector extends AbstractFacetCollector {
                 CacheRecycler.pushIntArray(aggregator.counts);
             }
 
-            return new InternalIpTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
+            return new InternalIpTermsFacet(facetName, comparator, size, Arrays.asList(list), missing, total);
         }
 
-        BoundedTreeSet<InternalIpTermsFacet.LongEntry> ordered = new BoundedTreeSet<InternalIpTermsFacet.LongEntry>(comparatorType.comparator(), size);
+        BoundedTreeSet<InternalIpTermsFacet.LongEntry> ordered = new BoundedTreeSet<InternalIpTermsFacet.LongEntry>(comparator, size);
 
         while (queue.size() > 0) {
             ReaderAggregator agg = queue.top();
@@ -220,7 +221,7 @@ public class TermsIpOrdinalsFacetCollector extends AbstractFacetCollector {
             CacheRecycler.pushIntArray(aggregator.counts);
         }
 
-        return new InternalIpTermsFacet(facetName, comparatorType, size, ordered, missing, total);
+        return new InternalIpTermsFacet(facetName, comparator, size, ordered, missing, total);
     }
 
     public static class ReaderAggregator implements FieldData.OrdinalInDocProc {

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/InternalLongTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/InternalLongTermsFacet.java
@@ -31,12 +31,15 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.InternalTermsFacet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -123,14 +126,14 @@ public class InternalLongTermsFacet extends InternalTermsFacet {
 
     Collection<LongEntry> entries = ImmutableList.of();
 
-    ComparatorType comparatorType;
+    TermsFacetComparator comparator;
 
     InternalLongTermsFacet() {
     }
 
-    public InternalLongTermsFacet(String name, ComparatorType comparatorType, int requiredSize, Collection<LongEntry> entries, long missing, long total) {
+    public InternalLongTermsFacet(String name, TermsFacetComparator comparator, int requiredSize, Collection<LongEntry> entries, long missing, long total) {
         this.name = name;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.requiredSize = requiredSize;
         this.entries = entries;
         this.missing = missing;
@@ -228,7 +231,7 @@ public class InternalLongTermsFacet extends InternalTermsFacet {
             }
         }
 
-        BoundedTreeSet<LongEntry> ordered = new BoundedTreeSet<LongEntry>(first.comparatorType.comparator(), first.requiredSize);
+        BoundedTreeSet<LongEntry> ordered = new BoundedTreeSet<LongEntry>(first.comparator, first.requiredSize);
         for (TLongIntIterator it = aggregated.iterator(); it.hasNext(); ) {
             it.advance();
             ordered.add(new LongEntry(it.key(), it.value()));
@@ -280,7 +283,13 @@ public class InternalLongTermsFacet extends InternalTermsFacet {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
-        comparatorType = ComparatorType.fromId(in.readByte());
+        String type = in.readUTF();
+        boolean reverse = in.readBoolean();
+        Locale locale =  new Locale(in.readUTF());
+        String rules = in.readOptionalUTF();
+        int decomp = in.readInt();
+        int strength = in.readInt();
+        comparator = AbstractTermsFacetComparator.getInstance(type, reverse, locale, rules, decomp, strength);
         requiredSize = in.readVInt();
         missing = in.readVLong();
         total = in.readVLong();
@@ -295,7 +304,12 @@ public class InternalLongTermsFacet extends InternalTermsFacet {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeByte(comparatorType.id());
+        out.writeUTF(comparator.getType());
+        out.writeBoolean(comparator.getReverse());
+        out.writeUTF(comparator.getLocale().toString());
+        out.writeOptionalUTF(comparator.getRules());
+        out.writeInt(comparator.getDecomposition());
+        out.writeInt(comparator.getStrength());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);
         out.writeVLong(total);

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetCollector.java
@@ -39,6 +39,7 @@ import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.FacetPhaseExecutionException;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.support.EntryPriorityQueue;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -62,7 +63,7 @@ public class TermsLongFacetCollector extends AbstractFacetCollector {
 
     private final String indexFieldName;
 
-    private final TermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
@@ -76,12 +77,12 @@ public class TermsLongFacetCollector extends AbstractFacetCollector {
 
     private final SearchScript script;
 
-    public TermsLongFacetCollector(String facetName, String fieldName, int size, TermsFacet.ComparatorType comparatorType, boolean allTerms, SearchContext context,
+    public TermsLongFacetCollector(String facetName, String fieldName, int size, TermsFacetComparator comparator, boolean allTerms, SearchContext context,
                                    ImmutableSet<String> excluded, String scriptLang, String script, Map<String, Object> params) {
         super(facetName);
         this.fieldDataCache = context.fieldDataCache();
         this.size = size;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.numberOfShards = context.numberOfShards();
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
@@ -149,10 +150,10 @@ public class TermsLongFacetCollector extends AbstractFacetCollector {
         TLongIntHashMap facets = aggregator.facets();
         if (facets.isEmpty()) {
             CacheRecycler.pushLongIntMap(facets);
-            return new InternalLongTermsFacet(facetName, comparatorType, size, ImmutableList.<InternalLongTermsFacet.LongEntry>of(), aggregator.missing(), aggregator.total());
+            return new InternalLongTermsFacet(facetName, comparator, size, ImmutableList.<InternalLongTermsFacet.LongEntry>of(), aggregator.missing(), aggregator.total());
         } else {
             if (size < EntryPriorityQueue.LIMIT) {
-                EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparatorType.comparator());
+                EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparator);
                 for (TLongIntIterator it = facets.iterator(); it.hasNext(); ) {
                     it.advance();
                     ordered.insertWithOverflow(new InternalLongTermsFacet.LongEntry(it.key(), it.value()));
@@ -162,15 +163,15 @@ public class TermsLongFacetCollector extends AbstractFacetCollector {
                     list[i] = (InternalLongTermsFacet.LongEntry) ordered.pop();
                 }
                 CacheRecycler.pushLongIntMap(facets);
-                return new InternalLongTermsFacet(facetName, comparatorType, size, Arrays.asList(list), aggregator.missing(), aggregator.total());
+                return new InternalLongTermsFacet(facetName, comparator, size, Arrays.asList(list), aggregator.missing(), aggregator.total());
             } else {
-                BoundedTreeSet<InternalLongTermsFacet.LongEntry> ordered = new BoundedTreeSet<InternalLongTermsFacet.LongEntry>(comparatorType.comparator(), size);
+                BoundedTreeSet<InternalLongTermsFacet.LongEntry> ordered = new BoundedTreeSet<InternalLongTermsFacet.LongEntry>(comparator, size);
                 for (TLongIntIterator it = facets.iterator(); it.hasNext(); ) {
                     it.advance();
                     ordered.add(new InternalLongTermsFacet.LongEntry(it.key(), it.value()));
                 }
                 CacheRecycler.pushLongIntMap(facets);
-                return new InternalLongTermsFacet(facetName, comparatorType, size, ordered, aggregator.missing(), aggregator.total());
+                return new InternalLongTermsFacet(facetName, comparator, size, ordered, aggregator.missing(), aggregator.total());
             }
         }
     }

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongOrdinalsFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongOrdinalsFacetCollector.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.support.EntryPriorityQueue;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -51,7 +52,7 @@ public class TermsLongOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final String indexFieldName;
 
-    private final TermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
@@ -72,12 +73,12 @@ public class TermsLongOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final TLongHashSet excluded;
 
-    public TermsLongOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacet.ComparatorType comparatorType, boolean allTerms, SearchContext context,
+    public TermsLongOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacetComparator comparator, boolean allTerms, SearchContext context,
                                            ImmutableSet<String> excluded) {
         super(facetName);
         this.fieldDataCache = context.fieldDataCache();
         this.size = size;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.numberOfShards = context.numberOfShards();
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
@@ -155,7 +156,7 @@ public class TermsLongOrdinalsFacetCollector extends AbstractFacetCollector {
         // YACK, we repeat the same logic, but once with an optimizer priority queue for smaller sizes
         if (size < EntryPriorityQueue.LIMIT) {
             // optimize to use priority size
-            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparatorType.comparator());
+            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparator);
 
             while (queue.size() > 0) {
                 ReaderAggregator agg = queue.top();
@@ -188,10 +189,10 @@ public class TermsLongOrdinalsFacetCollector extends AbstractFacetCollector {
                 CacheRecycler.pushIntArray(aggregator.counts);
             }
 
-            return new InternalLongTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
+            return new InternalLongTermsFacet(facetName, comparator, size, Arrays.asList(list), missing, total);
         }
 
-        BoundedTreeSet<InternalLongTermsFacet.LongEntry> ordered = new BoundedTreeSet<InternalLongTermsFacet.LongEntry>(comparatorType.comparator(), size);
+        BoundedTreeSet<InternalLongTermsFacet.LongEntry> ordered = new BoundedTreeSet<InternalLongTermsFacet.LongEntry>(comparator, size);
 
         while (queue.size() > 0) {
             ReaderAggregator agg = queue.top();
@@ -220,7 +221,7 @@ public class TermsLongOrdinalsFacetCollector extends AbstractFacetCollector {
             CacheRecycler.pushIntArray(aggregator.counts);
         }
 
-        return new InternalLongTermsFacet(facetName, comparatorType, size, ordered, missing, total);
+        return new InternalLongTermsFacet(facetName, comparator, size, ordered, missing, total);
     }
 
     public static class ReaderAggregator implements FieldData.OrdinalInDocProc {

--- a/src/main/java/org/elasticsearch/search/facet/terms/shorts/InternalShortTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/shorts/InternalShortTermsFacet.java
@@ -31,12 +31,15 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.InternalTermsFacet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -120,14 +123,14 @@ public class InternalShortTermsFacet extends InternalTermsFacet {
 
     Collection<ShortEntry> entries = ImmutableList.of();
 
-    ComparatorType comparatorType;
+    TermsFacetComparator comparator;
 
     InternalShortTermsFacet() {
     }
 
-    public InternalShortTermsFacet(String name, ComparatorType comparatorType, int requiredSize, Collection<ShortEntry> entries, long missing, long total) {
+    public InternalShortTermsFacet(String name, TermsFacetComparator comparator, int requiredSize, Collection<ShortEntry> entries, long missing, long total) {
         this.name = name;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.requiredSize = requiredSize;
         this.entries = entries;
         this.missing = missing;
@@ -225,7 +228,7 @@ public class InternalShortTermsFacet extends InternalTermsFacet {
             }
         }
 
-        BoundedTreeSet<ShortEntry> ordered = new BoundedTreeSet<ShortEntry>(first.comparatorType.comparator(), first.requiredSize);
+        BoundedTreeSet<ShortEntry> ordered = new BoundedTreeSet<ShortEntry>(first.comparator, first.requiredSize);
         for (TShortIntIterator it = aggregated.iterator(); it.hasNext(); ) {
             it.advance();
             ordered.add(new ShortEntry(it.key(), it.value()));
@@ -277,7 +280,13 @@ public class InternalShortTermsFacet extends InternalTermsFacet {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
-        comparatorType = ComparatorType.fromId(in.readByte());
+        String type = in.readUTF();
+        boolean reverse = in.readBoolean();
+        Locale locale =  new Locale(in.readUTF());
+        String rules = in.readOptionalUTF();
+        int decomp = in.readInt();
+        int strength = in.readInt();
+        comparator = AbstractTermsFacetComparator.getInstance(type, reverse, locale, rules, decomp, strength);
         requiredSize = in.readVInt();
         missing = in.readVLong();
         total = in.readVLong();
@@ -292,7 +301,12 @@ public class InternalShortTermsFacet extends InternalTermsFacet {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
-        out.writeByte(comparatorType.id());
+        out.writeUTF(comparator.getType());
+        out.writeBoolean(comparator.getReverse());
+        out.writeUTF(comparator.getLocale().toString());
+        out.writeOptionalUTF(comparator.getRules());
+        out.writeInt(comparator.getDecomposition());
+        out.writeInt(comparator.getStrength());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);
         out.writeVLong(total);

--- a/src/main/java/org/elasticsearch/search/facet/terms/shorts/TermsShortOrdinalsFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/shorts/TermsShortOrdinalsFacetCollector.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.support.EntryPriorityQueue;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -51,7 +52,7 @@ public class TermsShortOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final String indexFieldName;
 
-    private final TermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
@@ -72,12 +73,12 @@ public class TermsShortOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final TShortHashSet excluded;
 
-    public TermsShortOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacet.ComparatorType comparatorType, boolean allTerms, SearchContext context,
+    public TermsShortOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacetComparator comparator, boolean allTerms, SearchContext context,
                                             ImmutableSet<String> excluded) {
         super(facetName);
         this.fieldDataCache = context.fieldDataCache();
         this.size = size;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.numberOfShards = context.numberOfShards();
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
@@ -155,7 +156,7 @@ public class TermsShortOrdinalsFacetCollector extends AbstractFacetCollector {
         // YACK, we repeat the same logic, but once with an optimizer priority queue for smaller sizes
         if (size < EntryPriorityQueue.LIMIT) {
             // optimize to use priority size
-            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparatorType.comparator());
+            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparator);
 
             while (queue.size() > 0) {
                 ReaderAggregator agg = queue.top();
@@ -188,10 +189,10 @@ public class TermsShortOrdinalsFacetCollector extends AbstractFacetCollector {
                 CacheRecycler.pushIntArray(aggregator.counts);
             }
 
-            return new InternalShortTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
+            return new InternalShortTermsFacet(facetName, comparator, size, Arrays.asList(list), missing, total);
         }
 
-        BoundedTreeSet<InternalShortTermsFacet.ShortEntry> ordered = new BoundedTreeSet<InternalShortTermsFacet.ShortEntry>(comparatorType.comparator(), size);
+        BoundedTreeSet<InternalShortTermsFacet.ShortEntry> ordered = new BoundedTreeSet<InternalShortTermsFacet.ShortEntry>(comparator, size);
 
         while (queue.size() > 0) {
             ReaderAggregator agg = queue.top();
@@ -220,7 +221,7 @@ public class TermsShortOrdinalsFacetCollector extends AbstractFacetCollector {
             CacheRecycler.pushIntArray(aggregator.counts);
         }
 
-        return new InternalShortTermsFacet(facetName, comparatorType, size, ordered, missing, total);
+        return new InternalShortTermsFacet(facetName, comparator, size, ordered, missing, total);
     }
 
     public static class ReaderAggregator implements FieldData.OrdinalInDocProc {

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetCollector.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.facet.AbstractFacetCollector;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.TermsFacetComparator;
 import org.elasticsearch.search.facet.terms.support.EntryPriorityQueue;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -52,7 +53,7 @@ public class TermsStringOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final String indexFieldName;
 
-    private final TermsFacet.ComparatorType comparatorType;
+    private final TermsFacetComparator comparator;
 
     private final int size;
 
@@ -75,12 +76,12 @@ public class TermsStringOrdinalsFacetCollector extends AbstractFacetCollector {
 
     private final Matcher matcher;
 
-    public TermsStringOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacet.ComparatorType comparatorType, boolean allTerms, SearchContext context,
+    public TermsStringOrdinalsFacetCollector(String facetName, String fieldName, int size, TermsFacetComparator comparator, boolean allTerms, SearchContext context,
                                              ImmutableSet<String> excluded, Pattern pattern) {
         super(facetName);
         this.fieldDataCache = context.fieldDataCache();
         this.size = size;
-        this.comparatorType = comparatorType;
+        this.comparator = comparator;
         this.numberOfShards = context.numberOfShards();
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
@@ -156,7 +157,7 @@ public class TermsStringOrdinalsFacetCollector extends AbstractFacetCollector {
         // YACK, we repeat the same logic, but once with an optimizer priority queue for smaller sizes
         if (size < EntryPriorityQueue.LIMIT) {
             // optimize to use priority size
-            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparatorType.comparator());
+            EntryPriorityQueue ordered = new EntryPriorityQueue(size, comparator);
 
             while (queue.size() > 0) {
                 ReaderAggregator agg = queue.top();
@@ -193,10 +194,10 @@ public class TermsStringOrdinalsFacetCollector extends AbstractFacetCollector {
                 CacheRecycler.pushIntArray(aggregator.counts);
             }
 
-            return new InternalStringTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
+            return new InternalStringTermsFacet(facetName, comparator, size, Arrays.asList(list), missing, total);
         }
 
-        BoundedTreeSet<InternalStringTermsFacet.StringEntry> ordered = new BoundedTreeSet<InternalStringTermsFacet.StringEntry>(comparatorType.comparator(), size);
+        BoundedTreeSet<InternalStringTermsFacet.StringEntry> ordered = new BoundedTreeSet<InternalStringTermsFacet.StringEntry>(comparator, size);
 
         while (queue.size() > 0) {
             ReaderAggregator agg = queue.top();
@@ -230,7 +231,7 @@ public class TermsStringOrdinalsFacetCollector extends AbstractFacetCollector {
             CacheRecycler.pushIntArray(aggregator.counts);
         }
 
-        return new InternalStringTermsFacet(facetName, comparatorType, size, ordered, missing, total);
+        return new InternalStringTermsFacet(facetName, comparator, size, ordered, missing, total);
     }
 
     public static class ReaderAggregator implements FieldData.OrdinalInDocProc {

--- a/src/test/java/org/elasticsearch/test/integration/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/facet/SimpleFacetsTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test.integration.search.facet;
 
+import java.util.Locale;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.search.ShardSearchFailure;
@@ -34,6 +35,8 @@ import org.elasticsearch.search.facet.query.QueryFacet;
 import org.elasticsearch.search.facet.range.RangeFacet;
 import org.elasticsearch.search.facet.statistical.StatisticalFacet;
 import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.search.facet.terms.comparator.AbstractTermsFacetComparator;
+import org.elasticsearch.search.facet.terms.comparator.LocalizedTermsFacetComparator;
 import org.elasticsearch.search.facet.terms.bytes.InternalByteTermsFacet;
 import org.elasticsearch.search.facet.terms.doubles.InternalDoubleTermsFacet;
 import org.elasticsearch.search.facet.terms.ints.InternalIntTermsFacet;
@@ -478,6 +481,8 @@ public class SimpleFacetsTests extends AbstractNodesTests {
                     .addFacet(termsFacet("facet3").field("ltag").size(10).exclude(3000).executionHint(executionHint))
                     .execute().actionGet();
 
+            logger.debug(searchResponse.toString());
+            
             facet = searchResponse.facets().facet("facet1");
             assertThat(facet, instanceOf(InternalLongTermsFacet.class));
             assertThat(facet.name(), equalTo("facet1"));
@@ -652,9 +657,13 @@ public class SimpleFacetsTests extends AbstractNodesTests {
 
             searchResponse = client.prepareSearch()
                     .setQuery(matchAllQuery())
-                    .addFacet(termsFacet("facet1").field("tag").size(10).order(TermsFacet.ComparatorType.TERM).executionHint(executionHint))
+                    .addFacet(termsFacet("facet1").field("tag").size(10)
+                            .order(new LocalizedTermsFacetComparator(Locale.US, false))
+                            .executionHint(executionHint))
                     .execute().actionGet();
 
+            logger.debug(searchResponse.toString());
+            
             facet = searchResponse.facets().facet("facet1");
             assertThat(facet.name(), equalTo("facet1"));
             assertThat(facet.entries().size(), equalTo(3));
@@ -667,9 +676,13 @@ public class SimpleFacetsTests extends AbstractNodesTests {
 
             searchResponse = client.prepareSearch()
                     .setQuery(matchAllQuery())
-                    .addFacet(termsFacet("facet1").field("tag").size(10).order(TermsFacet.ComparatorType.REVERSE_TERM).executionHint(executionHint))
+                    .addFacet(termsFacet("facet1").field("tag").size(10)
+                            .order(new LocalizedTermsFacetComparator(Locale.US, true))
+                            .executionHint(executionHint))
                     .execute().actionGet();
 
+            logger.debug(searchResponse.toString());
+            
             facet = searchResponse.facets().facet("facet1");
             assertThat(facet.name(), equalTo("facet1"));
             assertThat(facet.entries().size(), equalTo(3));
@@ -684,7 +697,10 @@ public class SimpleFacetsTests extends AbstractNodesTests {
 
             searchResponse = client.prepareSearch()
                     .setQuery(matchAllQuery())
-                    .addFacet(termsFacet("facet1").field("tag").size(10).script("term + param1").param("param1", "a").order(TermsFacet.ComparatorType.TERM).executionHint(executionHint))
+                    .addFacet(termsFacet("facet1").field("tag").size(10)
+                            .script("term + param1").param("param1", "a")
+                            .order(new LocalizedTermsFacetComparator(Locale.US, false))
+                            .executionHint(executionHint))
                     .execute().actionGet();
 
             facet = searchResponse.facets().facet("facet1");
@@ -699,7 +715,10 @@ public class SimpleFacetsTests extends AbstractNodesTests {
 
             searchResponse = client.prepareSearch()
                     .setQuery(matchAllQuery())
-                    .addFacet(termsFacet("facet1").field("tag").size(10).script("term == 'xxx' ? false : true").order(TermsFacet.ComparatorType.TERM).executionHint(executionHint))
+                    .addFacet(termsFacet("facet1").field("tag").size(10)
+                            .script("term == 'xxx' ? false : true")
+                            .order(new LocalizedTermsFacetComparator(Locale.US, false))
+                            .executionHint(executionHint))
                     .execute().actionGet();
 
             facet = searchResponse.facets().facet("facet1");

--- a/src/test/java/org/elasticsearch/test/integration/search/facet/TermsFacetCollationTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/facet/TermsFacetCollationTests.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.search.facet;
+
+import java.util.List;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import org.elasticsearch.search.facet.terms.TermsFacet;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ *
+ */
+public class TermsFacetCollationTests extends AbstractNodesTests {
+
+    private Client client;
+
+    @BeforeClass
+    public void createNodes() throws Exception {
+        Settings settings = ImmutableSettings.settingsBuilder().put("index.number_of_shards", numberOfShards()).put("index.number_of_replicas", 0).build();
+        for (int i = 0; i < numberOfNodes(); i++) {
+            startNode("node" + i, settings);
+        }
+        client = getClient();
+    }
+
+    protected int numberOfShards() {
+        return 1;
+    }
+
+    protected int numberOfNodes() {
+        return 1;
+    }
+
+    protected int numberOfRuns() {
+        return 1;
+    }
+
+    @AfterClass
+    public void closeNodes() {
+        client.close();
+        closeAllNodes();
+    }
+
+    protected Client getClient() {
+        return client("node0");
+    }
+
+    @Test
+    public void testGermanFacetSort() throws Exception {
+        try {
+            client.admin().indices().prepareDelete("test").execute().actionGet();
+        } catch (Exception e) {
+            // ignore
+        }
+        client.admin().indices().prepareCreate("test").execute().actionGet();
+        client.admin().indices().preparePutMapping("test").setType("type1")
+                .setSource("{ type1 : { properties : { name : { type : \"string\", store : \"yes\" } } } }")
+                .execute().actionGet();
+
+        client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+
+        String [] words = new String[] {
+          "Göbel", "Goethe", "Goldmann", "Göthe", "Götz"  
+        };
+        
+        for (String word : words) {
+            client.prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
+                    .field("name", word)
+                    .endObject()).execute().actionGet();
+        }
+
+        client.admin().indices().prepareFlush().setRefresh(true).execute().actionGet();
+
+        for (int i = 0; i < numberOfRuns(); i++) {
+            SearchResponse searchResponse = client.prepareSearch()
+                    .setFacets(XContentFactory.jsonBuilder().startObject()
+                            .startObject("facet1")
+                            .startObject("terms")
+                            .field("locale", "de")
+                            .field("order", "term")
+                            .field("field", "name")
+                            .endObject()
+                            .endObject()
+                            .endObject().bytes() )
+                    .execute().actionGet();
+
+            logger.info(searchResponse.toString());
+            assertThat(searchResponse.hits().totalHits(), equalTo(5l));
+            TermsFacet facet = searchResponse.facets().facet("facet1");
+            assertThat(facet.name(), equalTo("facet1"));
+            List<? extends TermsFacet.Entry> facetResult = facet.entries();
+            assertThat(facetResult.size(), equalTo(5));
+            assertThat(facetResult.get(0).getTerm(), equalTo("göbel"));
+            assertThat(facetResult.get(1).getTerm(), equalTo("goethe"));
+            assertThat(facetResult.get(2).getTerm(), equalTo("goldmann"));
+            assertThat(facetResult.get(3).getTerm(), equalTo("göthe"));
+            assertThat(facetResult.get(4).getTerm(), equalTo("götz"));
+        }
+    }
+
+    @Test
+    public void testFrenchFacetSort() throws Exception {
+        try {
+            client.admin().indices().prepareDelete("test").execute().actionGet();
+        } catch (Exception e) {
+            // ignore
+        }
+        client.admin().indices().prepareCreate("test").execute().actionGet();
+        client.admin().indices().preparePutMapping("test").setType("type1")
+                .setSource("{ type1 : { properties : { name : { type : \"string\", store : \"yes\" } } } }")
+                .execute().actionGet();
+
+        client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+
+        String [] words = new String[] {
+          "café", "cafeteria", "cafe"
+        };
+        
+        for (String word : words) {
+            client.prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
+                    .field("name", word)
+                    .endObject()).execute().actionGet();
+        }
+
+        client.admin().indices().prepareFlush().setRefresh(true).execute().actionGet();
+
+        for (int i = 0; i < numberOfRuns(); i++) {
+            SearchResponse searchResponse = client.prepareSearch()
+                    .setFacets(XContentFactory.jsonBuilder().startObject()
+                            .startObject("facet1")
+                            .startObject("terms")
+                            .field("locale", "fr")
+                            .field("order", "term")
+                            .field("field", "name")
+                            .endObject()
+                            .endObject()
+                            .endObject().bytes() )
+                    .execute().actionGet();
+
+            logger.debug(searchResponse.toString());
+            
+            assertThat(searchResponse.hits().totalHits(), equalTo(3l));
+            TermsFacet facet = searchResponse.facets().facet("facet1");
+            assertThat(facet.name(), equalTo("facet1"));
+            List<? extends TermsFacet.Entry> facetResult = facet.entries();
+            assertThat(facetResult.size(), equalTo(3));
+            assertThat(facetResult.get(0).getTerm(), equalTo("cafe"));
+            assertThat(facetResult.get(1).getTerm(), equalTo("café"));
+            assertThat(facetResult.get(2).getTerm(), equalTo("cafeteria"));
+        }
+    }
+
+    @Test
+    public void testRuleBasedFacetSort() throws Exception {
+        try {
+            client.admin().indices().prepareDelete("test").execute().actionGet();
+        } catch (Exception e) {
+            // ignore
+        }
+        client.admin().indices().prepareCreate("test").execute().actionGet();
+        client.admin().indices().preparePutMapping("test").setType("type1")
+                .setSource("{ type1 : { properties : { name : { type : \"string\", store : \"yes\" } } } }")
+                .execute().actionGet();
+
+        client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+
+        String [] words = new String[] {
+          "earth", "ebola", "bird", "ebcidic", "eon", "aeternitas", "aether", "bet", "bath"
+        };
+        
+        for (String word : words) {
+            client.prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
+                    .field("name", word)
+                    .endObject()).execute().actionGet();
+        }
+
+        client.admin().indices().prepareFlush().setRefresh(true).execute().actionGet();
+
+        for (int i = 0; i < numberOfRuns(); i++) {
+            SearchResponse searchResponse = client.prepareSearch()
+                    .setFacets(XContentFactory.jsonBuilder().startObject()
+                            .startObject("facet1")
+                            .startObject("terms")
+                            .field("rules", "< a, A < e, E < i, I < o, O < u, U < b, B")
+                            .field("order", "term")
+                            .field("field", "name")
+                            .endObject()
+                            .endObject()
+                            .endObject().bytes() )
+                    .execute().actionGet();
+
+            logger.debug(searchResponse.toString());
+            
+            assertThat(searchResponse.hits().totalHits(), equalTo(9l));
+            TermsFacet facet = searchResponse.facets().facet("facet1");
+            assertThat(facet.name(), equalTo("facet1"));
+            List<? extends TermsFacet.Entry> facetResult = facet.entries();
+            assertThat(facetResult.size(), equalTo(9));
+            assertThat(facetResult.get(0).getTerm(), equalTo("aether"));
+            assertThat(facetResult.get(1).getTerm(), equalTo("aeternitas"));
+            assertThat(facetResult.get(2).getTerm(), equalTo("earth"));
+            assertThat(facetResult.get(3).getTerm(), equalTo("eon"));
+            assertThat(facetResult.get(4).getTerm(), equalTo("ebcidic"));
+            assertThat(facetResult.get(5).getTerm(), equalTo("ebola"));
+            assertThat(facetResult.get(6).getTerm(), equalTo("bath"));
+            assertThat(facetResult.get(7).getTerm(), equalTo("bet"));
+            assertThat(facetResult.get(8).getTerm(), equalTo("bird"));
+        }
+    }
+
+}


### PR DESCRIPTION
Hi, 

here is a non-ICU feature extension for the standard ES terms facets, which may be useful in linguistic applications. 

Right now it is not possible to sort names in facet entries according to locale settings. So I have added a subpackage org.elasticsearch.search.facet.terms.comparator with a set of comparator classes. One comparator is based on java.text.Collator.  Some new parameters can be given to a facet query: "locale", "reverse", "rules", "strength", and "decomp".

Test case is included in TermsFacetCollationTests.java for german and french sorting, also a rule-based demo.

Cheers, Jörg
