### PR TITLE
Improve stability of SimpleDataNodesTests

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -88,6 +88,11 @@ public class ClusterHealthRequestBuilder extends MasterNodeOperationRequestBuild
         return this;
     }
 
+    public ClusterHealthRequestBuilder setLocal(boolean local) {
+        request.local(local);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<ClusterHealthResponse> listener) {
         ((ClusterAdminClient) client).health(request, listener);

--- a/src/test/java/org/elasticsearch/test/integration/cluster/SimpleDataNodesTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/cluster/SimpleDataNodesTests.java
@@ -55,7 +55,7 @@ public class SimpleDataNodesTests extends AbstractNodesTests {
         }
 
         startNode("nonData2", settingsBuilder().put("node.data", false).build());
-        assertThat(client("nonData1").admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("2").execute().actionGet().isTimedOut(), equalTo(false));
+        assertThat(client("nonData2").admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("2").setLocal(true).execute().actionGet().isTimedOut(), equalTo(false));
 
         // still no shard should be allocated
         try {
@@ -67,7 +67,7 @@ public class SimpleDataNodesTests extends AbstractNodesTests {
 
         // now, start a node data, and see that it gets with shards
         startNode("data1", settingsBuilder().put("node.data", true).build());
-        assertThat(client("nonData1").admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("3").execute().actionGet().isTimedOut(), equalTo(false));
+        assertThat(client("nonData2").admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("3").setLocal(true).execute().actionGet().isTimedOut(), equalTo(false));
 
         IndexResponse indexResponse = client("nonData2").index(Requests.indexRequest("test").type("type1").id("1").source(source("1", "test"))).actionGet();
         assertThat(indexResponse.getId(), equalTo("1"));


### PR DESCRIPTION
Make sure that we are waiting for the new state to be propagated to the node where we are executing the followup query that depends on this state.
