### PR TITLE
Allowing pluggable highlighter implementations.

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -648,6 +648,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
+    public SearchRequestBuilder setHighlighterOptions(Map<String, Object> options) {
+        highlightBuilder().options(options);
+        return this;
+    }
+
     /**
      * Delegates to {@link org.elasticsearch.search.suggest.SuggestBuilder#setText(String)}.
      */

--- a/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.fetch.matchedfilters.MatchedFiltersFetchSubPhase
 import org.elasticsearch.search.fetch.partial.PartialFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.version.VersionFetchSubPhase;
+import org.elasticsearch.search.highlight.HighlightModule;
 import org.elasticsearch.search.highlight.HighlightPhase;
 import org.elasticsearch.search.query.QueryPhase;
 
@@ -43,7 +44,7 @@ public class SearchModule extends AbstractModule implements SpawnModules {
 
     @Override
     public Iterable<? extends Module> spawnModules() {
-        return ImmutableList.of(new TransportSearchModule(), new FacetModule());
+        return ImmutableList.of(new TransportSearchModule(), new FacetModule(), new HighlightModule());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.highlight;
+
+import com.google.common.collect.Maps;
+import org.apache.lucene.search.highlight.DefaultEncoder;
+import org.apache.lucene.search.highlight.Encoder;
+import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
+import org.apache.lucene.search.vectorhighlight.*;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.vectorhighlight.SimpleBoundaryScanner2;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.text.StringText;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.highlight.vectorhighlight.SourceScoreOrderFragmentsBuilder;
+import org.elasticsearch.search.highlight.vectorhighlight.SourceSimpleFragmentsBuilder;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.util.Map;
+
+/**
+ *
+ */
+public class FastVectorHighlighter implements Highlighter {
+
+    private static final String CACHE_KEY = "highlight-fsv";
+    private final Boolean termVectorMultiValue;
+
+    @Inject
+    public FastVectorHighlighter(Settings settings) {
+        this.termVectorMultiValue = settings.getAsBoolean("search.highlight.term_vector_multi_value", true);
+    }
+
+    @Override
+    public String[] names() {
+        return new String[] { "fvh", "fast-vector-highlighter" };
+    }
+
+    @Override
+    public HighlightField highlight(HighlighterContext highlighterContext) {
+        SearchContextHighlight.Field field = highlighterContext.field;
+        SearchContext context = highlighterContext.context;
+        FetchSubPhase.HitContext hitContext = highlighterContext.hitContext;
+        FieldMapper<?> mapper = highlighterContext.mapper;
+
+        if (!(mapper.fieldType().storeTermVectors() && mapper.fieldType().storeTermVectorOffsets() && mapper.fieldType().storeTermVectorPositions())) {
+            throw new ElasticSearchIllegalArgumentException("the field [" + field.field() + "] should be indexed with term vector with position offsets to be used with fast vector highlighter");
+        }
+
+        Encoder encoder = field.encoder().equals("html") ? Encoders.HTML : Encoders.DEFAULT;
+
+        if (!hitContext.cache().containsKey(CACHE_KEY)) {
+            hitContext.cache().put(CACHE_KEY, new HighlighterEntry());
+        }
+        HighlighterEntry cache = (HighlighterEntry) hitContext.cache().get(CACHE_KEY);
+
+        try {
+            MapperHighlightEntry entry = cache.mappers.get(mapper);
+            FieldQuery fieldQuery = null;
+            if (entry == null) {
+                FragListBuilder fragListBuilder;
+                BaseFragmentsBuilder fragmentsBuilder;
+
+                BoundaryScanner boundaryScanner = SimpleBoundaryScanner2.DEFAULT;
+                if (field.boundaryMaxScan() != SimpleBoundaryScanner2.DEFAULT_MAX_SCAN || field.boundaryChars() != SimpleBoundaryScanner2.DEFAULT_BOUNDARY_CHARS) {
+                    boundaryScanner = new SimpleBoundaryScanner2(field.boundaryMaxScan(), field.boundaryChars());
+                }
+
+                if (field.numberOfFragments() == 0) {
+                    fragListBuilder = new SingleFragListBuilder();
+
+                    if (mapper.fieldType().stored()) {
+                        fragmentsBuilder = new SimpleFragmentsBuilder(field.preTags(), field.postTags(), boundaryScanner);
+                    } else {
+                        fragmentsBuilder = new SourceSimpleFragmentsBuilder(mapper, context, field.preTags(), field.postTags(), boundaryScanner);
+                    }
+                } else {
+                    fragListBuilder = field.fragmentOffset() == -1 ? new SimpleFragListBuilder() : new SimpleFragListBuilder(field.fragmentOffset());
+                    if (field.scoreOrdered()) {
+                        if (mapper.fieldType().stored()) {
+                            fragmentsBuilder = new ScoreOrderFragmentsBuilder(field.preTags(), field.postTags(), boundaryScanner);
+                        } else {
+                            fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(mapper, context, field.preTags(), field.postTags(), boundaryScanner);
+                        }
+                    } else {
+                        if (mapper.fieldType().stored()) {
+                            fragmentsBuilder = new SimpleFragmentsBuilder(field.preTags(), field.postTags(), boundaryScanner);
+                        } else {
+                            fragmentsBuilder = new SourceSimpleFragmentsBuilder(mapper, context, field.preTags(), field.postTags(), boundaryScanner);
+                        }
+                    }
+                }
+                fragmentsBuilder.setDiscreteMultiValueHighlighting(termVectorMultiValue);
+                entry = new MapperHighlightEntry();
+                entry.fragListBuilder = fragListBuilder;
+                entry.fragmentsBuilder = fragmentsBuilder;
+                if (cache.fvh == null) {
+                    // parameters to FVH are not requires since:
+                    // first two booleans are not relevant since they are set on the CustomFieldQuery (phrase and fieldMatch)
+                    // fragment builders are used explicitly
+                    cache.fvh = new org.apache.lucene.search.vectorhighlight.FastVectorHighlighter();
+                }
+                CustomFieldQuery.highlightFilters.set(field.highlightFilter());
+                if (field.requireFieldMatch()) {
+                    if (cache.fieldMatchFieldQuery == null) {
+                        // we use top level reader to rewrite the query against all readers, with use caching it across hits (and across readers...)
+                        cache.fieldMatchFieldQuery = new CustomFieldQuery(context.parsedQuery().query(), hitContext.topLevelReader(), true, field.requireFieldMatch());
+                    }
+                    fieldQuery = cache.fieldMatchFieldQuery;
+                } else {
+                    if (cache.noFieldMatchFieldQuery == null) {
+                        // we use top level reader to rewrite the query against all readers, with use caching it across hits (and across readers...)
+                        cache.noFieldMatchFieldQuery = new CustomFieldQuery(context.parsedQuery().query(), hitContext.topLevelReader(), true, field.requireFieldMatch());
+                    }
+                    fieldQuery = cache.noFieldMatchFieldQuery;
+                }
+                cache.mappers.put(mapper, entry);
+            }
+
+            String[] fragments;
+
+            // a HACK to make highlighter do highlighting, even though its using the single frag list builder
+            int numberOfFragments = field.numberOfFragments() == 0 ? Integer.MAX_VALUE : field.numberOfFragments();
+            int fragmentCharSize = field.numberOfFragments() == 0 ? Integer.MAX_VALUE : field.fragmentCharSize();
+            // we highlight against the low level reader and docId, because if we load source, we want to reuse it if possible
+            fragments = cache.fvh.getBestFragments(fieldQuery, hitContext.reader(), hitContext.docId(), mapper.names().indexName(), fragmentCharSize, numberOfFragments,
+                    entry.fragListBuilder, entry.fragmentsBuilder, field.preTags(), field.postTags(), encoder);
+
+            if (fragments != null && fragments.length > 0) {
+                return new HighlightField(field.field(), StringText.convertFromStringArray(fragments));
+            }
+        } catch (Exception e) {
+            throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + highlighterContext.fieldName + "]", e);
+        }
+
+        return null;
+    }
+
+    private class MapperHighlightEntry {
+        public FragListBuilder fragListBuilder;
+        public FragmentsBuilder fragmentsBuilder;
+
+        public org.apache.lucene.search.highlight.Highlighter highlighter;
+    }
+
+    private class HighlighterEntry {
+        public org.apache.lucene.search.vectorhighlight.FastVectorHighlighter fvh;
+        public FieldQuery noFieldMatchFieldQuery;
+        public FieldQuery fieldMatchFieldQuery;
+        public Map<FieldMapper, MapperHighlightEntry> mappers = Maps.newHashMap();
+    }
+
+    private static class Encoders {
+        public static Encoder DEFAULT = new DefaultEncoder();
+        public static Encoder HTML = new SimpleHTMLEncoder();
+    }
+}

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -51,6 +52,8 @@ public class HighlightBuilder implements ToXContent {
     private String highlighterType;
 
     private String fragmenter;
+
+    private Map<String, Object> options;
 
     /**
      * Adds a field to be highlighted with default fragment size of 100 characters, and
@@ -198,6 +201,14 @@ public class HighlightBuilder implements ToXContent {
         return this;
     }
 
+    /**
+     * Allows to set custom options for custom highlighters
+     */
+    public HighlightBuilder options(Map<String, Object> options) {
+        this.options = options;
+        return this;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject("highlight");
@@ -225,6 +236,9 @@ public class HighlightBuilder implements ToXContent {
         if (fragmenter != null) {
             builder.field("fragmenter", fragmenter);
         }
+        if (options != null && options.size() > 0) {
+            builder.field("options", options);
+        }
         if (fields != null) {
             builder.startObject("fields");
             for (Field field : fields) {
@@ -247,6 +261,9 @@ public class HighlightBuilder implements ToXContent {
                 if (field.fragmenter != null) {
                     builder.field("fragmenter", field.fragmenter);
                 }
+                if (field.options != null && field.options.size() > 0) {
+                    builder.field("options", field.options);
+                }
 
                 builder.endObject();
             }
@@ -265,6 +282,7 @@ public class HighlightBuilder implements ToXContent {
         Boolean requireFieldMatch;
         String highlighterType;
         String fragmenter;
+        Map<String, Object> options;
 
         public Field(String name) {
             this.name = name;
@@ -301,6 +319,11 @@ public class HighlightBuilder implements ToXContent {
 
         public Field fragmenter(String fragmenter) {
             this.fragmenter = fragmenter;
+            return this;
+        }
+
+        public Field options(Map<String, Object> options) {
+            this.options = options;
             return this;
         }
     }

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightModule.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightModule.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.highlight;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
+
+import java.util.List;
+
+/**
+ *
+ */
+public class HighlightModule extends AbstractModule {
+
+    private List<Class<? extends Highlighter>> highlighters = Lists.newArrayList();
+
+    public HighlightModule() {
+        registerHighlighter(FastVectorHighlighter.class);
+        registerHighlighter(PlainHighlighter.class);
+    }
+
+    public void registerHighlighter(Class<? extends Highlighter> clazz) {
+        highlighters.add(clazz);
+    }
+
+    @Override
+    protected void configure() {
+        Multibinder<Highlighter> multibinder = Multibinder.newSetBinder(binder(), Highlighter.class);
+        for (Class<? extends Highlighter> highlighter : highlighters) {
+            multibinder.addBinding().to(highlighter);
+        }
+        bind(Highlighters.class).asEagerSingleton();
+    }
+}

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -21,36 +21,22 @@ package org.elasticsearch.search.highlight;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.highlight.*;
-import org.apache.lucene.search.highlight.Formatter;
-import org.apache.lucene.search.vectorhighlight.*;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.FastStringReader;
-import org.elasticsearch.common.lucene.search.vectorhighlight.SimpleBoundaryScanner2;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.text.StringText;
-import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.SearchParseElement;
-import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
 import org.elasticsearch.search.fetch.FetchSubPhase;
-import org.elasticsearch.search.highlight.vectorhighlight.SourceScoreOrderFragmentsBuilder;
-import org.elasticsearch.search.highlight.vectorhighlight.SourceSimpleFragmentsBuilder;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -59,17 +45,12 @@ import static com.google.common.collect.Maps.newHashMap;
  */
 public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
 
-    public static class Encoders {
-        public static Encoder DEFAULT = new DefaultEncoder();
-        public static Encoder HTML = new SimpleHTMLEncoder();
-    }
-
-    private final boolean termVectorMultiValue;
+    private Highlighters highlighters;
 
     @Inject
-    public HighlightPhase(Settings settings) {
+    public HighlightPhase(Settings settings, Highlighters highlighters) {
         super(settings);
-        this.termVectorMultiValue = componentSettings.getAsBoolean("term_vector_multi_value", true);
+        this.highlighters = highlighters;
     }
 
     @Override
@@ -93,238 +74,36 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
 
     @Override
     public void hitExecute(SearchContext context, HitContext hitContext) throws ElasticSearchException {
-        // we use a cache to cache heavy things, mainly the rewrite in FieldQuery for FVH
-        HighlighterEntry cache = (HighlighterEntry) hitContext.cache().get("highlight");
-        if (cache == null) {
-            cache = new HighlighterEntry();
-            hitContext.cache().put("highlight", cache);
-        }
-
-        DocumentMapper documentMapper = context.mapperService().documentMapper(hitContext.hit().type());
-
         Map<String, HighlightField> highlightFields = newHashMap();
         for (SearchContextHighlight.Field field : context.highlight().fields()) {
-            Encoder encoder;
-            if (field.encoder().equals("html")) {
-                encoder = Encoders.HTML;
-            } else {
-                encoder = Encoders.DEFAULT;
-            }
-
             Set<String> fieldNamesToHighlight;
             if (Regex.isSimpleMatchPattern(field.field())) {
+                DocumentMapper documentMapper = context.mapperService().documentMapper(hitContext.hit().type());
                 fieldNamesToHighlight = documentMapper.mappers().simpleMatchToFullName(field.field());
             } else {
                 fieldNamesToHighlight = ImmutableSet.of(field.field());
             }
 
             for (String fieldName : fieldNamesToHighlight) {
-
-                FieldMapper<?> mapper = documentMapper.mappers().smartNameFieldMapper(fieldName);
-                if (mapper == null) {
-                    MapperService.SmartNameFieldMappers fullMapper = context.mapperService().smartName(fieldName);
-                    if (fullMapper == null || !fullMapper.hasDocMapper()) {
-                        //Save skipping missing fields
-                        continue;
-                    }
-                    if (!fullMapper.docMapper().type().equals(hitContext.hit().type())) {
-                        continue;
-                    }
-                    mapper = fullMapper.mapper();
-                    if (mapper == null) {
-                        continue;
-                    }
+                FieldMapper<?> fieldMapper = getMapperForField(fieldName, context, hitContext);
+                if (fieldMapper == null) {
+                    continue;
                 }
-                boolean useFastVectorHighlighter;
+
                 if (field.highlighterType() == null) {
-                    // if we can do highlighting using Term Vectors, use FastVectorHighlighter, otherwise, use the
-                    // slower plain highlighter
-                    useFastVectorHighlighter = mapper.fieldType().storeTermVectors() && mapper.fieldType().storeTermVectorOffsets() && mapper.fieldType().storeTermVectorPositions();
-                } else if (field.highlighterType().equals("fast-vector-highlighter") || field.highlighterType().equals("fvh")) {
-                    if (!(mapper.fieldType().storeTermVectors() && mapper.fieldType().storeTermVectorOffsets() && mapper.fieldType().storeTermVectorPositions())) {
-                        throw new ElasticSearchIllegalArgumentException("the field [" + fieldName + "] should be indexed with term vector with position offsets to be used with fast vector highlighter");
-                    }
-                    useFastVectorHighlighter = true;
-                } else if (field.highlighterType().equals("highlighter") || field.highlighterType().equals("plain")) {
-                    useFastVectorHighlighter = false;
-                } else {
+                    boolean useFastVectorHighlighter = fieldMapper.fieldType().storeTermVectors() && fieldMapper.fieldType().storeTermVectorOffsets() && fieldMapper.fieldType().storeTermVectorPositions();
+                    field.highlighterType(useFastVectorHighlighter ? "fvh" : "plain");
+                }
+
+                Highlighter highlighter = highlighters.get(field.highlighterType());
+                if (highlighter == null) {
                     throw new ElasticSearchIllegalArgumentException("unknown highlighter type [" + field.highlighterType() + "] for the field [" + fieldName + "]");
                 }
-                if (!useFastVectorHighlighter) {
-                    MapperHighlightEntry entry = cache.mappers.get(mapper);
-                    if (entry == null) {
-                        // Don't use the context.query() since it might be rewritten, and we need to pass the non rewritten queries to
-                        // let the highlighter handle MultiTerm ones
 
-                        Query query = context.parsedQuery().query();
-                        QueryScorer queryScorer = new CustomQueryScorer(query, field.requireFieldMatch() ? mapper.names().indexName() : null);
-                        queryScorer.setExpandMultiTermQuery(true);
-                        Fragmenter fragmenter;
-                        if (field.numberOfFragments() == 0) {
-                            fragmenter = new NullFragmenter();
-                        } else if (field.fragmenter() == null) {
-                            fragmenter = new SimpleSpanFragmenter(queryScorer, field.fragmentCharSize());
-                        } else if ("simple".equals(field.fragmenter())) {
-                            fragmenter = new SimpleFragmenter(field.fragmentCharSize());
-                        } else if ("span".equals(field.fragmenter())) {
-                            fragmenter = new SimpleSpanFragmenter(queryScorer, field.fragmentCharSize());
-                        } else {
-                            throw new ElasticSearchIllegalArgumentException("unknown fragmenter option [" + field.fragmenter() + "] for the field [" + fieldName + "]");
-                        }
-                        Formatter formatter = new SimpleHTMLFormatter(field.preTags()[0], field.postTags()[0]);
-
-
-                        entry = new MapperHighlightEntry();
-                        entry.highlighter = new Highlighter(formatter, encoder, queryScorer);
-                        entry.highlighter.setTextFragmenter(fragmenter);
-                        // always highlight across all data
-                        entry.highlighter.setMaxDocCharsToAnalyze(Integer.MAX_VALUE);
-
-                        cache.mappers.put(mapper, entry);
-                    }
-
-                    List<Object> textsToHighlight;
-                    if (mapper.fieldType().stored()) {
-                        try {
-                            CustomFieldsVisitor fieldVisitor = new CustomFieldsVisitor(ImmutableSet.of(mapper.names().indexName()), false);
-                            hitContext.reader().document(hitContext.docId(), fieldVisitor);
-                            textsToHighlight = fieldVisitor.fields().get(mapper.names().indexName());
-                        } catch (Exception e) {
-                            throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + fieldName + "]", e);
-                        }
-                    } else {
-                        SearchLookup lookup = context.lookup();
-                        lookup.setNextReader(hitContext.readerContext());
-                        lookup.setNextDocId(hitContext.docId());
-                        textsToHighlight = lookup.source().extractRawValues(mapper.names().sourcePath());
-                    }
-
-                    // a HACK to make highlighter do highlighting, even though its using the single frag list builder
-                    int numberOfFragments = field.numberOfFragments() == 0 ? 1 : field.numberOfFragments();
-                    ArrayList<TextFragment> fragsList = new ArrayList<TextFragment>();
-                    try {
-                        for (Object textToHighlight : textsToHighlight) {
-                            String text = textToHighlight.toString();
-                            Analyzer analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();
-                            TokenStream tokenStream = analyzer.tokenStream(mapper.names().indexName(), new FastStringReader(text));
-                            tokenStream.reset();
-                            TextFragment[] bestTextFragments = entry.highlighter.getBestTextFragments(tokenStream, text, false, numberOfFragments);
-                            for (TextFragment bestTextFragment : bestTextFragments) {
-                                if (bestTextFragment != null && bestTextFragment.getScore() > 0) {
-                                    fragsList.add(bestTextFragment);
-                                }
-                            }
-                        }
-                    } catch (Exception e) {
-                        throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + fieldName + "]", e);
-                    }
-                    if (field.scoreOrdered()) {
-                        Collections.sort(fragsList, new Comparator<TextFragment>() {
-                            public int compare(TextFragment o1, TextFragment o2) {
-                                return Math.round(o2.getScore() - o1.getScore());
-                            }
-                        });
-                    }
-                    String[] fragments = null;
-                    // number_of_fragments is set to 0 but we have a multivalued field
-                    if (field.numberOfFragments() == 0 && textsToHighlight.size() > 1 && fragsList.size() > 0) {
-                        fragments = new String[fragsList.size()];
-                        for (int i = 0; i < fragsList.size(); i++) {
-                            fragments[i] = fragsList.get(i).toString();
-                        }
-                    } else {
-                        // refine numberOfFragments if needed
-                        numberOfFragments = fragsList.size() < numberOfFragments ? fragsList.size() : numberOfFragments;
-                        fragments = new String[numberOfFragments];
-                        for (int i = 0; i < fragments.length; i++) {
-                            fragments[i] = fragsList.get(i).toString();
-                        }
-                    }
-
-                    if (fragments != null && fragments.length > 0) {
-                        HighlightField highlightField = new HighlightField(fieldName, StringText.convertFromStringArray(fragments));
-                        highlightFields.put(highlightField.name(), highlightField);
-                    }
-                } else {
-                    try {
-                        MapperHighlightEntry entry = cache.mappers.get(mapper);
-                        FieldQuery fieldQuery = null;
-                        if (entry == null) {
-                            FragListBuilder fragListBuilder;
-                            BaseFragmentsBuilder fragmentsBuilder;
-
-                            BoundaryScanner boundaryScanner = SimpleBoundaryScanner2.DEFAULT;
-                            if (field.boundaryMaxScan() != SimpleBoundaryScanner2.DEFAULT_MAX_SCAN || field.boundaryChars() != SimpleBoundaryScanner2.DEFAULT_BOUNDARY_CHARS) {
-                                boundaryScanner = new SimpleBoundaryScanner2(field.boundaryMaxScan(), field.boundaryChars());
-                            }
-
-                            if (field.numberOfFragments() == 0) {
-                                fragListBuilder = new SingleFragListBuilder();
-
-                                if (mapper.fieldType().stored()) {
-                                    fragmentsBuilder = new SimpleFragmentsBuilder(field.preTags(), field.postTags(), boundaryScanner);
-                                } else {
-                                    fragmentsBuilder = new SourceSimpleFragmentsBuilder(mapper, context, field.preTags(), field.postTags(), boundaryScanner);
-                                }
-                            } else {
-                                fragListBuilder = field.fragmentOffset() == -1 ? new SimpleFragListBuilder() : new SimpleFragListBuilder(field.fragmentOffset());
-                                if (field.scoreOrdered()) {
-                                    if (mapper.fieldType().stored()) {
-                                        fragmentsBuilder = new ScoreOrderFragmentsBuilder(field.preTags(), field.postTags(), boundaryScanner);
-                                    } else {
-                                        fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(mapper, context, field.preTags(), field.postTags(), boundaryScanner);
-                                    }
-                                } else {
-                                    if (mapper.fieldType().stored()) {
-                                        fragmentsBuilder = new SimpleFragmentsBuilder(field.preTags(), field.postTags(), boundaryScanner);
-                                    } else {
-                                        fragmentsBuilder = new SourceSimpleFragmentsBuilder(mapper, context, field.preTags(), field.postTags(), boundaryScanner);
-                                    }
-                                }
-                            }
-                            fragmentsBuilder.setDiscreteMultiValueHighlighting(termVectorMultiValue);
-                            entry = new MapperHighlightEntry();
-                            entry.fragListBuilder = fragListBuilder;
-                            entry.fragmentsBuilder = fragmentsBuilder;
-                            if (cache.fvh == null) {
-                                // parameters to FVH are not requires since:
-                                // first two booleans are not relevant since they are set on the CustomFieldQuery (phrase and fieldMatch)
-                                // fragment builders are used explicitly
-                                cache.fvh = new FastVectorHighlighter();
-                            }
-                            CustomFieldQuery.highlightFilters.set(field.highlightFilter());
-                            if (field.requireFieldMatch()) {
-                                if (cache.fieldMatchFieldQuery == null) {
-                                    // we use top level reader to rewrite the query against all readers, with use caching it across hits (and across readers...)
-                                    cache.fieldMatchFieldQuery = new CustomFieldQuery(context.parsedQuery().query(), hitContext.topLevelReader(), true, field.requireFieldMatch());
-                                }
-                                fieldQuery = cache.fieldMatchFieldQuery;
-                            } else {
-                                if (cache.noFieldMatchFieldQuery == null) {
-                                    // we use top level reader to rewrite the query against all readers, with use caching it across hits (and across readers...)
-                                    cache.noFieldMatchFieldQuery = new CustomFieldQuery(context.parsedQuery().query(), hitContext.topLevelReader(), true, field.requireFieldMatch());
-                                }
-                                fieldQuery = cache.noFieldMatchFieldQuery;
-                            }
-                            cache.mappers.put(mapper, entry);
-                        }
-
-                        String[] fragments;
-
-                        // a HACK to make highlighter do highlighting, even though its using the single frag list builder
-                        int numberOfFragments = field.numberOfFragments() == 0 ? Integer.MAX_VALUE : field.numberOfFragments();
-                        int fragmentCharSize = field.numberOfFragments() == 0 ? Integer.MAX_VALUE : field.fragmentCharSize();
-                        // we highlight against the low level reader and docId, because if we load source, we want to reuse it if possible
-                        fragments = cache.fvh.getBestFragments(fieldQuery, hitContext.reader(), hitContext.docId(), mapper.names().indexName(), fragmentCharSize, numberOfFragments,
-                                entry.fragListBuilder, entry.fragmentsBuilder, field.preTags(), field.postTags(), encoder);
-
-                        if (fragments != null && fragments.length > 0) {
-                            HighlightField highlightField = new HighlightField(fieldName, StringText.convertFromStringArray(fragments));
-                            highlightFields.put(highlightField.name(), highlightField);
-                        }
-                    } catch (Exception e) {
-                        throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + fieldName + "]", e);
-                    }
+                HighlighterContext highlighterContext = new HighlighterContext(fieldName, field, fieldMapper, context, hitContext);
+                HighlightField highlightField = highlighter.highlight(highlighterContext);
+                if (highlightField != null) {
+                    highlightFields.put(highlightField.name(), highlightField);
                 }
             }
         }
@@ -332,17 +111,17 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
         hitContext.hit().highlightFields(highlightFields);
     }
 
-    static class MapperHighlightEntry {
-        public FragListBuilder fragListBuilder;
-        public FragmentsBuilder fragmentsBuilder;
+    private FieldMapper<?> getMapperForField(String fieldName, SearchContext searchContext, HitContext hitContext) {
+        DocumentMapper documentMapper = searchContext.mapperService().documentMapper(hitContext.hit().type());
+        FieldMapper<?> mapper = documentMapper.mappers().smartNameFieldMapper(fieldName);
+        if (mapper == null) {
+            MapperService.SmartNameFieldMappers fullMapper = searchContext.mapperService().smartName(fieldName);
+            if (fullMapper == null || !fullMapper.hasDocMapper() || fullMapper.docMapper().type().equals(hitContext.hit().type())) {
+                return null;
+            }
+            mapper = fullMapper.mapper();
+        }
 
-        public Highlighter highlighter;
-    }
-
-    static class HighlighterEntry {
-        public FastVectorHighlighter fvh;
-        public FieldQuery noFieldMatchFieldQuery;
-        public FieldQuery fieldMatchFieldQuery;
-        public Map<FieldMapper, MapperHighlightEntry> mappers = Maps.newHashMap();
+        return mapper;
     }
 }

--- a/src/main/java/org/elasticsearch/search/highlight/Highlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/Highlighter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.highlight;
+
+/**
+ *
+ */
+public interface Highlighter {
+
+    String[] names();
+
+    HighlightField highlight(HighlighterContext highlighterContext);
+}

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.highlight;
+
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ *
+ */
+public class HighlighterContext {
+
+    public String fieldName;
+    public SearchContextHighlight.Field field;
+    public FieldMapper<?> mapper;
+    public SearchContext context;
+    public FetchSubPhase.HitContext hitContext;
+
+    public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper<?> mapper, SearchContext context, FetchSubPhase.HitContext hitContext) {
+        this.fieldName = fieldName;
+        this.field = field;
+        this.mapper = mapper;
+        this.context = context;
+        this.hitContext = hitContext;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -27,6 +27,7 @@ import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -78,6 +79,7 @@ public class HighlighterParseElement implements SearchParseElement {
         char[] globalBoundaryChars = SimpleBoundaryScanner2.DEFAULT_BOUNDARY_CHARS;
         String globalHighlighterType = null;
         String globalFragmenter = null;
+        Map<String, Object> globalOptions = null;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -124,6 +126,8 @@ public class HighlighterParseElement implements SearchParseElement {
                 } else if ("fragmenter".equals(topLevelFieldName)) {
                     globalFragmenter = parser.text();
                 }
+            } else if (token == XContentParser.Token.START_OBJECT && "options".equals(topLevelFieldName)) {
+                globalOptions = parser.map();
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("fields".equals(topLevelFieldName)) {
                     String highlightFieldName = null;
@@ -172,6 +176,8 @@ public class HighlighterParseElement implements SearchParseElement {
                                     } else if ("fragmenter".equals(fieldName)) {
                                         field.fragmenter(parser.text());
                                     }
+                                } else if (fieldName.equals("options")) {
+                                    field.options(parser.map());
                                 }
                             }
                             fields.add(field);
@@ -221,6 +227,9 @@ public class HighlighterParseElement implements SearchParseElement {
             }
             if (field.fragmenter() == null) {
                 field.fragmenter(globalFragmenter);
+            }
+            if (field.options() == null || field.options().size() == 0) {
+                field.options(globalOptions);
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/highlight/Highlighters.java
+++ b/src/main/java/org/elasticsearch/search/highlight/Highlighters.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.highlight;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.inject.Inject;
+
+import java.util.Set;
+
+/**
+ *
+ */
+public class Highlighters {
+    private final ImmutableMap<String, Highlighter> parsers;
+
+    @Inject
+    public Highlighters(Set<Highlighter> parsers) {
+        MapBuilder<String, Highlighter> builder = MapBuilder.newMapBuilder();
+        for (Highlighter parser : parsers) {
+            for (String type : parser.names()) {
+                builder.put(type, parser);
+            }
+        }
+        this.parsers = builder.immutableMap();
+    }
+
+    public Highlighter get(String type) {
+        return parsers.get(type);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.highlight;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.highlight.*;
+import org.apache.lucene.search.highlight.Formatter;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.common.io.FastStringReader;
+import org.elasticsearch.common.text.StringText;
+import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.util.*;
+
+/**
+ *
+ */
+public class PlainHighlighter implements Highlighter {
+
+    private static final String CACHE_KEY = "highlight-plain";
+
+    @Override
+    public String[] names() {
+        return new String[] { "plain", "highlighter" };
+    }
+
+    public HighlightField highlight(HighlighterContext highlighterContext) {
+        SearchContextHighlight.Field field = highlighterContext.field;
+        SearchContext context = highlighterContext.context;
+        FetchSubPhase.HitContext hitContext = highlighterContext.hitContext;
+        FieldMapper<?> mapper = highlighterContext.mapper;
+
+        Encoder encoder = field.encoder().equals("html") ? Encoders.HTML : Encoders.DEFAULT;
+
+        if (!hitContext.cache().containsKey(CACHE_KEY)) {
+            Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter> mappers = Maps.newHashMap();
+            hitContext.cache().put(CACHE_KEY, mappers);
+        }
+        Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter> cache = (Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter>) hitContext.cache().get(CACHE_KEY);
+
+        org.apache.lucene.search.highlight.Highlighter entry = cache.get(mapper);
+        if (entry == null) {
+            // Don't use the context.query() since it might be rewritten, and we need to pass the non rewritten queries to
+            // let the highlighter handle MultiTerm ones
+            Query query = context.parsedQuery().query();
+            QueryScorer queryScorer = new CustomQueryScorer(query, field.requireFieldMatch() ? mapper.names().indexName() : null);
+            queryScorer.setExpandMultiTermQuery(true);
+            Fragmenter fragmenter;
+            if (field.numberOfFragments() == 0) {
+                fragmenter = new NullFragmenter();
+            } else if (field.fragmenter() == null) {
+                fragmenter = new SimpleSpanFragmenter(queryScorer, field.fragmentCharSize());
+            } else if ("simple".equals(field.fragmenter())) {
+                fragmenter = new SimpleFragmenter(field.fragmentCharSize());
+            } else if ("span".equals(field.fragmenter())) {
+                fragmenter = new SimpleSpanFragmenter(queryScorer, field.fragmentCharSize());
+            } else {
+                throw new ElasticSearchIllegalArgumentException("unknown fragmenter option [" + field.fragmenter() + "] for the field [" + highlighterContext.fieldName + "]");
+            }
+            Formatter formatter = new SimpleHTMLFormatter(field.preTags()[0], field.postTags()[0]);
+
+            entry = new org.apache.lucene.search.highlight.Highlighter(formatter, encoder, queryScorer);
+            entry.setTextFragmenter(fragmenter);
+            // always highlight across all data
+            entry.setMaxDocCharsToAnalyze(Integer.MAX_VALUE);
+
+            cache.put(mapper, entry);
+        }
+
+        List<Object> textsToHighlight;
+        if (mapper.fieldType().stored()) {
+            try {
+                CustomFieldsVisitor fieldVisitor = new CustomFieldsVisitor(ImmutableSet.of(mapper.names().indexName()), false);
+                hitContext.reader().document(hitContext.docId(), fieldVisitor);
+                textsToHighlight = fieldVisitor.fields().get(mapper.names().indexName());
+            } catch (Exception e) {
+                throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + highlighterContext.fieldName + "]", e);
+            }
+        } else {
+            SearchLookup lookup = context.lookup();
+            lookup.setNextReader(hitContext.readerContext());
+            lookup.setNextDocId(hitContext.docId());
+            textsToHighlight = lookup.source().extractRawValues(mapper.names().sourcePath());
+        }
+
+        // a HACK to make highlighter do highlighting, even though its using the single frag list builder
+        int numberOfFragments = field.numberOfFragments() == 0 ? 1 : field.numberOfFragments();
+        ArrayList<TextFragment> fragsList = new ArrayList<TextFragment>();
+        try {
+            for (Object textToHighlight : textsToHighlight) {
+                String text = textToHighlight.toString();
+                Analyzer analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();
+                TokenStream tokenStream = analyzer.tokenStream(mapper.names().indexName(), new FastStringReader(text));
+                tokenStream.reset();
+                TextFragment[] bestTextFragments = entry.getBestTextFragments(tokenStream, text, false, numberOfFragments);
+                for (TextFragment bestTextFragment : bestTextFragments) {
+                    if (bestTextFragment != null && bestTextFragment.getScore() > 0) {
+                        fragsList.add(bestTextFragment);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + highlighterContext.fieldName + "]", e);
+        }
+        if (field.scoreOrdered()) {
+            Collections.sort(fragsList, new Comparator<TextFragment>() {
+                public int compare(TextFragment o1, TextFragment o2) {
+                    return Math.round(o2.getScore() - o1.getScore());
+                }
+            });
+        }
+        String[] fragments = null;
+        // number_of_fragments is set to 0 but we have a multivalued field
+        if (field.numberOfFragments() == 0 && textsToHighlight.size() > 1 && fragsList.size() > 0) {
+            fragments = new String[fragsList.size()];
+            for (int i = 0; i < fragsList.size(); i++) {
+                fragments[i] = fragsList.get(i).toString();
+            }
+        } else {
+            // refine numberOfFragments if needed
+            numberOfFragments = fragsList.size() < numberOfFragments ? fragsList.size() : numberOfFragments;
+            fragments = new String[numberOfFragments];
+            for (int i = 0; i < fragments.length; i++) {
+                fragments[i] = fragsList.get(i).toString();
+            }
+        }
+
+        if (fragments != null && fragments.length > 0) {
+            return new HighlightField(highlighterContext.fieldName, StringText.convertFromStringArray(fragments));
+        }
+
+        return null;
+    }
+
+    private static class Encoders {
+        public static Encoder DEFAULT = new DefaultEncoder();
+        public static Encoder HTML = new SimpleHTMLEncoder();
+    }
+}

--- a/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.highlight;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -64,6 +65,8 @@ public class SearchContextHighlight {
 
         private int boundaryMaxScan = -1;
         private char[] boundaryChars = null;
+
+        private Map<String, Object> options;
 
         public Field(String field) {
             this.field = field;
@@ -175,6 +178,14 @@ public class SearchContextHighlight {
 
         public void boundaryChars(char[] boundaryChars) {
             this.boundaryChars = boundaryChars;
+        }
+
+        public Map<String, Object> options() {
+            return options;
+        }
+
+        public void options(Map<String, Object> options) {
+            this.options = options;
         }
     }
 }

--- a/src/test/java/org/elasticsearch/test/integration/search/highlight/CustomHighlighter.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/highlight/CustomHighlighter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.integration.search.highlight;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.common.text.StringText;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.highlight.HighlightField;
+import org.elasticsearch.search.highlight.Highlighter;
+import org.elasticsearch.search.highlight.HighlighterContext;
+import org.elasticsearch.search.highlight.SearchContextHighlight;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * total dumb highlighter used to test the pluggable highlighting functionality
+ */
+public class CustomHighlighter implements Highlighter {
+
+    @Override
+    public String[] names() {
+        return new String[] { "test-custom" };
+    }
+
+    @Override
+    public HighlightField highlight(HighlighterContext highlighterContext) {
+        SearchContextHighlight.Field field = highlighterContext.field;
+
+        List<Text> responses = Lists.newArrayList();
+        responses.add(new StringText("standard response"));
+
+        if (field.options() != null) {
+            for (Map.Entry<String, Object> entry : field.options().entrySet()) {
+                responses.add(new StringText("field:" + entry.getKey() + ":" + entry.getValue()));
+            }
+        }
+
+        return new HighlightField(highlighterContext.fieldName, responses.toArray(new Text[]{}));
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/search/highlight/CustomHighlighterPlugin.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/highlight/CustomHighlighterPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.search.highlight;
+
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.search.highlight.HighlightModule;
+
+public class CustomHighlighterPlugin extends AbstractPlugin {
+
+    @Override
+    public String name() {
+        return "test-plugin-custom-highlighter";
+    }
+
+    @Override
+    public String description() {
+        return "Custom highlighter to test pluggable implementation";
+    }
+
+    public void onModule(HighlightModule highlightModule) {
+        highlightModule.registerHighlighter(CustomHighlighter.class);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/search/highlight/CustomHighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/highlight/CustomHighlighterSearchTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.integration.search.highlight;
+
+import com.beust.jcommander.internal.Maps;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.builder;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHighlight;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ *
+ */
+public class CustomHighlighterSearchTests extends AbstractNodesTests {
+    private Client client;
+
+    @BeforeClass
+    public void createNodes() throws Exception {
+        ImmutableSettings.Builder settings = settingsBuilder().put("plugin.types", CustomHighlighterPlugin.class.getName());
+
+        startNode("server1", settings);
+        startNode("server2", settings);
+        client = getClient();
+
+        client.admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        client.prepareIndex("test", "test", "1").setSource(XContentFactory.jsonBuilder()
+                .startObject()
+                .field("name", "arbitrary content")
+                .endObject())
+            .setRefresh(true).execute().actionGet();
+    }
+
+    @AfterClass
+    public void closeNodes() {
+        client.close();
+        closeAllNodes();
+    }
+
+    protected Client getClient() {
+        return client("server1");
+    }
+
+    @Test
+    public void testThatCustomHighlightersAreSupported() throws IOException {
+        SearchResponse searchResponse = client.prepareSearch("test").setTypes("test")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addHighlightedField("name").setHighlighterType("test-custom")
+                .execute().actionGet();
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response"));
+    }
+
+    @Test
+    public void testThatCustomHighlighterCanBeConfiguredPerField() throws Exception {
+        HighlightBuilder.Field highlightConfig = new HighlightBuilder.Field("name");
+        highlightConfig.highlighterType("test-custom");
+        Map<String, Object> options = Maps.newHashMap();
+        options.put("myFieldOption", "someValue");
+        highlightConfig.options(options);
+
+        SearchResponse searchResponse = client.prepareSearch("test").setTypes("test")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .addHighlightedField(highlightConfig)
+                .execute().actionGet();
+
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response"));
+        assertHighlight(searchResponse, 0, "name", 1, equalTo("field:myFieldOption:someValue"));
+    }
+
+    @Test
+    public void testThatCustomHighlighterCanBeConfiguredGlobally() throws Exception {
+        Map<String, Object> options = Maps.newHashMap();
+        options.put("myGlobalOption", "someValue");
+
+        SearchResponse searchResponse = client.prepareSearch("test").setTypes("test")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .setHighlighterOptions(options)
+                .setHighlighterType("test-custom")
+                .addHighlightedField("name")
+                .execute().actionGet();
+
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response"));
+        assertHighlight(searchResponse, 0, "name", 1, equalTo("field:myGlobalOption:someValue"));
+    }
+}


### PR DESCRIPTION
Currently elasticsearch ships with the plain and the fast-vector highlighter.
In order to support arbitrary highlighters via plugins, you only need to
implement a Highlighter interface and register your implementation in your
plugin at the HighlightModule.

In addition you can also add arbitrary options via the 'options' field in
the highlight request, which can be parsed in the highlighter implementation.

In order to find out how to write add your own analyzer, check out the tests
classes (CustomHighlighterSearchTests and CustomHighlighter).

Closes #2828
