### PR TITLE
null pointer exception in 19.8. same code path exists in master branch

### DIFF
--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorService.java
@@ -176,7 +176,9 @@ public class PercolatorService extends AbstractIndexComponent {
             reader.document(doc, fieldsVisitor);
             String id = fieldsVisitor.uid().id();
             try {
-                queries.put(id, percolator.parseQuery(id, fieldsVisitor.source()));
+		Query query = percolator.parseQuery(id, fieldsVisitor.source());
+                if (query != null) queries.put(id, query);
+		else logger.warn("null query [{}]", id);
             } catch (Exception e) {
                 logger.warn("failed to add query [{}]", e, id);
             }

--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorService.java
@@ -176,9 +176,9 @@ public class PercolatorService extends AbstractIndexComponent {
             reader.document(doc, fieldsVisitor);
             String id = fieldsVisitor.uid().id();
             try {
-		Query query = percolator.parseQuery(id, fieldsVisitor.source());
+                Query query = percolator.parseQuery(id, fieldsVisitor.source());
                 if (query != null) queries.put(id, query);
-		else logger.warn("null query [{}]", id);
+                else logger.warn("null query [{}]", id);
             } catch (Exception e) {
                 logger.warn("failed to add query [{}]", e, id);
             }


### PR DESCRIPTION
Upon restarting an elasticsearch server, I received a "failed to recover commit_point" message from Elasticsearch. The cause was a null pointer being passed into a concurrent hashmap. The null comes from PercolatorExecutor.parseQuery, which seems to always parse a query or raise an exception. If there is no "query" token, however, the parseQuery method appears to return null.

I patched code in PercolatorService.QueryiesLoaderCollector.collect to check the return value of parseQuery for null before inserting it into the map, and that seemed to fix it.

I'm not familiar enough with ES to know if that's actually the fix. Maybe parseQuery should raise an exception, or maybe the _percolator index needs better sanitization. But in 19.8, at least, it seems possible to get the _percolator index into a state that makes the data unrecoverable without edits to the ES source.

org.elasticsearch.index.gateway.IndexShardGatewayRecoveryException: [_percolator][0] failed to recover commit_point [commit-19]/[45]
        at org.elasticsearch.index.gateway.blobstore.BlobStoreIndexShardGateway.recover(BlobStoreIndexShardGateway.java:424)
        at org.elasticsearch.index.gateway.IndexShardGatewayService$1.run(IndexShardGatewayService.java:177)
        at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
        at java.lang.Thread.run(Thread.java:662)
Caused by: java.lang.NullPointerException
        at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:881)
        at java.util.concurrent.ConcurrentHashMap.putAll(ConcurrentHashMap.java:909)
        at org.elasticsearch.index.percolator.PercolatorExecutor.addQueries(PercolatorExecutor.java:259)
        at org.elasticsearch.index.percolator.PercolatorService.loadQueries(PercolatorService.java:128)
        at org.elasticsearch.index.percolator.PercolatorService.access$700(PercolatorService.java:52)
        at org.elasticsearch.index.percolator.PercolatorService$ShardLifecycleListener.afterIndexShardStarted(PercolatorService.java:220)
        at org.elasticsearch.indices.InternalIndicesLifecycle.afterIndexShardStarted(InternalIndicesLifecycle.java:86)
        at org.elasticsearch.index.shard.service.InternalIndexShard.start(InternalIndexShard.java:277)
        at org.elasticsearch.index.gateway.blobstore.BlobStoreIndexShardGateway.recoverTranslog(BlobStoreIndexShardGateway.java:435)
        at org.elasticsearch.index.gateway.blobstore.BlobStoreIndexShardGateway.recover(BlobStoreIndexShardGateway.java:421)
