### PR TITLE
Set http headers on the response in a java plugin

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -36,6 +36,8 @@ import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.handler.codec.http.*;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -88,6 +90,16 @@ public class NettyHttpChannel implements HttpChannel {
         String opaque = request.getHeader("X-Opaque-Id");
         if (opaque != null) {
             resp.addHeader("X-Opaque-Id", opaque);
+        }
+
+        // Add all custom headers
+        Map<String, List<String>> customHeaders = response.getHeaders();
+        if (customHeaders != null) {
+            for (Map.Entry<String, List<String>> headerEntry : customHeaders.entrySet()) {
+                for (String headerValue : headerEntry.getValue()) {
+                    resp.addHeader(headerEntry.getKey(), headerValue);
+                }
+            }
         }
 
         // Convert the response content to a ChannelBuffer.

--- a/src/main/java/org/elasticsearch/rest/AbstractRestResponse.java
+++ b/src/main/java/org/elasticsearch/rest/AbstractRestResponse.java
@@ -19,10 +19,17 @@
 
 package org.elasticsearch.rest;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
 /**
  *
  */
 public abstract class AbstractRestResponse implements RestResponse {
+
+    Map<String, List<String>> customHeaders;
 
     @Override
     public byte[] prefixContent() {
@@ -52,5 +59,23 @@ public abstract class AbstractRestResponse implements RestResponse {
     @Override
     public int suffixContentOffset() {
         return 0;
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+        if (customHeaders == null) {
+            customHeaders = new HashMap<String, List<String>>();
+        }
+        List<String> header = customHeaders.get(name);
+        if (header == null) {
+            header = new ArrayList<String>();
+            customHeaders.put(name, header);
+        }
+        header.add(value);
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return customHeaders;
     }
 }

--- a/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.rest;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -59,4 +61,11 @@ public interface RestResponse {
     int suffixContentOffset();
 
     RestStatus status();
+
+    void addHeader(String name, String value);
+
+    /**
+     * @return The custom headers or null if none have been set
+     */
+    Map<String, List<String>> getHeaders();
 }

--- a/src/test/java/org/elasticsearch/test/integration/plugin/CustomHeaderPluginTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/plugin/CustomHeaderPluginTests.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.plugin;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.client.Requests.clusterHealthRequest;
+import static org.elasticsearch.test.integration.nodesinfo.plugin.dummyfilter.TestHttpServer.HEADER_NAME;
+import static org.elasticsearch.test.integration.nodesinfo.plugin.dummyfilter.TestHttpServer.HEADER_VALUE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.elasticsearch.test.integration.rest.helper.HttpClient;
+import org.elasticsearch.test.integration.rest.helper.HttpClientResponse;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+
+import java.io.File;
+
+/**
+ * Test a java plugin that replaces the http server and retruns a response
+ * with a custom header.
+ */
+public class CustomHeaderPluginTests extends AbstractNodesTests {
+
+    @BeforeMethod
+    public void startNode() throws Exception {
+    	String name = "test";
+        URL resource = CustomHeaderPluginTests.class.getResource("/org/elasticsearch/test/integration/customheader/");
+        ImmutableSettings.Builder settings = settingsBuilder();
+        if (resource != null) {
+            settings.put("path.plugins", new File(resource.toURI()).getAbsolutePath());
+        }
+
+        startNode(name, settings);
+
+        // We wait for a Green status
+        client(name).admin().cluster().health(clusterHealthRequest().waitForGreenStatus()).actionGet();
+
+        String serverNodeId = ((InternalNode) node(name)).injector()
+                .getInstance(ClusterService.class).state().nodes().localNodeId();
+        logger.debug("--> server {} started" + serverNodeId);
+    }
+
+    @AfterMethod
+    public void closeNodes() {
+        closeAllNodes();
+    }
+
+    public HttpClient httpClient(String id) {
+        HttpServerTransport httpServerTransport = ((InternalNode) node(id)).injector().getInstance(HttpServerTransport.class);
+        return new HttpClient(httpServerTransport.boundAddress().publishAddress());
+    }
+
+    @Test
+    public void testCustomHeaderPlugin() throws Exception {
+        // We use an HTTP Client to test redirection
+        HttpClientResponse response = httpClient("test").request("/_plugin/dummyfilter1");
+        assertThat(response.errorCode(), equalTo(RestStatus.UNAUTHORIZED.getStatus()));
+        assertThat(response.getHeader(HEADER_NAME), equalTo(HEADER_VALUE));
+    }
+
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/plugin/dummyfilter/TestCustomResponseHeaderPlugin.java
+++ b/src/test/java/org/elasticsearch/test/integration/plugin/dummyfilter/TestCustomResponseHeaderPlugin.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.nodesinfo.plugin.dummyfilter;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Collection;
+
+public class TestCustomResponseHeaderPlugin extends AbstractPlugin {
+
+    static final public class Fields {
+        static public final String NAME = "test-plugin-custom-header";
+        static public final String DESCRIPTION = NAME + " description";
+    }
+
+    private final Settings settings;
+
+    @Inject public TestCustomResponseHeaderPlugin(Settings settings) {
+        this.settings = settings;
+    }
+    @Override
+    public String name() {
+        return Fields.NAME;
+    }
+
+    @Override
+    public String description() {
+        return Fields.DESCRIPTION;
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> modules() {
+        Collection<Class<? extends Module>> modules = newArrayList();
+        modules.add(TestHttpServerModule.class);
+        return modules;
+    }
+
+    @Override
+    public Collection<Class<? extends LifecycleComponent>> services() {
+        Collection<Class<? extends LifecycleComponent>> services = newArrayList();
+        services.add(TestHttpServer.class);
+        return services;
+    }
+
+    @Override
+    public Settings additionalSettings() {
+        return ImmutableSettings.settingsBuilder().put("http.enabled", false).build();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/plugin/dummyfilter/TestHttpServer.java
+++ b/src/test/java/org/elasticsearch/test/integration/plugin/dummyfilter/TestHttpServer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.nodesinfo.plugin.dummyfilter;
+
+import org.elasticsearch.http.HttpChannel;
+import org.elasticsearch.http.HttpRequest;
+import org.elasticsearch.http.HttpServer;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.Base64;
+
+import org.elasticsearch.rest.RestRequest;
+
+import static org.elasticsearch.rest.RestStatus.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.rest.RestRequest.Method;
+import org.elasticsearch.rest.StringRestResponse;
+
+public class TestHttpServer extends HttpServer {
+
+    public static String HEADER_NAME = "WWW-Authenticate";
+    public static String HEADER_VALUE = "Basic realm='insert realm'";
+
+    @Inject
+    public TestHttpServer(Settings settings, Environment environment, HttpServerTransport transport,
+            RestController restController, NodeService nodeService) {
+        super(settings, environment, transport, restController, nodeService);
+    }
+
+    @Override
+    public void internalDispatchRequest(HttpRequest request, HttpChannel channel) {
+    	System.err.println("Adding the header!");
+    	//channel.addHeader("foo", "bar");
+		//super.internalDispatchRequest(request, channel);
+		StringRestResponse resp = new StringRestResponse(UNAUTHORIZED, "Authentication Required");
+		resp.addHeader(HEADER_NAME, HEADER_VALUE);
+		channel.sendResponse(resp);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/plugin/dummyfilter/TestHttpServerModule.java
+++ b/src/test/java/org/elasticsearch/test/integration/plugin/dummyfilter/TestHttpServerModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.nodesinfo.plugin.dummyfilter;
+
+import org.elasticsearch.http.HttpServerModule;
+import org.elasticsearch.common.settings.Settings;
+
+public class TestHttpServerModule extends HttpServerModule {
+    
+    public TestHttpServerModule(Settings settings) {
+        super(settings);
+    }
+    
+    @Override
+    protected void configure() {
+        bind(TestHttpServer.class).asEagerSingleton();
+    }
+}
+

--- a/src/test/java/org/elasticsearch/test/integration/rest/helper/HttpClientResponse.java
+++ b/src/test/java/org/elasticsearch/test/integration/rest/helper/HttpClientResponse.java
@@ -18,15 +18,20 @@
  */
 package org.elasticsearch.test.integration.rest.helper;
 
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 public class HttpClientResponse {
     private final String response;
     private final int errorCode;
+    private Map<String, List<String>> headers;
     private final Throwable e;
 
-    public HttpClientResponse(String response, int errorCode, Throwable e) {
+    public HttpClientResponse(String response, int errorCode, Map<String, List<String>> headers,  Throwable e) {
         this.response = response;
         this.errorCode = errorCode;
+        this.headers = headers;
         this.e = e;
     }
 
@@ -40,5 +45,20 @@ public class HttpClientResponse {
 
     public Throwable cause() {
         return e;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public String getHeader(String name) {
+        if (headers == null) {
+            return null;
+        }
+        List<String> vals = headers.get(name);
+        if (vals == null || vals.size() == 0) {
+            return null;
+        }
+        return vals.iterator().next();
     }
 }

--- a/src/test/resources/org/elasticsearch/test/integration/customheader/dummy-plugin/es-plugin.properties
+++ b/src/test/resources/org/elasticsearch/test/integration/customheader/dummy-plugin/es-plugin.properties
@@ -1,0 +1,20 @@
+################################################################
+# Licensed to ElasticSearch and Shay Banon under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. ElasticSearch licenses this
+# file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+################################################################
+plugin=org.elasticsearch.test.integration.nodesinfo.plugin.dummyfilter.TestCustomResponseHeaderPlugin
+


### PR DESCRIPTION
Taking up the work started by @spinscale in https://github.com/elasticsearch/elasticsearch/pull/2723

"this patch allows to set custom headers in HTTP responses (like setting the WWW-Authenticate header for basic auth) by adding RestRequest.addHeader() method."

The extra hashmap is created lazily so this has no overhead for the core ES requests.
This patch only deals with http-header and has nothing related to redirection.

I hope this helps!
