### PR TITLE
Using non-mapped fields in prefix queries shouldn't cause NullPointerExc...

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -109,7 +109,9 @@ public class PrefixQueryParser implements QueryParser {
         }
         if (query == null) {
             PrefixQuery prefixQuery = new PrefixQuery(new Term(fieldName, value));
-            prefixQuery.setRewriteMethod(method);
+            if (method != null) {
+                prefixQuery.setRewriteMethod(method);
+            }
             query = prefixQuery;
         }
         query.setBoost(boost);

--- a/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
@@ -618,6 +618,16 @@ public class SimpleIndexQueryParserTests {
     }
 
     @Test
+    public void testPrefixQueryWithUnknownField() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        Query parsedQuery = queryParser.parse(prefixQuery("unknown", "sh")).query();
+        assertThat(parsedQuery, instanceOf(PrefixQuery.class));
+        PrefixQuery prefixQuery = (PrefixQuery) parsedQuery;
+        assertThat(prefixQuery.getPrefix(), equalTo(new Term("unknown", "sh")));
+        assertThat(prefixQuery.getRewriteMethod(), notNullValue());
+    }
+
+    @Test
     public void testWildcardQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
         Query parsedQuery = queryParser.parse(wildcardQuery("name.first", "sh*")).query();


### PR DESCRIPTION
...eption

Fixes #2408
