### PR TITLE
Implementation to support geo circles (closes #2713)

### DIFF
--- a/src/test/java/org/elasticsearch/test/integration/search/geo/GeoShapeIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/geo/GeoShapeIntegrationTests.java
@@ -23,13 +23,19 @@ import com.spatial4j.core.shape.Shape;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.geo.GeoJSONShapeParser;
 import org.elasticsearch.common.geo.GeoJSONShapeSerializer;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.test.integration.AbstractNodesTests;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
 
 import static org.elasticsearch.common.geo.ShapeBuilder.newRectangle;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -37,6 +43,7 @@ import static org.elasticsearch.index.query.FilterBuilders.geoShapeFilter;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class GeoShapeIntegrationTests extends AbstractNodesTests {
 
@@ -203,4 +210,112 @@ public class GeoShapeIntegrationTests extends AbstractNodesTests {
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
     }
+
+    @Test
+    public void testThatIndexingAndSearchForCircleShapeWorks() throws IOException {
+        client.admin().indices().prepareDelete().execute().actionGet();
+
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .endObject().endObject()
+                .endObject().endObject().string();
+        client.admin().indices().prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
+        client.admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+
+        client.prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
+                .field("name", "Document 1")
+                .startObject("location")
+                .field("type", "circle")
+                .startArray("coordinates").value(10).value(10).endArray()
+                .field("radius", 2.0)
+                .endObject()
+                .endObject()).execute().actionGet();
+
+        client.admin().indices().prepareRefresh().execute().actionGet();
+
+        Shape shape = newRectangle().topLeft(-5, 40).bottomRight(40, -5).build();
+
+        QueryBuilder query = filteredQuery(matchAllQuery(), geoShapeFilter("location", shape));
+        SearchResponse searchResponse = client.prepareSearch()
+                .setQuery(query)
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
+    }
+
+    @Test
+    public void testThatPointsAreMatchedCorrectlyInCircle() throws IOException {
+        client.admin().indices().prepareDelete().execute().actionGet();
+
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "quadtree")
+                .field("precision", "10m")
+                .endObject().endObject()
+                .endObject().endObject().string();
+        client.admin().indices().prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
+        client.admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+
+        // index amsterdam
+        client.prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
+                .field("name", "Park Hotel Amsterdam")
+                .startObject("location")
+                .field("type", "point")
+                .startArray("coordinates").value(4.883208).value(52.362105).endArray()
+                //.startArray("coordinates").value(52.37125).value(4.895439).endArray()
+                .endObject()
+                .endObject()).execute().actionGet();
+
+        // index amsterdam schiphol airport
+        client.prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject()
+                .field("name", "Schiphol Airport")
+                .startObject("location")
+                .field("type", "point")
+                .startArray("coordinates").value(4.77253).value(52.313096).endArray()
+                //.startArray("coordinates").value(52.313096).value(4.77253).endArray()
+                .endObject()
+                .endObject()).execute().actionGet();
+
+        client.admin().indices().prepareRefresh().execute().actionGet();
+
+        // query for everything 10km around amsterdam centre, therefore excluding schiphol
+        XContentParser parser = JsonXContent.jsonXContent.createParser(
+                jsonBuilder().startObject().field("type", "circle")
+                        .startArray("coordinates").value(4.895439).value(52.37125).endArray()
+                        .field("radius", "10km")
+                        .endObject().string());
+        parser.nextToken();
+        Shape circleAroundAmsterdam = GeoJSONShapeParser.parse(parser);
+
+        QueryBuilder query = filteredQuery(matchAllQuery(), geoShapeFilter("location", circleAroundAmsterdam));
+        SearchResponse searchResponse = client.prepareSearch()
+                .setQuery(query)
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(0).sourceAsMap().get("name").toString(), is("Park Hotel Amsterdam"));
+
+        // now do the same with a bigger radius, therefore schiphol is included
+        parser = JsonXContent.jsonXContent.createParser(
+                jsonBuilder().startObject().field("type", "circle")
+                        .startArray("coordinates").value(4.895439).value(52.37125).endArray()
+                        .field("radius", 20000)
+                        .endObject().string());
+        parser.nextToken();
+        Shape biggerCircleAroundAmsterdam = GeoJSONShapeParser.parse(parser);
+
+        query = filteredQuery(matchAllQuery(), geoShapeFilter("location", biggerCircleAroundAmsterdam));
+        searchResponse = client.prepareSearch()
+                .setQuery(query)
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().hits().length, equalTo(2));
+    }
+
 }


### PR DESCRIPTION
This one is based on spatial4j in order to prevent the creation of an own geo_circle type.

The GeoJSON standard does not support circles. A proposal for this has been rejected:
https://github.com/GeoJSONWG/geojson-spec/wiki/Proposal---Circles-and-Ellipses-Geoms

This implementation extends the geo_shape parsers and serializers to support circles.

It works like this:

```
curl -X DELETE localhost:9200/geotest
curl -X PUT localhost:9200/geotest
curl -X PUT localhost:9200/geotest/geotest/_mapping -d '{ "geotest": { "properties":  { "location" : { "type":"geo_shape" } } } }'

curl -X PUT localhost:9200/geotest/geotest/parkhotel?refresh=true -d '{ "name":"Park Hotel Amsterdam", "location" : { "type" : "point", "coordinates" : [4.883208, 52.362105] } }'
curl -X PUT localhost:9200/geotest/geotest/schiphol?refresh=true -d '{ "name":"Schiphol Airport", "location" : { "type" : "point", "coordinates" : [4.77253, 52.313096] } }'

echo "Querying with a radius of 10km (excluding the airport)"
curl -X POST localhost:9200/geotest/geotest/_search -d '{
  "from":"0",
  "size":"10",
  "query" : {
    "filtered" : {
      "query": { "match_all" : {} },
      "filter" : {
        "geo_shape" : {
          "location" : {
            "shape" : {
              "type" : "circle",
              "coordinates" : [ 4.895439, 52.37125 ],
              "radius": "10"
            }
          }
        }
      }
    }
  }
}'

echo "Querying with a radius of 15km (including the airport)"
curl -X POST localhost:9200/geotest/geotest/_search -d '{
  "from":"0",
  "size":"10",
  "query" : {
    "filtered" : {
      "query": { "match_all" : {} },
      "filter" : {
        "geo_shape" : {
          "location" : {
            "shape" : {
              "type" : "circle",
              "coordinates" : [ 4.895439, 52.37125 ],
              "radius": "15"
            }
          }
        }
      }
    }
  }
}'
```

TODO:
- Add real corner case tests
