### PR TITLE
List of plugins on /_nodes/plugins/ end point, like #2664

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -33,6 +33,7 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.network.NetworkInfo;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.process.ProcessInfo;
+import org.elasticsearch.plugins.PluginsInfo;
 import org.elasticsearch.threadpool.ThreadPoolInfo;
 import org.elasticsearch.transport.TransportInfo;
 
@@ -76,12 +77,15 @@ public class NodeInfo extends NodeOperationResponse {
     @Nullable
     private HttpInfo http;
 
+    @Nullable
+    private PluginsInfo plugins;
+
     NodeInfo() {
     }
 
     public NodeInfo(@Nullable String hostname, Version version, DiscoveryNode node, @Nullable ImmutableMap<String, String> serviceAttributes, @Nullable Settings settings,
                     @Nullable OsInfo os, @Nullable ProcessInfo process, @Nullable JvmInfo jvm, @Nullable ThreadPoolInfo threadPool, @Nullable NetworkInfo network,
-                    @Nullable TransportInfo transport, @Nullable HttpInfo http) {
+                    @Nullable TransportInfo transport, @Nullable HttpInfo http, @Nullable PluginsInfo plugins) {
         super(node);
         this.hostname = hostname;
         this.version = version;
@@ -94,6 +98,7 @@ public class NodeInfo extends NodeOperationResponse {
         this.network = network;
         this.transport = transport;
         this.http = http;
+        this.plugins = plugins;
     }
 
     /**
@@ -174,6 +179,11 @@ public class NodeInfo extends NodeOperationResponse {
         return http;
     }
 
+    @Nullable
+    public PluginsInfo getPlugins() {
+        return plugins;
+    }
+
     public static NodeInfo readNodeInfo(StreamInput in) throws IOException {
         NodeInfo nodeInfo = new NodeInfo();
         nodeInfo.readFrom(in);
@@ -218,6 +228,9 @@ public class NodeInfo extends NodeOperationResponse {
         }
         if (in.readBoolean()) {
             http = HttpInfo.readHttpInfo(in);
+        }
+        if (in.readBoolean()) {
+            plugins = PluginsInfo.readPluginsInfo(in);
         }
     }
 
@@ -288,6 +301,12 @@ public class NodeInfo extends NodeOperationResponse {
         } else {
             out.writeBoolean(true);
             http.writeTo(out);
+        }
+        if (plugins == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            plugins.writeTo(out);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -38,6 +38,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
     private boolean network = false;
     private boolean transport = false;
     private boolean http = false;
+    private boolean plugins = false;
 
     public NodesInfoRequest() {
     }
@@ -62,6 +63,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         network = false;
         transport = false;
         http = false;
+        plugins = false;
         return this;
     }
 
@@ -77,6 +79,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         network = true;
         transport = true;
         http = true;
+        plugins = true;
         return this;
     }
 
@@ -200,6 +203,21 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         return this;
     }
 
+    /**
+     * Should the node plugins be returned.
+     */
+    public boolean plugins() {
+        return this.plugins;
+    }
+
+    /**
+     * Should the node plugins be returned.
+     */
+    public NodesInfoRequest plugins(boolean plugins) {
+        this.plugins = plugins;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -211,6 +229,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         network = in.readBoolean();
         transport = in.readBoolean();
         http = in.readBoolean();
+        plugins = in.readBoolean();
     }
 
     @Override
@@ -224,5 +243,6 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         out.writeBoolean(network);
         out.writeBoolean(transport);
         out.writeBoolean(http);
+        out.writeBoolean(plugins);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
@@ -113,6 +113,14 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
         return this;
     }
 
+    /**
+     * Should the node plugins info be returned.
+     */
+    public NodesInfoRequestBuilder setPlugins(boolean plugins) {
+        request.plugins(plugins);
+        return this;
+    }
+
 
     @Override
     protected void doExecute(ActionListener<NodesInfoResponse> listener) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -132,6 +132,9 @@ public class NodesInfoResponse extends NodesOperationResponse<NodeInfo> implemen
             if (nodeInfo.getHttp() != null) {
                 nodeInfo.getHttp().toXContent(builder, params);
             }
+            if (nodeInfo.getPlugins() != null) {
+                nodeInfo.getPlugins().toXContent(builder, params);
+            }
 
             builder.endObject();
         }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -97,7 +97,7 @@ public class TransportNodesInfoAction extends TransportNodesOperationAction<Node
     @Override
     protected NodeInfo nodeOperation(NodeInfoRequest nodeRequest) throws ElasticSearchException {
         NodesInfoRequest request = nodeRequest.request;
-        return nodeService.info(request.settings(), request.os(), request.process(), request.jvm(), request.threadPool(), request.network(), request.transport(), request.http());
+        return nodeService.info(request.settings(), request.os(), request.process(), request.jvm(), request.threadPool(), request.network(), request.transport(), request.http(), request.plugins());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -144,7 +144,6 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
             channel.sendResponse(new StringRestResponse(FORBIDDEN));
             return;
         }
