### PR TITLE
fixing SocketException handling in MulticastZenPing receiver

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -372,6 +372,9 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                     synchronized (receiveMutex) {
                         try {
                             multicastSocket.receive(datagramPacketReceive);
+                        } catch (SocketException ignore) {
+                            running = false;
+                            continue;
                         } catch (SocketTimeoutException ignore) {
                             continue;
                         } catch (Exception e) {


### PR DESCRIPTION
With this patch, Maven surefire test runs successful on Mac OS X 10.8 (1164 tests successful). 
Without patch, it hangs in infinite loop, logging a socket exception "socket is closed" over and over again.
