### PR TITLE
Tar.gz and Zip downloads are different: the tarball should have the same content as the zip

### DIFF
--- a/src/main/assemblies/targz-bin.xml
+++ b/src/main/assemblies/targz-bin.xml
@@ -9,12 +9,22 @@
 
     <fileSets>
         <fileSet>
+            <filtered>true</filtered>
+            <directory>bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <lineEnding>dos</lineEnding>
+            <includes>
+                <include>elasticsearch.bat</include>
+                <include>plugin.bat</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <filtered>true</filtered>
             <directory>bin</directory>
             <outputDirectory>bin</outputDirectory>
             <fileMode>0755</fileMode>
             <directoryMode>0755</directoryMode>
             <lineEnding>unix</lineEnding>
-            <filtered>true</filtered>
             <includes>
                 <include>elasticsearch.in.sh</include>
                 <include>elasticsearch</include>
@@ -25,9 +35,9 @@
         <fileSet>
             <directory>lib/sigar</directory>
             <outputDirectory>lib/sigar</outputDirectory>
-            <excludes>
-                <exclude>*.dll</exclude>
-            </excludes>
+            <includes>
+                <include>*</include>
+            </includes>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
@kimchy There is no reason IMHO for these to be different, which is quite surprising.

The .zip has extra files for Windows-only:

``` bin/elasticsearch.bat
bin/plugin.bat
lib/sigar/sigar-amd64-winnt.dll
lib/sigar/sigar-x86-winnt.dll
```

This means that the tar.gz distro CANNOT be used on Windows in practice.

The pull request fixes the file sets, though there is may be a simpler way to do this
