### PR TITLE
Added advance override for AvgParentScorer.

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -299,6 +299,25 @@ public class ChildrenQuery extends Query implements SearchContext.Rewrite {
                 }
             }
         }
+        
+        @Override
+        public int advance(int target) throws IOException {
+            currentDocId = parentsIterator.advance(target);
+            if (currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                return currentDocId;
+            }
+
+            currentUid = idTypeCache.idByDoc(currentDocId);
+            currentScore = uidToScore.get(currentUid);
+            if (Float.compare(currentScore, 0) > 0) {
+                currentScore /= uidToCount.get(currentUid);
+                return currentDocId;
+            }
+            else
+            {
+            	return nextDoc();
+            }
+        }
     }
 
     static class ChildUidCollector extends NoopCollector {


### PR DESCRIPTION
For scoring using advance the AvgParentScorer used the advance override for ParentScorer resulting in returning the sum. This fix adds the advancce override to the AvgParentScorer calculating the avg correctly.

This fix mainly fixes issues with the 0.20.x releasse where advance is used when calculating scores for child queries returning the wrong score when using the 'avg' score_type.
