### PR TITLE
Support source include/exclude for realtime GET

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -214,6 +214,14 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
         return this.enabled;
     }
 
+    public String[] excludes() {
+        return this.excludes;
+
+    }
+    public String[] includes() {
+        return this.includes;
+    }
+
     @Override
     public FieldType defaultFieldType() {
         return Defaults.FIELD_TYPE;

--- a/src/test/java/org/elasticsearch/test/integration/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/get/GetActionTests.java
@@ -381,4 +381,118 @@ public class GetActionTests extends AbstractNodesTests {
         assertThat(((List) response.getFields().get("field").getValues().get(0)).get(1).toString(), equalTo("2"));
     }
 
+    @Test
+    public void testThatGetFromTranslogShouldWorkWithExclude() throws Exception {
+        client.admin().indices().prepareDelete().execute().actionGet();
+        String index = "test";
+        String type = "type1";
+
+        String mapping = jsonBuilder()
+                .startObject()
+                    .startObject("source_excludes")
+                        .startObject("_source")
+                            .array("excludes", "excluded")
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .string();
+
+        client.admin().indices().prepareCreate(index)
+                .addMapping(type, mapping)
+                .setSettings(ImmutableSettings.settingsBuilder().put("index.refresh_interval", -1))
+                .execute().actionGet();
+
+        client.prepareIndex(index, type, "1")
+                .setSource(jsonBuilder().startObject().field("field", "1", "2").field("excluded", "should not be seen").endObject())
+                .execute().actionGet();
+
+        GetResponse responseBeforeFlush = client.prepareGet(index, type, "1").execute().actionGet();
+        client.admin().indices().prepareFlush(index).execute().actionGet();
+        GetResponse responseAfterFlush = client.prepareGet(index, type, "1").execute().actionGet();
+
+        assertThat(responseBeforeFlush.isExists(), is(true));
+        assertThat(responseAfterFlush.isExists(), is(true));
+        assertThat(responseBeforeFlush.getSourceAsMap(), hasKey("field"));
+        assertThat(responseBeforeFlush.getSourceAsMap(), not(hasKey("excluded")));
+        assertThat(responseBeforeFlush.getSourceAsString(), is(responseAfterFlush.getSourceAsString()));
+    }
+
+    @Test
+    public void testThatGetFromTranslogShouldWorkWithInclude() throws Exception {
+        client.admin().indices().prepareDelete().execute().actionGet();
+        String index = "test";
+        String type = "type1";
+
+        String mapping = jsonBuilder()
+            .startObject()
+                .startObject("source_excludes")
+                    .startObject("_source")
+                        .array("includes", "included")
+                    .endObject()
+                .endObject()
+            .endObject()
+            .string();
+
+        client.admin().indices().prepareCreate(index)
+                .addMapping(type, mapping)
+                .setSettings(ImmutableSettings.settingsBuilder().put("index.refresh_interval", -1))
+                .execute().actionGet();
+
+        client.prepareIndex(index, type, "1")
+                .setSource(jsonBuilder().startObject().field("field", "1", "2").field("included", "should be seen").endObject())
+                .execute().actionGet();
+
+        GetResponse responseBeforeFlush = client.prepareGet(index, type, "1").execute().actionGet();
+        client.admin().indices().prepareFlush(index).execute().actionGet();
+        GetResponse responseAfterFlush = client.prepareGet(index, type, "1").execute().actionGet();
+
+        assertThat(responseBeforeFlush.isExists(), is(true));
+        assertThat(responseAfterFlush.isExists(), is(true));
+        assertThat(responseBeforeFlush.getSourceAsMap(), not(hasKey("field")));
+        assertThat(responseBeforeFlush.getSourceAsMap(), hasKey("included"));
+        assertThat(responseBeforeFlush.getSourceAsString(), is(responseAfterFlush.getSourceAsString()));
+    }
+
+    @Test
+    public void testThatGetFromTranslogShouldWorkWithIncludeExcludeAndFields() throws Exception {
+        client.admin().indices().prepareDelete().execute().actionGet();
+        String index = "test";
+        String type = "type1";
+
+        String mapping = jsonBuilder()
+            .startObject()
+                .startObject("source_excludes")
+                    .startObject("_source")
+                        .array("includes", "included")
+                        .array("exlcudes", "excluded")
+                    .endObject()
+                .endObject()
+            .endObject()
+            .string();
+
+        client.admin().indices().prepareCreate(index)
+                .addMapping(type, mapping)
+                .setSettings(ImmutableSettings.settingsBuilder().put("index.refresh_interval", -1))
+                .execute().actionGet();
+
+        client.prepareIndex(index, type, "1")
+                .setSource(jsonBuilder().startObject()
+                        .field("field", "1", "2")
+                        .field("included", "should be seen")
+                        .field("excluded", "should not be seen")
+                    .endObject())
+                .execute().actionGet();
+
+        GetResponse responseBeforeFlush = client.prepareGet(index, type, "1").setFields("_source", "included", "excluded").execute().actionGet();
+        client.admin().indices().prepareFlush(index).execute().actionGet();
+        GetResponse responseAfterFlush = client.prepareGet(index, type, "1").setFields("_source", "included", "excluded").execute().actionGet();
+
+        assertThat(responseBeforeFlush.isExists(), is(true));
+        assertThat(responseAfterFlush.isExists(), is(true));
+        assertThat(responseBeforeFlush.getSourceAsMap(), not(hasKey("excluded")));
+        assertThat(responseBeforeFlush.getSourceAsMap(), not(hasKey("field")));
+        assertThat(responseBeforeFlush.getSourceAsMap(), hasKey("included"));
+        assertThat(responseBeforeFlush.getSourceAsString(), is(responseAfterFlush.getSourceAsString()));
+    }
+
 }


### PR DESCRIPTION
Currently realtime GET does not take source includes/excludes into account.
This patch adds support for the source field mapper includes/excludes
when getting an entry from the transaction log. Even though it introduces
a slight performance penalty, it now adheres to the defined configuration
instead of returning all source data when a realtime get is done.

Closes #2829
