### PR TITLE
Add alternative github download URL to PluginManager

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -114,28 +114,68 @@ public class PluginManager {
                         }
                         pluginFile = new File(environment.pluginsFile(), name + ".zip");
                         if (version == null) {
-                            // try with ES version from downloads
+                            // try with ES version from old '/downloads' URL
                             URL pluginUrl = new URL("https://github.com/downloads/" + userName + "/" + repoName + "/" + repoName + "-" + Version.CURRENT.number() + ".zip");
                             System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
                             try {
                                 downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
                                 downloaded = true;
                             } catch (IOException e) {
-                                // try a tag with ES version
-                                if (verbose) {
-                                    System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e));
-                                }
-                                pluginUrl = new URL("https://github.com/" + userName + "/" + repoName + "/zipball/v" + Version.CURRENT.number());
+                                // try at a different github location within repo, because uploads to '/downloads' URL were disabled
+                                pluginUrl = new URL("https://raw.github.com/" + userName + "/" + repoName + "/master/downloads/" + repoName + "-" + Version.CURRENT.number() + ".zip");
                                 System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
                                 try {
                                     downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
                                     downloaded = true;
                                 } catch (IOException e1) {
-                                    // download master
+                                    // try a tag with ES version
+                                    if (verbose) {
+                                        System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e));
+                                    }
+                                    pluginUrl = new URL("https://github.com/" + userName + "/" + repoName + "/zipball/v" + Version.CURRENT.number());
+                                    System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
+                                    try {
+                                        downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
+                                        downloaded = true;
+                                    } catch (IOException e2) {
+                                        // download master
+                                        if (verbose) {
+                                            System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e2));
+                                        }
+                                        pluginUrl = new URL("https://github.com/" + userName + "/" + repoName + "/zipball/master");
+                                        System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
+                                        try {
+                                            downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
+                                            downloaded = true;
+                                        } catch (IOException e3) {
+                                            // ignore
+                                            if (verbose) {
+                                                System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e3));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            // download explicit version from obsolete '/downloads' URL
+                            URL pluginUrl = new URL("https://github.com/downloads/" + userName + "/" + repoName + "/" + repoName + "-" + version + ".zip");
+                            System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
+                            try {
+                                downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
+                                downloaded = true;
+                            } catch (IOException e) {
+                                // try at a different github location within repo, because uploads to '/downloads' URL were disabled
+                                pluginUrl = new URL("https://raw.github.com/" + userName + "/" + repoName + "/master/downloads/" + repoName + "-" + Version.CURRENT.number() + ".zip");
+                                System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
+                                try {
+                                    downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
+                                    downloaded = true;
+                                } catch (IOException e1) {
+                                    // try a tag with ES version
                                     if (verbose) {
                                         System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e1));
                                     }
-                                    pluginUrl = new URL("https://github.com/" + userName + "/" + repoName + "/zipball/master");
+                                    pluginUrl = new URL("https://github.com/" + userName + "/" + repoName + "/zipball/v" + version);
                                     System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
                                     try {
                                         downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
@@ -145,30 +185,6 @@ public class PluginManager {
                                         if (verbose) {
                                             System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e2));
                                         }
-                                    }
-                                }
-                            }
-                        } else {
-                            // download explicit version
-                            URL pluginUrl = new URL("https://github.com/downloads/" + userName + "/" + repoName + "/" + repoName + "-" + version + ".zip");
-                            System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
-                            try {
-                                downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
-                                downloaded = true;
-                            } catch (IOException e) {
-                                // try a tag with ES version
-                                if (verbose) {
-                                    System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e));
-                                }
-                                pluginUrl = new URL("https://github.com/" + userName + "/" + repoName + "/zipball/v" + version);
-                                System.out.println("Trying " + pluginUrl.toExternalForm() + "...");
-                                try {
-                                    downloadHelper.download(pluginUrl, pluginFile, new HttpDownloadHelper.VerboseProgress(System.out));
-                                    downloaded = true;
-                                } catch (IOException e1) {
-                                    // ignore
-                                    if (verbose) {
-                                        System.out.println("Failed: " + ExceptionsHelper.detailedMessage(e1));
                                     }
                                 }
                             }


### PR DESCRIPTION
The Github downloads are gone

https://github.com/blog/1302-goodbye-uploads

so the PluginManager should be able to fetch zips from alternative location under https://raw.github.com

Plugin authors will have to commit their zip binaries to this different location:

```
https://raw.github.com/{user}/{repo}/master/downloads/{pluginname}-{version}.zip
```

which corresponds to a ${basename}/downloads folder in a Maven project.

Cheers,

Jörg
