### PR TITLE
GeoJSONShapParser can parse MultiLineString and GeometryCollection

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoJSONShapeParser.java
@@ -23,10 +23,7 @@ import com.spatial4j.core.shape.Shape;
 import com.spatial4j.core.shape.impl.RectangleImpl;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.*;
 import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -152,6 +149,12 @@ public class GeoJSONShapeParser {
         } else if ("envelope".equals(shapeType)) {
             Coordinate[] coordinates = toCoordinates(node);
             return new RectangleImpl(coordinates[0].x, coordinates[1].x, coordinates[1].y, coordinates[0].y, GeoShapeConstants.SPATIAL_CONTEXT);
+        } else if ("multilinestring".equals(shapeType)) {
+            LineString[] linestrings = new LineString[node.children.size()];
+            for (int i = 0; i < node.children.size(); i++) {
+                linestrings[i] = GEOMETRY_FACTORY.createLineString(toCoordinates(node.children.get(i)));
+            }
+            return new JtsGeometry(GEOMETRY_FACTORY.createMultiLineString(linestrings), GeoShapeConstants.SPATIAL_CONTEXT, true);
         } else if ("multipolygon".equals(shapeType)) {
             Polygon[] polygons = new Polygon[node.children.size()];
             for (int i = 0; i < node.children.size(); i++) {

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
@@ -53,6 +53,34 @@ public class GeoJSONShapeParserTests {
     }
 
     @Test
+    public void testParse_multiLineString() throws IOException {
+        String multilinesGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "MultiLineString")
+                .startArray("coordinates")
+                .startArray()
+                .startArray().value(100.0).value(0.0).endArray()
+                .startArray().value(101.0).value(1.0).endArray()
+                .endArray()
+                .startArray()
+                .startArray().value(102.0).value(2.0).endArray()
+                .startArray().value(103.0).value(3.0).endArray()
+                .endArray()
+                .endArray()
+                .endObject().string();
+
+        MultiLineString expected = GEOMETRY_FACTORY.createMultiLineString(new LineString[]{
+                GEOMETRY_FACTORY.createLineString(new Coordinate[]{
+                        new Coordinate(100, 0),
+                        new Coordinate(101, 1),
+                }),
+                GEOMETRY_FACTORY.createLineString(new Coordinate[]{
+                        new Coordinate(102, 2),
+                        new Coordinate(103, 3),
+                }),
+        });
+        assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), multilinesGeoJson);
+    }
+
+    @Test
     public void testParse_polygonNoHoles() throws IOException {
         String polygonGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
                 .startArray("coordinates")
@@ -205,7 +233,7 @@ public class GeoJSONShapeParserTests {
                 shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
         Polygon withoutHoles = GEOMETRY_FACTORY.createPolygon(shell, null);
 
-        MultiPolygon expected = GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {withoutHoles, withHoles});
+        MultiPolygon expected = GEOMETRY_FACTORY.createMultiPolygon(new Polygon[]{withoutHoles, withHoles});
 
         assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), multiPolygonGeoJson);
     }

--- a/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/geo/GeoJSONShapeParserTests.java
@@ -1,5 +1,6 @@
 package org.elasticsearch.test.unit.common.geo;
 
+import com.spatial4j.core.shape.MultiShape;
 import com.spatial4j.core.shape.Shape;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
@@ -236,6 +237,39 @@ public class GeoJSONShapeParserTests {
         MultiPolygon expected = GEOMETRY_FACTORY.createMultiPolygon(new Polygon[]{withoutHoles, withHoles});
 
         assertGeometryEquals(new JtsGeometry(expected, GeoShapeConstants.SPATIAL_CONTEXT, false), multiPolygonGeoJson);
+    }
+
+    @Test
+    public void testParse_geometryCollection() throws IOException {
+        String geometryCollectionGeoJson = XContentFactory.jsonBuilder().startObject()
+                .field("type","GeometryCollection")
+                .startArray("geometries")
+                    .startObject()
+                        .field("type", "LineString")
+                        .startArray("coordinates")
+                            .startArray().value(100.0).value(0.0).endArray()
+                            .startArray().value(101.0).value(1.0).endArray()
+                        .endArray()
+                    .endObject()
+                    .startObject()
+                        .field("type", "Point")
+                        .startArray("coordinates").value(102.0).value(2.0).endArray()
+                    .endObject()
+                .endArray()
+                .endObject()
+                .string();
+
+        List<Shape> expected = new ArrayList<Shape>();
+        LineString expectedLineString = GEOMETRY_FACTORY.createLineString(new Coordinate[]{
+                new Coordinate(100, 0),
+                new Coordinate(101, 1),
+        });
+        expected.add(new JtsGeometry(expectedLineString, GeoShapeConstants.SPATIAL_CONTEXT, false));
+        Point expectedPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(102.0, 2.0));
+        expected.add(new JtsPoint(expectedPoint, GeoShapeConstants.SPATIAL_CONTEXT));
+
+        //equals returns true only if geometries are in the same order
+        assertGeometryEquals(new MultiShape(expected, GeoShapeConstants.SPATIAL_CONTEXT), geometryCollectionGeoJson);
     }
 
     @Test


### PR DESCRIPTION
Here is an update of the GeoJSON Shape Parser so it can parse MultiLineString and GeometryCollection.

As far as I know, this was the only reason why elasticsearch geo_shape type was not supporting MultiLineString and GeometryCollection.
