### PR TITLE
Expose zero_terms_query to the mutl_match API

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import gnu.trove.impl.Constants;
 import gnu.trove.map.hash.TObjectFloatHashMap;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder.ZeroTermsQuery;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -70,7 +69,7 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
 
     private Float cutoffFrequency = null;
 
-    private ZeroTermsQuery zeroTermsQuery = null;
+    private MatchQueryBuilder.ZeroTermsQuery zeroTermsQuery = null;
 
     /**
      * Constructs a new text query.
@@ -209,7 +208,7 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
     }
 
 
-    public MultiMatchQueryBuilder zeroTermsQuery(ZeroTermsQuery zeroTermsQuery) {
+    public MultiMatchQueryBuilder zeroTermsQuery(MatchQueryBuilder.ZeroTermsQuery zeroTermsQuery) {
         this.zeroTermsQuery = zeroTermsQuery;
         return this;
     }

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import gnu.trove.impl.Constants;
 import gnu.trove.map.hash.TObjectFloatHashMap;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder.ZeroTermsQuery;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -68,6 +69,8 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
     private Boolean lenient;
 
     private Float cutoffFrequency = null;
+
+    private ZeroTermsQuery zeroTermsQuery = null;
 
     /**
      * Constructs a new text query.
@@ -205,6 +208,12 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
         return this;
     }
 
+
+    public MultiMatchQueryBuilder zeroTermsQuery(ZeroTermsQuery zeroTermsQuery) {
+        this.zeroTermsQuery = zeroTermsQuery;
+        return this;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(MultiMatchQueryParser.NAME);
@@ -271,6 +280,10 @@ public class MultiMatchQueryBuilder extends BaseQueryBuilder implements Boostabl
 
         if (cutoffFrequency != null) {
             builder.field("cutoff_frequency", cutoffFrequency);
+        }
+
+        if (zeroTermsQuery != null) {
+            builder.field("zero_terms_query", zeroTermsQuery.toString());
         }
 
         builder.endObject();

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -149,6 +149,15 @@ public class MultiMatchQueryParser implements QueryParser {
                     multiMatchQuery.setCommonTermsCutoff(parser.floatValue());
                 } else if ("lenient".equals(currentFieldName)) {
                     multiMatchQuery.setLenient(parser.booleanValue());
+                } else if ("zero_terms_query".equals(currentFieldName)) {
+                    String zeroTermsDocs = parser.text();
+                    if ("none".equalsIgnoreCase(zeroTermsDocs)) {
+                        multiMatchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE);
+                    } else if ("all".equalsIgnoreCase(zeroTermsDocs)) {
+                        multiMatchQuery.setZeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL);
+                    } else {
+                        throw new QueryParsingException(parseContext.index(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
+                    }
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[match] query does not support [" + currentFieldName + "]");
                 }


### PR DESCRIPTION
The MatchQuery already exposes the zero_terms_query property via the match API, this exposes the same to the multi_match API by adding parsing to the MultiMatchQueryParser and building to the MultiMatchQueryBuilder.
