### PR TITLE
Added options to DynamicTemplate

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.Iterator;
+
 /**
  *
  */
@@ -108,5 +110,43 @@ public class ContentPath {
 
     public String sourcePath() {
         return this.sourcePath;
+    }
+    
+    public Iterator<String> iterator()
+    {
+      return new PathIter();
+    }
+    
+    private class PathIter implements Iterator<String>
+    {
+      int ind = 0;
+      int len = 0;
+      String[] iterPath;
+      
+      public PathIter()
+      {
+        len = index;
+        iterPath = new String[len + 1];
+        System.arraycopy(path, 0, iterPath, 0, len);
+        ind = 0;
+      }
+
+      @Override
+      public boolean hasNext()
+      {
+        return(ind < len);
+      }
+
+      @Override
+      public String next()
+      {
+        return(iterPath[ind++]);
+      }
+
+      @Override
+      public void remove()
+      {
+        throw new UnsupportedOperationException("Not supported yet.");
+      }
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
@@ -28,12 +28,87 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.Iterator;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 /**
- *
+ * A DynamicTemaplate is used to generate mappings for fields for which there are not existing 
+ * entries in the type mapping associated with a document. DynamicTemplate instances are owned by
+ * instance of the {@link RootObjectMapper}. 
+ * <p>
+ * A DynamicTemplate instance is initialized by parsing an entry from the <code>dynamic_templates</code>
+ * array within a type mapping. A typical usage example is shown below:    
+ * <pre>
+ *  "template_1" : {
+ *    "match": "*__*",
+ *    "capture":"(([a-zA-Z0-9]+?)(?:_[a-zA-Z0-9]+)*)__[a-zA-Z0-9]+", 
+ *    "options" :{
+ *      "n":{"index_name":"{1}"},
+ *      "a":{"include_in_all":false},
+ *      "1":{"analyzer":"myAnalyzer"},
+ *      "f":{"index":"not_analyzed"},
+ *      "f":{"index":"no"},
+ *      "d":{"dynamic":false},
+ *      "e":{"enabled":false},
+ *      "s":{"store":true} 
+ *     },
+ *     "mapping": {
+ *       "index_name":"{2}"
+ *     }
+ *   }
+ * </pre>  
+ * Parameters not shown in the above example: <code>path_match</code>, <code>unmatch</code>,
+ * <code>path_unmatch</code>, <code>match_mapping_type</code> and <code>match_pattern</code>.
+ * <p>
+ *  The name, path and field type detected dynamically by ElasticSearch (dynamicType) must satisfy
+ *  the template's matching criteria in order for ElasticSearch to use the template to generate a
+ *  mapping for the field:
+ * <p>
+ *  <ul>
+ *  <li>The name of the field must match the <code>match</code> pattern if it is present
+ *  <li>The name of the field must not match the <code>unmatch</code> pattern if it is present
+ *  <li>The full path of the field must match the <code>path_match</code> pattern if it is present
+ *  <li>The full path of the field must not match the <code>path_match</code> pattern if it is present
+ *  <li>The type of the field detected by ElasticSearch must match the <code>match_mapping_type</code> pattern if it is present
+ *  <li><code>match_pattern</code> sets the matching method used: <code>simple</code> (where * is a wildcard) or <code>regex</code> (regular expression) 
+ *  <li>At least one of <code>match</code> or <code>path_match</code> must be present.
+ *  </ul>
+ *  <p>
+ *  Once the template matching criteria have been met the <code>mapping</code> and <code>options</code> 
+ *  elements of the template are used to generate a concrete mapping as follows:
+ * <p>
+ *  <ul>
+ *  <li>The dynamic template builds a parameter map containing mappings for the default parameters
+ *      {name}, {dynamicType}, {dynamic_type), {path}, {rawPath} and {raw_path}. The {path} 
+ *      parameter is the full path to the field with all option information stripped out (see below)
+ *      while the raw paths contain the option information.
+ *  <li>If a <code>capture</code> regular expression pattern is provided it is used to extract
+ *      substrings from the <code>name</code> of the field. The <code>capture</code> pattern must
+ *      define capture groups, as per regular expression syntax, to capture parts of the field name
+ *      as required. Key/value pairs associated with all captured groups are added to the parameter
+ *      map using keys of the for "{n}" where n is the group number. For example, the  capture 
+ *      pattern <code>(([a-zA-Z0-9]+?)(?:_[a-zA-Z0-9]+)*)__[a-zA-Z0-9]+</code> used with 
+ *      a field named <code>"first_name__s"</code> will result in the capture of parameters 
+ *      <code>{1}=>first_name</code> and <code>{2}=>first</code>. 
+ *  <li>If the field <code>name</code> contains two sequential underscore characters, ie "__", then 
+ *      all characters after them are interpreted as a list of option keys. These option keys are 
+ *      used to look up entries from the options map defined by the <code>options</code> element
+ *      in the dynamic template definition. 
+ *  <li>The dynamic template merges all options specified by the option keys into the default 
+ *      mapping defined by the <code>mapping</code> element in the dynamic template definition.
+ *      The dynamic template performs parameter substitution on the default mapping and all
+ *      options while performing the merge.
+ *  <li>The <code>mapping</code> element must be present, even if it is empty.
+ *  <li>The options list is optional.
+ * </ul>
  */
+
+
 public class DynamicTemplate {
 
     public static enum MatchType {
@@ -46,9 +121,12 @@ public class DynamicTemplate {
             } else if ("regex".equals(value)) {
                 return REGEX;
             }
+            
             throw new ElasticSearchIllegalArgumentException("No matching pattern matched on [" + value + "]");
         }
     }
+
+    //-------------------------------------------------------------------------------------------
 
     public static DynamicTemplate parse(String name, Map<String, Object> conf) throws MapperParsingException {
         String match = null;
@@ -58,6 +136,8 @@ public class DynamicTemplate {
         Map<String, Object> mapping = null;
         String matchMappingType = null;
         String matchPattern = "simple";
+        Map<String, Map<String, Object>> options = null;
+        String captureMask = null;
 
         for (Map.Entry<String, Object> entry : conf.entrySet()) {
             String propName = Strings.toUnderscoreCase(entry.getKey());
@@ -75,6 +155,10 @@ public class DynamicTemplate {
                 matchPattern = entry.getValue().toString();
             } else if ("mapping".equals(propName)) {
                 mapping = (Map<String, Object>) entry.getValue();
+            } else if ("options".equals(propName)) {
+                options = (Map<String, Map<String, Object>>) entry.getValue();
+            } else if ("capture".equals(propName)) {
+                captureMask = entry.getValue().toString();
             }
         }
 
@@ -84,9 +168,12 @@ public class DynamicTemplate {
         if (mapping == null) {
             throw new MapperParsingException("template must have mapping set");
         }
-        return new DynamicTemplate(name, conf, pathMatch, pathUnmatch, match, unmatch, matchMappingType, MatchType.fromString(matchPattern), mapping);
+        return new DynamicTemplate(name, conf, pathMatch, pathUnmatch, match, unmatch, matchMappingType, MatchType.fromString(matchPattern), mapping, options, captureMask);
     }
 
+    //-------------------------------------------------------------------------------------------
+
+    
     private final String name;
 
     private final Map<String, Object> conf;
@@ -104,8 +191,14 @@ public class DynamicTemplate {
     private final String matchMappingType;
 
     private final Map<String, Object> mapping;
+    private final Map<String, Map<String, Object>> options;
+    private Pattern capturePattern;
+    
+    //-------------------------------------------------------------------------------------------
 
-    public DynamicTemplate(String name, Map<String, Object> conf, String pathMatch, String pathUnmatch, String match, String unmatch, String matchMappingType, MatchType matchType, Map<String, Object> mapping) {
+    public DynamicTemplate(String name, Map<String, Object> conf, String pathMatch, String pathUnmatch,
+                           String match, String unmatch, String matchMappingType, MatchType matchType,
+                           Map<String, Object> mapping, Map<String, Map<String, Object>> options, String captureMask) {
         this.name = name;
         this.conf = new TreeMap<String, Object>(conf);
         this.pathMatch = pathMatch;
@@ -115,15 +208,23 @@ public class DynamicTemplate {
         this.matchType = matchType;
         this.matchMappingType = matchMappingType;
         this.mapping = mapping;
+        this.options = (options != null) ? options : new HashMap<String, Map<String, Object>>();
+        this.capturePattern = (captureMask != null) ? Pattern.compile(captureMask) : null;
     }
+
+    //-------------------------------------------------------------------------------------------
 
     public String name() {
         return this.name;
     }
 
+    //-------------------------------------------------------------------------------------------
+
     public Map<String, Object> conf() {
         return this.conf;
     }
+
+    //-------------------------------------------------------------------------------------------
 
     public boolean match(ContentPath path, String name, String dynamicType) {
         if (pathMatch != null && !patternMatch(pathMatch, path.fullPathAsText(name))) {
@@ -146,59 +247,229 @@ public class DynamicTemplate {
                 return false;
             }
         }
+
         return true;
     }
 
-    public boolean hasType() {
-        return mapping.containsKey("type");
+    //-------------------------------------------------------------------------------------------
+    
+    public boolean hasType(String name) {
+        // If there are no options we just check the for an explicit type in the mapping
+        String opts = getOpts(name);
+        if (opts == null)
+        {
+          return mapping.containsKey("type");
+        }
+
+        // A template with options will explicitely set the type or throw an exception if the
+        // generated mapping does not have a type. 
+        return(true);
     }
 
-    public String mappingType(String dynamicType) {
-        return mapping.containsKey("type") ? mapping.get("type").toString() : dynamicType;
+    //-------------------------------------------------------------------------------------------
+
+    public String mappingType(String name, String dynamicType) {
+        // If there are no options then just use the type from the mapping or the dynamic type
+        String opts = getOpts(name);
+        if (opts == null)
+        {
+          return mapping.containsKey("type") ? mapping.get("type").toString() : dynamicType;
+        }
+          
+        // We must calculate the mapping because the type may be determined by one of the 
+        // options, there are no shortcuts. The mapping is guaranteed to have a type because
+        // dynamicType is applied if no explicit type is found after merging options into the
+        // default mapping.
+        Map<String, Object> map = mappingForName(null, name, dynamicType);
+        return((String)map.get("type"));
     }
+
+    //-------------------------------------------------------------------------------------------
 
     private boolean patternMatch(String pattern, String str) {
         if (matchType == MatchType.SIMPLE) {
             return Regex.simpleMatch(pattern, str);
         }
+        
         return str.matches(pattern);
     }
 
-    public Map<String, Object> mappingForName(String name, String dynamicType) {
-        return processMap(mapping, name, dynamicType);
-    }
+    //-------------------------------------------------------------------------------------------
 
-    private Map<String, Object> processMap(Map<String, Object> map, String name, String dynamicType) {
+    public Map<String, Object> mappingForName(ContentPath path, String name, String dynamicType) {
+       
+      // Get params and process the mapping
+      Map<String, String> params = parseParams(path, name, dynamicType);
+      Map<String, Object> processedMap = processMap(mapping, params);
+              
+      // Apply options
+      String opts = getOpts(name);
+      if (opts != null && opts.length() > 1)
+      {
+        for (int n = 0 ; n < opts.length() ; n++)
+        {
+          // Get the next option and do parameter substitution before adding to processedMap
+          Map<String, Object> optNode = options.get(opts.substring(n, n + 1));
+          if (optNode != null)
+          {
+            Map<String, Object> values = processMap(optNode, params);
+            processedMap.putAll(values);
+          }
+        }
+      }
+
+      // Make sure that the type is explitely set
+      if (!processedMap.containsKey("type"))
+      {
+        processedMap.put("type", dynamicType);
+      }
+      
+      return processedMap;
+    }    
+
+    //-------------------------------------------------------------------------------------------
+    /**
+     * Parses the path, name and dynamic type to build map of parameters for substitution into
+     * mapping and options.
+     * 
+     * @param path Path to field being mapped
+     * @param name Name of field being mapped
+     * @param dynamicType Type detected by JSON parser
+     * @return Map of parameters, all keys contain opening and closing braces 
+     */
+    
+    private Map<String, String> parseParams(ContentPath path, String name, String dynamicType)
+    {
+      HashMap<String, String> params = new HashMap<String, String>();
+
+      // Add standard parameters
+      params.put("{name}", name);
+      params.put("{dynamic_type}", dynamicType);
+      params.put("{dynamicType}", dynamicType);
+
+      // Claculate and add path. Options are stripped out.
+      StringBuilder builder = new StringBuilder();
+      StringBuilder rawBuilder = new StringBuilder();
+      if (path != null)
+      {
+        Iterator<String> iter = path.iterator();
+        for (int n = 0 ; iter.hasNext() ; n++)
+        {
+          String node = iter.next();
+          rawBuilder.append((n > 0) ? "." : "" ).append(node);
+          int pos = node.lastIndexOf("__");
+          builder.append((n > 0) ? "." : "" ).append((pos <= 0) ? node : node.substring(0, pos));
+        }
+      }
+      params.put("{path}", builder.toString());
+      params.put("{raw_path}", rawBuilder.toString());
+      params.put("{rawPath}", rawBuilder.toString());
+      
+      // Parse the name using capture regular expression. Values for capture groups are added
+      // to parameter map.
+      if (capturePattern != null)
+      {
+        Matcher m = capturePattern.matcher(name);
+        if (!m.matches())
+        {
+          throw new ElasticSearchIllegalArgumentException("Name [" + name + "] does not match capture pattern [" + capturePattern.pattern() + "]");
+        }
+
+        for (int n = 1 ; n <= m.groupCount() ; n++)
+        {
+          params.put("{"+ n + "}", m.group(n));
+        }
+      }
+      
+      return(params);
+    }    
+    
+    //-------------------------------------------------------------------------------------------
+    /**
+     * Parses the name and extract the options suffix if present
+     * @param name
+     * @return 
+     */
+    
+    private String getOpts(String name)
+    {
+      // Opts will only exist if options have been provided 
+      int pos = name.lastIndexOf("__");
+      if (pos > 0)
+      {
+        return(name.substring(pos + 2));
+      }
+      
+      return null;
+    }
+    
+    //-------------------------------------------------------------------------------------------
+
+    private Map<String, Object> processMap(Map<String, Object> map, Map<String, String> params ) {
         Map<String, Object> processedMap = Maps.newHashMap();
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            String key = entry.getKey().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
+        for (Map.Entry<String, Object> entry : map.entrySet())
+        {
+            String key = doReplace(entry.getKey(), params);
             Object value = entry.getValue();
             if (value instanceof Map) {
-                value = processMap((Map<String, Object>) value, name, dynamicType);
+                value = processMap((Map<String, Object>) value, params);
             } else if (value instanceof List) {
-                value = processList((List) value, name, dynamicType);
+                value = processList((List) value, params);
             } else if (value instanceof String) {
-                value = value.toString().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
+                value = doReplace(value.toString(), params);
             }
             processedMap.put(key, value);
         }
         return processedMap;
     }
 
-    private List processList(List list, String name, String dynamicType) {
+    //-------------------------------------------------------------------------------------------
+
+    private List processList(List list, Map<String, String> params) {
         List processedList = new ArrayList();
         for (Object value : list) {
             if (value instanceof Map) {
-                value = processMap((Map<String, Object>) value, name, dynamicType);
+                value = processMap((Map<String, Object>) value, params);
             } else if (value instanceof List) {
-                value = processList((List) value, name, dynamicType);
+                value = processList((List) value, params);
             } else if (value instanceof String) {
-                value = value.toString().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
+                value = doReplace(value.toString(), params);
             }
             processedList.add(value);
         }
         return processedList;
     }
+
+    //-------------------------------------------------------------------------------------------
+
+    private String doReplace(String src, Map<String, String> params )
+    {
+      // Iterate the params in the source because there will generally be fewer of these than
+      // values in param map, maybe none at all.
+      String res = src;
+      int start;
+      while ( (start = res.indexOf("{")) >= 0)
+      {
+        int end = res.indexOf("}", start + 1);
+        if (end < 0)
+        {
+          throw new ElasticSearchIllegalArgumentException("Param substitution failure, malformed source [" + src + "]");
+        }
+        
+        String key = res.substring(start, end + 1);
+        String val = params.get(key);
+        if (val == null)
+        {
+          throw new ElasticSearchIllegalArgumentException("Param substitution failure, invalid param [" + key + "]");
+        }
+        
+        res = res.replace(key, val);
+      }      
+      
+      return(res);
+    }
+    
+    //-------------------------------------------------------------------------------------------
 
     @Override
     public boolean equals(Object o) {
@@ -216,6 +487,8 @@ public class DynamicTemplate {
 
         return true;
     }
+
+    //-------------------------------------------------------------------------------------------
 
     @Override
     public int hashCode() {

--- a/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -210,12 +210,12 @@ public class RootObjectMapper extends ObjectMapper {
             return null;
         }
         Mapper.TypeParser.ParserContext parserContext = context.docMapperParser().parserContext();
-        String mappingType = dynamicTemplate.mappingType(dynamicType);
+        String mappingType = dynamicTemplate.mappingType(name, dynamicType);
         Mapper.TypeParser typeParser = parserContext.typeParser(mappingType);
         if (typeParser == null) {
             throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");
         }
-        return typeParser.parse(name, dynamicTemplate.mappingForName(name, dynamicType), parserContext);
+        return typeParser.parse(name, dynamicTemplate.mappingForName(context.path(), name, dynamicType), parserContext);
     }
 
     public DynamicTemplate findTemplate(ContentPath path, String name, String matchType) {

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/OptionsDynamicTemplateTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/OptionsDynamicTemplateTests.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.index.mapper.dynamictemplate.options;
+
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+
+import java.io.ByteArrayOutputStream;
+
+import org.elasticsearch.test.unit.index.mapper.dynamictemplate.pathmatch.*;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Fieldable;
+import org.apache.lucene.index.FieldInfo;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.index.field.data.strings.StringFieldDataType;
+import org.elasticsearch.index.field.data.longs.LongFieldDataType;
+
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.index.mapper.ObjectMappers;
+import org.apache.lucene.index.FieldInfo.IndexOptions;
+import org.elasticsearch.index.mapper.core.*;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
+//import org.elasticsearch.index.mapper.*;
+//import static org.elasticsearch.index.mapper.MapperBuilders.*;
+
+
+import org.elasticsearch.test.unit.index.mapper.MapperTests;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+import static org.elasticsearch.common.io.Streams.copyToBytesFromClasspath;
+import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
+import org.elasticsearch.common.xcontent.ToXContent;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ *
+ */
+public class OptionsDynamicTemplateTests {
+
+    @Test
+    public void testSimpleOptions() throws Exception {
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/test-mapping.json");
+        DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
+        byte[] json = copyToBytesFromClasspath("/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/test-data.json");
+        Document doc = docMapper.parse(new BytesArray(json)).rootDoc();
+
+        // Print the mapping
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        XContentBuilder builder = XContentFactory.jsonBuilder(bos);        
+        builder.prettyPrint();
+        builder.startObject();
+        docMapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        builder.flush();
+  //     System.out.printf("map:\n%s\n", bos.toString("UTF8"));
+     
+        // Validate the updated mapping
+        ObjectMapper detailsMapper = docMapper.objectMappers().get("details__o");
+        assertThat(detailsMapper.fullPath(), equalTo("details__o"));
+        
+        FieldMappers fieldMappers = docMapper.mappers().fullName("details__o.age__l");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.age"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(LongFieldDataType.class));
+        
+        fieldMappers = docMapper.mappers().fullName("details__o.gender__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.gender"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+        
+        fieldMappers = docMapper.mappers().fullName("details__o.name_first__sni");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.name"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+        
+        fieldMappers = docMapper.mappers().fullName("details__o.name_initial__sj");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().indexed(), equalTo(false));
+        
+        fieldMappers = docMapper.mappers().fullName("details__o.name_last__sni");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.name"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+
+        fieldMappers = docMapper.mappers().fullName("details__o.position__s");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.position"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        
+        fieldMappers = docMapper.mappers().fullName("details__o.status__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.status"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+        
+        fieldMappers = docMapper.mappers().fullName("details__o.dob__d");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("details.dob"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(LongFieldDataType.class));
+
+        
+        ObjectMapper contactMapper = docMapper.objectMappers().get("contact__o");
+        assertThat(contactMapper.fullPath(), equalTo("contact__o"));
+
+        ObjectMapper addressMapper = docMapper.objectMappers().get("contact__o.address");
+        assertThat(addressMapper.fullPath(), equalTo("contact__o.address"));
+
+        fieldMappers = docMapper.mappers().fullName("contact__o.address.city__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.address.city"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+        
+        fieldMappers = docMapper.mappers().fullName("contact__o.address.lines__s");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.address.lines"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(true));
+
+        fieldMappers = docMapper.mappers().fullName("contact__o.address.pcode__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.address.pcode"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+        
+        fieldMappers = docMapper.mappers().fullName("contact__o.address.state__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.address.state"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+        
+        
+        ObjectMapper inetMapper = docMapper.objectMappers().get("contact__o.inet");
+        assertThat(inetMapper.fullPath(), equalTo("contact__o.inet"));
+
+        fieldMappers = docMapper.mappers().fullName("contact__o.inet.address__s");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.inet.address"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(true));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(false));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS));
+        
+        fieldMappers = docMapper.mappers().fullName("contact__o.inet.type__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.inet.type"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().omitNorms(), equalTo(true));
+        assertThat(fieldMappers.mapper().indexOptions(),  equalTo(IndexOptions.DOCS_ONLY));
+
+        
+        ObjectMapper phoneMapper = docMapper.objectMappers().get("contact__o.phone");
+        assertThat(phoneMapper.fullPath(), equalTo("contact__o.phone"));
+
+        fieldMappers = docMapper.mappers().fullName("contact__o.phone.acode__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.phone.acode"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        assertThat(fieldMappers.mapper().indexed(), equalTo(true));
+        
+        fieldMappers = docMapper.mappers().fullName("contact__o.phone.number__si");
+        assertThat(fieldMappers.mappers().size(), equalTo(1));
+        assertThat(fieldMappers.mapper().names().indexName(), equalTo("contact.phone.number"));
+        assertThat(fieldMappers.mapper().fieldDataType(), instanceOf(StringFieldDataType.class));
+        assertThat(fieldMappers.mapper().analyzed(), equalTo(false));
+        
+        ObjectMapper changeMapper = docMapper.objectMappers().get("change");
+        assertThat(changeMapper.fullPath(), equalTo("change"));
+        assertThat(changeMapper.dynamic(), equalTo(ObjectMapper.Dynamic.TRUE));
+        
+        ObjectMapper verMapper = docMapper.objectMappers().get("change.versions__ode");
+        assertThat(verMapper.fullPath(), equalTo("change.versions__ode"));
+        assertThat(verMapper.dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
+        
+        
+//        System.out.printf("doc:\n%s\n", doc.toString());
+        
+    }
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/test-data.json
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/test-data.json
@@ -1,0 +1,34 @@
+{
+    "_id":"1",
+    "details__o":{
+      "name_first__sni":"John",
+      "name_initial__sj":"S",
+      "name_last__sni":"Doe",
+      "age__l":42,
+      "gender__si":"male",
+      "status__si":"active",
+      "position__s":"Operations Manager",
+      "dob__d":"19700312T110000.000Z"
+    },
+    "contact__o":{
+      "phone":[
+        {"acode__si":2, "number__si":"1234 5678"},
+        {"acode__si":"+1 345", "number__si":12345678},
+        {"acode__si":"45", "number__si":"7685 4536"}
+      ],
+      "address":[
+        {"lines__s":"12 Help St", "city__si":"Ryde", "state__si":"NSW", "pcode__si":2121},
+        {"lines__s":"13 Hello Rd", "city__si":"Sydney", "state__si":"NSW", "pcode__si":"2000"}
+      ],
+      "inet":[
+        {"type__si":"email", "address__s":"me@example.com"},
+        {"type__si":"web", "address__s":"http://some.host.com"}
+      ]
+    },
+    "change":{
+      "versions__ode": [
+        {"verNo":2, "verDate":"20120502T130023.000Z", "verBy":"jim", "diff":{}},
+        {"verNo":1, "verDate":"20120302T130023.000Z", "verBy":"tom", "diff":{}}
+      ]
+    }
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/test-mapping.json
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/options/test-mapping.json
@@ -1,0 +1,89 @@
+{
+    "person" : {
+        "date_detection" : false,
+        "numeric_detection":false,
+        "dynamic_templates":[
+            {
+                "dt_1":{
+                      "match": "*__o*",
+                      "match_mapping_type" : "object",
+                      "options" :{
+                          "a":{"include_in_all":false},
+                          "d":{"dynamic":false},
+                          "e":{"enabled":false},
+                          "p":{"path":"full"}
+                      },
+                      "mapping": {
+                        "path" : "just_name"
+                      }
+                }
+            },
+            {
+                "dt_2":{
+                      "match": "*__d*",
+                      "capture":"(([a-zA-Z0-9]+?)(?:_[a-zA-Z0-9]+)*)__[a-zA-Z0-9]+", 
+                      "options" :{
+                          "n":{"index_name":"{path}.{1}"},
+                          "j":{"index":"no"},
+                          "s":{"store":true},
+                          "a":{"include_in_all":false},
+                          "1":{"boost":1.5}
+                      },
+                      "mapping": {
+                        "type" : "date",
+                        "index_name":"{path}.{2}",
+                        "format":"yyyyMMdd'T'HHmmss.SSS'Z'"				
+                      }
+                }
+            },
+            {
+                "dt_3":{
+                    "match": "*__r*",
+                    "capture":"(([a-zA-Z0-9]+?)(?:_[a-zA-Z0-9]+)*)__[a-zA-Z0-9]+", 
+                    "options" :{
+                        "n":{
+                            "properties":{
+                                "ref":{"type":"string", "index":"not_analyzed", "index_name":"ref"},
+                                "caption":{"type":"string", "index_name":"{path}.{2}"}
+                            }
+                        },
+                        "m":{
+                            "properties":{
+                                "ref":{"type":"string", "index":"not_analyzed", "index_name":"ref"},
+                                "caption":{"type":"string", "index_name":"{path}.{1}"}
+                            }
+                        }
+                    },
+                    "mapping": {
+                        "type" : "object",
+                        "dynamic":"false",
+                        "properties":{
+                            "ref":{"type":"string", "index":"not_analyzed", "index_name":"ref"},
+                            "caption":{"type":"string", "index":"no"}
+                        }
+                    }
+                }
+            },
+            {
+                "dt_4":{
+                      "match": "*__*",
+                      "capture":"(([a-zA-Z0-9]+?)(?:_[a-zA-Z0-9]+)*)__[a-zA-Z0-9]+", 
+                      "options" :{
+                          "s":{"type":"string"},
+                          "l":{"type":"long"},
+                          "m":{"index_name":"{1}"},
+                          "n":{"index_name":"{path}.{2}"},
+                          "i":{"index":"not_analyzed"},
+                          "j":{"index":"no"},
+                          "t":{"store":true},
+                          "a":{"include_in_all":false},
+                          "1":{"boost":1.5}
+                      },
+                      "mapping": {
+                          "index_name":"{path}.{1}"
+                      }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Dynamic templates are a great feature because they make it possible to control the dynamic mapping capabilities of ElasticSearch. One of the issues with dynamic templates is that it is necessary to have several templates to handle even very small differences in mapping objectives. 
For example, four templates are needed to handle the cases 'analyzed', 'not_analyzed',
'analyzed+stored' and 'not_analyzed+stored'. 

This change overcomes this limitation by adding three new features to dynamic templates
1. Options that are merged into the mapping based on keys specified in the field name
2. The ability to capture substrings from the field name and use these to parameterize the mapping and options 
3. The ContentPath is made available to the DynamicTemplate for use in parameterization 

Consider the following example:

{
  "template_1":{
    "match": "____",
    "capture":"(([a-zA-Z0-9]+?)(?:_[a-zA-Z0-9]+)*)__[a-zA-Z0-9]+", 
    "options" :{
      "s":{"type":"string"},
      "l":{"type":"long"},
      "m":{"index_name":"{1}"},
      "n":{"index_name":"{path}.{2}"},
      "i":{"index":"not_analyzed"},
      "j":{"index":"no"},
      "t":{"store":true},
      "a":{"include_in_all":false},
      "1":{"boost":1.5},
      "d":{"dynamic":false}
    },
    "mapping": {
      "index_name":"{path}.{1}"
    }
  }
}

The match, path_match, unmatch, path_unmatch are unchanged.
Two new optional fields: 
"capture" : This specifies a regular expression with capture groups that are used to
capture substrings from the field name that are made available as paramaeters ({1},{2}, etc)
for substitution into option and mapping key/value pairs in the same way that {name} and
{dynamic_type} are currently.

"options" : A list of key/value pairs where keys are single character identifiers
and values are objects containing mapping options that are merged into the "mapping".

If the field name has a double underscore "__" then the DynamicTemplate class treats any characters following it as option identifiers. The following example "person" document and resulting mapping illustrate how this one options enabled dynamic template does what would otherwise require 5 dynamic templates without options. 

Notes 
1. The {path} parameter strips out the option specifiers. A {raw_path} is also available.
2. Fields 'name_first_sn' and 'name_last_sn1' both map to the index field 'details.name'

index/person/id1
{
  "details__d":{
    "salutation":"Mr",
    "name_first__sn":"",
    "name_last__sn1":"",
    "marital_status__sit":"married",
    "num_children__l":3
  }
}

mapping for type person
{
  "person" :{
    "properties" : {
      "details__d" : {
        "type":"object", 
        "dynamic":false,                           // option 'd'
        "properties" {
          "salutation" : {
        "type":"string";                       // Not picked up by match, default mapping
          },
          "name_first__sn": {
            "type":"string",                       // option 's' 
            "index_name":"details.name"            // option 'n'
          },
          "name_last__sn1": {
            "type":"string",                       // option 's'
            "index_name":"details.name",           // option 'n'
            "boost":1.5                            // option '1'
          },
          "marital_status__sit": {
            "type":"string",                       // option 's'
            "index_name":"details.marital_status", // mapping
        "index":"not_analyzed",                // option 'i'
            "store":true                           // option 't'
          },
          "num_children__l":{
            "type":"long",                         // option l  
            "index_name":"details.num_children",   // mapping
          }
        }
      }
    }
  }  
}
