### PR TITLE
Add support for ignoring settings in system properties.

### DIFF
--- a/src/main/java/org/elasticsearch/node/internal/InternalSettingsPerparer.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalSettingsPerparer.java
@@ -38,32 +38,36 @@ public class InternalSettingsPerparer {
     public static Tuple<Settings, Environment> prepareSettings(Settings pSettings, boolean loadConfigSettings) {
         // ignore this prefixes when getting properties from es. and elasticsearch.
         String[] ignorePrefixes = new String[]{"es.default.", "elasticsearch.default."};
+        boolean useSystemProperties = !pSettings.getAsBoolean("node.ignore_system_properties", false);
         // just create enough settings to build the environment
-        ImmutableSettings.Builder settingsBuilder = settingsBuilder()
-                .put(pSettings)
-                .putProperties("elasticsearch.default.", System.getProperties())
-                .putProperties("es.default.", System.getProperties())
-                .putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
-                .putProperties("es.", System.getProperties(), ignorePrefixes)
-                .replacePropertyPlaceholders();
+        ImmutableSettings.Builder settingsBuilder = settingsBuilder().put(pSettings);
+        if (useSystemProperties) {
+            settingsBuilder.putProperties("elasticsearch.default.", System.getProperties())
+                    .putProperties("es.default.", System.getProperties())
+                    .putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
+                    .putProperties("es.", System.getProperties(), ignorePrefixes);
+        }
+        settingsBuilder.replacePropertyPlaceholders();
 
         Environment environment = new Environment(settingsBuilder.build());
 
         if (loadConfigSettings) {
             boolean loadFromEnv = true;
-            // if its default, then load it, but also load form env
-            if (System.getProperty("es.default.config") != null) {
-                loadFromEnv = true;
-                settingsBuilder.loadFromUrl(environment.resolveConfig(System.getProperty("es.default.config")));
-            }
-            // if explicit, just load it and don't load from env
-            if (System.getProperty("es.config") != null) {
-                loadFromEnv = false;
-                settingsBuilder.loadFromUrl(environment.resolveConfig(System.getProperty("es.config")));
-            }
-            if (System.getProperty("elasticsearch.config") != null) {
-                loadFromEnv = false;
-                settingsBuilder.loadFromUrl(environment.resolveConfig(System.getProperty("elasticsearch.config")));
+            if (useSystemProperties) {
+                // if its default, then load it, but also load form env
+                if (System.getProperty("es.default.config") != null) {
+                    loadFromEnv = true;
+                    settingsBuilder.loadFromUrl(environment.resolveConfig(System.getProperty("es.default.config")));
+                }
+                // if explicit, just load it and don't load from env
+                if (System.getProperty("es.config") != null) {
+                    loadFromEnv = false;
+                    settingsBuilder.loadFromUrl(environment.resolveConfig(System.getProperty("es.config")));
+                }
+                if (System.getProperty("elasticsearch.config") != null) {
+                    loadFromEnv = false;
+                    settingsBuilder.loadFromUrl(environment.resolveConfig(System.getProperty("elasticsearch.config")));
+                }
             }
             if (loadFromEnv) {
                 try {
@@ -86,10 +90,12 @@ public class InternalSettingsPerparer {
             }
         }
 
-        settingsBuilder.put(pSettings)
-                .putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
-                .putProperties("es.", System.getProperties(), ignorePrefixes)
-                .replacePropertyPlaceholders();
+        settingsBuilder.put(pSettings);
+        if (useSystemProperties) {
+            settingsBuilder.putProperties("elasticsearch.", System.getProperties(), ignorePrefixes)
+                    .putProperties("es.", System.getProperties(), ignorePrefixes);
+        }
+        settingsBuilder.replacePropertyPlaceholders();
 
         // generate the name
         if (settingsBuilder.get("name") == null) {

--- a/src/test/java/org/elasticsearch/test/unit/node/internal/InternalSettingsPerparerTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/node/internal/InternalSettingsPerparerTests.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.node.internal;
+
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.node.internal.InternalSettingsPerparer;
+import org.testng.annotations.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class InternalSettingsPerparerTests {
+    @Test
+    public void testIgnoreSystemProperties() {
+        System.setProperty("es.node.zone", "foo");
+        Tuple<Settings, Environment> tuple = InternalSettingsPerparer.prepareSettings(settingsBuilder().put("node.zone", "bar").build(), true);
+        // Should use setting from the system property
+        assertThat(tuple.v1().get("node.zone"), equalTo("foo"));
+
+        tuple = InternalSettingsPerparer.prepareSettings(settingsBuilder().put("node.ignore_system_properties", true).put("node.zone", "bar").build(), true);
+        // Should use setting from the system property
+        assertThat(tuple.v1().get("node.zone"), equalTo("bar"));
+    }
+}


### PR DESCRIPTION
An elasticsearch node can be instructed to ignore settings specified in system properties by setting node.ignore_system_properties setting to true.

Fixes #2312
