### PR TITLE
Add $JAVA_OPTS to the plugin manager, useful for those who have to use proxies

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -28,4 +28,4 @@ else
     JAVA=`which java`
 fi
 
-exec $JAVA -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*
+exec $JAVA $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*


### PR DESCRIPTION
Summary:
Facebook machines have on direct access to the internet. Need to tell java that we should use proxies.

Test Plan:
export JAVA_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=8080"
