### PR TITLE
allow index and type to be specified as arrays in MultiSearchRequest

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search;
 
 import com.google.common.collect.Lists;
+import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IgnoreIndices;
@@ -34,6 +35,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
@@ -124,6 +126,14 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
                                 } else if ("ignore_indices".equals(currentFieldName) || "ignoreIndices".equals(currentFieldName)) {
                                     searchRequest.ignoreIndices(IgnoreIndices.fromString(parser.text()));
                                 }
+                            } else if (token == XContentParser.Token.START_ARRAY) {
+                                if ("index".equals(currentFieldName) || "indices".equals(currentFieldName)) {
+                                    searchRequest.indices(parseArray(parser));
+                                } else if ("type".equals(currentFieldName) || "type".equals(currentFieldName)) {
+                                    searchRequest.types(parseArray(parser));
+                                } else {
+                                    throw new ElasticSearchParseException(currentFieldName + " doesn't support arrays");
+                                }
                             }
                         }
                     }
@@ -148,6 +158,14 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
         }
 
         return this;
+    }
+    private String[] parseArray(XContentParser parser) throws IOException {
+        final List<String> list = new ArrayList<String>();
+        assert parser.currentToken() == XContentParser.Token.START_ARRAY;
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            list.add(parser.text());
+        }
+        return list.toArray(new String[list.size()]);
     }
 
     private int findNextMarker(byte marker, int from, BytesReference data, int length) {

--- a/src/test/java/org/elasticsearch/test/unit/action/search/MultiSearchRequestTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/action/search/MultiSearchRequestTests.java
@@ -68,4 +68,23 @@ public class MultiSearchRequestTests {
         assertThat(request.requests().get(4).indices(), nullValue());
         assertThat(request.requests().get(4).types().length, equalTo(0));
     }
+    
+    @Test
+    public void simpleAdd3() throws Exception {
+        byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/test/unit/action/search/simple-msearch3.json");
+        MultiSearchRequest request = new MultiSearchRequest().add(data, 0, data.length, false, null, null, null);
+        assertThat(request.requests().size(), equalTo(4));
+        assertThat(request.requests().get(0).indices()[0], equalTo("test0"));
+        assertThat(request.requests().get(0).indices()[1], equalTo("test1"));
+        assertThat(request.requests().get(1).indices()[0], equalTo("test2"));
+        assertThat(request.requests().get(1).indices()[1], equalTo("test3"));
+        assertThat(request.requests().get(1).types()[0], equalTo("type1"));
+        assertThat(request.requests().get(2).indices()[0], equalTo("test4"));
+        assertThat(request.requests().get(2).indices()[1], equalTo("test1"));
+        assertThat(request.requests().get(2).types()[0], equalTo("type2"));
+        assertThat(request.requests().get(2).types()[1], equalTo("type1"));
+        assertThat(request.requests().get(3).indices(), nullValue());
+        assertThat(request.requests().get(3).types().length, equalTo(0));
+        assertThat(request.requests().get(3).searchType(), equalTo(SearchType.COUNT));
+    }
 }

--- a/src/test/java/org/elasticsearch/test/unit/action/search/simple-msearch3.json
+++ b/src/test/java/org/elasticsearch/test/unit/action/search/simple-msearch3.json
@@ -1,0 +1,8 @@
+{"index":["test0", "test1"]}
+{"query" : {"match_all" {}}}
+{"index" : "test2,test3", "type" : "type1"}
+{"query" : {"match_all" {}}}
+{"index" : ["test4", "test1"], "type" :  [ "type2", "type1" ]}
+{"query" : {"match_all" {}}}
+{"search_type" : "count"}
+{"query" : {"match_all" {}}}


### PR DESCRIPTION
currently MultiSearchRequest requries to specify indices and types as comma separated. This PR allows specification as arrays too.
