### PR TITLE
Fixing percolation of documents with TTL set

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -190,7 +190,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
 
     @Override
     protected Field innerParseCreateField(ParseContext context) throws IOException, AlreadyExpiredException {
-        if (enabledState.enabled) {
+        if (enabledState.enabled && !context.sourceToParse().flyweight()) {
             long ttl = context.sourceToParse().ttl();
             if (ttl <= 0 && defaultTTL > 0) { // no ttl provided so we use the default value
                 ttl = defaultTTL;


### PR DESCRIPTION
When a type is configured with a TTL, percolation of documents of this type
was not possible and threw an exception. This fix ignores the TTL for percolation instead of
throwing an exception that the document is already expired.

Closes #2975
