### PR TITLE
Reduced memory consumption of ordinal arrays

### DIFF
--- a/src/main/java/org/elasticsearch/index/field/data/MultiValueOrdinalArray.java
+++ b/src/main/java/org/elasticsearch/index/field/data/MultiValueOrdinalArray.java
@@ -1,0 +1,262 @@
+package org.elasticsearch.index.field.data;
+
+
+import gnu.trove.list.array.TIntArrayList;
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.RamUsage;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.util.concurrent.ThreadLocals;
+
+import java.util.ArrayList;
+
+/**
+ * a specialized container to hold ordinals for {@link FieldData }
+ */
+public class MultiValueOrdinalArray {
+
+   /*
+     A few words on how this works:
+     - The goal of this class is to provide an efficient storage
+
+     every document contains an entry in the firstLevel entry
+     - an entry of 0 means no ordinals
+     - a positive entry means a single ordinal for this document
+     - a negative entry means a pointer to (implemented as an offset into) storage data array(s)
+     - a storage array entry is a sequence of positive ordinal, terminated by a negative ordinal. All of these
+       are associated with the document.
+
+     - the class uses multiple storage arrays to avoid allocating huge array which need big continuous memory.
+     - the pointer to a storage array contains two parts: the high bits are an indication which storage array is used.
+       the lower bits are an offset into that array.
+
+     - Memory consumption:
+         - d0 = set docs with no ordinals
+         - d1 = set docs with one ordinal
+         - d2 = set of docs with two ordinals or more
+         - o2 = all the ordinals for docs in d2
+
+           -> (#d1+#d0)*INT32+ (#d2+#o2)*INT32 -> (#documents + #ordinals)*INT32
+
+
+
+    */
+
+   protected ESLogger logger = Loggers.getLogger(getClass());
+
+   protected final int MAX_STORAGE_SIZE_SHIFT;
+   protected final int MAX_STORAGE_SIZE;
+
+   protected final int[] firstLevel;
+   protected final int[][] storageArrays;
+
+   public MultiValueOrdinalArray(int[][] ordinalToStore) {
+      this(ordinalToStore,(1 << 26) / RamUsage.NUM_BYTES_INT); // storage array of 64MB
+   }
+
+   protected MultiValueOrdinalArray(int[][] ordinalToStore, int max_storage_size) {
+      int shift = 0;
+
+      // not need to over allocated.
+      if (ordinalToStore.length * ordinalToStore[0].length < max_storage_size)
+         max_storage_size = (ordinalToStore.length * ordinalToStore[0].length) + 1;
+
+      MAX_STORAGE_SIZE = max_storage_size;
+      max_storage_size--; // array is 0-based, remove one for maximum possible index
+      while (max_storage_size > 0) {
+         shift++;
+         max_storage_size = max_storage_size >> 1;
+      }
+
+      MAX_STORAGE_SIZE_SHIFT = shift;
+
+      ArrayList<int[]> storageArrays = new ArrayList<int[]>();
+
+      // temporary storage for doc ordinals
+      TIntArrayList docOrdinals = new TIntArrayList(ordinalToStore.length);
+
+      TIntArrayList curStorageArray = new TIntArrayList(MAX_STORAGE_SIZE);
+      int curStorageArrayIndex = 0;
+
+      // Two things about this:
+      // 1) First array must start with 1 as 0 pointer means no value.
+      // 2) Always points to the next usable place
+      int curOffsetWithInStorage = 1;
+      curStorageArray.add(Integer.MIN_VALUE); // first place is wasted.
+      int maxDoc = ordinalToStore[0].length;
+
+      firstLevel = new int[maxDoc];
+
+      for (int curDoc=0;curDoc < maxDoc; curDoc++) {
+         docOrdinals.clear(ordinalToStore.length);
+         for (int[] anOrdinalToStore : ordinalToStore) {
+            int o = anOrdinalToStore[curDoc];
+            if (o == 0) {
+               break;
+            }
+            docOrdinals.add(o);
+         }
+
+         switch (docOrdinals.size()) {
+            case 0:
+               break; // nothing to do
+            case 1:
+               firstLevel[curDoc] = docOrdinals.get(0);
+               break;
+            default:
+
+
+               if ((curOffsetWithInStorage + docOrdinals.size()) > MAX_STORAGE_SIZE) {
+                  if (docOrdinals.size() > MAX_STORAGE_SIZE-1) {
+                     throw new ElasticSearchException(
+                             String.format("Number of values for doc %s has a exceeded the maximum allowed "+
+                                     "(got %s values, max %s)",
+                                     curDoc,docOrdinals.size(),MAX_STORAGE_SIZE-1));
+                  }
+
+                  curStorageArrayIndex++;
+                  logger.debug("Allocating a new storage array. {} so far.",curStorageArrayIndex);
+
+                  storageArrays.add(curStorageArray.toArray());
+                  curOffsetWithInStorage=1; // for pointer consistency waste a slot.
+                  curStorageArray.clear(MAX_STORAGE_SIZE);
+                  curStorageArray.add(Integer.MIN_VALUE); // first place is wasted.
+               }
+
+               firstLevel[curDoc] = -((curStorageArrayIndex << MAX_STORAGE_SIZE_SHIFT) + curOffsetWithInStorage);
+
+               int j=0;
+               for(;j<docOrdinals.size()-1;j++) {
+                  curStorageArray.add(docOrdinals.get(j));
+                  curOffsetWithInStorage++;
+               }
+               // mark last with a negative value
+               curStorageArray.add(-docOrdinals.get(j));
+               curOffsetWithInStorage++;
+         }
+      }
+
+      // all done. populate final storage space
+      this.storageArrays = new int[storageArrays.size()+1][];
+      for (int i = 0; i < storageArrays.size(); i++) {
+         this.storageArrays[i] = storageArrays.get(i);
+      }
+      this.storageArrays[storageArrays.size()] = curStorageArray.toArray();
+
+      logger.debug("Ordinal array loaded. %s docs, %s secondary storage arrays. Memory signature: %sKB",
+              this.firstLevel.length,this.storageArrays.length,computeSizeInBytes()/1024);
+   }
+
+   public long computeSizeInBytes() {
+      long size = RamUsage.NUM_BYTES_ARRAY_HEADER + firstLevel.length * RamUsage.NUM_BYTES_INT;
+      size += RamUsage.NUM_BYTES_ARRAY_HEADER; // for the top level storagearray
+      for (int[] sa : storageArrays) {
+         size += RamUsage.NUM_BYTES_ARRAY_HEADER + RamUsage.NUM_BYTES_INT * sa.length;
+      }
+      size += RamUsage.NUM_BYTES_INT * 2; // constants
+      size += RamUsage.NUM_BYTES_OBJECT_REF; // logger
+
+      return size;
+   }
+
+   public boolean hasValue(int docId) {
+      return firstLevel[docId] != 0;
+   }
+
+   public void forEachOrdinalInDoc(int docId, FieldData.OrdinalInDocProc proc) {
+
+      OrdinalIterator iter = getOrdinalIteratorForDoc(docId);
+
+      int o = iter.getNextOrdinal();
+      if (o==0) {
+         proc.onOrdinal(docId, o); // first one is special as we need to communicate 0 if nothing is found
+         return;
+      }
+
+      while (o != 0) {
+         proc.onOrdinal(docId,o);
+         o = iter.getNextOrdinal();
+      }
+   }
+
+   public interface OrdinalIterator {
+      /**
+       * Returns the next ordinal for current docId or 0 when no more ordinals are available.
+       */
+      public int getNextOrdinal();
+   }
+
+   public OrdinalIterator getOrdinalIteratorForDoc(int docId) {
+      int ordinalOrPointer = firstLevel[docId];
+
+      if (ordinalOrPointer >= 0) {
+         return singleIteratorCache.get().get().init(ordinalOrPointer);
+      }
+
+      ordinalOrPointer = -ordinalOrPointer;
+
+      int storageArrayIndex = ordinalOrPointer >> MAX_STORAGE_SIZE_SHIFT;
+      int[] storageArray = storageArrays[storageArrayIndex];
+      ordinalOrPointer -= storageArrayIndex;
+
+      return multiOrdinalIteratorCache.get().get().init(storageArray,ordinalOrPointer);
+
+
+   }
+
+   private ThreadLocal<ThreadLocals.CleanableValue<SingleOrdinalIterator>> singleIteratorCache =
+           new ThreadLocal<ThreadLocals.CleanableValue<SingleOrdinalIterator>>() {
+      @Override
+      protected ThreadLocals.CleanableValue<SingleOrdinalIterator> initialValue() {
+         return new ThreadLocals.CleanableValue<SingleOrdinalIterator>(new SingleOrdinalIterator());
+      }
+   };
+
+   private ThreadLocal<ThreadLocals.CleanableValue<MultiOrdinalIterator>> multiOrdinalIteratorCache =
+           new ThreadLocal<ThreadLocals.CleanableValue<MultiOrdinalIterator>>() {
+              @Override
+              protected ThreadLocals.CleanableValue<MultiOrdinalIterator> initialValue() {
+                 return new ThreadLocals.CleanableValue<MultiOrdinalIterator>(new MultiOrdinalIterator());
+              }
+           };
+
+   protected static class SingleOrdinalIterator implements OrdinalIterator {
+
+      private int ordinal;
+
+      public SingleOrdinalIterator init(int ordinal) {
+         this.ordinal = ordinal;
+         return this;
+      }
+
+      public int getNextOrdinal() {
+         int i=ordinal;
+         ordinal=0; // reset for the next time.
+         return i;
+      }
+   }
+
+   protected static class MultiOrdinalIterator implements OrdinalIterator {
+
+      private int ordinalIndex;
+      private int[] storageArray;
+
+      public MultiOrdinalIterator init(int[] storageArray,int ordinalIndex) {
+         this.storageArray = storageArray;
+         this.ordinalIndex = ordinalIndex;
+         return this;
+      }
+
+
+      public int getNextOrdinal() {
+         if (ordinalIndex < 0) return 0;
+         int ordinal = storageArray[ordinalIndex++];
+         if (ordinal<0) {
+            // last one.
+            ordinal = -ordinal;
+            ordinalIndex = -1;
+         }
+         return ordinal;
+      }
+   }
+}

