### PR TITLE
Changed geo_shape relation contains to within

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/ShapeRelation.java
+++ b/src/main/java/org/elasticsearch/common/geo/ShapeRelation.java
@@ -29,7 +29,7 @@ public enum ShapeRelation {
 
     INTERSECTS("intersects"),
     DISJOINT("disjoint"),
-    CONTAINS("contains");
+    WITHIN("within");
 
     private final String relationName;
 

--- a/src/main/java/org/elasticsearch/common/lucene/spatial/SpatialStrategy.java
+++ b/src/main/java/org/elasticsearch/common/lucene/spatial/SpatialStrategy.java
@@ -77,8 +77,8 @@ public abstract class SpatialStrategy {
         switch (relation) {
             case INTERSECTS:
                 return createIntersectsFilter(shape);
-            case CONTAINS:
-                return createContainsFilter(shape);
+            case WITHIN:
+                return createWithinFilter(shape);
             case DISJOINT:
                 return createDisjointFilter(shape);
             default:
@@ -98,8 +98,8 @@ public abstract class SpatialStrategy {
         switch (relation) {
             case INTERSECTS:
                 return createIntersectsQuery(shape);
-            case CONTAINS:
-                return createContainsQuery(shape);
+            case WITHIN:
+                return createWithinQuery(shape);
             case DISJOINT:
                 return createDisjointQuery(shape);
             default:
@@ -151,7 +151,7 @@ public abstract class SpatialStrategy {
      * @param shape Shape to find the contained Shapes of
      * @return Filter for finding the contained indexed Shapes
      */
-    public abstract Filter createContainsFilter(Shape shape);
+    public abstract Filter createWithinFilter(Shape shape);
 
     /**
      * Creates a Query that will find all indexed Shapes that are properly
@@ -161,7 +161,7 @@ public abstract class SpatialStrategy {
      * @param shape Shape to find the contained Shapes of
      * @return Query for finding the contained indexed Shapes
      */
-    public abstract Query createContainsQuery(Shape shape);
+    public abstract Query createWithinQuery(Shape shape);
 
     /**
      * Returns the name of the field this Strategy applies to

--- a/src/main/java/org/elasticsearch/common/lucene/spatial/prefix/TermQueryPrefixTreeStrategy.java
+++ b/src/main/java/org/elasticsearch/common/lucene/spatial/prefix/TermQueryPrefixTreeStrategy.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class TermQueryPrefixTreeStrategy extends SpatialStrategy {
 
-    private static final double CONTAINS_BUFFER_DISTANCE = 0.5;
+    private static final double WITHIN_BUFFER_DISTANCE = 0.5;
     private static final BufferParameters BUFFER_PARAMETERS = new BufferParameters(3, BufferParameters.CAP_SQUARE);
 
     /**
@@ -113,11 +113,11 @@ public class TermQueryPrefixTreeStrategy extends SpatialStrategy {
      * {@inheritDoc}
      */
     @Override
-    public Filter createContainsFilter(Shape shape) {
+    public Filter createWithinFilter(Shape shape) {
         Filter intersectsFilter = createIntersectsFilter(shape);
 
         Geometry shapeGeometry = ShapeBuilder.toJTSGeometry(shape);
-        Geometry buffer = BufferOp.bufferOp(shapeGeometry, CONTAINS_BUFFER_DISTANCE, BUFFER_PARAMETERS);
+        Geometry buffer = BufferOp.bufferOp(shapeGeometry, WITHIN_BUFFER_DISTANCE, BUFFER_PARAMETERS);
         Shape bufferedShape = new JtsGeometry(buffer.difference(shapeGeometry), GeoShapeConstants.SPATIAL_CONTEXT, true);
         Filter bufferedFilter = createIntersectsFilter(bufferedShape);
 
@@ -132,11 +132,11 @@ public class TermQueryPrefixTreeStrategy extends SpatialStrategy {
      * {@inheritDoc}
      */
     @Override
-    public Query createContainsQuery(Shape shape) {
+    public Query createWithinQuery(Shape shape) {
         Query intersectsQuery = createIntersectsQuery(shape);
 
         Geometry shapeGeometry = ShapeBuilder.toJTSGeometry(shape);
-        Geometry buffer = BufferOp.bufferOp(shapeGeometry, CONTAINS_BUFFER_DISTANCE, BUFFER_PARAMETERS);
+        Geometry buffer = BufferOp.bufferOp(shapeGeometry, WITHIN_BUFFER_DISTANCE, BUFFER_PARAMETERS);
         Shape bufferedShape = new JtsGeometry(buffer.difference(shapeGeometry), GeoShapeConstants.SPATIAL_CONTEXT, true);
         Query bufferedQuery = createIntersectsQuery(bufferedShape);
 

--- a/src/test/java/org/elasticsearch/test/unit/common/lucene/spatial/prefix/TermQueryPrefixTreeStrategyTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/lucene/spatial/prefix/TermQueryPrefixTreeStrategyTests.java
@@ -132,13 +132,13 @@ public class TermQueryPrefixTreeStrategyTests {
     }
 
     @Test
-    public void testContainsRelation() throws IOException {
+    public void testWithinRelation() throws IOException {
         Rectangle rectangle = newRectangle().topLeft(-45, 45).bottomRight(45, -45).build();
 
-        Filter filter = STRATEGY.createContainsFilter(rectangle);
+        Filter filter = STRATEGY.createWithinFilter(rectangle);
         assertTopDocs(indexSearcher.search(new MatchAllDocsQuery(), filter, 10), "1");
 
-        Query query = STRATEGY.createContainsQuery(rectangle);
+        Query query = STRATEGY.createWithinQuery(rectangle);
         assertTopDocs(indexSearcher.search(query, 10), "1");
 
         Shape polygon = newPolygon()
@@ -148,10 +148,10 @@ public class TermQueryPrefixTreeStrategyTests {
                 .point(-45, -45)
                 .point(-45, 45).build();
 
-        filter = STRATEGY.createContainsFilter(polygon);
+        filter = STRATEGY.createWithinFilter(polygon);
         assertTopDocs(indexSearcher.search(new MatchAllDocsQuery(), filter, 10), "1");
 
-        query = STRATEGY.createContainsQuery(polygon);
+        query = STRATEGY.createWithinQuery(polygon);
         assertTopDocs(indexSearcher.search(query, 10), "1");
     }
 


### PR DESCRIPTION
The 'contains' relation is incorrectly named as it implies that the indexed shape contains the query shape, when in fact it's the other way round.  'within' correctly implies that the indexed shape is within the query shape.
