### PR TITLE
Simple query logging for debugging

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -446,6 +446,31 @@ public class SearchRequest extends ActionRequest<SearchRequest> {
     }
 
     @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[index=");
+        if (indices != null) {
+            for (String s : indices) {
+                sb.append(s).append(",");
+            }
+        } else {
+            sb.append(indices).append(",");
+        }
+        sb.append(",types=");
+        if (types != null) {
+            for (String s : types) {
+                sb.append(s).append(",");
+            }
+        } else {
+            sb.append(types).append(",");
+        }
+        sb.append(",source=").append(source != null ? source.toUtf8() : null)
+                .append(",extraSource=").append(extraSource != null ? extraSource.toUtf8() : null)
+                .append("]");
+        return sb.toString();
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         operationThreading = SearchOperationThreading.fromId(in.readByte());

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
@@ -80,6 +80,9 @@ public class TransportSearchCountAction extends TransportSearchTypeAction {
 
         @Override
         protected void processFirstPhaseResult(ShardRouting shard, QuerySearchResult result) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] processFirstPhaseResult: result for request {}", result.id(), request);
+            }
             queryFetchResults.put(result.shardTarget(), result);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -83,6 +83,9 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
 
         @Override
         protected void processFirstPhaseResult(ShardRouting shard, DfsSearchResult result) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] processFirstPhaseResult: result for request {}", result.id(), request);
+            }
             dfsResults.add(result);
         }
 
@@ -141,6 +144,10 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
             searchService.sendExecuteFetch(node, querySearchRequest, new SearchServiceListener<QueryFetchSearchResult>() {
                 @Override
                 public void onResult(QueryFetchSearchResult result) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] result for query {}", querySearchRequest.id(),
+                                querySearchRequest.searchRequest());
+                    }
                     result.shardTarget(dfsResult.shardTarget());
                     queryFetchResults.put(result.shardTarget(), result);
                     if (counter.decrementAndGet() == 0) {

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -88,6 +88,9 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
 
         @Override
         protected void processFirstPhaseResult(ShardRouting shard, DfsSearchResult result) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] processFirstPhaseResult: result for request {}", result.id(), request);
+            }
             dfsResults.add(result);
         }
 
@@ -148,6 +151,10 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
             searchService.sendExecuteQuery(node, querySearchRequest, new SearchServiceListener<QuerySearchResult>() {
                 @Override
                 public void onResult(QuerySearchResult result) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] result received for query {}", querySearchRequest.id(),
+                                querySearchRequest.searchRequest() );
+                    }
                     result.shardTarget(dfsResult.shardTarget());
                     queryResults.put(result.shardTarget(), result);
                     if (counter.decrementAndGet() == 0) {
@@ -239,6 +246,9 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
             searchService.sendExecuteFetch(node, fetchSearchRequest, new SearchServiceListener<FetchSearchResult>() {
                 @Override
                 public void onResult(FetchSearchResult result) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] result received for fetch", fetchSearchRequest.id());
+                    }
                     result.shardTarget(shardTarget);
                     fetchResults.put(result.shardTarget(), result);
                     if (counter.decrementAndGet() == 0) {

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
@@ -77,6 +77,9 @@ public class TransportSearchQueryAndFetchAction extends TransportSearchTypeActio
 
         @Override
         protected void processFirstPhaseResult(ShardRouting shard, QueryFetchSearchResult result) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] processFirstPhaseResult: result for request {}", result.id(), request);
+            }
             queryFetchResults.put(result.shardTarget(), result);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
@@ -82,6 +82,9 @@ public class TransportSearchQueryThenFetchAction extends TransportSearchTypeActi
 
         @Override
         protected void processFirstPhaseResult(ShardRouting shard, QuerySearchResult result) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] processFirstPhaseResult: result for request {}", result.id(), request);
+            }
             queryResults.put(result.shardTarget(), result);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
