### PR TITLE
Pass topScorer=false to sub-scorers if a scorer is wrapped. 

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -74,7 +74,6 @@ public class AllTermQuery extends SpanTermQuery {
             if (this.stats == null) {
                 return null;
             }
-            AtomicReader reader = context.reader();
             SloppySimScorer sloppySimScorer = similarity.sloppySimScorer(stats, context);
             return new AllTermSpanScorer((TermSpans) query.getSpans(context, acceptDocs, termContexts), this, sloppySimScorer);
         }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -138,7 +138,7 @@ public class FiltersFunctionScoreQuery extends Query {
 
         @Override
         public Scorer scorer(AtomicReaderContext context, boolean scoreDocsInOrder, boolean topScorer, Bits acceptDocs) throws IOException {
-            Scorer subQueryScorer = subQueryWeight.scorer(context, scoreDocsInOrder, topScorer, acceptDocs);
+            Scorer subQueryScorer = subQueryWeight.scorer(context, scoreDocsInOrder, false, acceptDocs);
             if (subQueryScorer == null) {
                 return null;
             }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -96,7 +96,7 @@ public class FunctionScoreQuery extends Query {
 
         @Override
         public Scorer scorer(AtomicReaderContext context, boolean scoreDocsInOrder, boolean topScorer, Bits acceptDocs) throws IOException {
-            Scorer subQueryScorer = subQueryWeight.scorer(context, scoreDocsInOrder, topScorer, acceptDocs);
+            Scorer subQueryScorer = subQueryWeight.scorer(context, scoreDocsInOrder, false, acceptDocs);
             if (subQueryScorer == null) {
                 return null;
             }


### PR DESCRIPTION
Wrapped BooleanQuery can return collect-only scorers. This closes #2505
