### PR TITLE
Apply minimum_should_match to inner clauses of multi_match query

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -21,10 +21,8 @@ package org.elasticsearch.index.query;
 
 import com.google.common.collect.Maps;
 import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.support.QueryParsers;
@@ -172,13 +170,9 @@ public class MultiMatchQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext.index(), "No fields specified for match_all query");
         }
 
-        Query query = multiMatchQuery.parse(type, fieldNameWithBoosts, value);
+        Query query = multiMatchQuery.parse(type, fieldNameWithBoosts, value,minimumShouldMatch);
         if (query == null) {
             return null;
-        }
-
-        if (query instanceof BooleanQuery) {
-            Queries.applyMinimumShouldMatch((BooleanQuery) query, minimumShouldMatch);
         }
 
         query.setBoost(boost);


### PR DESCRIPTION
When specifying minimum_should_match in a multi_match query it was being applied
to the outer bool query instead of to each of the inner field-specific bool queries.

Closes #2918
