### PR TITLE
Changing version semantics to be more readable

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -261,19 +261,19 @@ public class Version implements Serializable {
     }
 
     public boolean after(Version version) {
-        return version.id > id;
-    }
-
-    public boolean onOrAfter(Version version) {
-        return version.id >= id;
-    }
-
-    public boolean before(Version version) {
         return version.id < id;
     }
 
-    public boolean onOrBefore(Version version) {
+    public boolean onOrAfter(Version version) {
         return version.id <= id;
+    }
+
+    public boolean before(Version version) {
+        return version.id > id;
+    }
+
+    public boolean onOrBefore(Version version) {
+        return version.id >= id;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
@@ -595,7 +595,7 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
 
         searchSize = in.readVInt();
         searchFrom = in.readVInt();
-        if (Version.V_0_90_1.onOrAfter(in.getVersion())) {
+        if (in.getVersion().onOrAfter(Version.V_0_90_1)) {
             routing = in.readOptionalString();
         }
     }
@@ -665,7 +665,7 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
 
         out.writeVInt(searchSize);
         out.writeVInt(searchFrom);
-        if (Version.V_0_90_1.onOrAfter(out.getVersion())) {
+        if (out.getVersion().onOrAfter(Version.V_0_90_1)) {
             out.writeOptionalString(routing);
         }
     }

--- a/src/test/java/org/elasticsearch/test/unit/VersionTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/VersionTests.java
@@ -19,6 +19,32 @@
 
 package org.elasticsearch.test.unit;
 
+import org.testng.annotations.Test;
+
+import static org.elasticsearch.Version.V_0_20_0;
+import static org.elasticsearch.Version.V_0_90_0;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class VersionTests {
+
+    @Test
+    public void testVersions() throws Exception {
+        assertThat(V_0_20_0.before(V_0_90_0), is(true));
+        assertThat(V_0_20_0.before(V_0_20_0), is(false));
+        assertThat(V_0_90_0.before(V_0_20_0), is(false));
+
+        assertThat(V_0_20_0.onOrBefore(V_0_90_0), is(true));
+        assertThat(V_0_20_0.onOrBefore(V_0_20_0), is(true));
+        assertThat(V_0_90_0.onOrBefore(V_0_20_0), is(false));
+
+        assertThat(V_0_20_0.after(V_0_90_0), is(false));
+        assertThat(V_0_20_0.after(V_0_20_0), is(false));
+        assertThat(V_0_90_0.after(V_0_20_0), is(true));
+
+        assertThat(V_0_20_0.onOrAfter(V_0_90_0), is(false));
+        assertThat(V_0_20_0.onOrAfter(V_0_20_0), is(true));
+        assertThat(V_0_90_0.onOrAfter(V_0_20_0), is(true));
+    }
 
 }


### PR DESCRIPTION
The Version class had hard to understand semantics when two versions were
compared against each other.

Sample of the new logic (which is simply the old logic inverted):
- V_0_20_0.before(V_0_90_0) => true
- V_0_90_0.after(V_0_20_0)  => true

Closes #3124
