### PR TITLE
GeoHashes in GeoPointFieldMapper

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -440,7 +440,7 @@ public class GeoPointFieldMapper implements Mapper, ArrayValueMapperParser {
             }
         }
 
-        context.externalValue(Double.toString(point.lat()) + ',' + Double.toString(point.lat()));
+        context.externalValue(Double.toString(point.lat()) + ',' + Double.toString(point.lon()));
         geoStringMapper.parse(context);
         if (enableGeoHash) {
             context.externalValue(geohash);


### PR DESCRIPTION
Fixed the `GeoPointFieldMapper` to parse `geohashes` correctly.

Closes #3073
