### PR TITLE
Add support for ignore_indices to delete by query

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.replication;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.WriteConsistencyLevel;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -35,6 +36,8 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
 
     protected TimeValue timeout = ShardReplicationOperationRequest.DEFAULT_TIMEOUT;
     protected String[] indices;
+    private IgnoreIndices ignoreIndices = IgnoreIndices.DEFAULT;
+
     protected ReplicationType replicationType = ReplicationType.DEFAULT;
     protected WriteConsistencyLevel consistencyLevel = WriteConsistencyLevel.DEFAULT;
 
@@ -62,6 +65,15 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
 
     public String[] indices() {
         return this.indices;
+    }
+
+    public IgnoreIndices ignoreIndices() {
+        return ignoreIndices;
+    }
+
+    public T ignoreIndices(IgnoreIndices ignoreIndices) {
+        this.ignoreIndices = ignoreIndices;
+        return (T) this;
     }
 
     /**
@@ -118,6 +130,7 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
         consistencyLevel = WriteConsistencyLevel.fromId(in.readByte());
         timeout = TimeValue.readTimeValue(in);
         indices = in.readStringArray();
+        ignoreIndices = IgnoreIndices.fromId(in.readByte());
     }
 
     @Override
@@ -127,5 +140,6 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
         out.writeByte(consistencyLevel.id());
         timeout.writeTo(out);
         out.writeStringArrayNullable(indices);
+        out.writeByte(ignoreIndices.id());
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequestBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.replication;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.client.internal.InternalGenericClient;
 import org.elasticsearch.common.unit.TimeValue;
 
@@ -55,6 +56,14 @@ public abstract class IndicesReplicationOperationRequestBuilder<Request extends 
     @SuppressWarnings("unchecked")
     public final RequestBuilder setIndices(String... indices) {
         request.indices(indices);
+        return (RequestBuilder) this;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore. For example indices that don't exist.
+     */
+    public RequestBuilder setIgnoreIndices(IgnoreIndices ignoreIndices) {
+        request().ignoreIndices(ignoreIndices);
         return (RequestBuilder) this;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
@@ -75,7 +75,7 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
             throw blockException;
         }
         // get actual indices
-        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices());
+        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices(), request.ignoreIndices(), false);
         blockException = checkRequestBlock(clusterState, request, concreteIndices);
         if (blockException != null) {
             throw blockException;

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.deletebyquery.DeleteByQueryRequest;
 import org.elasticsearch.action.deletebyquery.DeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.IndexDeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.ShardDeleteByQueryRequest;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -82,6 +83,9 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
             String consistencyLevel = request.param("consistency");
             if (consistencyLevel != null) {
                 deleteByQueryRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
+            }
+            if (request.hasParam("ignore_indices")) {
+                deleteByQueryRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
             }
         } catch (Exception e) {
             try {


### PR DESCRIPTION
As the doc says all multi indices API support the ignore_indices option, and the delete by query API is a multi indices API I think it makes sense to support it.
