### PR TITLE
return date histogram interval in respone

### DIFF
--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/CountDateHistogramFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/CountDateHistogramFacetCollector.java
@@ -53,10 +53,13 @@ public class CountDateHistogramFacetCollector extends AbstractFacetCollector {
 
     private final DateHistogramProc histoProc;
 
-    public CountDateHistogramFacetCollector(String facetName, String fieldName, TimeZoneRounding tzRounding, DateHistogramFacet.ComparatorType comparatorType, SearchContext context) {
+    private final String interval;
+
+    public CountDateHistogramFacetCollector(String facetName, String fieldName, String interval, TimeZoneRounding tzRounding, DateHistogramFacet.ComparatorType comparatorType, SearchContext context) {
         super(facetName);
         this.comparatorType = comparatorType;
         this.fieldDataCache = context.fieldDataCache();
+        this.interval = interval;
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
@@ -87,7 +90,7 @@ public class CountDateHistogramFacetCollector extends AbstractFacetCollector {
 
     @Override
     public Facet facet() {
-        return new InternalCountDateHistogramFacet(facetName, comparatorType, histoProc.counts(), true);
+        return new InternalCountDateHistogramFacet(facetName, interval, comparatorType, histoProc.counts(), true);
     }
 
     public static class DateHistogramProc implements LongFieldData.LongValueInDocProc {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/DateHistogramFacetProcessor.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/DateHistogramFacetProcessor.java
@@ -171,11 +171,11 @@ public class DateHistogramFacetProcessor extends AbstractComponent implements Fa
                 .build();
 
         if (valueScript != null) {
-            return new ValueScriptDateHistogramFacetCollector(facetName, keyField, scriptLang, valueScript, params, tzRounding, comparatorType, context);
+            return new ValueScriptDateHistogramFacetCollector(facetName, keyField, interval, scriptLang, valueScript, params, tzRounding, comparatorType, context);
         } else if (valueField == null) {
-            return new CountDateHistogramFacetCollector(facetName, keyField, tzRounding, comparatorType, context);
+            return new CountDateHistogramFacetCollector(facetName, keyField, interval, tzRounding, comparatorType, context);
         } else {
-            return new ValueDateHistogramFacetCollector(facetName, keyField, valueField, tzRounding, comparatorType, context);
+            return new ValueDateHistogramFacetCollector(facetName, keyField, valueField, interval, tzRounding, comparatorType, context);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalCountDateHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalCountDateHistogramFacet.java
@@ -142,6 +142,8 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
 
     private String name;
 
+    private String interval;
+
     private ComparatorType comparatorType;
 
     TLongLongHashMap counts;
@@ -152,8 +154,9 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
     private InternalCountDateHistogramFacet() {
     }
 
-    public InternalCountDateHistogramFacet(String name, ComparatorType comparatorType, TLongLongHashMap counts, boolean cachedCounts) {
+    public InternalCountDateHistogramFacet(String name, String interval, ComparatorType comparatorType, TLongLongHashMap counts, boolean cachedCounts) {
         this.name = name;
+        this.interval = interval;
         this.comparatorType = comparatorType;
         this.counts = counts;
         this.cachedCounts = cachedCounts;
@@ -234,11 +237,12 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
 
         }
 
-        return new InternalCountDateHistogramFacet(name, comparatorType, counts, true);
+        return new InternalCountDateHistogramFacet(name, interval, comparatorType, counts, true);
     }
 
     static final class Fields {
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
+        static final XContentBuilderString _INTERVAL = new XContentBuilderString("_interval");
         static final XContentBuilderString ENTRIES = new XContentBuilderString("entries");
         static final XContentBuilderString TIME = new XContentBuilderString("time");
         static final XContentBuilderString COUNT = new XContentBuilderString("count");
@@ -248,6 +252,7 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(name);
         builder.field(Fields._TYPE, TYPE);
+        builder.field(Fields._INTERVAL, interval);
         builder.startArray(Fields.ENTRIES);
         for (Entry entry : computeEntries()) {
             builder.startObject();
@@ -269,6 +274,7 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
+        interval = in.readUTF();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         int size = in.readVInt();
@@ -283,6 +289,7 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
+        out.writeUTF(interval);
         out.writeByte(comparatorType.id());
         out.writeVInt(counts.size());
         for (TLongLongIterator it = counts.iterator(); it.hasNext(); ) {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalFullDateHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalFullDateHistogramFacet.java
@@ -150,6 +150,8 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
 
     private String name;
 
+    private String interval;
+
     private ComparatorType comparatorType;
 
     ExtTLongObjectHashMap<FullEntry> tEntries;
@@ -159,8 +161,9 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
     private InternalFullDateHistogramFacet() {
     }
 
-    public InternalFullDateHistogramFacet(String name, ComparatorType comparatorType, ExtTLongObjectHashMap<InternalFullDateHistogramFacet.FullEntry> entries, boolean cachedEntries) {
+    public InternalFullDateHistogramFacet(String name, String interval, ComparatorType comparatorType, ExtTLongObjectHashMap<InternalFullDateHistogramFacet.FullEntry> entries, boolean cachedEntries) {
         this.name = name;
+        this.interval = interval;
         this.comparatorType = comparatorType;
         this.tEntries = entries;
         this.cachedEntries = cachedEntries;
@@ -264,6 +267,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
         // just initialize it as already ordered facet
         InternalFullDateHistogramFacet ret = new InternalFullDateHistogramFacet();
         ret.name = name;
+        ret.interval = interval;
         ret.comparatorType = comparatorType;
         ret.entries = ordered;
         return ret;
@@ -271,6 +275,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
 
     static final class Fields {
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
+        static final XContentBuilderString _INTERVAL = new XContentBuilderString("_interval");
         static final XContentBuilderString ENTRIES = new XContentBuilderString("entries");
         static final XContentBuilderString TIME = new XContentBuilderString("time");
         static final XContentBuilderString COUNT = new XContentBuilderString("count");
@@ -285,6 +290,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(name);
         builder.field(Fields._TYPE, TYPE);
+        builder.field(Fields._INTERVAL, interval);
         builder.startArray(Fields.ENTRIES);
         for (Entry entry : entries()) {
             builder.startObject();
@@ -311,6 +317,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readUTF();
+        interval = in.readUTF();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         cachedEntries = false;
@@ -324,6 +331,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeUTF(name);
+        out.writeUTF(interval);
         out.writeByte(comparatorType.id());
         out.writeVInt(entries.size());
         for (FullEntry entry : entries) {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueDateHistogramFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueDateHistogramFacetCollector.java
@@ -55,10 +55,13 @@ public class ValueDateHistogramFacetCollector extends AbstractFacetCollector {
 
     private final DateHistogramProc histoProc;
 
-    public ValueDateHistogramFacetCollector(String facetName, String keyFieldName, String valueFieldName, TimeZoneRounding tzRounding, DateHistogramFacet.ComparatorType comparatorType, SearchContext context) {
+    private final String interval;
+
+    public ValueDateHistogramFacetCollector(String facetName, String keyFieldName, String valueFieldName, String interval, TimeZoneRounding tzRounding, DateHistogramFacet.ComparatorType comparatorType, SearchContext context) {
         super(facetName);
         this.comparatorType = comparatorType;
         this.fieldDataCache = context.fieldDataCache();
+        this.interval = interval;
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(keyFieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
@@ -96,7 +99,7 @@ public class ValueDateHistogramFacetCollector extends AbstractFacetCollector {
 
     @Override
     public Facet facet() {
-        return new InternalFullDateHistogramFacet(facetName, comparatorType, histoProc.entries, true);
+        return new InternalFullDateHistogramFacet(facetName, interval, comparatorType, histoProc.entries, true);
     }
 
     public static class DateHistogramProc implements LongFieldData.LongValueInDocProc {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueScriptDateHistogramFacetCollector.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueScriptDateHistogramFacetCollector.java
@@ -58,10 +58,13 @@ public class ValueScriptDateHistogramFacetCollector extends AbstractFacetCollect
 
     private final DateHistogramProc histoProc;
 
-    public ValueScriptDateHistogramFacetCollector(String facetName, String fieldName, String scriptLang, String valueScript, Map<String, Object> params, TimeZoneRounding tzRounding, DateHistogramFacet.ComparatorType comparatorType, SearchContext context) {
+    private final String interval;
+
+    public ValueScriptDateHistogramFacetCollector(String facetName, String fieldName, String interval, String scriptLang, String valueScript, Map<String, Object> params, TimeZoneRounding tzRounding, DateHistogramFacet.ComparatorType comparatorType, SearchContext context) {
         super(facetName);
         this.comparatorType = comparatorType;
         this.fieldDataCache = context.fieldDataCache();
+        this.interval = interval;
 
         MapperService.SmartNameFieldMappers smartMappers = context.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {
@@ -101,7 +104,7 @@ public class ValueScriptDateHistogramFacetCollector extends AbstractFacetCollect
 
     @Override
     public Facet facet() {
-        return new InternalFullDateHistogramFacet(facetName, comparatorType, histoProc.entries, true);
+        return new InternalFullDateHistogramFacet(facetName, interval, comparatorType, histoProc.entries, true);
     }
 
     public static class DateHistogramProc implements LongFieldData.LongValueInDocProc {


### PR DESCRIPTION
Users can provide various intervals for the date histogram but
application code doesn't know which interval was chosen at query time.
Knowing this is particularly useful when building client-side
visualizations where an axis is required or labels need to be generated.

This patch returns the interval inside the date histogram facet
response.
