### PR TITLE
Enabling offsets in MemoryIndex

### DIFF
--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorExecutor.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorExecutor.java
@@ -261,7 +261,7 @@ public class PercolatorExecutor extends AbstractIndexComponent {
             synchronized (this) {
                 if (poolCurrentSize < poolMaxSize) {
                     poolCurrentSize++;
-                    return new ReusableMemoryIndex(false, bytesPerMemoryIndex);
+                    return new ReusableMemoryIndex(true, bytesPerMemoryIndex);
                     
                 } 
             }
@@ -273,7 +273,7 @@ public class PercolatorExecutor extends AbstractIndexComponent {
                 // don't swallow the interrupt
                 Thread.currentThread().interrupt();
             }
-            return poll == null ? new ReusableMemoryIndex(false, bytesPerMemoryIndex) : poll;
+            return poll == null ? new ReusableMemoryIndex(true, bytesPerMemoryIndex) : poll;
         }
         
         public void release(ReusableMemoryIndex index) {


### PR DESCRIPTION
This allows for reusing the memory index pool for more advanced usages from consumer applications, for example through a highlighting percolator (see separate PR)