--- a/src/main/java/org/elasticsearch/index/field/data/doubles/MultiValueDoubleFieldData.java
+++ b/src/main/java/org/elasticsearch/index/field/data/doubles/MultiValueDoubleFieldData.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.field.data.doubles;
 
-import org.elasticsearch.common.RamUsage;
 import org.elasticsearch.common.util.concurrent.ThreadLocals;
+import org.elasticsearch.index.field.data.MultiValueOrdinalArray;
 
 /**
  *
@@ -41,20 +41,17 @@ public class MultiValueDoubleFieldData extends DoubleFieldData {
     };
 
     // order with value 0 indicates no value
-    private final int[][] ordinals;
+    private final MultiValueOrdinalArray ordinals;
 
     public MultiValueDoubleFieldData(String fieldName, int[][] ordinals, double[] values) {
         super(fieldName, values);
-        this.ordinals = ordinals;
+        this.ordinals = new MultiValueOrdinalArray(ordinals);
     }
 
     @Override
     protected long computeSizeInBytes() {
         long size = super.computeSizeInBytes();
-        size += RamUsage.NUM_BYTES_ARRAY_HEADER; // for the top level array
-        for (int[] ordinal : ordinals) {
-            size += RamUsage.NUM_BYTES_INT * ordinal.length + RamUsage.NUM_BYTES_ARRAY_HEADER;
-        }
+        size += ordinals.computeSizeInBytes();
         return size;
     }
 
@@ -65,104 +62,102 @@ public class MultiValueDoubleFieldData extends DoubleFieldData {
 
     @Override
     public boolean hasValue(int docId) {
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] != 0) {
-                return true;
-            }
-        }
-        return false;
+        return ordinals.hasValue(docId);
     }
 
     @Override
     public void forEachValueInDoc(int docId, StringValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, Double.toString(values[loc]));
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, Double.toString(values[o]));
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
+
     @Override
     public void forEachValueInDoc(int docId, DoubleValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, LongValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, (long) values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, (long) values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingDoubleValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o==0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingLongValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, (long) values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o==0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, (long) values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, ValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachOrdinalInDoc(int docId, OrdinalInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onOrdinal(docId, 0);
-                }
-                break;
-            }
-            proc.onOrdinal(docId, loc);
-        }
+        ordinals.forEachOrdinalInDoc(docId, proc);
+    }
+
+    protected int geValueCount(int docId) {
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int count = 0;
+        while (ordinalIter.getNextOrdinal() != 0) count++;
+        return count;
     }
 
     @Override
@@ -170,28 +165,20 @@ public class MultiValueDoubleFieldData extends DoubleFieldData {
         return values(docId);
     }
 
+
+
     @Override
     public double value(int docId) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc != 0) {
-                return values[loc];
-            }
-        }
-        return 0;
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        return o == 0 ? 0 : values[o];
     }
 
     @Override
     public double[] values(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
-            return EMPTY_DOUBLE_ARRAY;
+            return DoubleFieldData.EMPTY_DOUBLE_ARRAY;
         }
         double[] doubles;
         if (length < VALUE_CACHE_SIZE) {
@@ -199,8 +186,11 @@ public class MultiValueDoubleFieldData extends DoubleFieldData {
         } else {
             doubles = new double[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            doubles[i] = values[ordinals[i][docId]];
+            doubles[i] = values[ordinalIter.getNextOrdinal()];
         }
         return doubles;
     }

--- a/src/main/java/org/elasticsearch/index/field/data/floats/MultiValueFloatFieldData.java
+++ b/src/main/java/org/elasticsearch/index/field/data/floats/MultiValueFloatFieldData.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.field.data.floats;
 
-import org.elasticsearch.common.RamUsage;
 import org.elasticsearch.common.util.concurrent.ThreadLocals;
+import org.elasticsearch.index.field.data.MultiValueOrdinalArray;
 import org.elasticsearch.index.field.data.doubles.DoubleFieldData;
 
 /**
@@ -53,20 +53,17 @@ public class MultiValueFloatFieldData extends FloatFieldData {
     };
 
     // order with value 0 indicates no value
-    private final int[][] ordinals;
+    private final MultiValueOrdinalArray ordinals;
 
     public MultiValueFloatFieldData(String fieldName, int[][] ordinals, float[] values) {
         super(fieldName, values);
-        this.ordinals = ordinals;
+        this.ordinals = new MultiValueOrdinalArray(ordinals);
     }
 
     @Override
     protected long computeSizeInBytes() {
         long size = super.computeSizeInBytes();
-        size += RamUsage.NUM_BYTES_ARRAY_HEADER; // for the top level array
-        for (int[] ordinal : ordinals) {
-            size += RamUsage.NUM_BYTES_INT * ordinal.length + RamUsage.NUM_BYTES_ARRAY_HEADER;
-        }
+        size += ordinals.computeSizeInBytes();
         return size;
     }
 
@@ -77,115 +74,106 @@ public class MultiValueFloatFieldData extends FloatFieldData {
 
     @Override
     public boolean hasValue(int docId) {
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] != 0) {
-                return true;
-            }
-        }
-        return false;
+        return ordinals.hasValue(docId);
     }
 
     @Override
     public void forEachValueInDoc(int docId, StringValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, Double.toString(values[loc]));
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, Float.toString(values[o]));
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, DoubleValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, LongValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, (long) values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, (long) values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingDoubleValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingLongValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, (long) values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, (long) values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, ValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachOrdinalInDoc(int docId, OrdinalInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onOrdinal(docId, 0);
-                }
-                break;
-            }
-            proc.onOrdinal(docId, loc);
-        }
+        ordinals.forEachOrdinalInDoc(docId, proc);
+    }
+
+    protected int geValueCount(int docId) {
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int count = 0;
+        while (ordinalIter.getNextOrdinal() != 0) count++;
+        return count;
     }
 
     @Override
     public double[] doubleValues(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return DoubleFieldData.EMPTY_DOUBLE_ARRAY;
         }
@@ -195,32 +183,25 @@ public class MultiValueFloatFieldData extends FloatFieldData {
         } else {
             doubles = new double[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            doubles[i] = values[ordinals[i][docId]];
+            doubles[i] = values[ordinalIter.getNextOrdinal()];
         }
         return doubles;
     }
 
     @Override
     public float value(int docId) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc != 0) {
-                return values[loc];
-            }
-        }
-        return 0;
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        return o == 0 ? 0 : values[o];
     }
 
     @Override
     public float[] values(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return EMPTY_FLOAT_ARRAY;
         }
@@ -230,8 +211,11 @@ public class MultiValueFloatFieldData extends FloatFieldData {
         } else {
             floats = new float[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            floats[i] = values[ordinals[i][docId]];
+            floats[i] = values[ordinalIter.getNextOrdinal()];
         }
         return floats;
     }

--- a/src/main/java/org/elasticsearch/index/field/data/ints/MultiValueIntFieldData.java
+++ b/src/main/java/org/elasticsearch/index/field/data/ints/MultiValueIntFieldData.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.field.data.ints;
 
-import org.elasticsearch.common.RamUsage;
 import org.elasticsearch.common.util.concurrent.ThreadLocals;
+import org.elasticsearch.index.field.data.MultiValueOrdinalArray;
 import org.elasticsearch.index.field.data.doubles.DoubleFieldData;
 
 /**
@@ -52,21 +52,17 @@ public class MultiValueIntFieldData extends IntFieldData {
         }
     };
 
-    // order with value 0 indicates no value
-    private final int[][] ordinals;
+    private final MultiValueOrdinalArray ordinals;
 
     public MultiValueIntFieldData(String fieldName, int[][] ordinals, int[] values) {
         super(fieldName, values);
-        this.ordinals = ordinals;
+        this.ordinals = new MultiValueOrdinalArray(ordinals);
     }
 
     @Override
     protected long computeSizeInBytes() {
         long size = super.computeSizeInBytes();
-        size += RamUsage.NUM_BYTES_ARRAY_HEADER; // for the top level array
-        for (int[] ordinal : ordinals) {
-            size += RamUsage.NUM_BYTES_INT * ordinal.length + RamUsage.NUM_BYTES_ARRAY_HEADER;
-        }
+        size += ordinals.computeSizeInBytes();
         return size;
     }
 
@@ -77,115 +73,106 @@ public class MultiValueIntFieldData extends IntFieldData {
 
     @Override
     public boolean hasValue(int docId) {
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] != 0) {
-                return true;
-            }
-        }
-        return false;
+        return ordinals.hasValue(docId);
     }
 
     @Override
     public void forEachValueInDoc(int docId, StringValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, Integer.toString(values[loc]));
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, Integer.toString(values[o]));
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, DoubleValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, LongValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingDoubleValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingLongValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, ValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachOrdinalInDoc(int docId, OrdinalInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onOrdinal(docId, 0);
-                }
-                break;
-            }
-            proc.onOrdinal(docId, loc);
-        }
+        ordinals.forEachOrdinalInDoc(docId, proc);
+    }
+
+    protected int geValueCount(int docId) {
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int count = 0;
+        while (ordinalIter.getNextOrdinal() != 0) count++;
+        return count;
     }
 
     @Override
     public double[] doubleValues(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return DoubleFieldData.EMPTY_DOUBLE_ARRAY;
         }
@@ -195,32 +182,25 @@ public class MultiValueIntFieldData extends IntFieldData {
         } else {
             doubles = new double[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            doubles[i] = values[ordinals[i][docId]];
+            doubles[i] = values[ordinalIter.getNextOrdinal()];
         }
         return doubles;
     }
 
     @Override
     public int value(int docId) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc != 0) {
-                return values[loc];
-            }
-        }
-        return 0;
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        return o == 0 ? 0 : values[o];
     }
 
     @Override
     public int[] values(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return EMPTY_INT_ARRAY;
         }
@@ -230,8 +210,11 @@ public class MultiValueIntFieldData extends IntFieldData {
         } else {
             ints = new int[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            ints[i] = values[ordinals[i][docId]];
+            ints[i] = values[ordinalIter.getNextOrdinal()];
         }
         return ints;
     }

--- a/src/main/java/org/elasticsearch/index/field/data/longs/MultiValueLongFieldData.java
+++ b/src/main/java/org/elasticsearch/index/field/data/longs/MultiValueLongFieldData.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.field.data.longs;
 
-import org.elasticsearch.common.RamUsage;
 import org.elasticsearch.common.util.concurrent.ThreadLocals;
+import org.elasticsearch.index.field.data.MultiValueOrdinalArray;
 import org.elasticsearch.index.field.data.doubles.DoubleFieldData;
 import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
@@ -70,20 +70,17 @@ public class MultiValueLongFieldData extends LongFieldData {
     };
 
     // order with value 0 indicates no value
-    private final int[][] ordinals;
+    private final MultiValueOrdinalArray ordinals;
 
     public MultiValueLongFieldData(String fieldName, int[][] ordinals, long[] values) {
         super(fieldName, values);
-        this.ordinals = ordinals;
+        this.ordinals = new MultiValueOrdinalArray(ordinals);
     }
 
     @Override
     protected long computeSizeInBytes() {
         long size = super.computeSizeInBytes();
-        size += RamUsage.NUM_BYTES_ARRAY_HEADER; // for the top level array
-        for (int[] ordinal : ordinals) {
-            size += RamUsage.NUM_BYTES_INT * ordinal.length + RamUsage.NUM_BYTES_ARRAY_HEADER;
-        }
+        size += ordinals.computeSizeInBytes();
         return size;
     }
 
@@ -94,139 +91,128 @@ public class MultiValueLongFieldData extends LongFieldData {
 
     @Override
     public boolean hasValue(int docId) {
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] != 0) {
-                return true;
-            }
-        }
-        return false;
+        return ordinals.hasValue(docId);
     }
 
     @Override
     public void forEachValueInDoc(int docId, StringValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, Long.toString(values[loc]));
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, Long.toString(values[o]));
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, DoubleValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, LongValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingDoubleValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachValueInDoc(int docId, MissingLongValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachOrdinalInDoc(int docId, OrdinalInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onOrdinal(docId, 0);
-                }
-                break;
-            }
-            proc.onOrdinal(docId, loc);
-        }
+        ordinals.forEachOrdinalInDoc(docId, proc);
     }
 
     @Override
     public void forEachValueInDoc(int docId, ValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
+
+
 
     @Override
     public void forEachValueInDoc(int docId, DateValueInDocProc proc) {
         MutableDateTime dateTime = dateTimeCache.get().get();
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            dateTime.setMillis(values[loc]);
-            proc.onValue(docId, dateTime);
-        }
+        forEachValueInDoc(docId,dateTime,proc);
     }
 
     @Override
     public void forEachValueInDoc(int docId, MutableDateTime dateTime, DateValueInDocProc proc) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc == 0) {
-                break;
-            }
-            dateTime.setMillis(values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+
+        while (o != 0) {
+            dateTime.setMillis(values[o]);
             proc.onValue(docId, dateTime);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
+    protected int geValueCount(int docId) {
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int count = 0;
+        while (ordinalIter.getNextOrdinal() != 0) count++;
+        return count;
+    }
+
+
     @Override
     public MutableDateTime[] dates(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] != 0) {
-                length++;
-            }
-        }
+
+        int length = geValueCount(docId);
         if (length == 0) {
             return EMPTY_DATETIME_ARRAY;
         }
@@ -239,25 +225,18 @@ public class MultiValueLongFieldData extends LongFieldData {
                 dates[i] = new MutableDateTime();
             }
         }
-        int i = 0;
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc != 0) {
-                dates[i++].setMillis(values[loc]);
-            }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
+        for (int i = 0; i < length; i++) {
+            dates[i].setMillis(values[ordinalIter.getNextOrdinal()]);
         }
         return dates;
     }
 
     @Override
     public double[] doubleValues(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return DoubleFieldData.EMPTY_DOUBLE_ARRAY;
         }
@@ -267,32 +246,25 @@ public class MultiValueLongFieldData extends LongFieldData {
         } else {
             doubles = new double[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            doubles[i] = values[ordinals[i][docId]];
+            doubles[i] = values[ordinalIter.getNextOrdinal()];
         }
         return doubles;
     }
 
     @Override
     public long value(int docId) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc != 0) {
-                return values[loc];
-            }
-        }
-        return 0;
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        return o == 0 ? 0 : values[o];
     }
 
     @Override
     public long[] values(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return EMPTY_LONG_ARRAY;
         }
@@ -302,8 +274,11 @@ public class MultiValueLongFieldData extends LongFieldData {
         } else {
             longs = new long[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            longs[i] = values[ordinals[i][docId]];
+            longs[i] = values[ordinalIter.getNextOrdinal()];
         }
         return longs;
     }

--- a/src/main/java/org/elasticsearch/index/field/data/strings/MultiValueStringFieldData.java
+++ b/src/main/java/org/elasticsearch/index/field/data/strings/MultiValueStringFieldData.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.index.field.data.strings;
 
-import org.elasticsearch.common.RamUsage;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ThreadLocals;
+import org.elasticsearch.index.field.data.MultiValueOrdinalArray;
 
 /**
  *
@@ -42,20 +42,17 @@ public class MultiValueStringFieldData extends StringFieldData {
     };
 
     // order with value 0 indicates no value
-    private final int[][] ordinals;
+    private final MultiValueOrdinalArray ordinals;
 
     public MultiValueStringFieldData(String fieldName, int[][] ordinals, String[] values) {
         super(fieldName, values);
-        this.ordinals = ordinals;
+        this.ordinals = new MultiValueOrdinalArray(ordinals);
     }
 
     @Override
     protected long computeSizeInBytes() {
         long size = super.computeSizeInBytes();
-        size += RamUsage.NUM_BYTES_ARRAY_HEADER; // for the top level array
-        for (int[] ordinal : ordinals) {
-            size += RamUsage.NUM_BYTES_INT * ordinal.length + RamUsage.NUM_BYTES_ARRAY_HEADER;
-        }
+        size += ordinals.computeSizeInBytes();
         return size;
     }
 
@@ -66,62 +63,46 @@ public class MultiValueStringFieldData extends StringFieldData {
 
     @Override
     public boolean hasValue(int docId) {
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] != 0) {
-                return true;
-            }
-        }
-        return false;
+        return ordinals.hasValue(docId);
     }
 
     @Override
     public void forEachValueInDoc(int docId, StringValueInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onMissing(docId);
-                }
-                break;
-            }
-            proc.onValue(docId, values[loc]);
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        if (o == 0) {
+            proc.onMissing(docId); // first one is special as we need to communicate 0 if nothing is found
+            return;
+        }
+
+        while (o != 0) {
+            proc.onValue(docId, values[o]);
+            o = ordinalIter.getNextOrdinal();
         }
     }
 
     @Override
     public void forEachOrdinalInDoc(int docId, OrdinalInDocProc proc) {
-        for (int i = 0; i < ordinals.length; i++) {
-            int loc = ordinals[i][docId];
-            if (loc == 0) {
-                if (i == 0) {
-                    proc.onOrdinal(docId, 0);
-                }
-                break;
-            }
-            proc.onOrdinal(docId, loc);
-        }
+        ordinals.forEachOrdinalInDoc(docId, proc);
     }
 
     @Override
     public String value(int docId) {
-        for (int[] ordinal : ordinals) {
-            int loc = ordinal[docId];
-            if (loc != 0) {
-                return values[loc];
-            }
-        }
-        return null;
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int o = ordinalIter.getNextOrdinal();
+        return o == 0 ? null : values[o];
+    }
+
+    protected int geValueCount(int docId) {
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+        int count = 0;
+        while (ordinalIter.getNextOrdinal() != 0) count++;
+        return count;
     }
 
     @Override
     public String[] values(int docId) {
-        int length = 0;
-        for (int[] ordinal : ordinals) {
-            if (ordinal[docId] == 0) {
-                break;
-            }
-            length++;
-        }
+        int length = geValueCount(docId);
         if (length == 0) {
             return Strings.EMPTY_ARRAY;
         }
@@ -131,8 +112,11 @@ public class MultiValueStringFieldData extends StringFieldData {
         } else {
             strings = new String[length];
         }
+
+        MultiValueOrdinalArray.OrdinalIterator ordinalIter = ordinals.getOrdinalIteratorForDoc(docId);
+
         for (int i = 0; i < length; i++) {
-            strings[i] = values[ordinals[i][docId]];
+            strings[i] = values[ordinalIter.getNextOrdinal()];
         }
         return strings;
     }

--- a/src/test/java/org/elasticsearch/test/unit/index/field/data/MultiValueOrdinalArrayTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/field/data/MultiValueOrdinalArrayTests.java
@@ -1,0 +1,133 @@
+package org.elasticsearch.test.unit.index.field.data;
+
+import gnu.trove.list.array.TIntArrayList;
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.RamUsage;
+import org.elasticsearch.index.field.data.FieldData;
+import org.elasticsearch.index.field.data.MultiValueOrdinalArray;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class MultiValueOrdinalArrayTests {
+
+   protected int STORAGE_SIZE = 8;
+
+   class smallMultiValueOrdinalArray extends MultiValueOrdinalArray {
+
+      public smallMultiValueOrdinalArray(int[][] ordinalToStore) {
+         super(ordinalToStore,STORAGE_SIZE);
+      }
+   }
+
+   protected TIntArrayList collectOrdinals(MultiValueOrdinalArray a,int docId) {
+      final TIntArrayList ol = new TIntArrayList();
+      a.forEachOrdinalInDoc(docId, new FieldData.OrdinalInDocProc() {
+         @Override
+         public void onOrdinal(int docId, int ordinal) {
+            ol.add(ordinal);
+         }
+      });
+      return ol;
+   }
+
+   protected void regressToArray(ArrayList<int[]> ordinalsPerDoc) {
+      // invert ordinalsPerDoc to the structure MultiValueOrdinalArray expects
+
+      smallMultiValueOrdinalArray a = getSmallMultiValueOrdinalArray(ordinalsPerDoc);
+
+      for (int doc=0;doc<ordinalsPerDoc.size();doc++) {
+         assertThat(collectOrdinals(a, doc),
+                 equalTo(new TIntArrayList(ordinalsPerDoc.get(doc))));
+      }
+   }
+
+   private smallMultiValueOrdinalArray getSmallMultiValueOrdinalArray(ArrayList<int[]> ordinalsPerDoc) {
+      int maxLength = 0;
+      for (int[] ol: ordinalsPerDoc) {
+         if (maxLength < ol.length) maxLength =  ol.length;
+      }
+
+      int [][] ordinalArray= new int[maxLength][ordinalsPerDoc.size()];
+      for (int doc=0;doc<ordinalsPerDoc.size();doc++) {
+         for (int o=0;o<ordinalsPerDoc.get(doc).length;o++)
+            ordinalArray[o][doc]=ordinalsPerDoc.get(doc)[o];
+      }
+
+      return new smallMultiValueOrdinalArray(ordinalArray);
+   }
+
+
+   @Test
+   public void testSingleValue() {
+      ArrayList<int[]> o = new ArrayList<int[]>();
+      o.add(new int[] {1});
+      o.add(new int[] {0});
+      o.add(new int[] {1});
+      o.add(new int[] {2});
+      o.add(new int[] {3});
+
+      regressToArray(o);
+   }
+
+   @Test
+   public void testSingleDocMultiValue() {
+      ArrayList<int[]> o = new ArrayList<int[]>();
+      o.add(new int[] {1,2});
+      regressToArray(o);
+   }
+
+
+   @Test
+   public void testStorageOverflow() {
+      ArrayList<int[]> o = new ArrayList<int[]>();
+      o.add(new int[] {1});
+      o.add(new int[] {0});
+      o.add(new int[] {1});
+      o.add(new int[] {1,2,3,4,5,6});
+      o.add(new int[] {3});
+      regressToArray(o);
+   }
+
+
+   @Test
+   public void testComputeSizeInBytes() {
+      ArrayList<int[]> o = new ArrayList<int[]>();
+      o.add(new int[] {1});
+      o.add(new int[] {0});
+      o.add(new int[] {1});
+      o.add(new int[] {1,2,3,4,5,6});
+      smallMultiValueOrdinalArray a = getSmallMultiValueOrdinalArray(o);
+      assertThat(a.computeSizeInBytes(),greaterThan(9L*RamUsage.NUM_BYTES_INT));
+   }
+
+   @Test
+   public void testHasValue() {
+      ArrayList<int[]> o = new ArrayList<int[]>();
+      o.add(new int[] {1});
+      o.add(new int[] {0});
+      o.add(new int[] {1});
+      o.add(new int[] {1,2,3,4,5,6});
+      smallMultiValueOrdinalArray a = getSmallMultiValueOrdinalArray(o);
+      assertThat(a.hasValue(0),equalTo(true));
+      assertThat(a.hasValue(1),equalTo(false));
+      assertThat(a.hasValue(2),equalTo(true));
+      assertThat(a.hasValue(3),equalTo(true));
+   }
+
+   @Test(expectedExceptions = { ElasticSearchException.class } )
+   public void testImpossibleStorageOverflow() {
+      ArrayList<int[]> o = new ArrayList<int[]>();
+      o.add(new int[] {1});
+      o.add(new int[] {0});
+      o.add(new int[] {1});
+      o.add(new int[] {1,2,3,4,5,6,7,8});
+      o.add(new int[] {3});
+      regressToArray(o);
+   }
+
+}


### PR DESCRIPTION
Here is proposed to solution to the problem described in #2468 - the large of amount of memory consumed by the ordinal arrays of the field cache in highly uneven distribution.

I have introduced a new dedicated storage class ( src/main/java/org/elasticsearch/index/field/data/MultiValueOrdinalArray.java ) . The storage class' space complexity is linear in both the number of segment documents as the number of ordinals needed. 

Performance is identical to the current implementation if documents have no value or only a single one. For documents with two or more ordinals there is a slight per doc overhead due to some integer arithmetics. I suspect this is more then compensated by a more efficient traversing of memory, but this has to be measured (the class walks memory linearly within a single array rather jump through multiple arrays).

I've changed all the Field Data classes to use the new container. To keep impact on the code minimal, I have not changed the initial loading of the ordinals but rather compile the ordinal arrays into the new data store. This means that loading the Field cache initially has the same memory requirement as before.

Another caveat to note: at the moment you can store up to ~2^30 ordinals in it. For me this is not a problem, but it is a limitation the current implementation doesn't have (with enough memory). 

My hope is that you can see this as a drop in replacement for the next 0.20.x release as I believe it is equivalent to the current implementation but has a much better memory signature. 

To help integrating it,  I merged it already with the laters 0.20 branch (I also have a 0.19 variant, which we currently run in production) . All unit tests pass running this new code and we run it in production.

I know the team is busy with Lucene 4 but I hope you can take a couple of hours for this.  I'd love to able to go back to vanilla ES rather than have the overhead of running a custom build.

Let me know if I can help in any way,
Boaz
