### PR TITLE
Fixed parsing of track_scores in RestSearchAction

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -226,6 +226,13 @@ public class RestSearchAction extends BaseRestHandler {
             }
         }
 
+        if(request.hasParam("track_scores")) {
+            if (searchSourceBuilder == null) {
+                searchSourceBuilder = new SearchSourceBuilder();
+            }
+            searchSourceBuilder.trackScores(request.paramAsBoolean("track_scores", false));
+        }
+
         String sSorts = request.param("sort");
         if (sSorts != null) {
             if (searchSourceBuilder == null) {


### PR DESCRIPTION
The `track_scores` parameter is now parsed by the REST handler

Closes #2986
