### PR TITLE
Remove deprecated StreamInput/Output#read/writeUTF

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -236,7 +236,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
 
         out.writeVInt(validationFailures.size());
         for (String failure : validationFailures) {
-            out.writeUTF(failure);
+            out.writeString(failure);
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterIndexHealth.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterIndexHealth.java
@@ -170,7 +170,7 @@ public class ClusterIndexHealth implements Iterable<ClusterShardHealth>, Streama
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        index = in.readUTF();
+        index = in.readString();
         numberOfShards = in.readVInt();
         numberOfReplicas = in.readVInt();
         activePrimaryShards = in.readVInt();
@@ -190,14 +190,14 @@ public class ClusterIndexHealth implements Iterable<ClusterShardHealth>, Streama
             validationFailures = ImmutableList.of();
         } else {
             for (int i = 0; i < size; i++) {
-                validationFailures.add(in.readUTF());
+                validationFailures.add(in.readString());
             }
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(index);
+        out.writeString(index);
         out.writeVInt(numberOfShards);
         out.writeVInt(numberOfReplicas);
         out.writeVInt(activePrimaryShards);
@@ -214,7 +214,7 @@ public class ClusterIndexHealth implements Iterable<ClusterShardHealth>, Streama
 
         out.writeVInt(validationFailures.size());
         for (String failure : validationFailures) {
-            out.writeUTF(failure);
+            out.writeString(failure);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -262,14 +262,14 @@ public class NodeInfo extends NodeOperationResponse {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         if (in.readBoolean()) {
-            hostname = in.readUTF();
+            hostname = in.readString();
         }
         version = Version.readVersion(in);
         if (in.readBoolean()) {
             ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
             int size = in.readVInt();
             for (int i = 0; i < size; i++) {
-                builder.put(in.readUTF(), in.readUTF());
+                builder.put(in.readString(), in.readString());
             }
             serviceAttributes = builder.build();
         }
@@ -306,7 +306,7 @@ public class NodeInfo extends NodeOperationResponse {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(hostname);
+            out.writeString(hostname);
         }
         out.writeVInt(version.id);
         if (serviceAttributes() == null) {
@@ -315,8 +315,8 @@ public class NodeInfo extends NodeOperationResponse {
             out.writeBoolean(true);
             out.writeVInt(serviceAttributes.size());
             for (Map.Entry<String, String> entry : serviceAttributes.entrySet()) {
-                out.writeUTF(entry.getKey());
-                out.writeUTF(entry.getValue());
+                out.writeString(entry.getKey());
+                out.writeString(entry.getValue());
             }
         }
         if (settings == null) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -254,7 +254,7 @@ public class NodeStats extends NodeOperationResponse {
         super.readFrom(in);
         timestamp = in.readVLong();
         if (in.readBoolean()) {
-            hostname = in.readUTF();
+            hostname = in.readString();
         }
         if (in.readBoolean()) {
             indices = NodeIndicesStats.readIndicesStats(in);
@@ -293,7 +293,7 @@ public class NodeStats extends NodeOperationResponse {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(hostname);
+            out.writeString(hostname);
         }
         if (indices == null) {
             out.writeBoolean(false);

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheRequest.java
@@ -77,7 +77,7 @@ class ShardClearIndicesCacheRequest extends BroadcastShardOperationRequest {
         if (size > 0) {
             fields = new String[size];
             for (int i = 0; i < size; i++) {
-                fields[i] = in.readUTF();
+                fields[i] = in.readString();
             }
         }
     }
@@ -93,7 +93,7 @@ class ShardClearIndicesCacheRequest extends BroadcastShardOperationRequest {
         } else {
             out.writeVInt(fields.length);
             for (String field : fields) {
-                out.writeUTF(field);
+                out.writeString(field);
             }
         }
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -212,7 +212,7 @@ public class IndicesStatsRequest extends BroadcastOperationRequest<IndicesStatsR
         } else {
             out.writeVInt(types.length);
             for (String type : types) {
-                out.writeUTF(type);
+                out.writeString(type);
             }
         }
         if (groups == null) {
@@ -220,7 +220,7 @@ public class IndicesStatsRequest extends BroadcastOperationRequest<IndicesStatsR
         } else {
             out.writeVInt(groups.length);
             for (String group : groups) {
-                out.writeUTF(group);
+                out.writeString(group);
             }
         }
     }
@@ -241,14 +241,14 @@ public class IndicesStatsRequest extends BroadcastOperationRequest<IndicesStatsR
         if (size > 0) {
             types = new String[size];
             for (int i = 0; i < size; i++) {
-                types[i] = in.readUTF();
+                types[i] = in.readString();
             }
         }
         size = in.readVInt();
         if (size > 0) {
             groups = new String[size];
             for (int i = 0; i < size; i++) {
-                groups[i] = in.readUTF();
+                groups[i] = in.readString();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java
@@ -83,18 +83,18 @@ public class QueryExplanation  implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        index = in.readUTF();
+        index = in.readString();
         valid = in.readBoolean();
-        explanation = in.readOptionalUTF();
-        error = in.readOptionalUTF();
+        explanation = in.readOptionalString();
+        error = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(index);
+        out.writeString(index);
         out.writeBoolean(valid);
-        out.writeOptionalUTF(explanation);
-        out.writeOptionalUTF(error);
+        out.writeOptionalString(explanation);
+        out.writeOptionalString(error);
     }
 
     public static QueryExplanation readQueryExplanation(StreamInput in)  throws IOException {

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
@@ -65,15 +65,15 @@ class ShardValidateQueryResponse extends BroadcastShardOperationResponse {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         valid = in.readBoolean();
-        explanation = in.readOptionalUTF();
-        error = in.readOptionalUTF();
+        explanation = in.readOptionalString();
+        error = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(valid);
-        out.writeOptionalUTF(explanation);
-        out.writeOptionalUTF(error);
+        out.writeOptionalString(explanation);
+        out.writeOptionalString(error);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -199,7 +199,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
         if (typesSize > 0) {
             types = new String[typesSize];
             for (int i = 0; i < typesSize; i++) {
-                types[i] = in.readUTF();
+                types[i] = in.readString();
             }
         }
 
@@ -215,7 +215,7 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
 
         out.writeVInt(types.length);
         for (String type : types) {
-            out.writeUTF(type);
+            out.writeString(type);
         }
 
         out.writeBoolean(explain);

--- a/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -290,7 +290,7 @@ public class BulkItemResponse implements Streamable {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         id = in.readVInt();
-        opType = in.readUTF();
+        opType = in.readString();
 
         byte type = in.readByte();
         if (type == 0) {
@@ -302,14 +302,14 @@ public class BulkItemResponse implements Streamable {
         }
 
         if (in.readBoolean()) {
-            failure = new Failure(in.readUTF(), in.readUTF(), in.readUTF(), in.readUTF());
+            failure = new Failure(in.readString(), in.readString(), in.readString(), in.readString());
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(id);
-        out.writeUTF(opType);
+        out.writeString(opType);
         if (response == null) {
             out.writeByte((byte) 2);
         } else {
@@ -324,10 +324,10 @@ public class BulkItemResponse implements Streamable {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(failure.index());
-            out.writeUTF(failure.type());
-            out.writeUTF(failure.id());
-            out.writeUTF(failure.message());
+            out.writeString(failure.index());
+            out.writeString(failure.type());
+            out.writeString(failure.id());
+            out.writeString(failure.message());
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
@@ -81,14 +81,14 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
         if (typesSize > 0) {
             types = new String[typesSize];
             for (int i = 0; i < typesSize; i++) {
-                types[i] = in.readUTF();
+                types[i] = in.readString();
             }
         }
         int aliasesSize = in.readVInt();
         if (aliasesSize > 0) {
             filteringAliases = new String[aliasesSize];
             for (int i = 0; i < aliasesSize; i++) {
-                filteringAliases[i] = in.readUTF();
+                filteringAliases[i] = in.readString();
             }
         }
     }
@@ -102,12 +102,12 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
 
         out.writeVInt(types.length);
         for (String type : types) {
-            out.writeUTF(type);
+            out.writeString(type);
         }
         if (filteringAliases != null) {
             out.writeVInt(filteringAliases.length);
             for (String alias : filteringAliases) {
-                out.writeUTF(alias);
+                out.writeString(alias);
             }
         } else {
             out.writeVInt(0);

--- a/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -111,45 +111,45 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            index = in.readUTF();
+            index = in.readString();
             if (in.readBoolean()) {
-                type = in.readUTF();
+                type = in.readString();
             }
-            id = in.readUTF();
+            id = in.readString();
             if (in.readBoolean()) {
-                routing = in.readUTF();
+                routing = in.readString();
             }
             int size = in.readVInt();
             if (size > 0) {
                 fields = new String[size];
                 for (int i = 0; i < size; i++) {
-                    fields[i] = in.readUTF();
+                    fields[i] = in.readString();
                 }
             }
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeUTF(index);
+            out.writeString(index);
             if (type == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(type);
+                out.writeString(type);
             }
-            out.writeUTF(id);
+            out.writeString(id);
             if (routing == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(routing);
+                out.writeString(routing);
             }
             if (fields == null) {
                 out.writeVInt(0);
             } else {
                 out.writeVInt(fields.length);
                 for (String field : fields) {
-                    out.writeUTF(field);
+                    out.writeString(field);
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
@@ -540,7 +540,7 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
         } else {
             fields = new String[size];
             for (int i = 0; i < size; i++) {
-                fields[i] = in.readUTF();
+                fields[i] = in.readString();
             }
         }
 
@@ -551,7 +551,7 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
         if (size > 0) {
             stopWords = new String[size];
             for (int i = 0; i < size; i++) {
-                stopWords[i] = in.readUTF();
+                stopWords[i] = in.readString();
             }
         }
         minDocFreq = in.readVInt();
@@ -561,7 +561,7 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
         boostTerms = in.readFloat();
         searchType = SearchType.fromId(in.readByte());
         if (in.readBoolean()) {
-            searchQueryHint = in.readUTF();
+            searchQueryHint = in.readString();
         }
         size = in.readVInt();
         if (size == 0) {

--- a/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -126,7 +126,7 @@ public class ShardSearchFailure implements ShardOperationFailedException {
         if (in.readBoolean()) {
             shardTarget = readSearchShardTarget(in);
         }
-        reason = in.readUTF();
+        reason = in.readString();
         status = RestStatus.readFrom(in);
     }
 
@@ -138,7 +138,7 @@ public class ShardSearchFailure implements ShardOperationFailedException {
             out.writeBoolean(true);
             shardTarget.writeTo(out);
         }
-        out.writeUTF(reason);
+        out.writeString(reason);
         RestStatus.writeTo(out, status);
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
+++ b/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
@@ -79,10 +79,10 @@ public class DefaultShardOperationFailedException implements ShardOperationFaile
     @Override
     public void readFrom(StreamInput in) throws IOException {
         if (in.readBoolean()) {
-            index = in.readUTF();
+            index = in.readString();
         }
         shardId = in.readVInt();
-        reason = in.readUTF();
+        reason = in.readString();
     }
 
     @Override
@@ -91,10 +91,10 @@ public class DefaultShardOperationFailedException implements ShardOperationFaile
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(index);
+            out.writeString(index);
         }
         out.writeVInt(shardId);
-        out.writeUTF(reason);
+        out.writeString(reason);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/ClusterName.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterName.java
@@ -61,12 +61,12 @@ public class ClusterName implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        value = in.readUTF().intern();
+        value = in.readString().intern();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(value);
+        out.writeString(value);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -124,7 +124,7 @@ public class ClusterBlock implements Serializable, Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         id = in.readVInt();
-        description = in.readUTF();
+        description = in.readString();
         levels = new ClusterBlockLevel[in.readVInt()];
         for (int i = 0; i < levels.length; i++) {
             levels[i] = ClusterBlockLevel.fromId(in.readVInt());
@@ -137,7 +137,7 @@ public class ClusterBlock implements Serializable, Streamable, ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(id);
-        out.writeUTF(description);
+        out.writeString(description);
         out.writeVInt(levels.length);
         for (ClusterBlockLevel level : levels) {
             out.writeVInt(level.id());

--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -304,7 +304,7 @@ public class ClusterBlocks {
             ImmutableMap.Builder<String, ImmutableSet<ClusterBlock>> indicesBuilder = ImmutableMap.builder();
             int size = in.readVInt();
             for (int j = 0; j < size; j++) {
-                indicesBuilder.put(in.readUTF().intern(), readBlockSet(in));
+                indicesBuilder.put(in.readString().intern(), readBlockSet(in));
             }
             return new ClusterBlocks(global, indicesBuilder.build());
         }
@@ -313,7 +313,7 @@ public class ClusterBlocks {
             writeBlockSet(blocks.global(), out);
             out.writeVInt(blocks.indices().size());
             for (Map.Entry<String, ImmutableSet<ClusterBlock>> entry : blocks.indices().entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 writeBlockSet(entry.getValue(), out);
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
@@ -181,41 +181,41 @@ public class AliasAction implements Streamable {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         actionType = Type.fromValue(in.readByte());
-        index = in.readUTF();
-        alias = in.readUTF();
+        index = in.readString();
+        alias = in.readString();
         if (in.readBoolean()) {
-            filter = in.readUTF();
+            filter = in.readString();
         }
         if (in.readBoolean()) {
-            indexRouting = in.readUTF();
+            indexRouting = in.readString();
         }
         if (in.readBoolean()) {
-            searchRouting = in.readUTF();
+            searchRouting = in.readString();
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeByte(actionType.value());
-        out.writeUTF(index);
-        out.writeUTF(alias);
+        out.writeString(index);
+        out.writeString(alias);
         if (filter == null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(filter);
+            out.writeString(filter);
         }
         if (indexRouting == null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(indexRouting);
+            out.writeString(indexRouting);
         }
         if (searchRouting == null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeUTF(searchRouting);
+            out.writeString(searchRouting);
         }
     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -269,7 +269,7 @@ public class AliasMetaData {
         }
 
         public static void writeTo(AliasMetaData aliasMetaData, StreamOutput out) throws IOException {
-            out.writeUTF(aliasMetaData.alias());
+            out.writeString(aliasMetaData.alias());
             if (aliasMetaData.filter() != null) {
                 out.writeBoolean(true);
                 aliasMetaData.filter.writeTo(out);
@@ -278,13 +278,13 @@ public class AliasMetaData {
             }
             if (aliasMetaData.indexRouting() != null) {
                 out.writeBoolean(true);
-                out.writeUTF(aliasMetaData.indexRouting());
+                out.writeString(aliasMetaData.indexRouting());
             } else {
                 out.writeBoolean(false);
             }
             if (aliasMetaData.searchRouting() != null) {
                 out.writeBoolean(true);
-                out.writeUTF(aliasMetaData.searchRouting());
+                out.writeString(aliasMetaData.searchRouting());
             } else {
                 out.writeBoolean(false);
             }
@@ -292,18 +292,18 @@ public class AliasMetaData {
         }
 
         public static AliasMetaData readFrom(StreamInput in) throws IOException {
-            String alias = in.readUTF();
+            String alias = in.readString();
             CompressedString filter = null;
             if (in.readBoolean()) {
                 filter = CompressedString.readCompressedString(in);
             }
             String indexRouting = null;
             if (in.readBoolean()) {
-                indexRouting = in.readUTF();
+                indexRouting = in.readString();
             }
             String searchRouting = null;
             if (in.readBoolean()) {
-                searchRouting = in.readUTF();
+                searchRouting = in.readString();
             }
             return new AliasMetaData(alias, filter, indexRouting, searchRouting);
         }

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -659,7 +659,7 @@ public class IndexMetaData {
         }
 
         public static IndexMetaData readFrom(StreamInput in) throws IOException {
-            Builder builder = new Builder(in.readUTF());
+            Builder builder = new Builder(in.readString());
             builder.version(in.readLong());
             builder.state(State.fromId(in.readByte()));
             builder.settings(readSettingsFromStream(in));
@@ -675,7 +675,7 @@ public class IndexMetaData {
             }
             int customSize = in.readVInt();
             for (int i = 0; i < customSize; i++) {
-                String type = in.readUTF();
+                String type = in.readString();
                 Custom customIndexMetaData = lookupFactorySafe(type).readFrom(in);
                 builder.putCustom(type, customIndexMetaData);
             }
@@ -683,7 +683,7 @@ public class IndexMetaData {
         }
 
         public static void writeTo(IndexMetaData indexMetaData, StreamOutput out) throws IOException {
-            out.writeUTF(indexMetaData.index());
+            out.writeString(indexMetaData.index());
             out.writeLong(indexMetaData.version());
             out.writeByte(indexMetaData.state().id());
             writeSettingsToStream(indexMetaData.settings(), out);
@@ -697,7 +697,7 @@ public class IndexMetaData {
             }
             out.writeVInt(indexMetaData.customs().size());
             for (Map.Entry<String, Custom> entry : indexMetaData.customs().entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 lookupFactorySafe(entry.getKey()).writeTo(entry.getValue(), out);
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -332,17 +332,17 @@ public class IndexTemplateMetaData {
         }
 
         public static IndexTemplateMetaData readFrom(StreamInput in) throws IOException {
-            Builder builder = new Builder(in.readUTF());
+            Builder builder = new Builder(in.readString());
             builder.order(in.readInt());
-            builder.template(in.readUTF());
+            builder.template(in.readString());
             builder.settings(ImmutableSettings.readSettingsFromStream(in));
             int mappingsSize = in.readVInt();
             for (int i = 0; i < mappingsSize; i++) {
-                builder.putMapping(in.readUTF(), CompressedString.readCompressedString(in));
+                builder.putMapping(in.readString(), CompressedString.readCompressedString(in));
             }
             int customSize = in.readVInt();
             for (int i = 0; i < customSize; i++) {
-                String type = in.readUTF();
+                String type = in.readString();
                 IndexMetaData.Custom customIndexMetaData = IndexMetaData.lookupFactorySafe(type).readFrom(in);
                 builder.putCustom(type, customIndexMetaData);
             }
@@ -350,18 +350,18 @@ public class IndexTemplateMetaData {
         }
 
         public static void writeTo(IndexTemplateMetaData indexTemplateMetaData, StreamOutput out) throws IOException {
-            out.writeUTF(indexTemplateMetaData.name());
+            out.writeString(indexTemplateMetaData.name());
             out.writeInt(indexTemplateMetaData.order());
-            out.writeUTF(indexTemplateMetaData.template());
+            out.writeString(indexTemplateMetaData.template());
             ImmutableSettings.writeSettingsToStream(indexTemplateMetaData.settings(), out);
             out.writeVInt(indexTemplateMetaData.mappings().size());
             for (Map.Entry<String, CompressedString> entry : indexTemplateMetaData.mappings().entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 entry.getValue().writeTo(out);
             }
             out.writeVInt(indexTemplateMetaData.customs().size());
             for (Map.Entry<String, IndexMetaData.Custom> entry : indexTemplateMetaData.customs().entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 IndexMetaData.lookupFactorySafe(entry.getKey()).writeTo(entry.getValue(), out);
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -486,12 +486,12 @@ public class MappingMetaData {
     }
 
     public static void writeTo(MappingMetaData mappingMd, StreamOutput out) throws IOException {
-        out.writeUTF(mappingMd.type());
+        out.writeString(mappingMd.type());
         mappingMd.source().writeTo(out);
         // id
         if (mappingMd.id().hasPath()) {
             out.writeBoolean(true);
-            out.writeUTF(mappingMd.id().path());
+            out.writeString(mappingMd.id().path());
         } else {
             out.writeBoolean(false);
         }
@@ -499,7 +499,7 @@ public class MappingMetaData {
         out.writeBoolean(mappingMd.routing().required());
         if (mappingMd.routing().hasPath()) {
             out.writeBoolean(true);
-            out.writeUTF(mappingMd.routing().path());
+            out.writeString(mappingMd.routing().path());
         } else {
             out.writeBoolean(false);
         }
@@ -507,11 +507,11 @@ public class MappingMetaData {
         out.writeBoolean(mappingMd.timestamp().enabled());
         if (mappingMd.timestamp().hasPath()) {
             out.writeBoolean(true);
-            out.writeUTF(mappingMd.timestamp().path());
+            out.writeString(mappingMd.timestamp().path());
         } else {
             out.writeBoolean(false);
         }
-        out.writeUTF(mappingMd.timestamp().format());
+        out.writeString(mappingMd.timestamp().format());
     }
 
     @Override
@@ -541,14 +541,14 @@ public class MappingMetaData {
     }
 
     public static MappingMetaData readFrom(StreamInput in) throws IOException {
-        String type = in.readUTF();
+        String type = in.readString();
         CompressedString source = CompressedString.readCompressedString(in);
         // id
-        Id id = new Id(in.readBoolean() ? in.readUTF() : null);
+        Id id = new Id(in.readBoolean() ? in.readString() : null);
         // routing
-        Routing routing = new Routing(in.readBoolean(), in.readBoolean() ? in.readUTF() : null);
+        Routing routing = new Routing(in.readBoolean(), in.readBoolean() ? in.readString() : null);
         // timestamp
-        Timestamp timestamp = new Timestamp(in.readBoolean(), in.readBoolean() ? in.readUTF() : null, in.readUTF());
+        Timestamp timestamp = new Timestamp(in.readBoolean(), in.readBoolean() ? in.readString() : null, in.readString());
         return new MappingMetaData(type, source, id, routing, timestamp);
     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1039,7 +1039,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             }
             int customSize = in.readVInt();
             for (int i = 0; i < customSize; i++) {
-                String type = in.readUTF();
+                String type = in.readString();
                 Custom customIndexMetaData = lookupFactorySafe(type).readFrom(in);
                 builder.putCustom(type, customIndexMetaData);
             }
@@ -1060,7 +1060,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             }
             out.writeVInt(metaData.customs().size());
             for (Map.Entry<String, Custom> entry : metaData.customs().entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 lookupFactorySafe(entry.getKey()).writeTo(entry.getValue(), out);
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -588,7 +588,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode> {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(nodes.masterNodeId);
+                out.writeString(nodes.masterNodeId);
             }
             out.writeVInt(nodes.size());
             for (DiscoveryNode node : nodes) {
@@ -599,7 +599,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode> {
         public static DiscoveryNodes readFrom(StreamInput in, @Nullable DiscoveryNode localNode) throws IOException {
             Builder builder = new Builder();
             if (in.readBoolean()) {
-                builder.masterNodeId(in.readUTF());
+                builder.masterNodeId(in.readString());
             }
             if (localNode != null) {
                 builder.localNodeId(localNode.id());

--- a/src/main/java/org/elasticsearch/cluster/routing/ImmutableShardRouting.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/ImmutableShardRouting.java
@@ -224,11 +224,11 @@ public class ImmutableShardRouting implements Streamable, Serializable, ShardRou
     public void readFromThin(StreamInput in) throws IOException {
         version = in.readLong();
         if (in.readBoolean()) {
-            currentNodeId = in.readUTF();
+            currentNodeId = in.readString();
         }
 
         if (in.readBoolean()) {
-            relocatingNodeId = in.readUTF();
+            relocatingNodeId = in.readString();
         }
 
         primary = in.readBoolean();
@@ -237,7 +237,7 @@ public class ImmutableShardRouting implements Streamable, Serializable, ShardRou
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        readFrom(in, in.readUTF(), in.readVInt());
+        readFrom(in, in.readString(), in.readVInt());
     }
     
     /**
@@ -249,14 +249,14 @@ public class ImmutableShardRouting implements Streamable, Serializable, ShardRou
         out.writeLong(version);
         if (currentNodeId != null) {
             out.writeBoolean(true);
-            out.writeUTF(currentNodeId);
+            out.writeString(currentNodeId);
         } else {
             out.writeBoolean(false);
         }
 
         if (relocatingNodeId != null) {
             out.writeBoolean(true);
-            out.writeUTF(relocatingNodeId);
+            out.writeString(relocatingNodeId);
         } else {
             out.writeBoolean(false);
         }
@@ -267,7 +267,7 @@ public class ImmutableShardRouting implements Streamable, Serializable, ShardRou
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(index);
+        out.writeString(index);
         out.writeVInt(shardId);
         writeToThin(out);
     }

--- a/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -314,7 +314,7 @@ public class IndexRoutingTable implements Iterable<IndexShardRoutingTable> {
          * @throws IOException if something happens during read
          */
         public static IndexRoutingTable readFrom(StreamInput in) throws IOException {
-            String index = in.readUTF();
+            String index = in.readString();
             Builder builder = new Builder(index);
 
             int size = in.readVInt();
@@ -332,7 +332,7 @@ public class IndexRoutingTable implements Iterable<IndexShardRoutingTable> {
          * @throws IOException if something happens during write 
          */
         public static void writeTo(IndexRoutingTable index, StreamOutput out) throws IOException {
-            out.writeUTF(index.index());
+            out.writeString(index.index());
             out.writeVInt(index.shards.size());
             for (IndexShardRoutingTable indexShard : index) {
                 IndexShardRoutingTable.Builder.writeToThin(indexShard, out);

--- a/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -496,7 +496,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         }
 
         public static IndexShardRoutingTable readFrom(StreamInput in) throws IOException {
-            String index = in.readUTF();
+            String index = in.readString();
             return readFromThin(in, index);
         }
 
@@ -515,7 +515,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         }
 
         public static void writeTo(IndexShardRoutingTable indexShard, StreamOutput out) throws IOException {
-            out.writeUTF(indexShard.shardId().index().name());
+            out.writeString(indexShard.shardId().index().name());
             writeToThin(indexShard, out);
         }
 

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingTableValidation.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingTableValidation.java
@@ -127,7 +127,7 @@ public class RoutingTableValidation implements Serializable, Streamable {
         } else {
             failures = Lists.newArrayListWithCapacity(size);
             for (int i = 0; i < size; i++) {
-                failures.add(in.readUTF());
+                failures.add(in.readString());
             }
         }
         size = in.readVInt();
@@ -136,11 +136,11 @@ public class RoutingTableValidation implements Serializable, Streamable {
         } else {
             indicesFailures = newHashMap();
             for (int i = 0; i < size; i++) {
-                String index = in.readUTF();
+                String index = in.readString();
                 int size2 = in.readVInt();
                 List<String> indexFailures = newArrayListWithCapacity(size2);
                 for (int j = 0; j < size2; j++) {
-                    indexFailures.add(in.readUTF());
+                    indexFailures.add(in.readString());
                 }
                 indicesFailures.put(index, indexFailures);
             }
@@ -155,7 +155,7 @@ public class RoutingTableValidation implements Serializable, Streamable {
         } else {
             out.writeVInt(failures.size());
             for (String failure : failures) {
-                out.writeUTF(failure);
+                out.writeString(failure);
             }
         }
         if (indicesFailures == null) {
@@ -163,10 +163,10 @@ public class RoutingTableValidation implements Serializable, Streamable {
         } else {
             out.writeVInt(indicesFailures.size());
             for (Map.Entry<String, List<String>> entry : indicesFailures.entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 out.writeVInt(entry.getValue().size());
                 for (String failure : entry.getValue()) {
-                    out.writeUTF(failure);
+                    out.writeString(failure);
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationExplanation.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationExplanation.java
@@ -127,7 +127,7 @@ public class AllocationExplanation implements Streamable {
                 if (in.readBoolean()) {
                     node = DiscoveryNode.readNode(in);
                 }
-                ne.add(new NodeExplanation(node, in.readUTF()));
+                ne.add(new NodeExplanation(node, in.readString()));
             }
             explanations.put(shardId, ne);
         }
@@ -146,7 +146,7 @@ public class AllocationExplanation implements Streamable {
                     out.writeBoolean(true);
                     nodeExplanation.node().writeTo(out);
                 }
-                out.writeUTF(nodeExplanation.description());
+                out.writeString(nodeExplanation.description());
             }
         }
     }

--- a/src/main/java/org/elasticsearch/common/io/stream/AdapterStreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/AdapterStreamInput.java
@@ -99,11 +99,6 @@ public abstract class AdapterStreamInput extends StreamInput {
     }
 
     @Override
-    public String readUTF() throws IOException {
-        return in.readUTF();
-    }
-
-    @Override
     public String readString() throws IOException {
         return in.readString();
     }

--- a/src/main/java/org/elasticsearch/common/io/stream/AdapterStreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/AdapterStreamOutput.java
@@ -127,11 +127,6 @@ public class AdapterStreamOutput extends StreamOutput {
     }
 
     @Override
-    public void writeUTF(String str) throws IOException {
-        out.writeUTF(str);
-    }
-
-    @Override
     public void writeString(String str) throws IOException {
         out.writeString(str);
     }

--- a/src/main/java/org/elasticsearch/common/io/stream/HandlesStreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/HandlesStreamInput.java
@@ -43,31 +43,6 @@ public class HandlesStreamInput extends AdapterStreamInput {
     }
 
     @Override
-    @Deprecated
-    public String readUTF() throws IOException {
-        byte b = in.readByte();
-        if (b == 0) {
-            // full string with handle
-            int handle = in.readVInt();
-            String s = in.readUTF();
-            handles.put(handle, s);
-            return s;
-        } else if (b == 1) {
-            return handles.get(in.readVInt());
-        } else if (b == 2) {
-            // full string with handle
-            int handle = in.readVInt();
-            String s = in.readUTF();
-            identityHandles.put(handle, s);
-            return s;
-        } else if (b == 3) {
-            return identityHandles.get(in.readVInt());
-        } else {
-            throw new IOException("Expected handle header, got [" + b + "]");
-        }
-    }
-
-    @Override
     public String readString() throws IOException {
         byte b = in.readByte();
         if (b == 0) {

--- a/src/main/java/org/elasticsearch/common/io/stream/HandlesStreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/HandlesStreamOutput.java
@@ -51,35 +51,6 @@ public class HandlesStreamOutput extends AdapterStreamOutput {
     }
 
     @Override
-    @Deprecated
-    public void writeUTF(String s) throws IOException {
-        if (s.length() < identityThreshold) {
-            int handle = handles.get(s);
-            if (handle == -1) {
-                handle = handles.size();
-                handles.put(s, handle);
-                out.writeByte((byte) 0);
-                out.writeVInt(handle);
-                out.writeUTF(s);
-            } else {
-                out.writeByte((byte) 1);
-                out.writeVInt(handle);
-            }
-        } else {
-            int handle = identityHandles.lookup(s);
-            if (handle == -1) {
-                handle = identityHandles.assign(s);
-                out.writeByte((byte) 2);
-                out.writeVInt(handle);
-                out.writeUTF(s);
-            } else {
-                out.writeByte((byte) 3);
-                out.writeVInt(handle);
-            }
-        }
-    }
-
-    @Override
     public void writeString(String s) throws IOException {
         if (s.length() < identityThreshold) {
             int handle = handles.get(s);
@@ -88,7 +59,7 @@ public class HandlesStreamOutput extends AdapterStreamOutput {
                 handles.put(s, handle);
                 out.writeByte((byte) 0);
                 out.writeVInt(handle);
-                out.writeUTF(s);
+                out.writeString(s);
             } else {
                 out.writeByte((byte) 1);
                 out.writeVInt(handle);
@@ -99,7 +70,7 @@ public class HandlesStreamOutput extends AdapterStreamOutput {
                 handle = identityHandles.assign(s);
                 out.writeByte((byte) 2);
                 out.writeVInt(handle);
-                out.writeUTF(s);
+                out.writeString(s);
             } else {
                 out.writeByte((byte) 3);
                 out.writeVInt(handle);

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -180,18 +180,6 @@ public abstract class StreamInput extends InputStream {
         return i | ((b & 0x7FL) << 56);
     }
 
-    /**
-     * @deprecated use {@link #readOptionalString()}
-     */
-    @Nullable
-    @Deprecated
-    public String readOptionalUTF() throws IOException {
-        if (readBoolean()) {
-            return readUTF();
-        }
-        return null;
-    }
-
     @Nullable
     public Text readOptionalText() throws IOException {
         int length = readInt();
@@ -246,14 +234,6 @@ public abstract class StreamInput extends InputStream {
             }
         }
         return new String(chars, 0, charCount);
-    }
-
-    /**
-     * @deprecated use {@link #readString()}
-     */
-    @Deprecated
-    public String readUTF() throws IOException {
-        return readString();
     }
 
 

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -165,16 +165,6 @@ public abstract class StreamOutput extends OutputStream {
         writeByte((byte) i);
     }
 
-    @Deprecated
-    public void writeOptionalUTF(@Nullable String str) throws IOException {
-        if (str == null) {
-            writeBoolean(false);
-        } else {
-            writeBoolean(true);
-            writeUTF(str);
-        }
-    }
-
     public void writeOptionalString(@Nullable String str) throws IOException {
         if (str == null) {
             writeBoolean(false);
@@ -233,16 +223,6 @@ public abstract class StreamOutput extends OutputStream {
                 writeByte((byte) (0x80 | c >> 0 & 0x3F));
             }
         }
-    }
-
-    /**
-     * Writes a string.
-     *
-     * @deprecated use {@link #writeString(String)}
-     */
-    @Deprecated
-    public void writeUTF(String str) throws IOException {
-        writeString(str);
     }
 
     public void writeFloat(float v) throws IOException {

--- a/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -144,7 +144,7 @@ public class Lucene {
             for (int i = 0; i < fields.length; i++) {
                 String field = null;
                 if (in.readBoolean()) {
-                    field = in.readUTF();
+                    field = in.readString();
                 }
                 fields[i] = new SortField(field, readSortType(in), in.readBoolean());
             }
@@ -157,7 +157,7 @@ public class Lucene {
                     if (type == 0) {
                         cFields[j] = null;
                     } else if (type == 1) {
-                        cFields[j] = in.readUTF();
+                        cFields[j] = in.readString();
                     } else if (type == 2) {
                         cFields[j] = in.readInt();
                     } else if (type == 3) {
@@ -212,7 +212,7 @@ public class Lucene {
                     out.writeBoolean(false);
                 } else {
                     out.writeBoolean(true);
-                    out.writeUTF(sortField.getField());
+                    out.writeString(sortField.getField());
                 }
                 if (sortField.getComparatorSource() != null) {
                     writeSortType(out, ((FieldDataType.ExtendedFieldComparatorSource) sortField.getComparatorSource()).reducedType());
@@ -237,7 +237,7 @@ public class Lucene {
                         Class type = field.getClass();
                         if (type == String.class) {
                             out.writeByte((byte) 1);
-                            out.writeUTF((String) field);
+                            out.writeString((String) field);
                         } else if (type == Integer.class) {
                             out.writeByte((byte) 2);
                             out.writeInt((Integer) field);
@@ -299,7 +299,7 @@ public class Lucene {
 
     public static Explanation readExplanation(StreamInput in) throws IOException {
         float value = in.readFloat();
-        String description = in.readUTF();
+        String description = in.readString();
         Explanation explanation = new Explanation(value, description);
         if (in.readBoolean()) {
             int size = in.readVInt();
@@ -312,7 +312,7 @@ public class Lucene {
 
     public static void writeExplanation(StreamOutput out, Explanation explanation) throws IOException {
         out.writeFloat(explanation.getValue());
-        out.writeUTF(explanation.getDescription());
+        out.writeString(explanation.getDescription());
         Explanation[] subExplanations = explanation.getDetails();
         if (subExplanations == null) {
             out.writeBoolean(false);

--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -347,7 +347,7 @@ public class ImmutableSettings implements Settings {
         Builder builder = new Builder();
         int numberOfSettings = in.readVInt();
         for (int i = 0; i < numberOfSettings; i++) {
-            builder.put(in.readUTF(), in.readUTF());
+            builder.put(in.readString(), in.readString());
         }
         return builder.build();
     }
@@ -355,8 +355,8 @@ public class ImmutableSettings implements Settings {
     public static void writeSettingsToStream(Settings settings, StreamOutput out) throws IOException {
         out.writeVInt(settings.getAsMap().size());
         for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
-            out.writeUTF(entry.getKey());
-            out.writeUTF(entry.getValue());
+            out.writeString(entry.getKey());
+            out.writeString(entry.getValue());
         }
     }
 

--- a/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -118,7 +118,7 @@ public class InetSocketTransportAddress implements TransportAddress {
             int port = in.readInt();
             this.address = new InetSocketAddress(inetAddress, port);
         } else {
-            this.address = new InetSocketAddress(in.readUTF(), in.readInt());
+            this.address = new InetSocketAddress(in.readString(), in.readInt());
         }
     }
 
@@ -133,7 +133,7 @@ public class InetSocketTransportAddress implements TransportAddress {
                 out.writeInt(((Inet6Address) address.getAddress()).getScopeId());
         } else {
             out.writeByte((byte) 1);
-            out.writeUTF(address.getHostName());
+            out.writeString(address.getHostName());
         }
         out.writeInt(address.getPort());
     }

--- a/src/main/java/org/elasticsearch/common/transport/LocalTransportAddress.java
+++ b/src/main/java/org/elasticsearch/common/transport/LocalTransportAddress.java
@@ -59,12 +59,12 @@ public class LocalTransportAddress implements TransportAddress {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        id = in.readUTF();
+        id = in.readString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(id);
+        out.writeString(id);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/Index.java
+++ b/src/main/java/org/elasticsearch/index/Index.java
@@ -75,11 +75,11 @@ public class Index implements Serializable, Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF().intern();
+        name = in.readString().intern();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -133,7 +133,7 @@ public class Segment implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         generation = Long.parseLong(name.substring(1), Character.MAX_RADIX);
         committed = in.readBoolean();
         search = in.readBoolean();
@@ -144,7 +144,7 @@ public class Segment implements Streamable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeBoolean(committed);
         out.writeBoolean(search);
         out.writeInt(docCount);

--- a/src/main/java/org/elasticsearch/index/get/GetField.java
+++ b/src/main/java/org/elasticsearch/index/get/GetField.java
@@ -86,7 +86,7 @@ public class GetField implements Streamable, Iterable<Object> {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         int size = in.readVInt();
         values = new ArrayList<Object>(size);
         for (int i = 0; i < size; i++) {
@@ -96,7 +96,7 @@ public class GetField implements Streamable, Iterable<Object> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVInt(values.size());
         for (Object obj : values) {
             out.writeGenericValue(obj);

--- a/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -314,9 +314,9 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        index = in.readUTF();
-        type = in.readOptionalUTF();
-        id = in.readUTF();
+        index = in.readString();
+        type = in.readOptionalString();
+        id = in.readString();
         version = in.readLong();
         exists = in.readBoolean();
         if (exists) {
@@ -339,9 +339,9 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(index);
-        out.writeOptionalUTF(type);
-        out.writeUTF(id);
+        out.writeString(index);
+        out.writeOptionalString(type);
+        out.writeString(id);
         out.writeLong(version);
         out.writeBoolean(exists);
         if (exists) {

--- a/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
+++ b/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
@@ -260,7 +260,7 @@ public class IndexingStats implements Streamable, ToXContent {
             int size = in.readVInt();
             typeStats = new HashMap<String, Stats>(size);
             for (int i = 0; i < size; i++) {
-                typeStats.put(in.readUTF(), Stats.readStats(in));
+                typeStats.put(in.readString(), Stats.readStats(in));
             }
         }
     }
@@ -274,7 +274,7 @@ public class IndexingStats implements Streamable, ToXContent {
             out.writeBoolean(true);
             out.writeVInt(typeStats.size());
             for (Map.Entry<String, Stats> entry : typeStats.entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 entry.getValue().writeTo(out);
             }
         }

--- a/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -260,7 +260,7 @@ public class SearchStats implements Streamable, ToXContent {
             int size = in.readVInt();
             groupStats = new HashMap<String, Stats>(size);
             for (int i = 0; i < size; i++) {
-                groupStats.put(in.readUTF(), Stats.readStats(in));
+                groupStats.put(in.readString(), Stats.readStats(in));
             }
         }
     }
@@ -274,7 +274,7 @@ public class SearchStats implements Streamable, ToXContent {
             out.writeBoolean(true);
             out.writeVInt(groupStats.size());
             for (Map.Entry<String, Stats> entry : groupStats.entrySet()) {
-                out.writeUTF(entry.getKey());
+                out.writeString(entry.getKey());
                 entry.getValue().writeTo(out);
             }
         }

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -321,17 +321,17 @@ public interface Translog extends IndexShardComponent {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             int version = in.readVInt(); // version
-            id = in.readUTF();
-            type = in.readUTF();
+            id = in.readString();
+            type = in.readString();
             source = in.readBytesReference();
             if (version >= 1) {
                 if (in.readBoolean()) {
-                    routing = in.readUTF();
+                    routing = in.readString();
                 }
             }
             if (version >= 2) {
                 if (in.readBoolean()) {
-                    parent = in.readUTF();
+                    parent = in.readString();
                 }
             }
             if (version >= 3) {
@@ -348,20 +348,20 @@ public interface Translog extends IndexShardComponent {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(5); // version
-            out.writeUTF(id);
-            out.writeUTF(type);
+            out.writeString(id);
+            out.writeString(type);
             out.writeBytesReference(source);
             if (routing == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(routing);
+                out.writeString(routing);
             }
             if (parent == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(parent);
+                out.writeString(parent);
             }
             out.writeLong(version);
             out.writeLong(timestamp);
@@ -450,17 +450,17 @@ public interface Translog extends IndexShardComponent {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             int version = in.readVInt(); // version
-            id = in.readUTF();
-            type = in.readUTF();
+            id = in.readString();
+            type = in.readString();
             source = in.readBytesReference();
             if (version >= 1) {
                 if (in.readBoolean()) {
-                    routing = in.readUTF();
+                    routing = in.readString();
                 }
             }
             if (version >= 2) {
                 if (in.readBoolean()) {
-                    parent = in.readUTF();
+                    parent = in.readString();
                 }
             }
             if (version >= 3) {
@@ -477,20 +477,20 @@ public interface Translog extends IndexShardComponent {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(5); // version
-            out.writeUTF(id);
-            out.writeUTF(type);
+            out.writeString(id);
+            out.writeString(type);
             out.writeBytesReference(source);
             if (routing == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(routing);
+                out.writeString(routing);
             }
             if (parent == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(parent);
+                out.writeString(parent);
             }
             out.writeLong(version);
             out.writeLong(timestamp);
@@ -540,7 +540,7 @@ public interface Translog extends IndexShardComponent {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             int version = in.readVInt(); // version
-            uid = new Term(in.readUTF(), in.readUTF());
+            uid = new Term(in.readString(), in.readString());
             if (version >= 1) {
                 this.version = in.readLong();
             }
@@ -549,8 +549,8 @@ public interface Translog extends IndexShardComponent {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(1); // version
-            out.writeUTF(uid.field());
-            out.writeUTF(uid.text());
+            out.writeString(uid.field());
+            out.writeString(uid.text());
             out.writeLong(version);
         }
     }
@@ -608,14 +608,14 @@ public interface Translog extends IndexShardComponent {
             if (version < 2) {
                 // for query_parser_name, which was removed
                 if (in.readBoolean()) {
-                    in.readUTF();
+                    in.readString();
                 }
             }
             int typesSize = in.readVInt();
             if (typesSize > 0) {
                 types = new String[typesSize];
                 for (int i = 0; i < typesSize; i++) {
-                    types[i] = in.readUTF();
+                    types[i] = in.readString();
                 }
             }
             if (version >= 1) {
@@ -623,7 +623,7 @@ public interface Translog extends IndexShardComponent {
                 if (aliasesSize > 0) {
                     filteringAliases = new String[aliasesSize];
                     for (int i = 0; i < aliasesSize; i++) {
-                        filteringAliases[i] = in.readUTF();
+                        filteringAliases[i] = in.readString();
                     }
                 }
             }
@@ -635,12 +635,12 @@ public interface Translog extends IndexShardComponent {
             out.writeBytesReference(source);
             out.writeVInt(types.length);
             for (String type : types) {
-                out.writeUTF(type);
+                out.writeString(type);
             }
             if (filteringAliases != null) {
                 out.writeVInt(filteringAliases.length);
                 for (String alias : filteringAliases) {
-                    out.writeUTF(alias);
+                    out.writeString(alias);
                 }
             } else {
                 out.writeVInt(0);

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryResponse.java
@@ -58,7 +58,7 @@ class RecoveryResponse extends TransportResponse {
         int size = in.readVInt();
         phase1FileNames = Lists.newArrayListWithCapacity(size);
         for (int i = 0; i < size; i++) {
-            phase1FileNames.add(in.readUTF());
+            phase1FileNames.add(in.readString());
         }
         size = in.readVInt();
         phase1FileSizes = Lists.newArrayListWithCapacity(size);
@@ -69,7 +69,7 @@ class RecoveryResponse extends TransportResponse {
         size = in.readVInt();
         phase1ExistingFileNames = Lists.newArrayListWithCapacity(size);
         for (int i = 0; i < size; i++) {
-            phase1ExistingFileNames.add(in.readUTF());
+            phase1ExistingFileNames.add(in.readString());
         }
         size = in.readVInt();
         phase1ExistingFileSizes = Lists.newArrayListWithCapacity(size);
@@ -93,7 +93,7 @@ class RecoveryResponse extends TransportResponse {
         super.writeTo(out);
         out.writeVInt(phase1FileNames.size());
         for (String name : phase1FileNames) {
-            out.writeUTF(name);
+            out.writeString(name);
         }
         out.writeVInt(phase1FileSizes.size());
         for (long size : phase1FileSizes) {
@@ -102,7 +102,7 @@ class RecoveryResponse extends TransportResponse {
 
         out.writeVInt(phase1ExistingFileNames.size());
         for (String name : phase1ExistingFileNames) {
-            out.writeUTF(name);
+            out.writeString(name);
         }
         out.writeVInt(phase1ExistingFileSizes.size());
         for (long size : phase1ExistingFileSizes) {

--- a/src/main/java/org/elasticsearch/monitor/fs/FsStats.java
+++ b/src/main/java/org/elasticsearch/monitor/fs/FsStats.java
@@ -56,9 +56,9 @@ public class FsStats implements Iterable<FsStats.Info>, Streamable, ToXContent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            path = in.readUTF();
-            mount = in.readOptionalUTF();
-            dev = in.readOptionalUTF();
+            path = in.readString();
+            mount = in.readOptionalString();
+            dev = in.readOptionalString();
             total = in.readLong();
             free = in.readLong();
             available = in.readLong();
@@ -72,9 +72,9 @@ public class FsStats implements Iterable<FsStats.Info>, Streamable, ToXContent {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeUTF(path);
-            out.writeOptionalUTF(mount);
-            out.writeOptionalUTF(dev);
+            out.writeString(path);
+            out.writeOptionalString(mount);
+            out.writeOptionalString(dev);
             out.writeLong(total);
             out.writeLong(free);
             out.writeLong(available);

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -321,21 +321,21 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         pid = in.readLong();
-        version = in.readUTF();
-        vmName = in.readUTF();
-        vmVersion = in.readUTF();
-        vmVendor = in.readUTF();
+        version = in.readString();
+        vmName = in.readString();
+        vmVersion = in.readString();
+        vmVendor = in.readString();
         startTime = in.readLong();
         inputArguments = new String[in.readInt()];
         for (int i = 0; i < inputArguments.length; i++) {
-            inputArguments[i] = in.readUTF();
+            inputArguments[i] = in.readString();
         }
-        bootClassPath = in.readUTF();
-        classPath = in.readUTF();
+        bootClassPath = in.readString();
+        classPath = in.readString();
         systemProperties = new HashMap<String, String>();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            systemProperties.put(in.readUTF(), in.readUTF());
+            systemProperties.put(in.readString(), in.readString());
         }
         mem = new Mem();
         mem.readFrom(in);
@@ -344,21 +344,21 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(pid);
-        out.writeUTF(version);
-        out.writeUTF(vmName);
-        out.writeUTF(vmVersion);
-        out.writeUTF(vmVendor);
+        out.writeString(version);
+        out.writeString(vmName);
+        out.writeString(vmVersion);
+        out.writeString(vmVendor);
         out.writeLong(startTime);
         out.writeInt(inputArguments.length);
         for (String inputArgument : inputArguments) {
-            out.writeUTF(inputArgument);
+            out.writeString(inputArgument);
         }
-        out.writeUTF(bootClassPath);
-        out.writeUTF(classPath);
+        out.writeString(bootClassPath);
+        out.writeString(classPath);
         out.writeInt(systemProperties.size());
         for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
-            out.writeUTF(entry.getKey());
-            out.writeUTF(entry.getValue());
+            out.writeString(entry.getKey());
+            out.writeString(entry.getValue());
         }
         mem.writeTo(out);
     }

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -626,7 +626,7 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            name = in.readUTF();
+            name = in.readString();
             collectionCount = in.readVLong();
             collectionTime = in.readVLong();
             if (in.readBoolean()) {
@@ -636,7 +636,7 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeUTF(name);
+            out.writeString(name);
             out.writeVLong(collectionCount);
             out.writeVLong(collectionTime);
             if (lastGc == null) {
@@ -792,7 +792,7 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            name = in.readUTF();
+            name = in.readString();
             used = in.readVLong();
             max = in.readVLong();
             peakUsed = in.readVLong();
@@ -801,7 +801,7 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeUTF(name);
+            out.writeString(name);
             out.writeVLong(used);
             out.writeVLong(max);
             out.writeVLong(peakUsed);

--- a/src/main/java/org/elasticsearch/monitor/network/NetworkInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/network/NetworkInfo.java
@@ -145,16 +145,16 @@ public class NetworkInfo implements Streamable, Serializable, ToXContent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            name = in.readUTF();
-            address = in.readUTF();
-            macAddress = in.readUTF();
+            name = in.readString();
+            address = in.readString();
+            macAddress = in.readString();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeUTF(name);
-            out.writeUTF(address);
-            out.writeUTF(macAddress);
+            out.writeString(name);
+            out.writeString(address);
+            out.writeString(macAddress);
         }
 
     }

--- a/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -332,8 +332,8 @@ public class OsInfo implements Streamable, Serializable, ToXContent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            vendor = in.readUTF();
-            model = in.readUTF();
+            vendor = in.readString();
+            model = in.readString();
             mhz = in.readInt();
             totalCores = in.readInt();
             totalSockets = in.readInt();
@@ -343,8 +343,8 @@ public class OsInfo implements Streamable, Serializable, ToXContent {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeUTF(vendor);
-            out.writeUTF(model);
+            out.writeString(vendor);
+            out.writeString(model);
             out.writeInt(mhz);
             out.writeInt(totalCores);
             out.writeInt(totalSockets);

--- a/src/main/java/org/elasticsearch/rest/RestStatus.java
+++ b/src/main/java/org/elasticsearch/rest/RestStatus.java
@@ -484,10 +484,10 @@ public enum RestStatus {
     }
 
     public static RestStatus readFrom(StreamInput in) throws IOException {
-        return RestStatus.valueOf(in.readUTF());
+        return RestStatus.valueOf(in.readString());
     }
 
     public static void writeTo(StreamOutput out, RestStatus status) throws IOException {
-        out.writeUTF(status.name());
+        out.writeString(status.name());
     }
 }

--- a/src/main/java/org/elasticsearch/river/routing/RiverRouting.java
+++ b/src/main/java/org/elasticsearch/river/routing/RiverRouting.java
@@ -67,7 +67,7 @@ public class RiverRouting implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        riverName = new RiverName(in.readUTF(), in.readUTF());
+        riverName = new RiverName(in.readString(), in.readString());
         if (in.readBoolean()) {
             node = DiscoveryNode.readNode(in);
         }
@@ -75,8 +75,8 @@ public class RiverRouting implements Streamable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(riverName.type());
-        out.writeUTF(riverName.name());
+        out.writeString(riverName.type());
+        out.writeString(riverName.name());
         if (node == null) {
             out.writeBoolean(false);
         } else {

--- a/src/main/java/org/elasticsearch/search/facet/InternalFacets.java
+++ b/src/main/java/org/elasticsearch/search/facet/InternalFacets.java
@@ -139,7 +139,7 @@ public class InternalFacets implements Facets, Streamable, ToXContent, Iterable<
         } else {
             facets = Lists.newArrayListWithCapacity(size);
             for (int i = 0; i < size; i++) {
-                String type = in.readUTF();
+                String type = in.readString();
                 Facet facet = InternalFacet.Streams.stream(type).readFacet(type, in);
                 facets.add(facet);
             }
@@ -151,7 +151,7 @@ public class InternalFacets implements Facets, Streamable, ToXContent, Iterable<
         out.writeVInt(facets.size());
         for (Facet facet : facets) {
             InternalFacet internalFacet = (InternalFacet) facet;
-            out.writeUTF(internalFacet.streamType());
+            out.writeString(internalFacet.streamType());
             internalFacet.writeTo(out);
         }
     }

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalCountDateHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalCountDateHistogramFacet.java
@@ -268,7 +268,7 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         int size = in.readVInt();
@@ -282,7 +282,7 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeVInt(counts.size());
         for (TLongLongIterator it = counts.iterator(); it.hasNext(); ) {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalFullDateHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalFullDateHistogramFacet.java
@@ -310,7 +310,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         cachedEntries = false;
@@ -323,7 +323,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeVInt(entries.size());
         for (FullEntry entry : entries) {

--- a/src/main/java/org/elasticsearch/search/facet/filter/InternalFilterFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/filter/InternalFilterFacet.java
@@ -122,13 +122,13 @@ public class InternalFilterFacet implements FilterFacet, InternalFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         count = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVLong(count);
     }
 }

--- a/src/main/java/org/elasticsearch/search/facet/geodistance/InternalGeoDistanceFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/geodistance/InternalGeoDistanceFacet.java
@@ -109,7 +109,7 @@ public class InternalGeoDistanceFacet implements GeoDistanceFacet, InternalFacet
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         entries = new Entry[in.readVInt()];
         for (int i = 0; i < entries.length; i++) {
             entries[i] = new Entry(in.readDouble(), in.readDouble(), in.readVLong(), in.readVLong(), in.readDouble(), in.readDouble(), in.readDouble());
@@ -118,7 +118,7 @@ public class InternalGeoDistanceFacet implements GeoDistanceFacet, InternalFacet
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVInt(entries.length);
         for (Entry entry : entries) {
             out.writeDouble(entry.from);

--- a/src/main/java/org/elasticsearch/search/facet/histogram/bounded/InternalBoundedCountHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/bounded/InternalBoundedCountHistogramFacet.java
@@ -276,7 +276,7 @@ public class InternalBoundedCountHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
         offset = in.readLong();
         interval = in.readVLong();
@@ -290,7 +290,7 @@ public class InternalBoundedCountHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeLong(offset);
         out.writeVLong(interval);

--- a/src/main/java/org/elasticsearch/search/facet/histogram/bounded/InternalBoundedFullHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/bounded/InternalBoundedFullHistogramFacet.java
@@ -336,7 +336,7 @@ public class InternalBoundedFullHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         offset = in.readLong();
@@ -353,7 +353,7 @@ public class InternalBoundedFullHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeLong(offset);
         out.writeVLong(interval);

--- a/src/main/java/org/elasticsearch/search/facet/histogram/unbounded/InternalCountHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/unbounded/InternalCountHistogramFacet.java
@@ -269,7 +269,7 @@ public class InternalCountHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         int size = in.readVInt();
@@ -283,7 +283,7 @@ public class InternalCountHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         // optimize the write, since we know we have the same buckets as keys
         out.writeVInt(counts.size());

--- a/src/main/java/org/elasticsearch/search/facet/histogram/unbounded/InternalFullHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/unbounded/InternalFullHistogramFacet.java
@@ -309,7 +309,7 @@ public class InternalFullHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
 
         cachedEntries = false;
@@ -322,7 +322,7 @@ public class InternalFullHistogramFacet extends InternalHistogramFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeVInt(entries.size());
         for (FullEntry entry : entries) {

--- a/src/main/java/org/elasticsearch/search/facet/query/InternalQueryFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/query/InternalQueryFacet.java
@@ -122,13 +122,13 @@ public class InternalQueryFacet implements QueryFacet, InternalFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         count = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVLong(count);
     }
 }

--- a/src/main/java/org/elasticsearch/search/facet/range/InternalRangeFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/range/InternalRangeFacet.java
@@ -109,17 +109,17 @@ public class InternalRangeFacet implements RangeFacet, InternalFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         entries = new Entry[in.readVInt()];
         for (int i = 0; i < entries.length; i++) {
             Entry entry = new Entry();
             entry.from = in.readDouble();
             entry.to = in.readDouble();
             if (in.readBoolean()) {
-                entry.fromAsString = in.readUTF();
+                entry.fromAsString = in.readString();
             }
             if (in.readBoolean()) {
-                entry.toAsString = in.readUTF();
+                entry.toAsString = in.readString();
             }
             entry.count = in.readVLong();
             entry.totalCount = in.readVLong();
@@ -132,7 +132,7 @@ public class InternalRangeFacet implements RangeFacet, InternalFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVInt(entries.length);
         for (Entry entry : entries) {
             out.writeDouble(entry.from);
@@ -141,13 +141,13 @@ public class InternalRangeFacet implements RangeFacet, InternalFacet {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(entry.fromAsString);
+                out.writeString(entry.fromAsString);
             }
             if (entry.toAsString == null) {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeUTF(entry.toAsString);
+                out.writeString(entry.toAsString);
             }
             out.writeVLong(entry.count);
             out.writeVLong(entry.totalCount);

--- a/src/main/java/org/elasticsearch/search/facet/statistical/InternalStatisticalFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/statistical/InternalStatisticalFacet.java
@@ -210,7 +210,7 @@ public class InternalStatisticalFacet implements StatisticalFacet, InternalFacet
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         count = in.readVLong();
         total = in.readDouble();
         min = in.readDouble();
@@ -220,7 +220,7 @@ public class InternalStatisticalFacet implements StatisticalFacet, InternalFacet
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVLong(count);
         out.writeDouble(total);
         out.writeDouble(min);

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/longs/InternalTermsStatsLongFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/longs/InternalTermsStatsLongFacet.java
@@ -341,7 +341,7 @@ public class InternalTermsStatsLongFacet extends InternalTermsStatsFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
         requiredSize = in.readVInt();
         missing = in.readVLong();
@@ -355,7 +355,7 @@ public class InternalTermsStatsLongFacet extends InternalTermsStatsFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/strings/InternalTermsStatsStringFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/strings/InternalTermsStatsStringFacet.java
@@ -347,7 +347,7 @@ public class InternalTermsStatsStringFacet extends InternalTermsStatsFacet {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         comparatorType = ComparatorType.fromId(in.readByte());
         requiredSize = in.readVInt();
         missing = in.readVLong();
@@ -361,7 +361,7 @@ public class InternalTermsStatsStringFacet extends InternalTermsStatsFacet {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeByte(comparatorType.id());
         out.writeVInt(requiredSize);
         out.writeVLong(missing);

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightField.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightField.java
@@ -86,7 +86,7 @@ public class HighlightField implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         if (in.readBoolean()) {
             int size = in.readVInt();
             if (size == 0) {
@@ -102,7 +102,7 @@ public class HighlightField implements Streamable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         if (fragments == null) {
             out.writeBoolean(false);
         } else {

--- a/src/main/java/org/elasticsearch/search/internal/InternalSearchHitField.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalSearchHitField.java
@@ -91,7 +91,7 @@ public class InternalSearchHitField implements SearchHitField {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        name = in.readUTF();
+        name = in.readString();
         int size = in.readVInt();
         values = new ArrayList<Object>(size);
         for (int i = 0; i < size; i++) {
@@ -101,7 +101,7 @@ public class InternalSearchHitField implements SearchHitField {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
         out.writeVInt(values.size());
         for (Object value : values) {
             out.writeGenericValue(value);

--- a/src/main/java/org/elasticsearch/search/warmer/IndexWarmersMetaData.java
+++ b/src/main/java/org/elasticsearch/search/warmer/IndexWarmersMetaData.java
@@ -99,7 +99,7 @@ public class IndexWarmersMetaData implements IndexMetaData.Custom {
         public IndexWarmersMetaData readFrom(StreamInput in) throws IOException {
             Entry[] entries = new Entry[in.readVInt()];
             for (int i = 0; i < entries.length; i++) {
-                entries[i] = new Entry(in.readUTF(), in.readStringArray(), in.readBoolean() ? in.readBytesReference() : null);
+                entries[i] = new Entry(in.readString(), in.readStringArray(), in.readBoolean() ? in.readBytesReference() : null);
             }
             return new IndexWarmersMetaData(entries);
         }
@@ -108,7 +108,7 @@ public class IndexWarmersMetaData implements IndexMetaData.Custom {
         public void writeTo(IndexWarmersMetaData warmers, StreamOutput out) throws IOException {
             out.writeVInt(warmers.entries().size());
             for (Entry entry : warmers.entries()) {
-                out.writeUTF(entry.name());
+                out.writeString(entry.name());
                 out.writeStringArray(entry.types());
                 if (entry.source() == null) {
                     out.writeBoolean(false);

--- a/src/test/java/org/elasticsearch/test/unit/common/io/streams/BytesStreamsTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/io/streams/BytesStreamsTests.java
@@ -46,8 +46,8 @@ public class BytesStreamsTests {
         out.writeVLong(4);
         out.writeFloat(1.1f);
         out.writeDouble(2.2);
-        out.writeUTF("hello");
-        out.writeUTF("goodbye");
+        out.writeString("hello");
+        out.writeString("goodbye");
 
         BytesStreamInput in = new BytesStreamInput(out.bytes().toBytes(), false);
         assertThat(in.readBoolean(), equalTo(false));
@@ -59,7 +59,7 @@ public class BytesStreamsTests {
         assertThat(in.readVLong(), equalTo((long) 4));
         assertThat((double) in.readFloat(), closeTo(1.1, 0.0001));
         assertThat(in.readDouble(), closeTo(2.2, 0.0001));
-        assertThat(in.readUTF(), equalTo("hello"));
-        assertThat(in.readUTF(), equalTo("goodbye"));
+        assertThat(in.readString(), equalTo("hello"));
+        assertThat(in.readString(), equalTo("goodbye"));
     }
 }

--- a/src/test/java/org/elasticsearch/test/unit/common/io/streams/HandlesStreamsTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/io/streams/HandlesStreamsTests.java
@@ -40,19 +40,19 @@ public class HandlesStreamsTests {
         HandlesStreamOutput out = new HandlesStreamOutput(bytesOut, 5);
         String lowerThresholdValue = "test";
         String higherThresholdValue = "something that is higher than 5";
-        out.writeUTF(lowerThresholdValue);
-        out.writeUTF(higherThresholdValue);
+        out.writeString(lowerThresholdValue);
+        out.writeString(higherThresholdValue);
         out.writeInt(1);
-        out.writeUTF("else");
-        out.writeUTF(higherThresholdValue);
-        out.writeUTF(lowerThresholdValue);
+        out.writeString("else");
+        out.writeString(higherThresholdValue);
+        out.writeString(lowerThresholdValue);
 
         HandlesStreamInput in = new HandlesStreamInput(new BytesStreamInput(bytesOut.bytes().toBytes(), false));
-        assertThat(in.readUTF(), equalTo(lowerThresholdValue));
-        assertThat(in.readUTF(), equalTo(higherThresholdValue));
+        assertThat(in.readString(), equalTo(lowerThresholdValue));
+        assertThat(in.readString(), equalTo(higherThresholdValue));
         assertThat(in.readInt(), equalTo(1));
-        assertThat(in.readUTF(), equalTo("else"));
-        assertThat(in.readUTF(), equalTo(higherThresholdValue));
-        assertThat(in.readUTF(), equalTo(lowerThresholdValue));
+        assertThat(in.readString(), equalTo("else"));
+        assertThat(in.readString(), equalTo(higherThresholdValue));
+        assertThat(in.readString(), equalTo(lowerThresholdValue));
     }
 }


### PR DESCRIPTION
StreamInput / Output # read/writeUTF has been deprecated quite a while now. We should get rid of this deprecated api.
