### PR TITLE
fix npe due to copy/paste bug

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -163,7 +163,7 @@ public class Analysis {
         }
         List<String> pathLoadedStopWords = getWordList(env, settings, "stopwords");
         if (pathLoadedStopWords != null) {
-            return resolveNamedStopWords(stopWords, version, ignore_case);
+            return resolveNamedStopWords(pathLoadedStopWords, version, ignore_case);
         }
 
         return defaultStopWords;


### PR DESCRIPTION
if stopWords is not null, it is handled above, otherwise, code should be using getWordList() value, but doesn't. code npe's if it gets here.
