### PR TITLE
Inverting logic of parsing timestamp fields

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -161,17 +161,24 @@ public class MappingMetaData {
         public static String parseStringTimestamp(String timestampAsString, FormatDateTimeFormatter dateTimeFormatter) throws TimestampParsingException {
             long ts;
             try {
-                // if we manage to parse it, its a millisecond timestamp, just return the string as is
-                ts = Long.parseLong(timestampAsString);
-                return timestampAsString;
-            } catch (NumberFormatException e) {
-                try {
-                    ts = dateTimeFormatter.parser().parseMillis(timestampAsString);
-                } catch (RuntimeException e1) {
-                    throw new TimestampParsingException(timestampAsString);
+                ts = dateTimeFormatter.parser().parseMillis(timestampAsString);
+                // ugly workaround in order to not create negative timestamps, but rather treat it as unix timestamp
+                if (ts < 0) {
+                    ts = parseLong(timestampAsString);
                 }
+            } catch (RuntimeException e) {
+                ts = parseLong(timestampAsString);
             }
             return Long.toString(ts);
+        }
+
+        private static Long parseLong(String timestampAsString) {
+            try {
+                // if we manage to parse it, its a millisecond timestamp, just return the string as is
+                return Long.parseLong(timestampAsString);
+            } catch (NumberFormatException e1) {
+                throw new TimestampParsingException(timestampAsString);
+            }
         }
 
 


### PR DESCRIPTION
The current implementation tries to parse every timestamp as a long first
and uses it as a unix timestamp.
This fails if the configured timestamp is like 'YYYYMMDD' and also
resembles a long by coincidence.

This PR tries to fix this issue by trying to parse it as a date first and
only it fails is tried to be parsed as a long from unix timestamp.

Possible problems:
- Performance: Reversing the order might make things slower.
- Wrong parsing: An additional check was added to make sure no negative
  unix timestamps can be generated.

Closes #2937
