### PR TITLE
Add {path} keyword to dynamic templates to be replaced with the full path of the field

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
@@ -164,40 +164,47 @@ public class DynamicTemplate {
         return str.matches(pattern);
     }
 
-    public Map<String, Object> mappingForName(String name, String dynamicType) {
-        return processMap(mapping, name, dynamicType);
+    public Map<String, Object> mappingForName(String name, String fullPath, String dynamicType) {
+        return processMap(mapping, name, fullPath, dynamicType);
     }
 
-    private Map<String, Object> processMap(Map<String, Object> map, String name, String dynamicType) {
+    private Map<String, Object> processMap(Map<String, Object> map, String name, String fullPath, String dynamicType) {
         Map<String, Object> processedMap = Maps.newHashMap();
         for (Map.Entry<String, Object> entry : map.entrySet()) {
-            String key = entry.getKey().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
+            String key = replacePlaceHolders(entry.getKey(), name, fullPath, dynamicType);
             Object value = entry.getValue();
             if (value instanceof Map) {
-                value = processMap((Map<String, Object>) value, name, dynamicType);
+                value = processMap((Map<String, Object>) value, name, fullPath, dynamicType);
             } else if (value instanceof List) {
-                value = processList((List) value, name, dynamicType);
+                value = processList((List) value, name, fullPath, dynamicType);
             } else if (value instanceof String) {
-                value = value.toString().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
+                value = replacePlaceHolders(value.toString(), name, fullPath, dynamicType);
             }
             processedMap.put(key, value);
         }
         return processedMap;
     }
 
-    private List processList(List list, String name, String dynamicType) {
+    private List processList(List list, String name, String fullPath, String dynamicType) {
         List processedList = new ArrayList();
         for (Object value : list) {
             if (value instanceof Map) {
-                value = processMap((Map<String, Object>) value, name, dynamicType);
+                value = processMap((Map<String, Object>) value, name, fullPath, dynamicType);
             } else if (value instanceof List) {
-                value = processList((List) value, name, dynamicType);
+                value = processList((List) value, name, fullPath,  dynamicType);
             } else if (value instanceof String) {
-                value = value.toString().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
+                value = replacePlaceHolders(value.toString(), name, fullPath, dynamicType);
             }
             processedList.add(value);
         }
         return processedList;
+    }
+
+    private String replacePlaceHolders(String value, String fieldName, String fullPath, String dynamicType) {
+        return value.replace("{name}", fieldName)
+                .replace("{path}", fullPath)
+                .replace("{dynamic_type}", dynamicType)
+                .replace("{dynamicType}", dynamicType);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -215,7 +215,7 @@ public class RootObjectMapper extends ObjectMapper {
         if (typeParser == null) {
             throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");
         }
-        return typeParser.parse(name, dynamicTemplate.mappingForName(name, dynamicType), parserContext);
+        return typeParser.parse(name, dynamicTemplate.mappingForName(name, context.path().fullPathAsText(name), dynamicType), parserContext);
     }
 
     public DynamicTemplate findTemplate(ContentPath path, String name, String matchType) {

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/pathmatch/test-data.json
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/pathmatch/test-data.json
@@ -11,5 +11,13 @@
         "obj4":{
             "prop1":"prop1_value"
         }
+    },
+    "obj5":{
+        "title":"obj5_title",
+        "title2":"obj5_title2",
+        "obj6":{
+            "title":"obj6_title",
+            "title2":"obj6_title2"
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/pathmatch/test-mapping.json
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/dynamictemplate/pathmatch/test-mapping.json
@@ -24,6 +24,19 @@
                         "type":"string"
                     }
                 }
+            },
+            {
+                "template_4":{
+                    "path_match":"*.title*",
+                    "mapping":{
+                        "type": "multi_field",
+                        "path":"just_name",
+                        "fields":{
+                            "{name}": {"type": "{dynamic_type}", "store":"no"},
+                            "{path}": {"type": "{dynamic_type}", "store":"yes"}
+                        }
+                    }
+                }
             }
         ]
     }


### PR DESCRIPTION
For a project I've been working on I have json documents that contain multiple inner objects, which contain similar fields, as in the following example:

```
{
    "inner1" : {
        "title" : "title inner1" 
    },
    "inner2" : {
        "title" : "title inner2"
    }
}
```

I want to keep all the titles in separate fields `inner1.title` and `inner2.title`, but at the same time I want to have a catch all field that contains all the titles, possibly as a top level field called `title`. I achieved this with a multi_field using the `just_name` path like this:

```
"inner1" : {
    "type" : "object",
    "properties" : {
        "title" : {
            "type" : "multi_field",
            "path" : "just_name",
            "fields" : {
                "title" : {"type":"string"},
                "inner1.title" : {"type":"string"}
            }
        }
    }
}
```

It is tricky because it's exactly the opposite of what a normal multi_field would do, since the first title (without path)  becomes the top level catch all, while the other `inner1.title` is the usual `inner1.title` field. Since I have to repeat in the mapping the same multi_field for every level where I want to take the title from, I decided to use dynamic templates to keep the mapping to submit when creating the index more concise. Unfortunately the fact that the second field in the multi_field contains the path is a problem and not supported through a placeholder like {name} or {dynamic_type}.

The pull request adds the support for a new {path} placeholder that makes it possible to do the following:

```
"template":{
    "path_match":"*.title",
    "mapping":{
        "type": "multi_field",
        "path":"just_name",
        "fields":{
            "{name}": {"type": "{dynamic_type}"},
            "{path}": {"type": "{dynamic_type}"}
        }
    }
}
```

This way with a single dynamic template I can achieve what I want for multiple fields taken from multiple levels in the json tree.
