### PR TITLE
Interpret .yaml files as YAML instead of JSON

### DIFF
--- a/src/main/java/org/elasticsearch/common/settings/loader/SettingsLoaderFactory.java
+++ b/src/main/java/org/elasticsearch/common/settings/loader/SettingsLoaderFactory.java
@@ -37,7 +37,7 @@ public final class SettingsLoaderFactory {
     public static SettingsLoader loaderFromResource(String resourceName) {
         if (resourceName.endsWith(".json")) {
             return new JsonSettingsLoader();
-        } else if (resourceName.endsWith(".yml")) {
+        } else if (resourceName.endsWith(".yml") || resourceName.endsWith(".yaml")) {
             return new YamlSettingsLoader();
         } else if (resourceName.endsWith(".properties")) {
             return new PropertiesSettingsLoader();


### PR DESCRIPTION
This is a very minor change to allow the ElasticSearch config to have a ".yaml" extension. The current version interprets ".yaml" files as JSON.

One test is currently failing, though I don't think this is related to my change. Here's the surefire report,

---
## Test set: TestSuite

Tests run: 920, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1,537.94 sec <<< FAILURE!
testSimpleRecovery(org.elasticsearch.test.integration.recovery.SimpleRecoveryTests)  Time elapsed: 73826 sec  <<< FAILURE!
java.lang.AssertionError: 
Expected: <false>
     but: was <true>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
        at org.elasticsearch.test.integration.recovery.SimpleRecoveryTests.testSimpleRecovery(SimpleRecoveryTests.java:101)
