### PR TITLE
Provide more information if a null DocumentMapper is returned

### DIFF
--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -136,7 +136,10 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
                 }
                 final BoolQueryBuilder boolBuilder = boolQuery();
                 try {
-                    DocumentMapper docMapper = indicesService.indexServiceSafe(concreteIndex).mapperService().documentMapper(request.type());
+                    final DocumentMapper docMapper = indicesService.indexServiceSafe(concreteIndex).mapperService().documentMapper(request.type());
+                    if (docMapper == null) {
+                        throw new ElasticSearchException("No DocumentMapper found for type [" + request.type() + "]");
+                    }
                     final Set<String> fields = newHashSet();
                     if (request.fields() != null) {
                         for (String field : request.fields()) {


### PR DESCRIPTION
if a null DocumentMapper is returned from the mapping service in TransportMoreLikeThisAction we almost certainly run into a NPE. We should throw a more reasonable exception here.
