### PR TITLE
QueryStringQuery overwrites parsed boost value

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -214,7 +214,7 @@ public class QueryStringQueryParser implements QueryParser {
             if (query == null) {
                 return null;
             }
-            query.setBoost(qpSettings.boost());
+            query.setBoost(query.getBoost() * qpSettings.boost());
             query = optimizeQuery(fixNegativeQueryIfNeeded(query));
             if (query instanceof BooleanQuery) {
                 Queries.applyMinimumShouldMatch((BooleanQuery) query, qpSettings.minimumShouldMatch());

--- a/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/query/SimpleIndexQueryParserTests.java
@@ -54,6 +54,7 @@ import org.elasticsearch.index.mapper.MapperServiceModule;
 import org.elasticsearch.index.query.IndexQueryParserModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.search.NumericRangeFieldDataFilter;
 import org.elasticsearch.index.search.geo.GeoDistanceFilter;
 import org.elasticsearch.index.search.geo.GeoPolygonFilter;
@@ -160,6 +161,19 @@ public class SimpleIndexQueryParserTests {
         assertThat(termQuery.getTerm(), equalTo(new Term("content", "test")));
     }
 
+    @Test
+    public void testQueryStringBoostsBuilder() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        QueryStringQueryBuilder builder = queryString("field:boosted^2");
+        Query parsedQuery = queryParser.parse(builder).query();
+        assertThat(parsedQuery, instanceOf(TermQuery.class));
+        assertThat(((TermQuery) parsedQuery).getTerm(), equalTo(new Term("field", "boosted")));
+        assertThat(parsedQuery.getBoost(), equalTo(2.0f));
+        builder.boost(2.0f);
+        parsedQuery = queryParser.parse(builder).query();
+        assertThat(parsedQuery.getBoost(), equalTo(4.0f));
+    }
+    
     @Test
     public void testQueryStringFields1Builder() throws Exception {
         IndexQueryParserService queryParser = queryParser();


### PR DESCRIPTION
Set the query boost of a parsed query string query to the product of
the parsed query boost and the boost value specified in the "boost"
query string parameter.

fixes #3024