@@ -77,6 +77,9 @@ public class TransportSearchScanAction extends TransportSearchTypeAction {
 
         @Override
         protected void processFirstPhaseResult(ShardRouting shard, QuerySearchResult result) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[{}] processFirstPhaseResult: result for request {}", result.id(), request);
+            }
             queryResults.put(result.shardTarget(), result);
         }
 

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
@@ -199,6 +199,9 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
             searchService.sendExecuteFetch(node, internalScrollSearchRequest(searchId, request), new SearchServiceListener<QueryFetchSearchResult>() {
                 @Override
                 public void onResult(QueryFetchSearchResult result) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendExecuteFetch: result received for request {}", result.id(), request);
+                    }
                     queryFetchResults.put(result.shardTarget(), result);
                     if (counter.decrementAndGet() == 0) {
                         finishHim();

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
@@ -191,6 +191,9 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
             searchService.sendExecuteQuery(node, internalScrollSearchRequest(searchId, request), new SearchServiceListener<QuerySearchResult>() {
                 @Override
                 public void onResult(QuerySearchResult result) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendExecuteQuery: result received for request {}", result.id(), request);
+                    }
                     queryResults.put(result.shardTarget(), result);
                     if (counter.decrementAndGet() == 0) {
                         executeFetchPhase();
@@ -224,11 +227,14 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
             for (final Map.Entry<SearchShardTarget, ExtTIntArrayList> entry : docIdsToLoad.entrySet()) {
                 SearchShardTarget shardTarget = entry.getKey();
                 ExtTIntArrayList docIds = entry.getValue();
-                FetchSearchRequest fetchSearchRequest = new FetchSearchRequest(request, queryResults.get(shardTarget).id(), docIds);
+                final FetchSearchRequest fetchSearchRequest = new FetchSearchRequest(request, queryResults.get(shardTarget).id(), docIds);
                 DiscoveryNode node = nodes.get(shardTarget.nodeId());
                 searchService.sendExecuteFetch(node, fetchSearchRequest, new SearchServiceListener<FetchSearchResult>() {
                     @Override
                     public void onResult(FetchSearchResult result) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("[{}] result received for fetch", fetchSearchRequest.id());
+                        }
                         result.shardTarget(entry.getKey());
                         fetchResults.put(result.shardTarget(), result);
                         if (counter.decrementAndGet() == 0) {

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
@@ -205,6 +205,9 @@ public class TransportSearchScrollScanAction extends AbstractComponent {
             searchService.sendExecuteScan(node, internalScrollSearchRequest(searchId, request), new SearchServiceListener<QueryFetchSearchResult>() {
                 @Override
                 public void onResult(QueryFetchSearchResult result) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendExecuteScan: result received for scan {}", result.id(), request);
+                    }
                     queryFetchResults.put(result.shardTarget(), result);
                     if (counter.decrementAndGet() == 0) {
                         finishHim();

--- a/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
+++ b/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
@@ -105,6 +105,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 DfsSearchResult result = searchService.executeDfsPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteDfs: handling response for shard search request {}", result.id(), request);
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -119,6 +122,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(DfsSearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for shard search request {}", response.id(), request);
+                    }
                     listener.onResult(response);
                 }
 
@@ -139,6 +145,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 QuerySearchResult result = searchService.executeQueryPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteQuery: handling response for shard search request {}", result.id(), request);
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -153,6 +162,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(QuerySearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for shard search request {}", response.id(), request);
+                    }
                     listener.onResult(response);
                 }
 
@@ -173,6 +185,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 QuerySearchResult result = searchService.executeQueryPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteQuery: handling response for query search request {}", result.id(), request.searchRequest());
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -187,6 +202,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(QuerySearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for query search request {}", response.id(), request.searchRequest());
+                    }
                     listener.onResult(response);
                 }
 
@@ -207,6 +225,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 ScrollQuerySearchResult result = searchService.executeQueryPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteQuery: handling response for scroll search request {}", result.queryResult().id(), request.id());
+                }
                 listener.onResult(result.queryResult());
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -221,6 +242,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(ScrollQuerySearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for scroll search request {}", response.queryResult().id(), request.id());
+                    }
                     listener.onResult(response.queryResult());
                 }
 
@@ -241,6 +265,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 QueryFetchSearchResult result = searchService.executeFetchPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteFetch: handling response for shard search request {}", result.id(), request);
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -255,6 +282,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(QueryFetchSearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for shard search request {}", response.id(), request);
+                    }
                     listener.onResult(response);
                 }
 
@@ -275,6 +305,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 QueryFetchSearchResult result = searchService.executeFetchPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteFetch: handling response for query search request {}", result.id(), request.searchRequest());
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -289,6 +322,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(QueryFetchSearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for query search request {}", response.id(), request.searchRequest());
+                    }
                     listener.onResult(response);
                 }
 
@@ -309,6 +345,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 ScrollQueryFetchSearchResult result = searchService.executeFetchPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteFetch: handling response for scroll search request {}", result.result().id(), request.id());
+                }
                 listener.onResult(result.result());
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -323,6 +362,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(ScrollQueryFetchSearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for scroll search request {}", response.result().id(), request.id());
+                    }
                     listener.onResult(response.result());
                 }
 
@@ -343,6 +385,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 FetchSearchResult result = searchService.executeFetchPhase(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteFetch: handling response for fetch search request {}", result.id(), request.id());
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -357,6 +402,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(FetchSearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for fetch search request {}", response.id(), request.id());
+                    }
                     listener.onResult(response);
                 }
 
@@ -377,6 +425,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 QuerySearchResult result = searchService.executeScan(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteScan: handling response for shard search request {}", result.id(), request);
+                }
                 listener.onResult(result);
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -391,6 +442,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(QuerySearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for shard search request {}", response.id(), request);
+                    }
                     listener.onResult(response);
                 }
 
