### PR TITLE
Replace à with a

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -147,7 +147,7 @@
 # path.data: /path/to/data
 #
 # Can optionally include more than one location, causing data to be striped across
-# the locations (à la RAID 0) on a file level, favouring locations with most free
+# the locations (a la RAID 0) on a file level, favouring locations with most free
 # space on creation. For example:
 #
 # path.data: /path/to/data1,/path/to/data2


### PR DESCRIPTION
There are some encoding issues when the `à` char is in `elasticsearch.yml`, encoding for this file **MUST** be in UTF-8. On windows systems, that cause some issues with default platform encoding.

It would be nice to avoid non ISO characters in the configuration file.
