### PR TITLE
Allow to update ttl field mapping after initial creation. Fixes #2136

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/EnabledAttributeMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/EnabledAttributeMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper.internal;
+
+public enum EnabledAttributeMapper {
+    ENABLED(true), UNSET_ENABLED(true), DISABLED(false), UNSET_DISABLED(false);
+
+    public final boolean enabled;
+
+    EnabledAttributeMapper(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean unset() {
+        return this == UNSET_DISABLED || this == UNSET_ENABLED;
+    }
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/ttl/TTLMappingTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/ttl/TTLMappingTests.java
@@ -70,7 +70,7 @@ public class TTLMappingTests {
     public void testDefaultValues() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().string();
         DocumentMapper docMapper = MapperTests.newParser().parse(mapping);
-        assertThat(docMapper.TTLFieldMapper().enabled(), equalTo(TTLFieldMapper.Defaults.ENABLED));
+        assertThat(docMapper.TTLFieldMapper().enabled(), equalTo(TTLFieldMapper.Defaults.ENABLED_STATE.enabled));
         assertThat(docMapper.TTLFieldMapper().fieldType().stored(), equalTo(TTLFieldMapper.Defaults.TTL_FIELD_TYPE.stored()));
         assertThat(docMapper.TTLFieldMapper().fieldType().indexed(), equalTo(TTLFieldMapper.Defaults.TTL_FIELD_TYPE.indexed()));
     }
@@ -87,5 +87,54 @@ public class TTLMappingTests {
         assertThat(docMapper.TTLFieldMapper().enabled(), equalTo(true));
         assertThat(docMapper.TTLFieldMapper().fieldType().stored(), equalTo(false));
         assertThat(docMapper.TTLFieldMapper().fieldType().indexed(), equalTo(false));
+    }
+
+    @Test
+    public void testThatEnablingTTLFieldOnMergeWorks() throws Exception {
+        String mappingWithoutTtl = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").field("field").startObject().field("type", "string").endObject().endObject()
+                .endObject().endObject().string();
+
+        String mappingWithTtl = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_ttl")
+                .field("enabled", "yes").field("store", "no").field("index", "no")
+                .endObject()
+                .startObject("properties").field("field").startObject().field("type", "string").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapperWithoutTtl = MapperTests.newParser().parse(mappingWithoutTtl);
+        DocumentMapper mapperWithTtl = MapperTests.newParser().parse(mappingWithTtl);
+
+        DocumentMapper.MergeFlags mergeFlags = DocumentMapper.MergeFlags.mergeFlags().simulate(false);
+        DocumentMapper.MergeResult mergeResult = mapperWithoutTtl.merge(mapperWithTtl, mergeFlags);
+
+        assertThat(mergeResult.hasConflicts(), equalTo(false));
+        assertThat(mapperWithoutTtl.TTLFieldMapper().enabled(), equalTo(true));
+    }
+
+    @Test
+    public void testThatChangingTTLKeepsMapperEnabled() throws Exception {
+        String mappingWithTtl = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_ttl")
+                .field("enabled", "yes")
+                .endObject()
+                .startObject("properties").field("field").startObject().field("type", "string").endObject().endObject()
+                .endObject().endObject().string();
+
+        String updatedMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_ttl")
+                .field("default", "1w")
+                .endObject()
+                .startObject("properties").field("field").startObject().field("type", "string").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper initialMapper = MapperTests.newParser().parse(mappingWithTtl);
+        DocumentMapper updatedMapper = MapperTests.newParser().parse(updatedMapping);
+
+        DocumentMapper.MergeFlags mergeFlags = DocumentMapper.MergeFlags.mergeFlags().simulate(false);
+        DocumentMapper.MergeResult mergeResult = initialMapper.merge(updatedMapper, mergeFlags);
+
+        assertThat(mergeResult.hasConflicts(), equalTo(false));
+        assertThat(initialMapper.TTLFieldMapper().enabled(), equalTo(true));
     }
 }


### PR DESCRIPTION
Several field mappers cannot be changed via the Mapping API after initial creation. However I do not see something speaking against this, see bug report #2136...

This PR allows the TTL field mapper to be enabled or disabled at runtime.
