### PR TITLE
Changed Java dependency from Depends to Suggest for Debian. 

### DIFF
--- a/src/deb/control/control
+++ b/src/deb/control/control
@@ -2,7 +2,8 @@ Package: elasticsearch
 Version: [[version]]
 Architecture: all
 Maintainer: Nicolas Huray <nicolas.huray@gmail.com>
-Depends: libc6, adduser, java7-runtime-headless | java6-runtime-headless | java7-runtime | java6-runtime
+Depends: libc6, adduser
+Suggest: java7-runtime-headless | java6-runtime-headless | java7-runtime | java6-runtime
 Section: web
 Priority: optional
 Homepage: http://www.elasticsearch.org/


### PR DESCRIPTION
Since people are also using the Oracle JAVA distribution and not the OpenJDK.

Now the installation will at least continue, and it will not give dependency errors when installing other packages after the installation of ElasticSearch.
