### PR TITLE
Add support for Collections to TermsQuery/InQuery 

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -22,6 +22,8 @@ package org.elasticsearch.index.query;
 import com.spatial4j.core.shape.Shape;
 import org.elasticsearch.common.Nullable;
 
+import java.util.Collection;
+
 /**
  * A static factory for simple "import static" usage.
  */
@@ -667,6 +669,16 @@ public abstract class QueryBuilders {
      * @param name   The field name
      * @param values The terms
      */
+    public static TermsQueryBuilder termsQuery(String name, Collection values) {
+        return new TermsQueryBuilder(name, values);
+    }
+
+    /**
+     * A filer for a field based on several terms matching on any of them.
+     *
+     * @param name   The field name
+     * @param values The terms
+     */
     public static TermsQueryBuilder inQuery(String name, String... values) {
         return new TermsQueryBuilder(name, values);
     }
@@ -718,6 +730,16 @@ public abstract class QueryBuilders {
      * @param values The terms
      */
     public static TermsQueryBuilder inQuery(String name, Object... values) {
+        return new TermsQueryBuilder(name, values);
+    }
+
+    /**
+     * A filer for a field based on several terms matching on any of them.
+     *
+     * @param name   The field name
+     * @param values The terms
+     */
+    public static TermsQueryBuilder inQuery(String name, Collection values) {
         return new TermsQueryBuilder(name, values);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  *
@@ -113,6 +114,16 @@ public class TermsQueryBuilder extends BaseQueryBuilder implements BoostableQuer
     public TermsQueryBuilder(String name, Object... values) {
         this.name = name;
         this.values = values;
+    }
+
+  /**
+   * A query for a field based on several terms matching on any of them.
+   *
+   * @param name    The field name
+   * @param values  The terms
+   */
+    public TermsQueryBuilder(String name, Collection values) {
+        this(name, values.toArray());
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test.unit.index.query;
 
+import com.google.common.collect.Lists;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.BoostingQuery;
 import org.apache.lucene.queries.FilterClause;
@@ -1194,6 +1195,23 @@ public class SimpleIndexQueryParserTests {
     }
 
     @Test
+    public void testTermsQueryBuilder() throws IOException {
+      IndexQueryParserService queryParser = queryParser();
+      Query parsedQuery = queryParser.parse(termsQuery("name.first", Lists.newArrayList("shay", "test"))).query();
+      assertThat(parsedQuery, instanceOf(BooleanQuery.class));
+      BooleanQuery booleanQuery = (BooleanQuery) parsedQuery;
+      BooleanClause[] clauses = booleanQuery.getClauses();
+
+      assertThat(clauses.length, equalTo(2));
+
+      assertThat(((TermQuery) clauses[0].getQuery()).getTerm(), equalTo(new Term("name.first", "shay")));
+      assertThat(clauses[0].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+      assertThat(((TermQuery) clauses[1].getQuery()).getTerm(), equalTo(new Term("name.first", "test")));
+      assertThat(clauses[1].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+    }
+
+    @Test
     public void testTermsQuery() throws IOException {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/test/unit/index/query/terms-query.json");
@@ -1209,6 +1227,26 @@ public class SimpleIndexQueryParserTests {
 
         assertThat(((TermQuery) clauses[1].getQuery()).getTerm(), equalTo(new Term("name.first", "test")));
         assertThat(clauses[1].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+    }
+
+    @Test
+    public void testInQuery() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        Query parsedQuery = queryParser.parse(termsQuery("name.first", Lists.newArrayList("test1", "test2", "test3"))).query();
+        assertThat(parsedQuery, instanceOf(BooleanQuery.class));
+        BooleanQuery booleanQuery = (BooleanQuery) parsedQuery;
+        BooleanClause[] clauses = booleanQuery.getClauses();
+
+        assertThat(clauses.length, equalTo(3));
+
+        assertThat(((TermQuery) clauses[0].getQuery()).getTerm(), equalTo(new Term("name.first", "test1")));
+        assertThat(clauses[0].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+        assertThat(((TermQuery) clauses[1].getQuery()).getTerm(), equalTo(new Term("name.first", "test2")));
+        assertThat(clauses[1].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+        assertThat(((TermQuery) clauses[2].getQuery()).getTerm(), equalTo(new Term("name.first", "test3")));
+        assertThat(clauses[2].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
     }
 
     @Test


### PR DESCRIPTION
Currently passing in a collection such as List<Integer> to search a field in will not work unless you first convert it to an array. 
