### PR TITLE
Fix for #2837 by checking if all the indices were missing and failing that.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -505,6 +505,10 @@ public class MetaData implements Iterable<IndexMetaData> {
             String[] actualLst = aliasAndIndexToIndexMap.get(aliasOrIndex);
             if (actualLst == null) {
                 if (ignoreIndices == IgnoreIndices.MISSING) {
+                	//if nothing was found but something requested break for this will cause you to search everything instead
+                    if(aliasesOrIndices != null && aliasesOrIndices.length > 0) {
+                    	throw new IndexMissingException(new Index(Arrays.toString(aliasesOrIndices)));
+                    }
                     return Strings.EMPTY_ARRAY;
                 }
                 throw new IndexMissingException(new Index(aliasOrIndex));
@@ -539,6 +543,12 @@ public class MetaData implements Iterable<IndexMetaData> {
                 }
             }
         }
+        
+        //if nothing was found but something requested break for this will cause you to search everything instead
+        if(aliasesOrIndices != null && aliasesOrIndices.length > 0 && actualIndices.isEmpty()) {
+        	throw new IndexMissingException(new Index(Arrays.toString(aliasesOrIndices)));
+        }
+        
         return actualIndices.toArray(new String[actualIndices.size()]);
     }
 

--- a/src/test/java/org/elasticsearch/test/integration/indices/IgnoreIndicesTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/IgnoreIndicesTests.java
@@ -53,6 +53,28 @@ public class IgnoreIndicesTests extends AbstractNodesTests {
     }
 
     @Test
+    public void testAllMissing() throws Exception {
+    	client.admin().indices().prepareDelete().execute().actionGet();
+    	client.admin().indices().prepareCreate("test1").execute().actionGet();
+        ClusterHealthResponse clusterHealthResponse = client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet();
+        assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
+        try {
+            client.prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()).setIgnoreIndices(IgnoreIndices.MISSING).execute().actionGet();
+            fail("Exception should have been thrown.");
+        } catch (IndexMissingException e) {
+        }
+        
+        try {
+            client.prepareSearch("test2","test3").setQuery(QueryBuilders.matchAllQuery()).setIgnoreIndices(IgnoreIndices.MISSING).execute().actionGet();
+            fail("Exception should have been thrown.");
+        } catch (IndexMissingException e) {
+        }
+      
+        //you should still be able to run empty searches without things blowing up
+        client.prepareSearch().setQuery(QueryBuilders.matchAllQuery()).setIgnoreIndices(IgnoreIndices.MISSING).execute().actionGet();
+    }
+    
+    @Test
     public void testMissing() throws Exception {
         client.admin().indices().prepareDelete().execute().actionGet();
 

--- a/src/test/java/org/elasticsearch/test/unit/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/cluster/metadata/MetaDataTests.java
@@ -24,7 +24,10 @@ import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.indices.IndexMissingException;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Sets;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -65,5 +68,41 @@ public class MetaDataTests {
 
     private IndexMetaData.Builder indexBuilder(String index) {
         return IndexMetaData.builder(index).settings(ImmutableSettings.settingsBuilder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
+    }
+    
+    @Test(expectedExceptions = IndexMissingException.class)
+    public void concreteIndicesIgnoreIndicesOneMissingIndex() {
+    	 MetaData.Builder mdBuilder = MetaData.builder()
+                 .put(indexBuilder("testXXX"))
+                 .put(indexBuilder("kuku"));
+         MetaData md = mdBuilder.build();
+         md.concreteIndices(new String[]{"testZZZ"}, IgnoreIndices.MISSING, true);
+    }
+    
+    @Test
+    public void concreteIndicesIgnoreIndicesOneMissingIndexOtherFound() {
+    	 MetaData.Builder mdBuilder = MetaData.builder()
+                 .put(indexBuilder("testXXX"))
+                 .put(indexBuilder("kuku"));
+         MetaData md = mdBuilder.build();
+        assertThat(newHashSet(md.concreteIndices(new String[]{"testXXX","testZZZ"}, IgnoreIndices.MISSING, true)), equalTo(newHashSet("testXXX")));
+    }
+
+    @Test(expectedExceptions = IndexMissingException.class)
+    public void concreteIndicesIgnoreIndicesAllMissing() {
+    	 MetaData.Builder mdBuilder = MetaData.builder()
+                 .put(indexBuilder("testXXX"))
+                 .put(indexBuilder("kuku"));
+         MetaData md = mdBuilder.build();
+        assertThat(newHashSet(md.concreteIndices(new String[]{"testMo","testMahdy"}, IgnoreIndices.MISSING, true)), equalTo(newHashSet("testXXX")));
+    }
+    
+    @Test
+    public void concreteIndicesIgnoreIndicesEmptyRequest() {
+    	 MetaData.Builder mdBuilder = MetaData.builder()
+                 .put(indexBuilder("testXXX"))
+                 .put(indexBuilder("kuku"));
+         MetaData md = mdBuilder.build();
+        assertThat(newHashSet(md.concreteIndices(new String[]{}, IgnoreIndices.MISSING, true)), equalTo(Sets.<String>newHashSet("kuku","testXXX")));
     }
 }


### PR DESCRIPTION
setting ignore_indices=missing will fail your query if all the indices are missing as opposed to making your query run against everything.. fixes #2837
