### PR TITLE
Rest Get Source

### DIFF
--- a/src/main/java/org/elasticsearch/action/get/GetResponse.java
+++ b/src/main/java/org/elasticsearch/action/get/GetResponse.java
@@ -93,6 +93,14 @@ public class GetResponse extends ActionResponse implements Iterable<GetField>, T
     }
 
     /**
+     * Returns the internal source bytes, as they are returned without munging (for example,
+     * might still be compressed).
+     */
+    public BytesReference getSourceInternal() {
+        return getResult.internalSourceRef();
+    }
+
+    /**
      * Returns bytes reference, also un compress the source if needed.
      */
     public BytesReference getSourceAsBytesRef() {

--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -68,6 +68,7 @@ import org.elasticsearch.rest.action.delete.RestDeleteAction;
 import org.elasticsearch.rest.action.deletebyquery.RestDeleteByQueryAction;
 import org.elasticsearch.rest.action.explain.RestExplainAction;
 import org.elasticsearch.rest.action.get.RestGetAction;
+import org.elasticsearch.rest.action.get.RestGetSourceAction;
 import org.elasticsearch.rest.action.get.RestHeadAction;
 import org.elasticsearch.rest.action.get.RestMultiGetAction;
 import org.elasticsearch.rest.action.index.RestIndexAction;
@@ -149,6 +150,7 @@ public class RestActionModule extends AbstractModule {
 
         bind(RestIndexAction.class).asEagerSingleton();
         bind(RestGetAction.class).asEagerSingleton();
+        bind(RestGetSourceAction.class).asEagerSingleton();
         bind(RestHeadAction.class).asEagerSingleton();
         bind(RestMultiGetAction.class).asEagerSingleton();
         bind(RestDeleteAction.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -76,7 +76,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
             @Override
             public void onResponse(AnalyzeResponse response) {
                 try {
-                    XContentBuilder builder = restContentBuilder(request, false);
+                    XContentBuilder builder = restContentBuilder(request, null);
                     builder.startObject();
                     response.toXContent(builder, request);
                     builder.endObject();

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
@@ -19,30 +19,32 @@
 
 package org.elasticsearch.rest.action.get;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
-import static org.elasticsearch.rest.RestRequest.Method.HEAD;
+import java.io.IOException;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.action.support.RestXContentBuilder.restContentBuilder;
 
 /**
  *
  */
-public class RestHeadAction extends BaseRestHandler {
+public class RestGetSourceAction extends BaseRestHandler {
 
     @Inject
-    public RestHeadAction(Settings settings, Client client, RestController controller) {
+    public RestGetSourceAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
-        controller.registerHandler(HEAD, "/{index}/{type}/{id}", this);
-        controller.registerHandler(HEAD, "/{index}/{type}/{id}/_source", this);
+        controller.registerHandler(GET, "/{index}/{type}/{id}/_source", this);
     }
 
     @Override
@@ -51,22 +53,22 @@ public class RestHeadAction extends BaseRestHandler {
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);
         getRequest.refresh(request.paramAsBoolean("refresh", getRequest.refresh()));
+        getRequest.routing(request.param("routing"));  // order is important, set it after routing, so it will set the routing
         getRequest.parent(request.param("parent"));
-        getRequest.routing(request.param("routing"));
         getRequest.preference(request.param("preference"));
         getRequest.realtime(request.paramAsBooleanOptional("realtime", null));
-        // don't get any fields back...
-        getRequest.fields(Strings.EMPTY_ARRAY);
-        // TODO we can also just return the document size as Content-Length
 
         client.get(getRequest, new ActionListener<GetResponse>() {
             @Override
             public void onResponse(GetResponse response) {
+
                 try {
+                    XContentBuilder builder = restContentBuilder(request, response.getSourceInternal());
                     if (!response.isExists()) {
-                        channel.sendResponse(new StringRestResponse(NOT_FOUND));
+                        channel.sendResponse(new XContentRestResponse(request, NOT_FOUND, builder));
                     } else {
-                        channel.sendResponse(new StringRestResponse(OK));
+                        RestXContentBuilder.directSource(response.getSourceInternal(), builder, request);
+                        channel.sendResponse(new XContentRestResponse(request, OK, builder));
                     }
                 } catch (Throwable e) {
                     onFailure(e);
@@ -76,8 +78,8 @@ public class RestHeadAction extends BaseRestHandler {
             @Override
             public void onFailure(Throwable e) {
                 try {
-                    channel.sendResponse(new StringRestResponse(ExceptionsHelper.status(e)));
-                } catch (Exception e1) {
+                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
+                } catch (IOException e1) {
                     logger.error("Failed to send failure response", e1);
                 }
             }

--- a/src/main/java/org/elasticsearch/rest/action/support/RestXContentBuilder.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestXContentBuilder.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.rest.action.support;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedStreamInput;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.CachedStreamOutput;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.rest.RestRequest;
@@ -35,15 +37,16 @@ import java.io.IOException;
 public class RestXContentBuilder {
 
     public static XContentBuilder restContentBuilder(RestRequest request) throws IOException {
-        return restContentBuilder(request, true);
+        // use the request body as the auto detect source (if it exists)
+        return restContentBuilder(request, request.hasContent() ? request.content() : null);
     }
 
-    public static XContentBuilder restContentBuilder(RestRequest request, boolean autoDetect) throws IOException {
+    public static XContentBuilder restContentBuilder(RestRequest request, @Nullable BytesReference autoDetectSource) throws IOException {
         XContentType contentType = XContentType.fromRestContentType(request.param("format", request.header("Content-Type")));
         if (contentType == null) {
-            // try and guess it from the body, if exists
-            if (autoDetect && request.hasContent()) {
-                contentType = XContentFactory.xContentType(request.content());
+            // try and guess it from the auto detect source
+            if (autoDetectSource != null) {
+                contentType = XContentFactory.xContentType(autoDetectSource);
             }
         }
         if (contentType == null) {
@@ -64,6 +67,42 @@ public class RestXContentBuilder {
             builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.NONE);
         }
         return builder;
+    }
+
+    /**
+     * Directly writes the source to the output builder
+     */
+    public static void directSource(BytesReference source, XContentBuilder rawBuilder, ToXContent.Params params) throws IOException {
+        Compressor compressor = CompressorFactory.compressor(source);
+        if (compressor != null) {
+            CompressedStreamInput compressedStreamInput = compressor.streamInput(source.streamInput());
+            XContentType contentType = XContentFactory.xContentType(compressedStreamInput);
+            compressedStreamInput.resetToBufferStart();
+            if (contentType == rawBuilder.contentType()) {
+                Streams.copy(compressedStreamInput, rawBuilder.stream());
+            } else {
+                XContentParser parser = XContentFactory.xContent(contentType).createParser(compressedStreamInput);
+                try {
+                    parser.nextToken();
+                    rawBuilder.copyCurrentStructure(parser);
+                } finally {
+                    parser.close();
+                }
+            }
+        } else {
+            XContentType contentType = XContentFactory.xContentType(source);
+            if (contentType == rawBuilder.contentType()) {
+                source.writeTo(rawBuilder.stream());
+            } else {
+                XContentParser parser = XContentFactory.xContent(contentType).createParser(source);
+                try {
+                    parser.nextToken();
+                    rawBuilder.copyCurrentStructure(parser);
+                } finally {
+                    parser.close();
+                }
+            }
+        }
     }
 
     public static void restDocumentSource(BytesReference source, XContentBuilder builder, ToXContent.Params params) throws IOException {


### PR DESCRIPTION
Allow to get the source directly using a specific REST endpoint without any additional content around it, the endpoint is `{index}/{type}/{id}/_source`.
Note, HEAD now also support the _source endpoint.
closes #2993