-        // TODO for a "/_plugin" endpoint, we should have a page that lists all the plugins?
 
         String path = request.rawPath().substring("/_plugin/".length());
         int i1 = path.indexOf('/');

--- a/src/main/java/org/elasticsearch/node/service/NodeService.java
+++ b/src/main/java/org/elasticsearch/node/service/NodeService.java
@@ -34,6 +34,7 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.monitor.MonitorService;
+import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -53,6 +54,8 @@ public class NodeService extends AbstractComponent {
 
     private final IndicesService indicesService;
 
+    private final PluginsService pluginsService;
+
     @Nullable
     private HttpServer httpServer;
 
@@ -64,13 +67,16 @@ public class NodeService extends AbstractComponent {
     private final Version version;
 
     @Inject
-    public NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService, Discovery discovery, ClusterService clusterService, TransportService transportService, IndicesService indicesService) {
+    public NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService,
+                       Discovery discovery, ClusterService clusterService, TransportService transportService,
+                       IndicesService indicesService, PluginsService pluginsService) {
         super(settings);
         this.threadPool = threadPool;
         this.monitorService = monitorService;
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.indicesService = indicesService;
+        this.pluginsService = pluginsService;
         discovery.setNodeService(this);
         InetAddress address = NetworkUtils.getLocalAddress();
         if (address != null) {
@@ -117,11 +123,13 @@ public class NodeService extends AbstractComponent {
                 threadPool.info(),
                 monitorService.networkService().info(),
                 transportService.info(),
-                httpServer == null ? null : httpServer.info()
+                httpServer == null ? null : httpServer.info(),
+                pluginsService.info()
         );
     }
 
-    public NodeInfo info(boolean settings, boolean os, boolean process, boolean jvm, boolean threadPool, boolean network, boolean transport, boolean http) {
+    public NodeInfo info(boolean settings, boolean os, boolean process, boolean jvm, boolean threadPool,
+                         boolean network, boolean transport, boolean http, boolean plugins) {
         return new NodeInfo(hostname, version, clusterService.state().nodes().localNode(), serviceAttributes,
                 settings ? this.settings : null,
                 os ? monitorService.osService().info() : null,
@@ -130,7 +138,8 @@ public class NodeService extends AbstractComponent {
                 threadPool ? this.threadPool.info() : null,
                 network ? monitorService.networkService().info() : null,
                 transport ? transportService.info() : null,
-                http ? (httpServer == null ? null : httpServer.info()) : null
+                http ? (httpServer == null ? null : httpServer.info()) : null,
+                plugins ? pluginsService.info() : null
         );
     }
 

--- a/src/main/java/org/elasticsearch/plugins/PluginsInfo.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ *
+ */
+public class PluginsInfo implements Streamable, Serializable, ToXContent {
+
+    private static final String[] EMPTY = new String[0];
+
+    private String[] mandatoryPlugins;
+    private String[] sitePlugins;
+    private String[] nonsitePlugins;
+
+    public PluginsInfo() {
+    }
+
+    public PluginsInfo(@Nullable Set<String> mandatoryPlugins, Set<String> sitePlugins, Set<String> nonsitePlugins) {
+        this.mandatoryPlugins = mandatoryPlugins == null ? EMPTY :
+                mandatoryPlugins.toArray(new String[mandatoryPlugins.size()]);
+        this.sitePlugins = sitePlugins.toArray(new String[sitePlugins.size()]);
+        this.nonsitePlugins = nonsitePlugins.toArray(new String[nonsitePlugins.size()]);
+        Arrays.sort(this.mandatoryPlugins);
+        Arrays.sort(this.sitePlugins);
+        Arrays.sort(this.nonsitePlugins);
+    }
+
+    static final class Fields {
+        static final XContentBuilderString PLUGINS = new XContentBuilderString("plugins");
+        static final XContentBuilderString MANDATORY = new XContentBuilderString("mandatory");
+        static final XContentBuilderString SITES = new XContentBuilderString("sites");
+        static final XContentBuilderString NONSITES = new XContentBuilderString("nonsites");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.PLUGINS);
+        builder.array(Fields.MANDATORY, mandatoryPlugins);
+        builder.array(Fields.SITES, sitePlugins);
+        builder.array(Fields.NONSITES, nonsitePlugins);
+        builder.endObject();
+        return builder;
+    }
+
+    public static PluginsInfo readPluginsInfo(StreamInput in) throws IOException {
+        PluginsInfo info = new PluginsInfo();
+        info.readFrom(in);
+        return info;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        mandatoryPlugins = in.readStringArray();
+        sitePlugins = in.readStringArray();
+        nonsitePlugins = in.readStringArray();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeStringArray(mandatoryPlugins);
+        out.writeStringArray(sitePlugins);
+        out.writeStringArray(nonsitePlugins);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -134,6 +134,14 @@ public class PluginsService extends AbstractComponent {
         return plugins;
     }
 
+    public PluginsInfo info() {
+        String[] mandatoryPlugins = settings.getAsArray("plugin.mandatory", null);
+        return new PluginsInfo(
+                mandatoryPlugins == null ? null : new HashSet<String>(Arrays.asList(mandatoryPlugins)),
+                PluginsHelper.sitePlugins(this.environment),
+                plugins.keySet());
+    }
+
     public void processModules(Iterable<Module> modules) {
         for (Module module : modules) {
             processModule(module);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -73,6 +73,9 @@ public class RestNodesInfoAction extends BaseRestHandler {
         controller.registerHandler(RestRequest.Method.GET, "/_nodes/http", new RestHttpHandler());
         controller.registerHandler(RestRequest.Method.GET, "/_nodes/{nodeId}/http", new RestHttpHandler());
 
+        controller.registerHandler(RestRequest.Method.GET, "/_nodes/plugins", new RestPluginsHandler());
+        controller.registerHandler(RestRequest.Method.GET, "/_nodes/{nodeId}/plugins", new RestPluginsHandler());
+
         this.settingsFilter = settingsFilter;
     }
 
@@ -97,6 +100,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
         nodesInfoRequest.network(request.paramAsBoolean("network", nodesInfoRequest.network()));
         nodesInfoRequest.transport(request.paramAsBoolean("transport", nodesInfoRequest.transport()));
         nodesInfoRequest.http(request.paramAsBoolean("http", nodesInfoRequest.http()));
+        nodesInfoRequest.plugins(request.paramAsBoolean("plugins", nodesInfoRequest.plugins()));
 
         executeNodeRequest(request, channel, nodesInfoRequest);
     }
@@ -198,6 +202,15 @@ public class RestNodesInfoAction extends BaseRestHandler {
         public void handleRequest(final RestRequest request, final RestChannel channel) {
             NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
             nodesInfoRequest.clear().http(true);
+            executeNodeRequest(request, channel, nodesInfoRequest);
+        }
+    }
+
+    class RestPluginsHandler implements RestHandler {
+        @Override
+        public void handleRequest(final RestRequest request, final RestChannel channel) {
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            nodesInfoRequest.clear().plugins(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
     }


### PR DESCRIPTION
As #2664 got reverted and closed, here is a new pull request with an implementation, integrated in Nodes Info API.

Added parameter `plugins`.
Added end point `_nodes/plugins`.
Output information follows the struture below:

``` json
{
  "plugins" : {
    "mandatory": [],
    "sites": ["head"],
    "nonsites": ["foo"]
  }
}
```
