### PR TITLE
Accept loopback interfaces in the network.host setting

### DIFF
--- a/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -172,11 +172,15 @@ public class NetworkService extends AbstractComponent {
                 }
                 Collection<NetworkInterface> allInterfs = NetworkUtils.getAllAvailableInterfaces();
                 for (NetworkInterface ni : allInterfs) {
-                    if (!ni.isUp() || ni.isLoopback()) {
+                    if (!ni.isUp()) {
                         continue;
                     }
                     if (host.equals(ni.getName()) || host.equals(ni.getDisplayName())) {
-                        return NetworkUtils.getFirstNonLoopbackAddress(ni, stackType);
+                        if (ni.isLoopback()) {
+                            return NetworkUtils.getFirstAddress(ni, stackType);
+                        } else {
+                            return NetworkUtils.getFirstNonLoopbackAddress(ni, stackType);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -163,6 +163,25 @@ public abstract class NetworkUtils {
     }
 
     /**
+     * Returns the first address with the proper ipVersion on the given interface on the current host.
+     *
+     * @param intf      the interface to be checked
+     * @param ipVersion Constraint on IP version of address to be returned, 4 or 6
+     */
+    public static InetAddress getFirstAddress(NetworkInterface intf, StackType ipVersion) throws SocketException {
+        if (intf == null)
+            throw new IllegalArgumentException("Network interface pointer is null");
+
+        for (Enumeration addresses = intf.getInetAddresses(); addresses.hasMoreElements(); ) {
+            InetAddress address = (InetAddress) addresses.nextElement();
+            if ((address instanceof Inet4Address && ipVersion == StackType.IPv4) ||
+                    (address instanceof Inet6Address && ipVersion == StackType.IPv6))
+                return address;
+        }
+        return null;
+    }
+
+    /**
      * A function to check if an interface supports an IP version (i.e has addresses
      * defined for that IP version).
      *


### PR DESCRIPTION
Closes #2924. Adds support for loopback interfaces such as `_lo0_` in `network.host` and other network settings.
