### PR TITLE
Fixes #2361 - geo_shape filter does not match false positives.

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
@@ -49,7 +49,7 @@ import java.util.Locale;
  * ]
  * }
  * <p/>
- * Note, currently MultiPolygon and GeometryCollections are not supported
+ * Note, currently GeometryCollections are not supported
  */
 public class GeoJSONShapeParser {
 

--- a/src/main/java/org/elasticsearch/index/field/data/DocFieldData.java
+++ b/src/main/java/org/elasticsearch/index/field/data/DocFieldData.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.field.data;
 import org.apache.lucene.util.BytesRef;
 
 /**
- *
+ * Provides the {@link FieldData} for a single Document.
  */
 public abstract class DocFieldData<T extends FieldData> {
 

--- a/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -116,6 +116,10 @@ public interface Mapper extends ToXContent {
 
     String name();
 
+    /**
+     * Parse part of a document's JSON representation from context.parser(),
+     * and instantiate and add the appropriate {@link Field}s to context.doc().
+     */
     void parse(ParseContext context) throws IOException;
 
     void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException;

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -48,6 +48,10 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseStore;
 
 /**
+ * A mapping for points on a grid that encapsulates a String field for "lat,lon".
+ * Also optionally indexes a String field for geohash and/or two fields containing
+ * the lat and lon separately as Doubles.
+ * <p/>
  * Parsing: We handle:
  * <p/>
  * - "field" : "geo_hash"

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -1,12 +1,15 @@
 package org.elasticsearch.index.mapper.geo;
 
+import com.spatial4j.core.shape.Shape;
+import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
+import com.vividsolutions.jts.io.WKBWriter;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.FieldInfo;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJSONShapeParser;
 import org.elasticsearch.common.geo.GeoShapeConstants;
+import org.elasticsearch.common.geo.ShapeBuilder;
 import org.elasticsearch.common.lucene.spatial.SpatialStrategy;
 import org.elasticsearch.common.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.GeohashPrefixTree;
@@ -14,14 +17,25 @@ import org.elasticsearch.common.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.FieldMapperListener;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MergeContext;
+import org.elasticsearch.index.mapper.MergeMappingException;
+import org.elasticsearch.index.mapper.ObjectMapperListener;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
 
 import java.io.IOException;
 import java.util.Map;
+
+import static org.elasticsearch.common.Booleans.parseBoolean;
+import static org.elasticsearch.common.Strings.toUnderscoreCase;
+import static org.elasticsearch.index.mapper.MapperBuilders.stringField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
 
 /**
  * FieldMapper for indexing {@link com.spatial4j.core.shape.Shape}s.
@@ -38,8 +52,13 @@ import java.util.Map;
  *         [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
  *     ]
  * }
+ * <p/>
+ * Index format:<br />
+ * GeoShapeFieldMapper writes GeoShapeIndexFieldMapper keys directly under its
+ * top-level name. When 'wkb' is true, also a StringFieldMapper containing the
+ * Shape's base64-encoded WKB serialization under the "wkb" subpath.
  */
-public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
+public class GeoShapeFieldMapper implements Mapper {
 
     public static final String CONTENT_TYPE = "geo_shape";
 
@@ -49,13 +68,17 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
         public static final String GEOHASH = "geohash";
         public static final String QUADTREE = "quadtree";
         public static final String DISTANCE_ERROR_PCT = "distance_error_pct";
+        public static final String WKB = "wkb";
     }
 
     public static class Defaults {
+        public static final ContentPath.Type PATH_TYPE = ContentPath.Type.FULL;
+
         public static final String TREE = Names.GEOHASH;
         public static final int GEOHASH_LEVELS = GeohashPrefixTree.getMaxLevelsPossible();
         public static final int QUADTREE_LEVELS = QuadPrefixTree.DEFAULT_MAX_LEVELS;
         public static final double DISTANCE_ERROR_PCT = 0.025d;
+        public static final boolean STORE_WKB = false;
 
         public static final FieldType GEO_SHAPE_FIELD_TYPE = new FieldType();
 
@@ -70,16 +93,22 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
         }
     }
 
-    public static class Builder extends AbstractFieldMapper.Builder<Builder, GeoShapeFieldMapper> {
+    public static class Builder extends Mapper.Builder<Builder, GeoShapeFieldMapper> {
+        private ContentPath.Type pathType = Defaults.PATH_TYPE;
 
+        private boolean storeWkb = Defaults.STORE_WKB;
         private String tree = Defaults.TREE;
         private int treeLevels;
         private double distanceErrorPct = Defaults.DISTANCE_ERROR_PCT;
 
-        private SpatialPrefixTree prefixTree;
-
         public Builder(String name) {
-            super(name, new FieldType(Defaults.GEO_SHAPE_FIELD_TYPE));
+            super(name);
+            this.builder = this;
+        }
+
+        public Builder pathType(ContentPath.Type pathType) {
+            this.pathType = pathType;
+            return this;
         }
 
         public Builder tree(String tree) {
@@ -97,8 +126,18 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
             return this;
         }
 
+        public Builder storeWkb(boolean storeWkb) {
+            this.storeWkb = storeWkb;
+            return this;
+        }
+
+
         @Override
         public GeoShapeFieldMapper build(BuilderContext context) {
+            ContentPath.Type origPathType = context.path().pathType();
+            context.path().pathType(pathType);
+
+            SpatialPrefixTree prefixTree;
             if (tree.equals(Names.GEOHASH)) {
                 int levels = treeLevels != 0 ? treeLevels : Defaults.GEOHASH_LEVELS;
                 prefixTree = new GeohashPrefixTree(GeoShapeConstants.SPATIAL_CONTEXT, levels);
@@ -108,89 +147,239 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
             } else {
                 throw new ElasticSearchIllegalArgumentException("Unknown prefix tree type [" + tree + "]");
             }
+            GeoShapeIndexFieldMapper spatialTreeMapper =
+                    new GeoShapeIndexFieldMapper.Builder(name)
+                                .prefixTree(prefixTree)
+                                .distanceErrorPct(distanceErrorPct)
+                                .build(context);
 
-            return new GeoShapeFieldMapper(buildNames(context), prefixTree, distanceErrorPct, fieldType, provider);
+
+            context.path().add(name);
+            StringFieldMapper wkbMapper = null;
+            if (storeWkb) {
+                wkbMapper = stringField(Names.WKB)
+                                .index(true) // This is required for reading on the other end; how to bypass?
+                                .tokenized(false)
+                                .includeInAll(false)
+                                .omitNorms(true)
+                                .indexOptions(FieldInfo.IndexOptions.DOCS_ONLY)
+                                .store(true)
+                                .build(context);
+            }
+
+            context.path().remove();
+            context.path().pathType(origPathType);
+            return new GeoShapeFieldMapper(name, pathType, storeWkb, spatialTreeMapper, wkbMapper);
         }
     }
 
     public static class TypeParser implements Mapper.TypeParser {
-
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            Builder builder = new Builder(name);
+        public Mapper.Builder parse(String name, Map<String, Object> node, TypeParser.ParserContext parserContext) throws MapperParsingException {
+            GeoShapeFieldMapper.Builder builder = new GeoShapeFieldMapper.Builder(name);
 
             for (Map.Entry<String, Object> entry : node.entrySet()) {
-                String fieldName = Strings.toUnderscoreCase(entry.getKey());
+                String fieldName = toUnderscoreCase(entry.getKey());
                 Object fieldNode = entry.getValue();
+                if (fieldName.equals("path")) {
+                    builder.pathType(parsePathType(name, fieldNode.toString()));
+                } else
                 if (Names.TREE.equals(fieldName)) {
                     builder.tree(fieldNode.toString());
                 } else if (Names.TREE_LEVELS.equals(fieldName)) {
                     builder.treeLevels(Integer.parseInt(fieldNode.toString()));
                 } else if (Names.DISTANCE_ERROR_PCT.equals(fieldName)) {
                     builder.distanceErrorPct(Double.parseDouble(fieldNode.toString()));
+                } else if (Names.WKB.equals(fieldName)) {
+                    builder.storeWkb(parseBoolean(fieldNode.toString(), Defaults.STORE_WKB));
                 }
             }
             return builder;
         }
     }
 
-    private final SpatialStrategy spatialStrategy;
+    private final String name;
+    private final ContentPath.Type pathType;
 
-    public GeoShapeFieldMapper(FieldMapper.Names names, SpatialPrefixTree prefixTree, double distanceErrorPct,
-                               FieldType fieldType, PostingsFormatProvider provider) {
-        super(names, 1, fieldType, null, null, provider, null);
-        this.spatialStrategy = new TermQueryPrefixTreeStrategy(names, prefixTree, distanceErrorPct);
+    private final GeoShapeIndexFieldMapper spatialTreeMapper;
+    private final StringFieldMapper wkbMapper;
+    private final boolean storeWkb;
+
+    private GeoShapeFieldMapper(String name, ContentPath.Type pathType, boolean storeWkb,
+                                GeoShapeIndexFieldMapper spatialTreeMapper, StringFieldMapper wkbMapper) {
+        this.name = name;
+        this.pathType = pathType;
+        this.storeWkb = storeWkb;
+        this.spatialTreeMapper = spatialTreeMapper;
+        this.spatialTreeMapper.geoMapper = this;
+        this.wkbMapper = wkbMapper;
     }
 
     @Override
-    protected Field parseCreateField(ParseContext context) throws IOException {
-        return spatialStrategy.createField(GeoJSONShapeParser.parse(context.parser()));
-    }
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
+        builder.field("type", CONTENT_TYPE);
 
-    @Override
-    protected void doXContentBody(XContentBuilder builder) throws IOException {
-        builder.field("type", contentType());
+        if (pathType != Defaults.PATH_TYPE) {
+            builder.field("path", pathType.name().toLowerCase());
+        }
+        if (storeWkb != Defaults.STORE_WKB) {
+            builder.field(Names.WKB, storeWkb);
+        }
 
         // TODO: Come up with a better way to get the name, maybe pass it from builder
-        if (spatialStrategy.getPrefixTree() instanceof GeohashPrefixTree) {
+        if (spatialStrategy().getPrefixTree() instanceof GeohashPrefixTree) {
             // Don't emit the tree name since GeohashPrefixTree is the default
             // Only emit the tree levels if it isn't the default value
-            if (spatialStrategy.getPrefixTree().getMaxLevels() != Defaults.GEOHASH_LEVELS) {
-                builder.field(Names.TREE_LEVELS, spatialStrategy.getPrefixTree().getMaxLevels());
+            if (spatialStrategy().getPrefixTree().getMaxLevels() != Defaults.GEOHASH_LEVELS) {
+                builder.field(Names.TREE_LEVELS, spatialStrategy().getPrefixTree().getMaxLevels());
             }
         } else {
             builder.field(Names.TREE, Names.QUADTREE);
-            if (spatialStrategy.getPrefixTree().getMaxLevels() != Defaults.QUADTREE_LEVELS) {
-                builder.field(Names.TREE_LEVELS, spatialStrategy.getPrefixTree().getMaxLevels());
+            if (spatialStrategy().getPrefixTree().getMaxLevels() != Defaults.QUADTREE_LEVELS) {
+                builder.field(Names.TREE_LEVELS, spatialStrategy().getPrefixTree().getMaxLevels());
             }
         }
 
-        if (spatialStrategy.getDistanceErrorPct() != Defaults.DISTANCE_ERROR_PCT) {
-            builder.field(Names.DISTANCE_ERROR_PCT, spatialStrategy.getDistanceErrorPct());
+        if (spatialStrategy().getDistanceErrorPct() != Defaults.DISTANCE_ERROR_PCT) {
+            builder.field(Names.DISTANCE_ERROR_PCT, spatialStrategy().getDistanceErrorPct());
+        }
+
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public void parse(ParseContext context) throws IOException {
+        ContentPath.Type origPathType = context.path().pathType();
+        context.path().pathType(pathType);
+        context.path().add(name);
+
+        Shape shape = GeoJSONShapeParser.parse(context.parser());
+        context.externalValue(shape);
+        this.spatialTreeMapper.parse(context);
+
+        if (storeWkb) {
+            parseWkb(context, shape);
+        }
+
+        context.path().remove();
+        context.path().pathType(origPathType);
+    }
+
+    /**
+     * Writes the WKB serialization of the <tt>shape</tt> to the given ParseContext
+     * as an external value.
+     */
+    private void parseWkb(ParseContext context, Shape shape) throws IOException {
+        WKBWriter serializer = new WKBWriter(2);
+        byte[] wkb = serializer.write(ShapeBuilder.toJTSGeometry(shape));
+        context.externalValue(Base64.encode(wkb)); // FIXME: If I can get FieldDataCache to read a non-indexed field, use BinaryFieldMapper.
+        this.wkbMapper.parse(context);
+    }
+
+
+    @Override
+    public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
+        // TODO (this method is also a TODO in GeoPointFieldMapper, the prototype for this class)
+    }
+
+    @Override
+    public void traverse(FieldMapperListener fieldMapperListener) {
+        spatialTreeMapper.traverse(fieldMapperListener);
+        if (storeWkb) {
+            wkbMapper.traverse(fieldMapperListener);
         }
     }
 
     @Override
-    protected String contentType() {
-        return CONTENT_TYPE;
+    public void traverse(ObjectMapperListener objectMapperListener) {
     }
 
     @Override
-    public String value(Field field) {
-        throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
-    }
-
-    @Override
-    public String valueFromString(String value) {
-        throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
-    }
-
-    @Override
-    public String valueAsString(Field field) {
-        throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
+    public void close() {
+        spatialTreeMapper.close();
+        if (wkbMapper != null) {
+            wkbMapper.close();
+        }
     }
 
     public SpatialStrategy spatialStrategy() {
-        return this.spatialStrategy;
+        return spatialTreeMapper.spatialStrategy();
+    }
+
+    public static class GeoShapeIndexFieldMapper extends AbstractFieldMapper<String> {
+
+        public static class Builder extends AbstractFieldMapper.Builder<Builder, GeoShapeIndexFieldMapper> {
+
+            private double distanceErrorPct;
+            private SpatialPrefixTree prefixTree;
+
+            public Builder(String name) {
+                super(name, new FieldType(GeoShapeFieldMapper.Defaults.GEO_SHAPE_FIELD_TYPE));
+            }
+
+            public Builder prefixTree(SpatialPrefixTree prefixTree) {
+                this.prefixTree = prefixTree;
+                return this;
+            }
+
+            public Builder distanceErrorPct(double distanceErrorPct) {
+                this.distanceErrorPct = distanceErrorPct;
+                return this;
+            }
+
+            @Override
+            public GeoShapeIndexFieldMapper build(BuilderContext context) {
+                return new GeoShapeIndexFieldMapper(buildNames(context), prefixTree, distanceErrorPct, fieldType, provider);
+            }
+        }
+
+        private final SpatialStrategy spatialStrategy;
+        private GeoShapeFieldMapper geoMapper;
+
+        public GeoShapeIndexFieldMapper(FieldMapper.Names names, SpatialPrefixTree prefixTree, double distanceErrorPct,
+                                   FieldType fieldType, PostingsFormatProvider provider) {
+            super(names, 1, fieldType, null, null, provider, null);
+            this.spatialStrategy = new TermQueryPrefixTreeStrategy(names, prefixTree, distanceErrorPct);
+        }
+
+        @Override
+        protected Field parseCreateField(ParseContext context) throws IOException {
+            return spatialStrategy.createField((Shape) context.externalValue());
+        }
+
+        @Override
+        protected String contentType() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public String value(Field field) {
+            throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
+        }
+
+        @Override
+        public String valueFromString(String value) {
+            throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
+        }
+
+        @Override
+        public String valueAsString(Field field) {
+            throw new UnsupportedOperationException("GeoShape fields cannot be converted to String values");
+        }
+
+        public SpatialStrategy spatialStrategy() {
+            return this.spatialStrategy;
+        }
+
+        public GeoShapeFieldMapper geoMapper() {
+            return this.geoMapper;
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -30,13 +30,13 @@ import java.util.Map;
  * {@link org.elasticsearch.index.query.GeoShapeFilterParser}, consequently
  * a lot of behavior in this Mapper is disabled.
  * <p/>
- * Format supported:
+ * Format supported is equivalent to GeoJSON:
  * <p/>
  * "field" : {
- * "type" : "polygon",
- * "coordinates" : [
- * [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
- * ]
+ *     "type" : "polygon",
+ *     "coordinates" : [
+ *         [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
+ *     ]
  * }
  */
 public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -249,6 +249,10 @@ public class GeoShapeFieldMapper implements Mapper {
         return builder;
     }
 
+    public boolean isStoreWkb() {
+        return this.storeWkb;
+    }
+
     @Override
     public String name() {
         return this.name;

--- a/src/main/java/org/elasticsearch/index/mapper/multifield/MultiFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/multifield/MultiFieldMapper.java
@@ -38,7 +38,11 @@ import static org.elasticsearch.index.mapper.MapperBuilders.multiField;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
 
 /**
+ * Allows multiple mappers for a single field.
  *
+ * One mapper can be the default; if this default mapper is set, it is accessible
+ * via the field's name, and it is the only mapper that can (optionally) be included
+ * in _all.
  */
 public class MultiFieldMapper implements Mapper, AllFieldMapper.IncludeInAll {
 
@@ -170,6 +174,11 @@ public class MultiFieldMapper implements Mapper, AllFieldMapper.IncludeInAll {
         return this.name;
     }
 
+    /**
+     * Includes the default mapper in _all only if the default mapper is not null
+     * and includeInAll is true.  No other mappers in this MultiFieldMapper are
+     * included in _all under any circumstances.
+     */
     @Override
     public void includeInAll(Boolean includeInAll) {
         if (includeInAll != null && defaultMapper != null && (defaultMapper instanceof AllFieldMapper.IncludeInAll)) {

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterBuilder.java
@@ -36,6 +36,7 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
     private ShapeRelation relation = ShapeRelation.INTERSECTS;
 
     private final Shape shape;
+    private boolean fuzzy = GeoShapeFilterParser.DEFAULTS.FUZZY;
 
     private Boolean cache;
     private String cacheKey;
@@ -87,6 +88,17 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
      */
     public GeoShapeFilterBuilder relation(ShapeRelation relation) {
         this.relation = relation;
+        return this;
+    }
+
+    /**
+     * Sets whether the Filter is allowed to use fuzzy matching for better efficiency,
+     * that is, whether it is allowed to return false positives.
+     * @param fuzzy true if false positives are allowed, false to only return exact matches.
+     * @return this
+     */
+    public GeoShapeFilterBuilder fuzzy(boolean fuzzy) {
+        this.fuzzy = fuzzy;
         return this;
     }
 
@@ -179,6 +191,9 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
         }
         if (cacheKey != null) {
             builder.field("_cache_key", cacheKey);
+        }
+        if (fuzzy != GeoShapeFilterParser.DEFAULTS.FUZZY) {
+            builder.field("fuzzy", fuzzy);
         }
 
         builder.endObject();

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
@@ -25,11 +25,12 @@ import org.elasticsearch.common.geo.GeoJSONShapeParser;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.internal.Nullable;
+import org.elasticsearch.common.lucene.spatial.SpatialStrategy;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.cache.filter.support.CacheKeyFilter;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper.GeoShapeIndexFieldMapper;
 import org.elasticsearch.index.search.shape.ShapeFetchService;
 
 import java.io.IOException;
@@ -158,12 +159,12 @@ public class GeoShapeFilterParser implements FilterParser {
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
-        if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
+        if (!(fieldMapper instanceof GeoShapeIndexFieldMapper)) {
             throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape");
         }
 
-        GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
-        Filter filter = shapeFieldMapper.spatialStrategy().createFilter(shape, shapeRelation);
+        SpatialStrategy spatialStrategy = ((GeoShapeIndexFieldMapper) fieldMapper).spatialStrategy();
+        Filter filter = spatialStrategy.createFilter(shape, shapeRelation);
 
         if (cache) {
             filter = parseContext.cacheFilter(filter, cacheKey);

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -26,10 +26,11 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJSONShapeParser;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.spatial.SpatialStrategy;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper.GeoShapeIndexFieldMapper;
 import org.elasticsearch.index.search.shape.ShapeFetchService;
 
 import java.io.IOException;
@@ -129,13 +130,13 @@ public class GeoShapeQueryParser implements QueryParser {
 
         FieldMapper fieldMapper = smartNameFieldMappers.mapper();
         // TODO: This isn't the nicest way to check this
-        if (!(fieldMapper instanceof GeoShapeFieldMapper)) {
+        if (!(fieldMapper instanceof GeoShapeIndexFieldMapper)) {
             throw new QueryParsingException(parseContext.index(), "Field [" + fieldName + "] is not a geo_shape");
         }
 
-        GeoShapeFieldMapper shapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
+        SpatialStrategy spatialStrategy = ((GeoShapeIndexFieldMapper) fieldMapper).spatialStrategy();
 
-        Query query = shapeFieldMapper.spatialStrategy().createQuery(shape, shapeRelation);
+        Query query = spatialStrategy.createQuery(shape, shapeRelation);
         query.setBoost(boost);
         return query;
     }

--- a/src/main/java/org/elasticsearch/index/search/geo/IndexedGeoBoundingBoxFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/IndexedGeoBoundingBoxFilter.java
@@ -31,6 +31,9 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import java.io.IOException;
 
 /**
+ * Filters documents to within a spatial bounding box (topLeft to bottomRight) based
+ * on an indexed GeoPoint field (by delegating to range filters on the indexed
+ * GeoPoint's lat and lon).
  */
 public class IndexedGeoBoundingBoxFilter {
 

--- a/src/main/java/org/elasticsearch/index/search/geo/VerifiedShapeRelationFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/VerifiedShapeRelationFilter.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.search.geo;
+
+import com.spatial4j.core.shape.Shape;
+import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKBReader;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.FilteredDocIdSet;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.ElasticSearchParseException;
+import org.elasticsearch.common.geo.ShapeBuilder;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.index.cache.field.data.FieldDataCache;
+import org.elasticsearch.index.field.data.FieldData;
+import org.elasticsearch.index.field.data.FieldDataType;
+import org.elasticsearch.index.field.data.strings.StringFieldData;
+import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
+
+import java.io.IOException;
+
+/**
+ * Wraps a GeoShape {@link Filter} that may produce false positive matches, to
+ * limit the docs returned DocIdSet to only include docs that actually match the
+ * geo shape query.  This is accomplished by doing a JTS relation between the doc's
+ * serialized WKB field and the query shape.
+ *
+ * The Filter that this class wraps must produce at least all docs that match; it
+ * should not wrongly omit a matching doc from its DocIdSet.
+ */
+public class VerifiedShapeRelationFilter extends Filter {
+    private Filter baseFilter;
+    private FieldDataCache fieldDataCache;
+    private String fieldName;
+    private ShapeRelation shapeRelation;
+    private Geometry geometry;
+
+    /**
+     * Instantiates a Filter that accepts documents where both the following are true:
+     * <ul><li>baseFilter accepts the doc;</li>
+     *     <li>(the doc's Geometry at <tt>fieldName<tt>).shapeRelation(shape) returns true.</li>
+     * </ul>
+     */
+    public VerifiedShapeRelationFilter(Filter baseFilter, GeoShapeFieldMapper fieldMapper, FieldDataCache fieldDataCache, String fieldName, ShapeRelation relation, Shape shape) {
+        if (!fieldMapper.isStoreWkb()) {
+            throw new ElasticSearchIllegalArgumentException("wkb is not enabled (indexed) for field [" + fieldMapper.name() + "], can't use non-fuzzy matching on it");
+        }
+        this.baseFilter = baseFilter;
+        this.fieldDataCache = fieldDataCache;
+        this.fieldName = fieldName;
+        this.shapeRelation = relation;
+        this.geometry = ShapeBuilder.toJTSGeometry(shape);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DocIdSet getDocIdSet(AtomicReaderContext context, Bits bits) throws IOException {
+        final StringFieldData fieldData = (StringFieldData)fieldDataCache.cache(FieldDataType.DefaultTypes.STRING, context.reader(), fieldName);
+        DocIdSet candidates = baseFilter.getDocIdSet(context, bits);
+        return new VerifiedShapeRelationDocIdSet(candidates, fieldData, shapeRelation, geometry);
+    }
+
+    private static class VerifiedShapeRelationDocIdSet extends FilteredDocIdSet {
+        // FIXME: fieldData should be binary, once I can figure out how to get
+        // the FieldCache to read stored (non-indexed) fields.
+        private StringFieldData fieldData;
+        private ShapeRelation shapeRelation;
+        private Geometry queryGeometry;
+
+        // Uses default GeometryFactory with double floating point precision.
+        private WKBReader deserializer = new WKBReader();
+
+        private VerifiedShapeRelationDocIdSet(DocIdSet innerCandidates, FieldData fieldData,
+                                              ShapeRelation shapeRelation, Geometry geometry) {
+            // This is the assumption that candidates might return false positives,
+            // but will never falsely miss a matching document.
+            super(innerCandidates);
+            this.fieldData = (StringFieldData) fieldData;
+            this.shapeRelation = shapeRelation;
+            this.queryGeometry = geometry;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected boolean match(int docId) {
+            String value = fieldData.docFieldData(docId).getValue();
+            Geometry docGeom = null;
+            try {
+                docGeom = deserializer.read(Base64.decode(value));
+            } catch (ParseException parseEx) {
+                throw new ElasticSearchParseException("Problem reading document Geometry from cache.", parseEx);
+            }
+            switch (shapeRelation) {
+                case DISJOINT:
+                    return docGeom.disjoint(queryGeometry);
+                case INTERSECTS:
+                    return docGeom.intersects(queryGeometry);
+                case WITHIN:
+                    return docGeom.within(queryGeometry);
+                default:
+                    throw new UnsupportedOperationException("Shape Relation [" + shapeRelation.getRelationName() + "] not currently supported");
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/geo/GeoShapeFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/geo/GeoShapeFieldMapperTests.java
@@ -1,20 +1,31 @@
 package org.elasticsearch.test.unit.index.mapper.geo;
 
+import com.spatial4j.core.context.jts.JtsSpatialContext;
+import com.spatial4j.core.shape.Shape;
+import com.spatial4j.core.shape.SpatialRelation;
+import com.spatial4j.core.shape.jts.JtsGeometry;
+import com.vividsolutions.jts.io.WKBReader;
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.geo.GeoJSONShapeSerializer;
 import org.elasticsearch.common.lucene.spatial.SpatialStrategy;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.elasticsearch.common.lucene.spatial.prefix.tree.QuadPrefixTree;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.test.unit.index.mapper.MapperTests;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.geo.ShapeBuilder.newRectangle;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 public class GeoShapeFieldMapperTests {
 
@@ -28,9 +39,9 @@ public class GeoShapeFieldMapperTests {
 
         DocumentMapper defaultMapper = MapperTests.newParser().parse(mapping);
         FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.GeoShapeIndexFieldMapper.class));
 
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
+        GeoShapeFieldMapper geoShapeFieldMapper = ((GeoShapeFieldMapper.GeoShapeIndexFieldMapper) fieldMapper).geoMapper();
         SpatialStrategy strategy = geoShapeFieldMapper.spatialStrategy();
 
         assertThat(strategy.getDistanceErrorPct(), equalTo(GeoShapeFieldMapper.Defaults.DISTANCE_ERROR_PCT));
@@ -51,9 +62,9 @@ public class GeoShapeFieldMapperTests {
 
         DocumentMapper defaultMapper = MapperTests.newParser().parse(mapping);
         FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.GeoShapeIndexFieldMapper.class));
 
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
+        GeoShapeFieldMapper geoShapeFieldMapper = ((GeoShapeFieldMapper.GeoShapeIndexFieldMapper) fieldMapper).geoMapper();
         SpatialStrategy strategy = geoShapeFieldMapper.spatialStrategy();
 
         assertThat(strategy.getDistanceErrorPct(), equalTo(0.1));
@@ -74,13 +85,44 @@ public class GeoShapeFieldMapperTests {
 
         DocumentMapper defaultMapper = MapperTests.newParser().parse(mapping);
         FieldMapper fieldMapper = defaultMapper.mappers().name("location").mapper();
-        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.GeoShapeIndexFieldMapper.class));
 
-        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
+        GeoShapeFieldMapper geoShapeFieldMapper = ((GeoShapeFieldMapper.GeoShapeIndexFieldMapper) fieldMapper).geoMapper();
         SpatialStrategy strategy = geoShapeFieldMapper.spatialStrategy();
 
         assertThat(strategy.getDistanceErrorPct(), equalTo(0.5));
         assertThat(strategy.getPrefixTree(), instanceOf(QuadPrefixTree.class));
         assertThat(strategy.getPrefixTree().getMaxLevels(), equalTo(6));
+    }
+
+    /**
+     * Test that setting the "wkb" attribute in the mapping is correctly serialized
+     * in the index.
+     */
+    @Test
+    public void testWkbStorage() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                    .field("type", "geo_shape")
+                    .field("wkb", "true")
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper defaultMapper = MapperTests.newParser().parse(mapping);
+
+        Shape shape = newRectangle().topLeft(-45, 45).bottomRight(45, -45).build();
+
+        XContentBuilder docBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("location");
+        GeoJSONShapeSerializer.serialize(shape, docBuilder);
+        docBuilder.endObject().endObject();
+
+        ParsedDocument doc = defaultMapper.parse("type1", "1", docBuilder.bytes());
+        String base64 = doc.rootDoc().get("location.wkb");
+        Shape testingGeom = new JtsGeometry(new WKBReader().read(Base64.decode(base64)), JtsSpatialContext.GEO, false);
+        // There's not a great way to test for shape equality, especially between
+        // JTS Geometrys and spatial4j Shapes.
+        assertThat(testingGeom.relate(shape), not(SpatialRelation.DISJOINT));
     }
 }


### PR DESCRIPTION
This fixes #2361, geo_shape filter should not match false positives, by indexing the shape's WKB and doing an actual comparison between the doc's shape and the filter's shape to verify results from the spatial prefix tree.  This comparison is optional, and used only when "fuzzy"="false" (fuzzy matching is "true" by default), as there will be a slight performance hit when used.

I would prefer you do not actually merge this, because there are a few things I don't love about the implementation; I wasn't able to find the appropriate solution by myself but instead request your advice about the best way to solve this problem:
1. Right now I base64-encode the WKB into a `StringFieldMapper`, which is wasteful. I had preferred to use the `BinaryFieldMapper`, but that gives "Fields with BytesRef values cannot be indexed at org.apache.lucene.document.Field.<init>(Field.java:222)".
2. I'd prefer to only store, _but not index,_ the WKB (with whatever mapper gets used).  However it seems that the fieldDataCache can only read indexed fields.  I am still not clear on the difference.

Once we establish the best way to resolve bullet 2, should this non-fuzzy filter be cachable or not?  Which data, precisely, is getting cached in memory (the Geometrys themselves or just a bitmask over docs)?  My inclination is not to cache by default, assuming that repetition of the exact same query shape will be low, but this depends on the end use case.

Please provide guidance around these concerns and I can iterate on this patchset and provide a follow-up pull request afterwards.
