### PR TITLE
Throw a more meaningful message when no document is specified for indexing

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -537,6 +537,11 @@ public class DocumentMapper implements ToXContent {
                 throw (MapperParsingException) e;
             }
 
+            // Throw a more meaningful message if the document is empty.
+            if (source.source() != null && source.source().length() == 0) {
+                throw new MapperParsingException("failed to parse, document is empty");
+            }
+
             throw new MapperParsingException("failed to parse", e);
         } finally {
             // only close the parser when its not provided externally


### PR DESCRIPTION
Currently the a user forgets to send a document when indexing, they get a cryptic error that doesn't point to the actual cause:

```
∴ curl -s -XPUT localhost:9200/test/doc/1 | python -mjson.tool
{
    "error": "ElasticSearchParseException[Failed to derive xcontent from (offset=0, length=0): []]",
    "status": 400
}
```

This change makes the error message a bit more readable for someone who runs into this issue:

```
∴ curl -s -XPUT localhost:9200/test/doc/1 | python -mjson.tool
{
    "error": "MapperParsingException[failed to parse, document is empty]",
    "status": 400
}
```

The Exception originates from https://github.com/elasticsearch/elasticsearch/blob/ed09ba0a18ebe720db32b78e5146d4383525d014/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java#L456

I chose to make this a MapperParsingException to match the Exception that would normally get thrown in the case that a document didn't map correctly: https://github.com/elasticsearch/elasticsearch/blob/ed09ba0a18ebe720db32b78e5146d4383525d014/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java#L540
