### PR TITLE
Fixing possible NoClassDefFoundError bubbling from SettingsBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -332,13 +332,19 @@ public class ImmutableSettings implements Settings {
             try {
                 return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
             } catch (ClassNotFoundException e1) {
-                fullClassName = prefixValue + toCamelCase(sValue).toLowerCase() + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
-                try {
-                    return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
-                } catch (ClassNotFoundException e2) {
-                    throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + get(setting) + "]", e2);
-                }
+                return loadClass(prefixValue, sValue, suffixClassName, setting);
+            } catch (NoClassDefFoundError e1) {
+                return loadClass(prefixValue, sValue, suffixClassName, setting);
             }
+        }
+    }
+
+    private <T> Class<? extends T> loadClass(String prefixValue, String sValue, String suffixClassName, String setting) {
+        String fullClassName = prefixValue + toCamelCase(sValue).toLowerCase() + "." + Strings.capitalize(toCamelCase(sValue)) + suffixClassName;
+        try {
+            return (Class<? extends T>) getClassLoader().loadClass(fullClassName);
+        } catch (ClassNotFoundException e2) {
+            throw new NoClassSettingsException("Failed to load class setting [" + setting + "] with value [" + get(setting) + "]", e2);
         }
     }
 

--- a/src/test/java/org/elasticsearch/test/unit/common/settings/ImmutableSettingsTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/settings/ImmutableSettingsTests.java
@@ -81,4 +81,10 @@ public class ImmutableSettingsTests {
         assertThat(settings.toDelimitedString(';'), equalTo("key1=value1;key2=value2;"));
     }
 
+    @Test(expectedExceptions = NoClassSettingsException.class)
+    public void testThatAllClassNotFoundExceptionsAreCaught() {
+        // this should be nGram in order to really work, but for sure not not throw a NoClassDefFoundError
+        Settings settings = settingsBuilder().put("type", "ngram").build();
+        settings.getAsClass("type", null, "org.elasticsearch.index.analysis.", "TokenFilterFactory");
+    }
 }


### PR DESCRIPTION
In order to handle exceptions correctly, when classes are not found, one
needs to handle ClassNotFoundException as well as NoClassDefFoundError
in order to be sure to have caught every possible case. We did not cater
for the latter in ImmutableSettings yet.

This fix is just executing the same logic for both exceptions instead of
simply bubbling up NoClassDefFoundError.

I still do not like the notion of loading classes via the SettingsBuilder, but that is a another issue :-)
