### PR TITLE
Correct order of routing and parent params for Get Requests

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
@@ -53,8 +53,8 @@ public class RestGetAction extends BaseRestHandler {
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);
         getRequest.refresh(request.paramAsBoolean("refresh", getRequest.refresh()));
+        getRequest.routing(request.param("routing"));  // order is important, set it after routing, so it will set the routing
         getRequest.parent(request.param("parent"));
-        getRequest.routing(request.param("routing"));
         getRequest.preference(request.param("preference"));
         getRequest.realtime(request.paramAsBooleanOptional("realtime", null));
 


### PR DESCRIPTION
The order in which routing and parent parameters are set is important.  The
routing parameter must be set first or it will overwrite the parent routing
value.
