### PR TITLE
GeoJSONShapeParser parses JSON correctly if "crs" field is included

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
@@ -88,7 +88,7 @@ public class GeoJSONShapeParser {
                 } else if ("coordinates".equals(fieldName)) {
                     parser.nextToken();
                     node = parseCoordinates(parser);
-                } else if ("crs".equals(fieldName) || "bbox".equals(fieldName)) { // valid geojson, but not interesting
+                } else {
                     parser.nextToken();
                     parser.skipChildren();
                 }

--- a/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
@@ -80,14 +80,17 @@ public class GeoJSONShapeParser {
                 String fieldName = parser.currentName();
 
                 if ("type".equals(fieldName)) {
-                    token = parser.nextToken();
+                    parser.nextToken();
                     shapeType = parser.text().toLowerCase(Locale.ENGLISH);
                     if (shapeType == null) {
                         throw new ElasticSearchParseException("Unknown Shape type [" + parser.text() + "]");
                     }
                 } else if ("coordinates".equals(fieldName)) {
-                    token = parser.nextToken();
+                    parser.nextToken();
                     node = parseCoordinates(parser);
+                } else if ("crs".equals(fieldName) || "bbox".equals(fieldName)) { // valid geojson, but not interesting
+                    parser.nextToken();
+                    parser.skipChildren();
                 }
             }
         }

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
@@ -223,8 +223,8 @@ public class GeoJSONShapeParserTests {
                 .field("type", "point")
                 .field("bubu", "foobar")
                 .startArray("coordinates").value(100.0).value(0.0).endArray()
+                .startObject("nested").startArray("coordinates").value(200.0).value(0.0).endArray().endObject()
                 .startObject("lala").field("type", "NotAPoint").endObject()
-                .startObject("nested").startArray("coordinates").value(100.0).value(0.0).endArray().endObject()
                 .endObject().string();
 
         Point expected = GEOMETRY_FACTORY.createPoint(new Coordinate(100.0, 0.0));

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
@@ -210,6 +210,23 @@ public class GeoJSONShapeParserTests {
         assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), multiPolygonGeoJson);
     }
 
+    @Test
+    public void testThatValidGeoJsonIncludingCrsCanBeParsed() throws IOException {
+        String pointGeoJson = XContentFactory.jsonBuilder().startObject()
+                .field("type", "point")
+                .startArray("coordinates").value(100.0).value(0.0).endArray()
+                .startObject("crs")
+                    .field("type", "name")
+                    .startObject("properties")
+                        .field("name", "urn:ogc:def:crs:OGC:1.3:CRS84")
+                    .endObject()
+                .endObject()
+                .endObject().string();
+
+        Point expected = GEOMETRY_FACTORY.createPoint(new Coordinate(100.0, 0.0));
+        assertGeometryEquals(new JtsPoint(expected, GeoShapeConstants.SPATIAL_CONTEXT), pointGeoJson);
+    }
+
     private void assertGeometryEquals(Shape expected, String geoJson) throws IOException {
         XContentParser parser = JsonXContent.jsonXContent.createParser(geoJson);
         parser.nextToken();

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
@@ -211,16 +211,20 @@ public class GeoJSONShapeParserTests {
     }
 
     @Test
-    public void testThatValidGeoJsonIncludingCrsCanBeParsed() throws IOException {
+    public void testThatParserExtractsCorrectTypeAndCoordinatesFromArbitraryJson() throws IOException {
         String pointGeoJson = XContentFactory.jsonBuilder().startObject()
-                .field("type", "point")
-                .startArray("coordinates").value(100.0).value(0.0).endArray()
                 .startObject("crs")
                     .field("type", "name")
                     .startObject("properties")
                         .field("name", "urn:ogc:def:crs:OGC:1.3:CRS84")
                     .endObject()
                 .endObject()
+                .field("bbox", "foobar")
+                .field("type", "point")
+                .field("bubu", "foobar")
+                .startArray("coordinates").value(100.0).value(0.0).endArray()
+                .startObject("lala").field("type", "NotAPoint").endObject()
+                .startObject("nested").startArray("coordinates").value(100.0).value(0.0).endArray().endObject()
                 .endObject().string();
 
         Point expected = GEOMETRY_FACTORY.createPoint(new Coordinate(100.0, 0.0));


### PR DESCRIPTION
Fixes #2763

The [http://www.geojson.org/geojson-spec.html](GeoJSON spec) defines additional fields like `bbox` and `crs`. The latter one can include its own `type` field, which might overwrite the shape type in the current parser implementation.

This fix simply skips the `bbox` and `crs` fields during parsing if found, so that no overwriting happens. In addition the skipping prevents the parser from exiting too early, because of finding the end of an object.
