### PR TITLE
Index/Update/Create/Delete now report the previous version of the docume...

### DIFF
--- a/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.delete;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.engine.Engine;
 
 import java.io.IOException;
 
@@ -37,17 +38,19 @@ public class DeleteResponse extends ActionResponse {
     private String id;
     private String type;
     private long version;
+    private long previousVersion = Engine.VERSION_NOT_FOUND;
     private boolean notFound;
 
     public DeleteResponse() {
 
     }
 
-    public DeleteResponse(String index, String type, String id, long version, boolean notFound) {
+    public DeleteResponse(String index, String type, String id, long version, long previousVersion, boolean notFound) {
         this.index = index;
         this.id = id;
         this.type = type;
         this.version = version;
+        this.previousVersion = previousVersion;
         this.notFound = notFound;
     }
 
@@ -80,6 +83,14 @@ public class DeleteResponse extends ActionResponse {
     }
 
     /**
+     * The version of the document that was deleted, {@link Engine.VERSION_NOT_FOUND} if not found.
+     */
+    public long getPreviousVersion() {
+        return previousVersion;
+    }
+
+
+    /**
      * Returns <tt>true</tt> if there was no doc found to delete.
      */
     public boolean isNotFound() {
@@ -93,6 +104,7 @@ public class DeleteResponse extends ActionResponse {
         id = in.readString();
         type = in.readString();
         version = in.readLong();
+        previousVersion = in.readLong();
         notFound = in.readBoolean();
     }
 
@@ -103,6 +115,8 @@ public class DeleteResponse extends ActionResponse {
         out.writeString(id);
         out.writeString(type);
         out.writeLong(version);
+        out.writeLong(previousVersion);
         out.writeBoolean(notFound);
     }
+
 }

--- a/src/main/java/org/elasticsearch/action/delete/index/ShardDeleteResponse.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/ShardDeleteResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.delete.index;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.engine.Engine;
 
 import java.io.IOException;
 
@@ -31,18 +32,24 @@ import java.io.IOException;
 public class ShardDeleteResponse extends ActionResponse {
 
     private long version;
+    private long previousVersion = Engine.VERSION_NOT_FOUND;
     private boolean notFound;
 
     public ShardDeleteResponse() {
     }
 
-    public ShardDeleteResponse(long version, boolean notFound) {
+    public ShardDeleteResponse(long version, long previousVersion, boolean notFound) {
         this.version = version;
+        this.previousVersion = previousVersion;
         this.notFound = notFound;
     }
 
     public long getVersion() {
         return version;
+    }
+
+    public long getPreviousVersion() {
+        return previousVersion;
     }
 
     public boolean isNotFound() {
@@ -53,6 +60,7 @@ public class ShardDeleteResponse extends ActionResponse {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         version = in.readLong();
+        previousVersion = in.readLong();
         notFound = in.readBoolean();
     }
 
@@ -60,6 +68,7 @@ public class ShardDeleteResponse extends ActionResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeLong(version);
+        out.writeLong(previousVersion);
         out.writeBoolean(notFound);
     }
 }

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
@@ -107,7 +107,7 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
         }
 
 
-        ShardDeleteResponse response = new ShardDeleteResponse(delete.version(), delete.notFound());
+        ShardDeleteResponse response = new ShardDeleteResponse(delete.version(), delete.previousVersion(), delete.notFound());
         return new PrimaryResponse<ShardDeleteResponse, ShardDeleteRequest>(shardRequest.request, response, null);
     }
 

--- a/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -40,17 +40,19 @@ public class IndexResponse extends ActionResponse {
     private String id;
     private String type;
     private long version;
+    private long previousVersion;
     private List<String> matches;
 
     public IndexResponse() {
 
     }
 
-    public IndexResponse(String index, String type, String id, long version) {
+    public IndexResponse(String index, String type, String id, long version, long previousVersion) {
         this.index = index;
         this.id = id;
         this.type = type;
         this.version = version;
+        this.previousVersion = previousVersion;
     }
 
     /**
@@ -75,10 +77,17 @@ public class IndexResponse extends ActionResponse {
     }
 
     /**
-     * Returns the version of the doc indexed.
+     * Returns the current version of the doc indexed.
      */
     public long getVersion() {
         return this.version;
+    }
+
+    /**
+     * Returns the previous version of the doc, if found
+     */
+    public long getPreviousVersion() {
+        return this.previousVersion;
     }
 
     /**
@@ -102,6 +111,7 @@ public class IndexResponse extends ActionResponse {
         id = in.readString();
         type = in.readString();
         version = in.readLong();
+        previousVersion = in.readLong();
         if (in.readBoolean()) {
             int size = in.readVInt();
             if (size == 0) {
@@ -132,6 +142,7 @@ public class IndexResponse extends ActionResponse {
         out.writeString(id);
         out.writeString(type);
         out.writeLong(version);
+        out.writeLong(previousVersion);
         if (matches == null) {
             out.writeBoolean(false);
         } else {

--- a/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -193,7 +193,8 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(upsertRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getIndex(), response.getType(), response.getId(), response.getVersion());
+                        UpdateResponse update = new UpdateResponse(response.getIndex(), response.getType(), response.getId(),
+                                                                   response.getVersion(), response.getPreviousVersion());
                         update.setMatches(response.getMatches());
                         if (request.fields() != null && request.fields().length > 0) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(upsertSourceBytes, true);
@@ -229,7 +230,8 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getIndex(), response.getType(), response.getId(), response.getVersion());
+                        UpdateResponse update = new UpdateResponse(response.getIndex(), response.getType(), response.getId(),
+                                                                   response.getVersion(), response.getPreviousVersion());
                         update.setMatches(response.getMatches());
                         update.setGetResult(updateHelper.extractGetResult(request, response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                         listener.onResponse(update);
@@ -258,7 +260,8 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getIndex(), response.getType(), response.getId(), response.getVersion());
+                        UpdateResponse update = new UpdateResponse(response.getIndex(), response.getType(), response.getId(), response.getVersion(),
+                                response.getPreviousVersion());
                         update.setGetResult(updateHelper.extractGetResult(request, response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                         listener.onResponse(update);
                     }

--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -149,6 +149,7 @@ public class UpdateHelper extends AbstractComponent {
         }
 
         // TODO: external version type, does it make sense here? does not seem like it...
+        // TODO: because we use  getResult.getVersion we loose the doc.version. The question is where is the right place?
         if (operation == null || "index".equals(operation)) {
             final IndexRequest indexRequest = Requests.indexRequest(request.index()).type(request.type()).id(request.id()).routing(routing).parent(parent)
                     .source(updatedSourceAsMap, updateSourceContentType)
@@ -164,12 +165,15 @@ public class UpdateHelper extends AbstractComponent {
             deleteRequest.operationThreaded(false);
             return new Result(deleteRequest, Operation.DELETE, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
-            UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(), getResult.getVersion());
+            // we do nothing, previousVersion = current version
+            UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(), getResult.getVersion(),
+                                                       getResult.getVersion());
             update.setGetResult(extractGetResult(request, getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, null));
             return new Result(update, Operation.NONE, updatedSourceAsMap, updateSourceContentType);
         } else {
             logger.warn("Used update operation [{}] for script [{}], doing nothing...", operation, request.script);
-            UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(), getResult.getVersion());
+            UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(),
+                                        getResult.getVersion(), getResult.getVersion());
             return new Result(update, Operation.NONE, updatedSourceAsMap, updateSourceContentType);
         }
     }

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -359,6 +359,14 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     }
 
     /**
+     * Sets the doc for a simple single field / value update.
+     */
+    public UpdateRequest doc(String field, Object value) {
+        safeDoc().source(field,value);
+        return this;
+    }
+
+    /**
      * Sets the doc to use for updates when a script is not specified.
      */
     public UpdateRequest doc(Map source, XContentType contentType) {

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -177,6 +177,14 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
     }
 
     /**
+     * Sets the doc for a simple single field / value update.
+     */
+    public UpdateRequestBuilder setDoc(String field, Object value) {
+        request.doc(field,value);
+        return this;
+    }
+
+    /**
      * Sets the doc to use for updates when a script is not specified.
      */
     public UpdateRequestBuilder setDoc(Map source) {

--- a/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -37,6 +37,7 @@ public class UpdateResponse extends ActionResponse {
     private String id;
     private String type;
     private long version;
+    private long previousVersion;
     private List<String> matches;
     private GetResult getResult;
 
@@ -44,11 +45,12 @@ public class UpdateResponse extends ActionResponse {
 
     }
 
-    public UpdateResponse(String index, String type, String id, long version) {
+    public UpdateResponse(String index, String type, String id, long version, long previousVersion) {
         this.index = index;
         this.id = id;
         this.type = type;
         this.version = version;
+        this.previousVersion = previousVersion;
     }
 
     /**
@@ -73,10 +75,18 @@ public class UpdateResponse extends ActionResponse {
     }
 
     /**
-     * Returns the version of the doc indexed.
+     * Returns the current version of the doc indexed.
      */
     public long getVersion() {
         return this.version;
+
+    }
+
+    /**
+     * Returns the previous version of the doc found in index.
+     */
+    public long getPreviousVersion() {
+        return this.previousVersion;
     }
 
     /**
@@ -108,6 +118,7 @@ public class UpdateResponse extends ActionResponse {
         id = in.readString();
         type = in.readString();
         version = in.readLong();
+        previousVersion = in.readLong();
         if (in.readBoolean()) {
             int size = in.readVInt();
             if (size == 0) {
@@ -141,6 +152,7 @@ public class UpdateResponse extends ActionResponse {
         out.writeString(id);
         out.writeString(type);
         out.writeLong(version);
+        out.writeLong(previousVersion);
         if (matches == null) {
             out.writeBoolean(false);
         } else {

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
@@ -114,7 +115,8 @@ public class RestIndexAction extends BaseRestHandler {
                             .field(Fields._INDEX, response.getIndex())
                             .field(Fields._TYPE, response.getType())
                             .field(Fields._ID, response.getId())
-                            .field(Fields._VERSION, response.getVersion());
+                            .field(Fields._VERSION, response.getVersion())
+                            .field(Fields._PREVIOUS_VERSION, response.getPreviousVersion());
                     if (response.getMatches() != null) {
                         builder.startArray(Fields.MATCHES);
                         for (String match : response.getMatches()) {
@@ -124,7 +126,7 @@ public class RestIndexAction extends BaseRestHandler {
                     }
                     builder.endObject();
                     RestStatus status = OK;
-                    if (response.getVersion() == 1) {
+                    if (response.getPreviousVersion() == Engine.VERSION_NOT_FOUND) {
                         status = CREATED;
                     }
                     channel.sendResponse(new XContentRestResponse(request, status, builder));
@@ -150,6 +152,7 @@ public class RestIndexAction extends BaseRestHandler {
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
         static final XContentBuilderString _ID = new XContentBuilderString("_id");
         static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
+        static final XContentBuilderString _PREVIOUS_VERSION = new XContentBuilderString("_previous_version");
         static final XContentBuilderString MATCHES = new XContentBuilderString("matches");
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -126,13 +126,17 @@ public class RestUpdateAction extends BaseRestHandler {
             @Override
             public void onResponse(UpdateResponse response) {
                 try {
+
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject()
                             .field(Fields.OK, true)
                             .field(Fields._INDEX, response.getIndex())
                             .field(Fields._TYPE, response.getType())
                             .field(Fields._ID, response.getId())
-                            .field(Fields._VERSION, response.getVersion());
+                            .field(Fields._VERSION, response.getVersion())
+                            .field(Fields._PREVIOUS_VERSION, response.getPreviousVersion());
+
+
 
                     if (response.getGetResult() != null) {
                         builder.startObject(Fields.GET);
@@ -149,7 +153,7 @@ public class RestUpdateAction extends BaseRestHandler {
                     }
                     builder.endObject();
                     RestStatus status = OK;
-                    if (response.getVersion() == 1) {
+                    if (response.getPreviousVersion() == -1) {
                         status = CREATED;
                     }
                     channel.sendResponse(new XContentRestResponse(request, status, builder));
@@ -175,6 +179,7 @@ public class RestUpdateAction extends BaseRestHandler {
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
         static final XContentBuilderString _ID = new XContentBuilderString("_id");
         static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
+        static final XContentBuilderString _PREVIOUS_VERSION = new XContentBuilderString("_previous_version");
         static final XContentBuilderString MATCHES = new XContentBuilderString("matches");
         static final XContentBuilderString GET = new XContentBuilderString("get");
     }

--- a/src/test/java/org/elasticsearch/test/integration/versioning/SimpleVersioningTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/versioning/SimpleVersioningTests.java
@@ -28,14 +28,17 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.DocumentAlreadyExistsException;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.test.integration.AbstractNodesTests;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
+
+import java.util.HashMap;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -64,27 +67,9 @@ public class SimpleVersioningTests extends AbstractNodesTests {
         closeAllNodes();
     }
 
-    @Test
-    public void testExternalVersioningInitialDelete() throws Exception {
-        client.admin().indices().prepareDelete().execute().actionGet();
 
-        client.admin().indices().prepareCreate("test").execute().actionGet();
-        client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
-
-        DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(deleteResponse.isNotFound(), equalTo(true));
-
-        try {
-            client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(13).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
-
-        client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(18).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-    }
-
-    @Test
-    public void testExternalVersioning() throws Exception {
+    @BeforeMethod
+    public void setUp() {
         try {
             client.admin().indices().prepareDelete("test").execute().actionGet();
         } catch (IndexMissingException e) {
@@ -93,89 +78,153 @@ public class SimpleVersioningTests extends AbstractNodesTests {
         client.admin().indices().prepareCreate("test").execute().actionGet();
         client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
 
-        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(12).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(12l));
+    }
 
-        indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(14).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(14l));
+
+    @Test
+    public void testExternalVersioningInitialDelete() throws Exception {
+
+        // Note - external version doesn't throw version conflicts on deletes of non existent records. This is different from internal versioning
+        DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(deleteResponse.isNotFound(), equalTo(true));
 
         try {
+            // this should conflict with the delete command transaction which told us that the object was deleted at version 17.
             client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(13).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+            throw new AssertionError("Expected to get a version conflict but didn't get one");
         } catch (ElasticSearchException e) {
             assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
         }
+
+        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(18).
+                setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(indexResponse.getVersion(), equalTo(18L));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(17L));
+
+
+    }
+
+    @Test
+    public void testExternalVersioning() throws Exception {
+
+        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(12).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(indexResponse.getVersion(), equalTo(12l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
+
+        indexResponse = client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(14).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(indexResponse.getVersion(), equalTo(14l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(12l));
+
+        assertThrows(client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(13).setVersionType(VersionType.EXTERNAL).execute(),
+                     VersionConflictEngineException.class);
+
 
         client.admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 10; i++) {
             assertThat(client.prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(14l));
         }
 
+        // deleting with a lower version fails.
+        assertThrows(
+            client2.prepareDelete("test", "type", "1").setVersion(2).setVersionType(VersionType.EXTERNAL).execute(),
+            VersionConflictEngineException.class);
+
+
+
+        // Delete with a higher version deletes all versions up to the given one.
         DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
         assertThat(deleteResponse.isNotFound(), equalTo(false));
         assertThat(deleteResponse.getVersion(), equalTo(17l));
+        assertThat(deleteResponse.getPreviousVersion(), equalTo(14l));
 
-        try {
-            client2.prepareDelete("test", "type", "1").setVersion(2).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        // Deleting with a lower version keeps on failing after a delete.
+        assertThrows(
+            client2.prepareDelete("test", "type", "1").setVersion(2).setVersionType(VersionType.EXTERNAL).execute(),
+            VersionConflictEngineException.class);
 
+
+        // But delete with a higher version is OK.
         deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL).execute().actionGet();
         assertThat(deleteResponse.isNotFound(), equalTo(true));
         assertThat(deleteResponse.getVersion(), equalTo(18l));
+
+
+        // TODO: This behavior breaks rest api returning http status 201, good news is that it this is only the case until deletes GC kicks in.
+        indexResponse = client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(19).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(indexResponse.getVersion(), equalTo(19l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(18l));
+
+
+        deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(deleteResponse.isNotFound(), equalTo(false));
+        assertThat(deleteResponse.getVersion(), equalTo(20l));
+        assertThat(deleteResponse.getPreviousVersion(), equalTo(19l));
+
+        // Make sure that the next delete will be GC. Note we do it on the index settings so it will be cleaned up
+        HashMap<String,Object> newSettings = new HashMap<String, Object>();
+        newSettings.put("index.gc_deletes",-1);
+        client.admin().indices().prepareUpdateSettings("test").setSettings(newSettings).execute().actionGet();
+
+        Thread.sleep(300); // gc works based on estimated sampled time. Give it a chance...
+
+        // And now we have previous version return -1
+        indexResponse = client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        assertThat(indexResponse.getVersion(), equalTo(20l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
+
+
     }
 
     @Test
-    public void testSimpleVersioning() throws Exception {
-        try {
-            client.admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (IndexMissingException e) {
-            // its ok
-        }
-        client.admin().indices().prepareCreate("test").execute().actionGet();
-        client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+    public void testInternalVersioningInitialDelete() throws Exception {
+        assertThrows(client2.prepareDelete("test", "type", "1").setVersion(17).execute(),
+                VersionConflictEngineException.class);
+
+        IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1")
+                .setCreate(true).execute().actionGet();
+        assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
+    }
+
+
+    @Test
+    public void testInternalVersioning() throws Exception {
+
+
 
         IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
         assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
 
         indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(1).execute().actionGet();
         assertThat(indexResponse.getVersion(), equalTo(2l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(1l));
 
-        try {
-            client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(
+            client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute(),
+            VersionConflictEngineException.class);
 
-        try {
-            client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(
+            client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute(),
+            VersionConflictEngineException.class);
 
-        try {
-            client.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(
+            client.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute(),
+                VersionConflictEngineException.class);
+        assertThrows(
+            client2.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute(),
+                VersionConflictEngineException.class);
 
-        try {
-            client2.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(
+                client.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(2).execute(),
+                DocumentAlreadyExistsException.class);
+        assertThrows(
+                client2.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(2).execute(),
+                DocumentAlreadyExistsException.class);
 
-        try {
-            client.prepareDelete("test", "type", "1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
 
-        try {
-            client2.prepareDelete("test", "type", "1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(client.prepareDelete("test", "type", "1").setVersion(1).execute(), VersionConflictEngineException.class);
+        assertThrows(client2.prepareDelete("test", "type", "1").setVersion(1).execute(), VersionConflictEngineException.class);
 
         client.admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 10; i++) {
@@ -191,79 +240,53 @@ public class SimpleVersioningTests extends AbstractNodesTests {
         // search without versioning
         for (int i = 0; i < 10; i++) {
             SearchResponse searchResponse = client.prepareSearch().setQuery(matchAllQuery()).execute().actionGet();
-            assertThat(searchResponse.getHits().getAt(0).version(), equalTo(-1l));
+            assertThat(searchResponse.getHits().getAt(0).version(), equalTo(Engine.VERSION_NOT_FOUND));
         }
 
         DeleteResponse deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(2).execute().actionGet();
         assertThat(deleteResponse.isNotFound(), equalTo(false));
         assertThat(deleteResponse.getVersion(), equalTo(3l));
+        assertThat(deleteResponse.getPreviousVersion(), equalTo(2l));
 
-        try {
-            client2.prepareDelete("test", "type", "1").setVersion(2).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(client2.prepareDelete("test", "type", "1").setVersion(2).execute(), VersionConflictEngineException.class);
 
+
+        // This is intricate - the object was deleted but a delete transaction was with the right version. We add another one
+        // and thus the transcation is increased.
         deleteResponse = client2.prepareDelete("test", "type", "1").setVersion(3).execute().actionGet();
         assertThat(deleteResponse.isNotFound(), equalTo(true));
         assertThat(deleteResponse.getVersion(), equalTo(4l));
+        assertThat(deleteResponse.getPreviousVersion(), equalTo(3l));
     }
 
     @Test
     public void testSimpleVersioningWithFlush() throws Exception {
-        try {
-            client.admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (IndexMissingException e) {
-            // its ok
-        }
-        client.admin().indices().prepareCreate("test").execute().actionGet();
-        client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
 
         IndexResponse indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
         assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
 
         client.admin().indices().prepareFlush().execute().actionGet();
 
         indexResponse = client.prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(1).execute().actionGet();
         assertThat(indexResponse.getVersion(), equalTo(2l));
+        assertThat(indexResponse.getPreviousVersion(), equalTo(1l));
 
         client.admin().indices().prepareFlush().execute().actionGet();
 
-        try {
-            client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(client.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute(),
+                VersionConflictEngineException.class);
 
-        try {
-            client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(client2.prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute(),
+                VersionConflictEngineException.class);
+        assertThrows(client.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute(),
+                VersionConflictEngineException.class);
 
-        try {
-            client.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(client2.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute(),
+                VersionConflictEngineException.class);
 
-        try {
-            client2.prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
-
-        try {
-            client.prepareDelete("test", "type", "1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
-
-        try {
-            client2.prepareDelete("test", "type", "1").setVersion(1).execute().actionGet();
-        } catch (ElasticSearchException e) {
-            assertThat(e.unwrapCause(), instanceOf(VersionConflictEngineException.class));
-        }
+        assertThrows(client.prepareDelete("test", "type", "1").setVersion(1).execute(), VersionConflictEngineException.class);
+        assertThrows(client2.prepareDelete("test", "type", "1").setVersion(1).execute(), VersionConflictEngineException.class);
 
         client.admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 10; i++) {
@@ -278,13 +301,6 @@ public class SimpleVersioningTests extends AbstractNodesTests {
 
     @Test
     public void testVersioningWithBulk() {
-        try {
-            client.admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (IndexMissingException e) {
-            // its ok
-        }
-        client.admin().indices().prepareCreate("test").execute().actionGet();
-        client.admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
 
         BulkResponse bulkResponse = client.prepareBulk().add(client.prepareIndex("test", "type", "1").setSource("field1", "value1_1")).execute().actionGet();
         assertThat(bulkResponse.hasFailures(), equalTo(false));

--- a/src/test/java/org/elasticsearch/test/unit/index/engine/AbstractSimpleEngineTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/engine/AbstractSimpleEngineTests.java
@@ -640,6 +640,7 @@ public abstract class AbstractSimpleEngineTests {
         Engine.Index index = new Engine.Index(null, newUid("1"), doc).versionType(VersionType.EXTERNAL).version(12);
         engine.index(index);
         assertThat(index.version(), equalTo(12l));
+        assertThat(index.previousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
 
         index = new Engine.Index(null, newUid("1"), doc).version(index.version()).origin(REPLICA);
         replicaEngine.index(index);
@@ -681,10 +682,12 @@ public abstract class AbstractSimpleEngineTests {
         Engine.Index index = new Engine.Index(null, newUid("1"), doc).versionType(VersionType.EXTERNAL).version(12);
         engine.index(index);
         assertThat(index.version(), equalTo(12l));
+        assertThat(index.previousVersion(), equalTo(Engine.VERSION_NOT_FOUND));
 
         index = new Engine.Index(null, newUid("1"), doc).versionType(VersionType.EXTERNAL).version(14);
         engine.index(index);
         assertThat(index.version(), equalTo(14l));
+        assertThat(index.previousVersion(), equalTo(12l));
 
         index = new Engine.Index(null, newUid("1"), doc).versionType(VersionType.EXTERNAL).version(13l);
         try {


### PR DESCRIPTION
...nt they have touched (new version already) reported.

Added an assertThrows to ElasticsearchAssertions. Added a shortcut function to UpdateRequest to quickly update a single doc field.

Closes #3066 . Closes #3084.
