### PR TITLE
Throw correct exception when looking for discovery module

### DIFF
--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -241,7 +241,7 @@ public class ImmutableSettings implements Settings {
                 try {
                     return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
                 } catch (ClassNotFoundException e2) {
-                    throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + get(setting) + "]", e);
+                    throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + get(setting) + "]", e2);
                 }
             }
         }


### PR DESCRIPTION
Currently throws the ClassNotFoundException from the original module loading attempt (something unhelpful like "ec2") instead of the fully qualified class ES looks for in the end (i.e. "org.elasticsearch.discovery.ec2.Ec2DiscoveryModule")

Helped me debug classloader issues with OSGI.
