### PR TITLE
Alternate model for field AND logic within MultiMatch query

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -47,7 +47,11 @@ public class MatchQueryBuilder extends BaseQueryBuilder implements BoostableQuer
         /**
          * The text is analyzed and used in a phrase query, with the last term acting as a prefix.
          */
-        PHRASE_PREFIX
+        PHRASE_PREFIX,
+        /**
+         * The text is analyzed and terms in each position must match in at least one field.
+         */
+        ACROSS
     }
 
     public static enum ZeroTermsQuery {

--- a/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -109,6 +109,8 @@ public class MultiMatchQueryParser implements QueryParser {
                         type = MatchQuery.Type.PHRASE;
                     } else if ("phrase_prefix".equals(tStr) || "phrasePrefix".equals(currentFieldName)) {
                         type = MatchQuery.Type.PHRASE_PREFIX;
+                    } else if ("across".equals(tStr)) {
+                        type = MatchQuery.Type.ACROSS;
                     }
                 } else if ("analyzer".equals(currentFieldName)) {
                     String analyzer = parser.text();

--- a/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -53,7 +53,8 @@ public class MatchQuery {
     public static enum Type {
         BOOLEAN,
         PHRASE,
-        PHRASE_PREFIX
+        PHRASE_PREFIX,
+        ACROSS
     }
 
     public static enum ZeroTermsQuery {
@@ -337,7 +338,7 @@ public class MatchQuery {
         throw new ElasticSearchIllegalStateException("No type found for [" + type + "]");
     }
 
-    private Query newTermQuery(@Nullable FieldMapper mapper, Term term) {
+    protected Query newTermQuery(@Nullable FieldMapper mapper, Term term) {
         if (fuzziness != null) {
             if (mapper != null) {
                 Query query = mapper.fuzzyQuery(term.text(), fuzziness, fuzzyPrefixLength, maxExpansions, transpositions);
@@ -362,7 +363,7 @@ public class MatchQuery {
         return new TermQuery(term);
     }
     
-    private static BytesRef termToByteRef(CharTermAttribute attr) {
+    protected static BytesRef termToByteRef(CharTermAttribute attr) {
         final BytesRef ref = new BytesRef();
         UnicodeUtil.UTF16toUTF8(attr.buffer(), 0, attr.length(), ref);
         return ref;

--- a/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -19,14 +19,31 @@
 
 package org.elasticsearch.index.search;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CachingTokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.ElasticSearchIllegalStateException;
+import org.elasticsearch.common.io.FastStringReader;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
 
 public class MultiMatchQuery extends MatchQuery {
 
@@ -47,6 +64,11 @@ public class MultiMatchQuery extends MatchQuery {
 
     public Query parse(Type type, Map<String, Float> fieldNames, Object value) throws IOException {
         if (fieldNames.size() == 1) {
+            if (type == Type.ACROSS){
+                // In a single term case we're just doing a boolean AND query
+                type = Type.BOOLEAN;
+                this.setOccur(BooleanClause.Occur.MUST);
+            }
             Map.Entry<String, Float> fieldBoost = fieldNames.entrySet().iterator().next();
             Float boostValue = fieldBoost.getValue();
             if (boostValue == null) {
@@ -57,8 +79,143 @@ public class MultiMatchQuery extends MatchQuery {
                 return query;
             }
         }
+        if (type == Type.ACROSS) {
+            final BooleanQuery booleanQuery = new BooleanQuery();
+            final List<List<Query>> termMatrix = new ArrayList<List<Query>>();
+            int fieldNumber = 0;
+            for (String fieldName : fieldNames.keySet()){
+                FieldMapper mapper = null;
+                final String field;
+                MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
+                if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
+                    mapper = smartNameFieldMappers.mapper();
+                    field = mapper.names().indexName();
+                } else {
+                    field = fieldName;
+                }
 
-        if (useDisMax) {
+                if (mapper != null && mapper.useTermQueryWithQueryString()) {
+                    if (smartNameFieldMappers.explicitTypeInNameWithDocMapper()) {
+                        String[] previousTypes = QueryParseContext.setTypesWithPrevious(new String[]{smartNameFieldMappers.docMapper().type()});
+                        try {
+                            return wrapSmartNameQuery(mapper.termQuery(value, parseContext), smartNameFieldMappers, parseContext);
+                        } catch (RuntimeException e) {
+                            if (lenient) {
+                                return null;
+                            }
+                            throw e;
+                        } finally {
+                            QueryParseContext.setTypes(previousTypes);
+                        }
+                    } else {
+                        try {
+                            return wrapSmartNameQuery(mapper.termQuery(value, parseContext), smartNameFieldMappers, parseContext);
+                        } catch (RuntimeException e) {
+                            if (lenient) {
+                                return null;
+                            }
+                            throw e;
+                        }
+                    }
+                }
+
+                Analyzer analyzer = null;
+                if (this.analyzer == null) {
+                    if (mapper != null) {
+                        analyzer = mapper.searchAnalyzer();
+                    }
+                    if (analyzer == null && smartNameFieldMappers != null) {
+                        analyzer = smartNameFieldMappers.searchAnalyzer();
+                    }
+                    if (analyzer == null) {
+                        analyzer = parseContext.mapperService().searchAnalyzer();
+                    }
+                } else {
+                    analyzer = parseContext.mapperService().analysisService().analyzer(this.analyzer);
+                    if (analyzer == null) {
+                        throw new ElasticSearchIllegalArgumentException("No analyzer found for [" + this.analyzer + "]");
+                    }
+                }
+
+                // Logic similar to QueryParser#getFieldQuery
+                final TokenStream source = analyzer.tokenStream(field, new FastStringReader(value.toString()));
+                source.reset();
+                int numTokens = 0;
+                int positionCount = 0;
+                boolean severalTokensAtSamePosition = false;
+
+                final CachingTokenFilter buffer = new CachingTokenFilter(source);
+                buffer.reset();
+                final CharTermAttribute termAtt = buffer.addAttribute(CharTermAttribute.class);
+                final PositionIncrementAttribute posIncrAtt = buffer.addAttribute(PositionIncrementAttribute.class);
+                boolean hasMoreTokens =  buffer.incrementToken();
+                while (hasMoreTokens) {
+                    numTokens++;
+                    int positionIncrement = posIncrAtt.getPositionIncrement();
+                    if (positionIncrement != 0) {
+                        positionCount += positionIncrement;
+                    } else {
+                        severalTokensAtSamePosition = true;
+                    }
+                    hasMoreTokens = buffer.incrementToken();
+                }
+                // rewind the buffer stream
+                buffer.reset();
+                source.close();
+
+                int matrixMissing = positionCount - termMatrix.size();
+                for (int i = 0; i < matrixMissing; i++){
+                    List<Query> termList = new ArrayList<Query>();
+                    for (int j = 0; j < fieldNumber; j++){
+                        termList.add(null);
+                    }
+                    termMatrix.add(termList);
+                }
+
+                int position = 0;
+                for (int i = 0; i < numTokens; i++) {
+                    boolean hasNext = buffer.incrementToken();
+                    assert hasNext == true;
+                    int positionIncrement = posIncrAtt.getPositionIncrement();
+                    for (int p = 1; p < positionIncrement; p++) {
+                        termMatrix.get(position).add(null);
+                        position++;
+                    }
+                    Query q = newTermQuery(mapper, new Term(field, termToByteRef(termAtt)));
+                    Float boostValue = fieldNames.get(field);
+                    if (boostValue != null) {
+                        q.setBoost(boostValue);
+                    }
+                    termMatrix.get(position).add(wrapSmartNameQuery(q, smartNameFieldMappers, parseContext));
+                    if (positionIncrement > 0){
+                        position++;
+                    }
+                }
+                int termsToPad = termMatrix.size() - position;
+                for (int i = 0; i < termsToPad; i++){
+                    termMatrix.get(position + i).add(null);
+                }
+                fieldNumber++;
+            }
+
+            for (List<Query> termList : termMatrix){
+                if(termList.contains(null)){
+                    // At least once field evalues token to nothing, so this is a SHOULD
+                    for (Query query : termList){
+                        if (query != null){
+                            booleanQuery.add(query, BooleanClause.Occur.SHOULD);
+                        }
+                    }
+                }else{
+                    BooleanQuery crossQuery = new BooleanQuery();
+                    for (Query query : termList){ //never null. see above test
+                        crossQuery.add(query, BooleanClause.Occur.SHOULD);
+                    }
+                    booleanQuery.add(crossQuery, BooleanClause.Occur.MUST);
+                }
+            }
+            return !booleanQuery.clauses().isEmpty() ? booleanQuery : null;
+        }else if (useDisMax) {
             DisjunctionMaxQuery disMaxQuery = new DisjunctionMaxQuery(tieBreaker);
             boolean clauseAdded = false;
             for (String fieldName : fieldNames.keySet()) {


### PR DESCRIPTION
I wrote a patch to MultiMatch query that provides more natural and processing when considering multiple fields.

Consider document with fields:
title:  Something
description: featured on their 1969 album Abbey Road
author: Beatles
Now if I take user's input and run a query to match my documents, it would be natural to consider ether the dreaded _all field or a multi_match query like:
multi_match:{"query":"Something Beatles", "fields":["title", "description", "author"], "operator":"and"}

Which would get transformed into a boolean query such as:
(+title:something +title:beatles) (+description:something +description:beatles) (+author:something +author: beatles)

There is no match for our document! From human input perspective often the most natural way to AND multi-field search is to ensure each term is matched somewhere across all fields such as:
+(title:something description:something author:something) +(title:beatles description:beatles author:beatles)

My patch does exactly that and it also accounts for use of multiple analyzers which may remove tokens from some fields (ex: The Beatles). If a token is skipped by an analyzer it will be turned into a should requirement on remaining fields instead of a must.

I am using facilities of match query for minimum should match as well as fuzzy processing so a new match type felt natural. 
multi_match:{"query":"Something Beatles", "fields":["title", "description", "author"], "type":"across"}
