### PR TITLE
Don't fail highlighting if the field to highlight is missing.

### DIFF
--- a/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -52,7 +52,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -322,7 +321,7 @@ public class ShardGetService extends AbstractIndexShardComponent {
             }
             source = fieldVisitor.source();
 
-            if (fieldVisitor.fields() != null) {
+            if (!fieldVisitor.fields().isEmpty()) {
                 fieldVisitor.postProcess(docMapper);
                 fields = new HashMap<String, GetField>(fieldVisitor.fields().size());
                 for (Map.Entry<String, List<Object>> entry : fieldVisitor.fields().entrySet()) {

--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -145,7 +145,7 @@ public class FetchPhase implements SearchPhase {
             fieldsVisitor.postProcess(context.mapperService());
 
             Map<String, SearchHitField> searchFields = null;
-            if (fieldsVisitor.fields() != null) {
+            if (!fieldsVisitor.fields().isEmpty()) {
                 searchFields = new HashMap<String, SearchHitField>(fieldsVisitor.fields().size());
                 for (Map.Entry<String, List<Object>> entry : fieldsVisitor.fields().entrySet()) {
                     searchFields.put(entry.getKey(), new InternalSearchHitField(entry.getKey(), entry.getValue()));


### PR DESCRIPTION
PlainHighlighter fails at highlighting with a hard exception in case the field
to highlight is missing. This patch fixes this issue by
- making FieldsVisitor.fields() return an empty list instead of null when no
  stored field was found,
- replacing the fields to highlight with an empty list in case they are absent.

Closes: #3109
