### PR TITLE
Highlighting percolator

### DIFF
--- a/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
+import org.elasticsearch.search.highlight.HighlightField;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +42,7 @@ public class IndexResponse extends ActionResponse {
     private String id;
     private String type;
     private long version;
-    private List<String> matches;
+    private List<PercolatorExecutor.PercolationMatch> matches;
 
     public IndexResponse() {
 
@@ -112,21 +114,21 @@ public class IndexResponse extends ActionResponse {
     /**
      * Returns the percolate queries matches. <tt>null</tt> if no percolation was requested.
      */
-    public List<String> matches() {
+    public List<PercolatorExecutor.PercolationMatch> matches() {
         return this.matches;
     }
 
     /**
      * Returns the percolate queries matches. <tt>null</tt> if no percolation was requested.
      */
-    public List<String> getMatches() {
+    public List<PercolatorExecutor.PercolationMatch> getMatches() {
         return this.matches;
     }
 
     /**
      * Internal.
      */
-    public void matches(List<String> matches) {
+    public void matches(List<PercolatorExecutor.PercolationMatch> matches) {
         this.matches = matches;
     }
 
@@ -142,19 +144,13 @@ public class IndexResponse extends ActionResponse {
             if (size == 0) {
                 matches = ImmutableList.of();
             } else if (size == 1) {
-                matches = ImmutableList.of(in.readString());
+                matches = ImmutableList.of(PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
             } else if (size == 2) {
-                matches = ImmutableList.of(in.readString(), in.readString());
-            } else if (size == 3) {
-                matches = ImmutableList.of(in.readString(), in.readString(), in.readString());
-            } else if (size == 4) {
-                matches = ImmutableList.of(in.readString(), in.readString(), in.readString(), in.readString());
-            } else if (size == 5) {
-                matches = ImmutableList.of(in.readString(), in.readString(), in.readString(), in.readString(), in.readString());
+                matches = ImmutableList.of(PercolatorExecutor.PercolationMatch.readPercolationMatch(in), PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
             } else {
-                matches = new ArrayList<String>();
+                matches = new ArrayList<PercolatorExecutor.PercolationMatch>();
                 for (int i = 0; i < size; i++) {
-                    matches.add(in.readString());
+                    matches.add(PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
                 }
             }
         }
@@ -172,8 +168,8 @@ public class IndexResponse extends ActionResponse {
         } else {
             out.writeBoolean(true);
             out.writeVInt(matches.size());
-            for (String match : matches) {
-                out.writeString(match);
+            for (PercolatorExecutor.PercolationMatch match : matches) {
+                match.writeTo(out);
             }
         }
     }

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
@@ -22,33 +22,33 @@ package org.elasticsearch.action.percolate;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
+import org.elasticsearch.search.highlight.HighlightField;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  *
  */
-public class PercolateResponse extends ActionResponse implements Iterable<String> {
+public class PercolateResponse extends ActionResponse implements Iterable<PercolatorExecutor.PercolationMatch> {
 
-    private List<String> matches;
+    private List<PercolatorExecutor.PercolationMatch> matches;
 
     PercolateResponse() {
 
     }
 
-    public PercolateResponse(List<String> matches) {
+    public PercolateResponse(List<PercolatorExecutor.PercolationMatch> matches) {
         this.matches = matches;
     }
 
-    public List<String> matches() {
+    public List<PercolatorExecutor.PercolationMatch> matches() {
         return this.matches;
     }
 
     @Override
-    public Iterator<String> iterator() {
+    public Iterator<PercolatorExecutor.PercolationMatch> iterator() {
         return matches.iterator();
     }
 
@@ -56,9 +56,9 @@ public class PercolateResponse extends ActionResponse implements Iterable<String
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         int size = in.readVInt();
-        matches = new ArrayList<String>(size);
+        matches = new ArrayList<PercolatorExecutor.PercolationMatch>(size);
         for (int i = 0; i < size; i++) {
-            matches.add(in.readString());
+            matches.add(PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
         }
     }
 
@@ -66,8 +66,8 @@ public class PercolateResponse extends ActionResponse implements Iterable<String
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVInt(matches.size());
-        for (String match : matches) {
-            out.writeString(match);
+        for (PercolatorExecutor.PercolationMatch match : matches) {
+            match.writeTo(out);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ public class UpdateResponse extends ActionResponse {
     private String id;
     private String type;
     private long version;
-    private List<String> matches;
+    private List<PercolatorExecutor.PercolationMatch> matches;
     private GetResult getResult;
 
     public UpdateResponse() {
@@ -110,14 +111,14 @@ public class UpdateResponse extends ActionResponse {
     /**
      * Returns the percolate queries matches. <tt>null</tt> if no percolation was requested.
      */
-    public List<String> matches() {
+    public List<PercolatorExecutor.PercolationMatch> matches() {
         return this.matches;
     }
 
     /**
      * Returns the percolate queries matches. <tt>null</tt> if no percolation was requested.
      */
-    public List<String> getMatches() {
+    public List<PercolatorExecutor.PercolationMatch> getMatches() {
         return this.matches;
     }
 
@@ -136,7 +137,7 @@ public class UpdateResponse extends ActionResponse {
     /**
      * Internal.
      */
-    public void matches(List<String> matches) {
+    public void matches(List<PercolatorExecutor.PercolationMatch> matches) {
         this.matches = matches;
     }
 
@@ -152,19 +153,16 @@ public class UpdateResponse extends ActionResponse {
             if (size == 0) {
                 matches = ImmutableList.of();
             } else if (size == 1) {
-                matches = ImmutableList.of(in.readString());
+                matches = ImmutableList.of(PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
             } else if (size == 2) {
-                matches = ImmutableList.of(in.readString(), in.readString());
+                matches = ImmutableList.of(PercolatorExecutor.PercolationMatch.readPercolationMatch(in), PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
             } else if (size == 3) {
-                matches = ImmutableList.of(in.readString(), in.readString(), in.readString());
-            } else if (size == 4) {
-                matches = ImmutableList.of(in.readString(), in.readString(), in.readString(), in.readString());
-            } else if (size == 5) {
-                matches = ImmutableList.of(in.readString(), in.readString(), in.readString(), in.readString(), in.readString());
+                matches = ImmutableList.of(PercolatorExecutor.PercolationMatch.readPercolationMatch(in), PercolatorExecutor.PercolationMatch.readPercolationMatch(in),
+                        PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
             } else {
-                matches = new ArrayList<String>();
+                matches = new ArrayList<PercolatorExecutor.PercolationMatch>();
                 for (int i = 0; i < size; i++) {
-                    matches.add(in.readString());
+                    matches.add(PercolatorExecutor.PercolationMatch.readPercolationMatch(in));
                 }
             }
         }
@@ -185,8 +183,8 @@ public class UpdateResponse extends ActionResponse {
         } else {
             out.writeBoolean(true);
             out.writeVInt(matches.size());
-            for (String match : matches) {
-                out.writeString(match);
+            for (PercolatorExecutor.PercolationMatch match : matches) {
+                match.writeTo(out);
             }
         }
         if (getResult == null) {

--- a/src/main/java/org/elasticsearch/common/text/BytesText.java
+++ b/src/main/java/org/elasticsearch/common/text/BytesText.java
@@ -61,4 +61,15 @@ public class BytesText implements Text {
     public String toString() {
         return string();
     }
+
+    @Override
+    public boolean equals(Object o){
+        if (o instanceof BytesText){
+            BytesText other = (BytesText) o;
+            if (this.bytes == null)
+                return other.bytes == null;
+            return this.bytes.equals(other.bytes);
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/elasticsearch/common/text/StringAndBytesText.java
+++ b/src/main/java/org/elasticsearch/common/text/StringAndBytesText.java
@@ -87,4 +87,13 @@ public class StringAndBytesText implements Text {
     public String toString() {
         return string();
     }
+
+    @Override
+    public boolean equals(Object o){
+        if (o instanceof StringAndBytesText){
+            StringAndBytesText other = (StringAndBytesText) o;
+            return this.bytes().equals(other.bytes());
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/elasticsearch/common/text/StringText.java
+++ b/src/main/java/org/elasticsearch/common/text/StringText.java
@@ -71,4 +71,15 @@ public class StringText implements Text {
     public String toString() {
         return string();
     }
+
+    @Override
+    public boolean equals(Object o){
+        if (o instanceof StringText){
+            StringText other = (StringText) o;
+            if (this.text == null)
+                return other.text == null;
+            return this.text.equals(other.text);
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -30,10 +30,12 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
+import org.elasticsearch.search.highlight.HighlightField;
 
 import java.io.IOException;
 
@@ -122,7 +124,27 @@ public class RestBulkAction extends BaseRestHandler {
                             if (indexResponse.matches() != null) {
                                 builder.startArray(Fields.MATCHES);
                                 for (PercolatorExecutor.PercolationMatch match : indexResponse.matches()) {
-                                    builder.value(match); // TODO
+                                    builder.startObject();
+                                    builder.field("match", match.getMatch());
+
+                                    if (match.getHighlightFields() != null && !match.getHighlightFields().isEmpty()) {
+                                        builder.startObject("highlight");
+                                        for (HighlightField field : match.getHighlightFields().values()) {
+                                            builder.field(field.name());
+                                            if (field.fragments() == null) {
+                                                builder.nullValue();
+                                            } else {
+                                                builder.startArray();
+                                                for (Text fragment : field.fragments()) {
+                                                    builder.value(fragment);
+                                                }
+                                                builder.endArray();
+                                            }
+                                        }
+                                        builder.endObject();
+                                    }
+
+                                    builder.endObject();
                                 }
                                 builder.endArray();
                             }

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
 
 import java.io.IOException;
@@ -120,8 +121,8 @@ public class RestBulkAction extends BaseRestHandler {
                             IndexResponse indexResponse = itemResponse.response();
                             if (indexResponse.matches() != null) {
                                 builder.startArray(Fields.MATCHES);
-                                for (String match : indexResponse.matches()) {
-                                    builder.value(match);
+                                for (PercolatorExecutor.PercolationMatch match : indexResponse.matches()) {
+                                    builder.value(match); // TODO
                                 }
                                 builder.endArray();
                             }

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
@@ -117,8 +118,8 @@ public class RestIndexAction extends BaseRestHandler {
                             .field(Fields._VERSION, response.version());
                     if (response.matches() != null) {
                         builder.startArray(Fields.MATCHES);
-                        for (String match : response.matches()) {
-                            builder.value(match);
+                        for (PercolatorExecutor.PercolationMatch match : response.matches()) {
+                            builder.value(match); // TODO
                         }
                         builder.endArray();
                     }

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
@@ -34,6 +35,7 @@ import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
+import org.elasticsearch.search.highlight.HighlightField;
 
 import java.io.IOException;
 
@@ -119,7 +121,27 @@ public class RestIndexAction extends BaseRestHandler {
                     if (response.matches() != null) {
                         builder.startArray(Fields.MATCHES);
                         for (PercolatorExecutor.PercolationMatch match : response.matches()) {
-                            builder.value(match); // TODO
+                            builder.startObject();
+                            builder.field("match", match.getMatch());
+
+                            if (match.getHighlightFields() != null && !match.getHighlightFields().isEmpty()) {
+                                builder.startObject("highlight");
+                                for (HighlightField field : match.getHighlightFields().values()) {
+                                    builder.field(field.name());
+                                    if (field.fragments() == null) {
+                                        builder.nullValue();
+                                    } else {
+                                        builder.startArray();
+                                        for (Text fragment : field.fragments()) {
+                                            builder.value(fragment);
+                                        }
+                                        builder.endArray();
+                                    }
+                                }
+                                builder.endObject();
+                            }
+
+                            builder.endObject();
                         }
                         builder.endArray();
                     }

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
@@ -25,11 +25,13 @@ import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
+import org.elasticsearch.search.highlight.HighlightField;
 
 import java.io.IOException;
 
@@ -70,8 +72,28 @@ public class RestPercolateAction extends BaseRestHandler {
 
                     builder.field(Fields.OK, true);
                     builder.startArray(Fields.MATCHES);
-                    for (PercolatorExecutor.PercolationMatch match : response) {
-                        builder.value(match); // TODO
+                    for (PercolatorExecutor.PercolationMatch match : response.matches()) {
+                        builder.startObject();
+                        builder.field("match", match.getMatch());
+
+                        if (match.getHighlightFields() != null && !match.getHighlightFields().isEmpty()) {
+                            builder.startObject("highlight");
+                            for (HighlightField field : match.getHighlightFields().values()) {
+                                builder.field(field.name());
+                                if (field.fragments() == null) {
+                                    builder.nullValue();
+                                } else {
+                                    builder.startArray();
+                                    for (Text fragment : field.fragments()) {
+                                        builder.value(fragment);
+                                    }
+                                    builder.endArray();
+                                }
+                            }
+                            builder.endObject();
+                        }
+
+                        builder.endObject();
                     }
                     builder.endArray();
 

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
@@ -69,8 +70,8 @@ public class RestPercolateAction extends BaseRestHandler {
 
                     builder.field(Fields.OK, true);
                     builder.startArray(Fields.MATCHES);
-                    for (String match : response) {
-                        builder.value(match);
+                    for (PercolatorExecutor.PercolationMatch match : response) {
+                        builder.value(match); // TODO
                     }
                     builder.endArray();
 

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
@@ -142,8 +143,8 @@ public class RestUpdateAction extends BaseRestHandler {
 
                     if (response.matches() != null) {
                         builder.startArray(Fields.MATCHES);
-                        for (String match : response.matches()) {
-                            builder.value(match);
+                        for (PercolatorExecutor.PercolationMatch match : response.matches()) {
+                            builder.value(match); // TODO
                         }
                         builder.endArray();
                     }

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightField.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightField.java
@@ -113,4 +113,18 @@ public class HighlightField implements Streamable {
             }
         }
     }
+
+    @Override
+    public boolean equals(Object o){
+        if (o instanceof HighlightField){
+            HighlightField other = (HighlightField) o;
+            if (!this.name.equals(other.name)) return false;
+
+            if (this.fragments == null || other.fragments == null)
+                return this.fragments == other.fragments;
+
+            return Arrays.equals(this.fragments, other.fragments);
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -62,6 +62,16 @@ public class HighlighterParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
+        try {
+            context.highlight(parseImpl(parser));
+        }
+        catch (IllegalArgumentException ex)
+        {
+            throw new SearchParseException(context, "Highlighter global preTags are set, but global postTags are not set");
+        }
+    }
+
+    public static SearchContextHighlight parseImpl(XContentParser parser) throws Exception {
         XContentParser.Token token;
         String topLevelFieldName = null;
         List<SearchContextHighlight.Field> fields = newArrayList();
@@ -176,7 +186,7 @@ public class HighlighterParseElement implements SearchParseElement {
             }
         }
         if (globalPreTags != null && globalPostTags == null) {
-            throw new SearchParseException(context, "Highlighter global preTags are set, but global postTags are not set");
+            throw new IllegalArgumentException("Highlighter global preTags are set, but global postTags are not set");
         }
 
         // now, go over and fill all fields with default values from the global state
@@ -216,6 +226,6 @@ public class HighlighterParseElement implements SearchParseElement {
             }
         }
 
-        context.highlight(new SearchContextHighlight(fields));
+        return new SearchContextHighlight(fields);
     }
 }

--- a/src/test/java/org/elasticsearch/test/integration/percolator/SimplePercolatorTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/percolator/SimplePercolatorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.percolator.PercolatorExecutor;
 import org.elasticsearch.test.integration.AbstractNodesTests;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -226,14 +227,14 @@ public class SimplePercolatorTests extends AbstractNodesTests {
             IndexResponse index = client.prepareIndex("test", "type1", Integer.toString(i)).setSource("field1", "value1")
                     .setPercolate("*").execute().actionGet();
             assertThat(index.matches().size(), equalTo(1));
-            assertThat(index.matches(), hasItem("kuku"));
+            assertThat(index.matches(), hasItem(new PercolatorExecutor.PercolationMatch("kuku")));
         }
 
         for (int i = 0; i < 10; i++) {
             IndexResponse index = client.prepareIndex("test", "type1", Integer.toString(i)).setSource("field1", "value1")
                     .setPercolate("color:blue").execute().actionGet();
             assertThat(index.matches().size(), equalTo(1));
-            assertThat(index.matches(), hasItem("kuku"));
+            assertThat(index.matches(), hasItem(new PercolatorExecutor.PercolationMatch("kuku")));
         }
 
         for (int i = 0; i < 10; i++) {
@@ -253,7 +254,7 @@ public class SimplePercolatorTests extends AbstractNodesTests {
         for (BulkItemResponse bulkItemResponse : bulkResponse) {
             IndexResponse index = bulkItemResponse.response();
             assertThat(index.matches().size(), equalTo(1));
-            assertThat(index.matches(), hasItem("kuku"));
+            assertThat(index.matches(), hasItem(new PercolatorExecutor.PercolationMatch("kuku")));
         }
     }
 
@@ -297,14 +298,14 @@ public class SimplePercolatorTests extends AbstractNodesTests {
                 .endObject().endObject())
                 .execute().actionGet();
         assertThat(percolate.matches().size(), equalTo(1));
-        assertThat(percolate.matches(), hasItem("kuku"));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("kuku")));
 
         percolate = client.preparePercolate("test", "type1").setSource(jsonBuilder().startObject().startObject("doc").startObject("type1")
                 .field("field1", "value2")
                 .endObject().endObject().endObject())
                 .execute().actionGet();
         assertThat(percolate.matches().size(), equalTo(1));
-        assertThat(percolate.matches(), hasItem("bubu"));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("bubu")));
 
     }
 
@@ -339,7 +340,7 @@ public class SimplePercolatorTests extends AbstractNodesTests {
                 .endObject().endObject())
                 .execute().actionGet();
         assertThat(percolate.matches().size(), equalTo(1));
-        assertThat(percolate.matches(), hasItem("kuku"));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("kuku")));
 
         logger.info("--> register a query 2");
         client.prepareIndex("_percolator", "test", "bubu")
@@ -355,7 +356,7 @@ public class SimplePercolatorTests extends AbstractNodesTests {
                 .endObject().endObject().endObject())
                 .execute().actionGet();
         assertThat(percolate.matches().size(), equalTo(1));
-        assertThat(percolate.matches(), hasItem("bubu"));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("bubu")));
 
         logger.info("--> register a query 3");
         client.prepareIndex("_percolator", "test", "susu")
@@ -376,7 +377,7 @@ public class SimplePercolatorTests extends AbstractNodesTests {
                 .endObject())
                 .execute().actionGet();
         assertThat(percolate.matches().size(), equalTo(1));
-        assertThat(percolate.matches(), hasItem("susu"));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("susu")));
 
         logger.info("--> deleting query 1");
         client.prepareDelete("_percolator", "test", "kuku").setRefresh(true).execute().actionGet();
@@ -427,7 +428,7 @@ public class SimplePercolatorTests extends AbstractNodesTests {
                 .endObject())
                 .execute().actionGet();
         assertThat(percolate.matches().size(), equalTo(1));
-        assertThat(percolate.matches(), hasItem("kuku"));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("kuku")));
     }
 
 }

--- a/src/test/java/org/elasticsearch/test/unit/index/percolator/PercolatorExecutorTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/percolator/PercolatorExecutorTests.java
@@ -28,6 +28,8 @@ import org.elasticsearch.common.inject.util.Providers;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.text.StringText;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.Index;
@@ -44,11 +46,14 @@ import org.elasticsearch.index.similarity.SimilarityModule;
 import org.elasticsearch.indices.query.IndicesQueriesModule;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.search.highlight.HighlightField;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolModule;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.util.HashMap;
 
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -102,22 +107,6 @@ public class PercolatorExecutorTests {
     }
 
     @Test
-    public void testSimplePercolatorFoo() throws Exception {
-        // introduce the doc
-        XContentBuilder doc = XContentFactory.jsonBuilder().startObject().startObject("doc")
-                .field("field1", 1)
-                .field("field2", "value")
-                .endObject().endObject();
-        BytesReference source = doc.bytes();
-
-        // add a query
-        percolatorExecutor.addQuery("test1", termQuery("field2", "value"), new HighlightBuilder().field("field2"));
-
-        PercolatorExecutor.Response percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", source));
-        assertThat(percolate.matches(), hasSize(1));
-    }
-
-    @Test
     public void testSimplePercolator() throws Exception {
         // introduce the doc
         XContentBuilder doc = XContentFactory.jsonBuilder().startObject().startObject("doc")
@@ -165,5 +154,50 @@ public class PercolatorExecutorTests {
         percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", source));
         assertThat(percolate.matches(), hasSize(1));
         assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("test1")));
+    }
+
+    @Test
+    public void testHighlightingPercolator() throws Exception {
+        // introduce the doc
+        XContentBuilder doc = XContentFactory.jsonBuilder().startObject().startObject("doc")
+                .field("field1", 1)
+                .field("field2", "value")
+                .endObject().endObject();
+        BytesReference source = doc.bytes();
+
+        XContentBuilder docWithType = XContentFactory.jsonBuilder().startObject().startObject("doc").startObject("type1")
+                .field("field1", 1)
+                .field("field2", "value")
+                .endObject().endObject().endObject();
+        BytesReference sourceWithType = docWithType.bytes();
+
+        PercolatorExecutor.Response percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", source));
+        assertThat(percolate.matches(), hasSize(0));
+
+        // add a query
+        percolatorExecutor.addQuery("test1", termQuery("field2", "value"), new HighlightBuilder().field("field2"));
+
+        HashMap<String, HighlightField> map = new HashMap<String, HighlightField>(1);
+        map.put("field2", new HighlightField("field2", new StringText[]{ new StringText("<em>value</em>")}));
+
+        percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", source));
+        assertThat(percolate.matches(), hasSize(1));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("test1", map)));
+
+        percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", sourceWithType));
+        assertThat(percolate.matches(), hasSize(1));
+        assertThat(percolate.matches(), hasItem(new PercolatorExecutor.PercolationMatch("test1", map)));
+
+        percolatorExecutor.addQuery("test2", termQuery("field1", 1));
+
+        percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", source));
+        assertThat(percolate.matches(), hasSize(2));
+        assertThat(percolate.matches(), hasItems(new PercolatorExecutor.PercolationMatch("test1", map), new PercolatorExecutor.PercolationMatch("test2")));
+
+
+        percolatorExecutor.removeQuery("test2");
+        percolate = percolatorExecutor.percolate(new PercolatorExecutor.SourceRequest("type1", source));
+        assertThat(percolate.matches(), hasSize(1));
+        assertThat(percolate.matches(), hasItems(new PercolatorExecutor.PercolationMatch("test1", map)));
     }
 }


### PR DESCRIPTION
I linked the percolator functionality with the Highlighting API, so you could percolate and get highlights as well (not just an ack). This added functionality is completely optional, and doesn't introduce performance hit if not used. I also verified compatibility with queries which were stored using the old API (highlight section on the Query document is completely optional).

For that to work, I changed HighlightingPhase to use a static method for the actual process, and changed the Matches response to a container class (PercolationMatch) instead of a simple string.

At this point highlighting works per query, that is - you would need to store the highlighting settings per query. A feature I'm likely to add to this soon is to have the ability to define global highlighting settings (when percolating).

Assumptions / gotchas:
- Assumes one document per percolation operation. Lucene.ExistsCollector is used which makes it possible for using more than one doc while percolating, but the rest of the API doesn't show like that is supported.
- Various REST responses were changed
- Works only with string fields. When you think of it, it does make sense...
- Some cleanup may be required
