### PR TITLE
Disable startup by default after package installation

### DIFF
--- a/src/deb/default/elasticsearch
+++ b/src/deb/default/elasticsearch
@@ -1,3 +1,6 @@
+# Comment or change to enable ElasticSearch running as a service
+ENABLE=False
+
 # Run ElasticSearch as this user ID and group ID
 #ES_USER=elasticsearch
 #ES_GROUP=elasticsearch

--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -99,6 +99,11 @@ if [ -f "$DEFAULT" ]; then
 	. "$DEFAULT"
 fi
 
+if [ "$ENABLE" = "False" ]; then
+  echo "Service is disabled by $DEFAULT"
+  exit 0
+fi
+
 # Define other required variables
 PID_FILE=/var/run/$NAME.pid
 DAEMON=$ES_HOME/bin/elasticsearch


### PR DESCRIPTION
Hi there,

Happy new year first.

This patch add envar used by init.d script to prevent from starting by default.
Often before you have to work on config files to fit your needs (manually or with provisioning tool like chef or puppet) and then only start the service.
This can be used also for tier programs that depends on ES libs but does not need for the service running on the same host.

Cheers,
