### PR TITLE
Added stolen time to OsStats output

### DIFF
--- a/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -114,6 +114,7 @@ public class OsStats implements Streamable, Serializable, ToXContent {
         static final XContentBuilderString SYS = new XContentBuilderString("sys");
         static final XContentBuilderString USER = new XContentBuilderString("user");
         static final XContentBuilderString IDLE = new XContentBuilderString("idle");
+        static final XContentBuilderString STOLEN = new XContentBuilderString("stolen");
 
         static final XContentBuilderString MEM = new XContentBuilderString("mem");
         static final XContentBuilderString SWAP = new XContentBuilderString("swap");
@@ -154,6 +155,7 @@ public class OsStats implements Streamable, Serializable, ToXContent {
             builder.field(Fields.SYS, cpu.sys());
             builder.field(Fields.USER, cpu.user());
             builder.field(Fields.IDLE, cpu.idle());
+            builder.field(Fields.STOLEN, cpu.stolen());
             builder.endObject();
         }
 
@@ -370,6 +372,7 @@ public class OsStats implements Streamable, Serializable, ToXContent {
         short sys = -1;
         short user = -1;
         short idle = -1;
+        short stolen = -1;
 
         Cpu() {
 
@@ -386,6 +389,7 @@ public class OsStats implements Streamable, Serializable, ToXContent {
             sys = in.readShort();
             user = in.readShort();
             idle = in.readShort();
+            stolen = in.readShort();
         }
 
         @Override
@@ -393,6 +397,7 @@ public class OsStats implements Streamable, Serializable, ToXContent {
             out.writeShort(sys);
             out.writeShort(user);
             out.writeShort(idle);
+            out.writeShort(stolen);
         }
 
         public short sys() {
@@ -417,6 +422,14 @@ public class OsStats implements Streamable, Serializable, ToXContent {
 
         public short getIdle() {
             return idle();
+        }
+
+        public short stolen() {
+            return stolen;
+        }
+
+        public short getStolen() {
+            return stolen();
         }
     }
 }

--- a/src/main/java/org/elasticsearch/monitor/os/SigarOsProbe.java
+++ b/src/main/java/org/elasticsearch/monitor/os/SigarOsProbe.java
@@ -101,6 +101,7 @@ public class SigarOsProbe extends AbstractComponent implements OsProbe {
             stats.cpu.sys = (short) (cpuPerc.getSys() * 100);
             stats.cpu.user = (short) (cpuPerc.getUser() * 100);
             stats.cpu.idle = (short) (cpuPerc.getIdle() * 100);
+            stats.cpu.stolen = (short) (cpuPerc.getStolen() * 100);
         } catch (SigarException e) {
             // ignore
         }


### PR DESCRIPTION
Sigar supports stolen time, this adds support in OsStats for it.

Stolen time is important for virtualized environments, as it can tell possibly you if other systems are limiting performance.

We have to find out and document if this helps in virtualized blackbox environments like AWS (in order to be sure if this number is accurate).