@@ -411,6 +465,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             try {
                 ScrollQueryFetchSearchResult result = searchService.executeScan(request);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[{}] sendExecuteScan: handling response for scroll search request {}", result.result().id(), request);
+                }
                 listener.onResult(result.result());
             } catch (Throwable e) {
                 listener.onFailure(e);
@@ -425,6 +482,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
                 @Override
                 public void handleResponse(ScrollQueryFetchSearchResult response) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[{}] sendRequest: handling response for scroll search request {}", response.result().id(), request);
+                    }
                     listener.onResult(response.result());
                 }
 

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -169,6 +169,24 @@ public class ShardSearchRequest extends TransportRequest {
     }
 
     @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[index=").append(index).append(",types=");
+        if (types != null) {
+            for (String s : types) {
+                sb.append(s).append(",");
+            }
+        } else {
+            sb.append(types).append(",");
+        }
+        sb.append("shardId=").append(shardId)
+            .append(",source=").append(source != null ? source.toUtf8() : null)
+            .append(",extraSource=").append(extraSource != null ? extraSource.toUtf8() : null)
+            .append("]");
+        return sb.toString();
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         index = in.readString();

--- a/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
@@ -38,6 +38,8 @@ public class QuerySearchRequest extends TransportRequest {
 
     private AggregatedDfs dfs;
 
+    private SearchRequest request;
+
     public QuerySearchRequest() {
     }
 
@@ -45,6 +47,7 @@ public class QuerySearchRequest extends TransportRequest {
         super(request);
         this.id = id;
         this.dfs = dfs;
+        this.request = request;
     }
 
     public long id() {
@@ -55,11 +58,16 @@ public class QuerySearchRequest extends TransportRequest {
         return dfs;
     }
 
+    public SearchRequest searchRequest() {
+        return request;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         id = in.readLong();
         dfs = readAggregatedDfs(in);
+
     }
 
     @Override


### PR DESCRIPTION
Hi Elasticsearch team,
some users want simple query logging, so I added some debug statements. By adding a line "search: DEBUG" in logging.yml, the node requested should output some information about query execution and the JSON source.
