### PR TITLE
Display list of all available site plugins on /_plugins/ end point

### DIFF
--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -21,12 +21,15 @@ package org.elasticsearch.http;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.plugins.PluginsHelper;
 import org.elasticsearch.rest.*;
 
 import java.io.File;
@@ -34,6 +37,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.RestStatus.*;
 
 /**
@@ -144,15 +148,37 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
             channel.sendResponse(new StringRestResponse(FORBIDDEN));
             return;
         }
-        // TODO for a "/_plugin" endpoint, we should have a page that lists all the plugins?
 
         String path = request.rawPath().substring("/_plugin/".length());
         int i1 = path.indexOf('/');
         String pluginName;
         String sitePath;
         if (i1 == -1) {
-            pluginName = path;
-            sitePath = null;
+            // If user tries to reach "/_plugin/" endpoint, we display a page that lists all the plugins #2664
+            if (!Strings.hasText(path)) {
+                try {
+                    XContentBuilder json = jsonBuilder();
+                    if (request.hasParam("pretty")) {
+                        json.prettyPrint();
+                    }
+                    json.startObject().startArray("sites");
+
+                    for(String plugin : PluginsHelper.sitePlugins(environment)) {
+                        json.startObject()
+                                .field("name", plugin)
+                                .field("url", "/_plugin/" + plugin +"/")
+                            .endObject();
+                    }
+                    json.endArray().endObject();
+                    channel.sendResponse(new BytesRestResponse(json.bytes().toBytes(),
+                            guessMimeType(guessMimeType("index.json"))));
+                } catch (IOException e) {
+                    channel.sendResponse(new StringRestResponse(INTERNAL_SERVER_ERROR));
+                }
+
+                return;
+            }
+
             // If a trailing / is missing, we redirect to the right page #2654
             channel.sendResponse(new HttpRedirectRestResponse(request.rawPath()+"/"));
             return;
@@ -190,7 +216,6 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
             channel.sendResponse(new StringRestResponse(INTERNAL_SERVER_ERROR));
         }
     }
-
 
     // TODO: Don't respond with a mime type that violates the request's Accept header
     private String guessMimeType(String path) {

--- a/src/main/java/org/elasticsearch/plugins/PluginsHelper.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import com.google.common.collect.Sets;
+import org.elasticsearch.env.Environment;
+
+import java.io.File;
+import java.util.Set;
+
+/**
+ * Helper class for plugins
+ */
+public class PluginsHelper {
+
+    /**
+     * Build a list of existing site plugins for a given environment
+     * @param environment We look into Environment#pluginsFile()
+     * @return A Set of existing site plugins
+     */
+    public static Set<String> sitePlugins(Environment environment) {
+        File pluginsFile = environment.pluginsFile();
+        Set<String> sitePlugins = Sets.newHashSet();
+
+        if (!pluginsFile.exists() || !pluginsFile.isDirectory()) {
+            return sitePlugins;
+        }
+
+        for (File pluginFile : pluginsFile.listFiles()) {
+            if (new File(pluginFile, "_site").exists()) {
+                sitePlugins.add(pluginFile.getName());
+            }
+        }
+        return sitePlugins;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -85,7 +85,7 @@ public class PluginsService extends AbstractComponent {
         // now, find all the ones that are in the classpath
         loadPluginsIntoClassLoader();
         plugins.putAll(loadPluginsFromClasspath(settings));
-        Set<String> sitePlugins = sitePlugins();
+        Set<String> sitePlugins = PluginsHelper.sitePlugins(this.environment);
 
         String[] mandatoryPlugins = settings.getAsArray("plugin.mandatory", null);
         if (mandatoryPlugins != null) {
@@ -238,24 +238,6 @@ public class PluginsService extends AbstractComponent {
             services.addAll(plugin.shardServices());
         }
         return services;
-    }
-
-    private Set<String> sitePlugins() {
-        File pluginsFile = environment.pluginsFile();
-        Set<String> sitePlugins = Sets.newHashSet();
-        if (!pluginsFile.exists()) {
-            return sitePlugins;
-        }
-        if (!pluginsFile.isDirectory()) {
-            return sitePlugins;
-        }
-        File[] pluginsFiles = pluginsFile.listFiles();
-        for (File pluginFile : pluginsFiles) {
-            if (new File(pluginFile, "_site").exists()) {
-                sitePlugins.add(pluginFile.getName());
-            }
-        }
-        return sitePlugins;
     }
 
     private void loadPluginsIntoClassLoader() {

--- a/src/test/java/org/elasticsearch/test/integration/plugin/SitePluginTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/plugin/SitePluginTests.java
@@ -78,4 +78,13 @@ public class SitePluginTests extends AbstractNodesTests {
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin</title>"));
     }
+
+    @Test
+    public void testListSitePlugin() throws Exception {
+        // We use an HTTP Client to test redirection
+        HttpClientResponse response = httpClient("test").request("/_plugin/");
+        assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
+        assertThat(response.response(), containsString("dummy"));
+        assertThat(response.response(), containsString("anotherplugin"));
+    }
 }

--- a/src/test/resources/org/elasticsearch/test/integration/plugin/anotherplugin/_site/index.html
+++ b/src/test/resources/org/elasticsearch/test/integration/plugin/anotherplugin/_site/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Another Site Plugin</title>
+</head>
+<body>
+<p>Welcome to this another elasticsearch plugin</p>
+</body>
+</html>


### PR DESCRIPTION
See issue #2664

When you need to know all available site plugins, you can send:

``` sh
$ curl localhost:9200/_plugin/
```

And get the following result:

``` javascript
{
  "sites" : [ {
    "name" : "anotherplugin",
    "url" : "/_plugin/anotherplugin/"
  }, {
    "name" : "dummy",
    "url" : "/_plugin/dummy/"
  } ]
}
```
