### PR TITLE
The index of the next RestFilter must be incremented before the current filter starts processing.

### DIFF
--- a/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/src/main/java/org/elasticsearch/rest/RestController.java
@@ -209,6 +209,7 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
         public void continueProcessing(RestRequest request, RestChannel channel) {
             try {
                 int loc = index;
+                index++;
                 if (loc > filters.length) {
                     throw new ElasticSearchIllegalStateException("filter continueProcessing was called more than expected");
                 } else if (loc == filters.length) {
@@ -217,7 +218,6 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
                     RestFilter preProcessor = filters[loc];
                     preProcessor.process(request, channel, this);
                 }
-                index++;
             } catch (Exception e) {
                 try {
                     channel.sendResponse(new XContentThrowableRestResponse(request, e));


### PR DESCRIPTION
Otherwise, synchronous filters will not work. For example, the following filter would cause a `java.lang.StackOverflowError`:

```
public class SimpleRestFilter extends RestFilter {
    @Override
    public void process(RestRequest request, RestChannel channel, RestFilterChain filterChain) {
        filterChain.continueProcessing(request, channel);
    }
}
```
