### PR TITLE
Multi-cluster discovery

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -452,7 +452,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                 return;
             }
 
-            if (!clusterName.equals(MulticastZenPing.this.clusterName.value())) {
+            if (!clusterName.equals("*") && !clusterName.equals(MulticastZenPing.this.clusterName.value())) {
                 logger.trace("got request for cluster_name {}, but our cluster_name is {}, from {}, content {}", clusterName, MulticastZenPing.this.clusterName.value(), remoteAddress, externalPingData);
                 return;
             }
@@ -469,6 +469,15 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                 builder.startObject("version").field("number", Version.CURRENT.number()).field("snapshot_build", Version.CURRENT.snapshot).endObject();
                 builder.field("transport_address", localNode.address().toString());
 
+                builder.startObject("node")
+                    .field("master", localNode.isMasterNode())
+                    .field("client", localNode.isClientNode())
+                    .field("data", localNode.isDataNode())
+                    .field("id", localNode.id())
+                    .field("version", localNode.version())
+                    .field("name", localNode.name())
+                .endObject();
+                
                 if (nodesProvider.nodeService() != null) {
                     for (Map.Entry<String, String> attr : nodesProvider.nodeService().attributes().entrySet()) {
                         builder.field(attr.getKey(), attr.getValue());


### PR DESCRIPTION
This tiny patch allows a cluster name of '*' (asterisk) in a multicast request to be accepted by all nodes.

The asterisk pseudo cluster name is intended for future discovery tools that want to discover all active clusters without knowing cluster names beforehand.

Additionally, the multicast response is extended by some basic node info (client mode, data mode, node name, node ID), so future discovery tools can take immediate actions depending on the type of the responding node.

Useful examples for multi-cluster discovery are
- data center wide multi-cluster multi-tenant ES node monitoring tools ("ES cluster radar")
-  zero-conf clients: by implementing multicast ping requesters in Perl/Ruby/Python/PHP, the current HTTP REST clients could be enhanced - no more bothering with cluster names, no static IP lists, no switching to unicast discovery

Nodes should respond with a list of transport / HTTP REST / other transport plugin addresses to the requester (optional addresses by using the node attributes). If there was only a single cluster, Perl/Ruby/Python/PHP clients could connect instantly to it.
