### PR TITLE
Upsert shouldn't require an extra document

### DIFF
--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -66,10 +66,10 @@ public class UpdateHelper extends AbstractComponent {
                 new String[]{SourceFieldMapper.NAME, RoutingFieldMapper.NAME, ParentFieldMapper.NAME, TTLFieldMapper.NAME}, true);
 
         if (!getResult.isExists()) {
-            if (request.upsertRequest() == null) {
+            if (request.upsertRequest() == null && !request.shouldUpsertDoc()) {
                 throw new DocumentMissingException(new ShardId(request.index(), request.shardId()), request.type(), request.id());
             }
-            IndexRequest indexRequest = request.upsertRequest();
+            IndexRequest indexRequest = request.shouldUpsertDoc() ? request.doc() : request.upsertRequest();
             indexRequest.index(request.index()).type(request.type()).id(request.id())
                     // it has to be a "create!"
                     .create(true)

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -297,4 +297,9 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
     protected void doExecute(ActionListener<UpdateResponse> listener) {
         ((Client) client).update(request, listener);
     }
+
+	public UpdateRequestBuilder setShouldUpsertDoc(boolean shouldUpsertDoc) {
+		request.shouldUpsertDoc(shouldUpsertDoc);
+		return this;
+	}
 }

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -70,6 +70,7 @@ public class RestUpdateAction extends BaseRestHandler {
             updateRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
         updateRequest.percolate(request.param("percolate", null));
+        updateRequest.shouldUpsertDoc(request.paramAsBoolean("doc_as_upsert",updateRequest.shouldUpsertDoc()));
         updateRequest.script(request.param("script"));
         updateRequest.scriptLang(request.param("lang"));
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
@@ -111,7 +112,7 @@ public class RestUpdateAction extends BaseRestHandler {
                     }
                     doc.version(RestActions.parseVersion(request));
                     doc.versionType(VersionType.fromString(request.param("version_type"), doc.versionType()));
-                }
+                }                
             } catch (Exception e) {
                 try {
                     channel.sendResponse(new XContentThrowableRestResponse(request, e));

--- a/src/test/java/org/elasticsearch/test/integration/update/UpdateTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/update/UpdateTests.java
@@ -165,7 +165,22 @@ public class UpdateTests extends AbstractSharedClusterTest {
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("2"));
         }
     }
-
+    @Test
+    public void testUpsertDoc() throws Exception {
+    	createIndex();
+        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.isTimedOut(), equalTo(false));
+        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        
+        UpdateResponse updateResponse = client().prepareUpdate("test", "type1", "1")
+        		.setDoc(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())        		
+        		.setShouldUpsertDoc(true)
+                .setFields("_source")
+                .execute().actionGet();
+        assertThat(updateResponse.getGetResult(), notNullValue());
+        assertThat(updateResponse.getGetResult().sourceAsMap().get("bar").toString(), equalTo("baz"));
+    }
+    
     @Test
     public void testUpsertFields() throws Exception {
         createIndex();
@@ -371,6 +386,25 @@ public class UpdateTests extends AbstractSharedClusterTest {
             assertThat(e.validationErrors().size(), equalTo(1));
             assertThat(e.validationErrors().get(0), containsString("can't provide both script and doc"));
             assertThat(e.getMessage(), containsString("can't provide both script and doc"));
+        }
+    }
+    
+    @Test
+    public void testUpdateRequestWithScriptAndShouldUpsertDoc() throws Exception{
+    	createIndex();
+        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertThat(clusterHealth.isTimedOut(), equalTo(false));
+        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        try {
+            client().prepareUpdate("test", "type1", "1")
+                    .setScript("ctx._source.field += 1")
+                    .setShouldUpsertDoc(true)
+                    .execute().actionGet();
+            fail("Should have thrown ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.validationErrors().size(), equalTo(1));
+            assertThat(e.validationErrors().get(0), containsString("can't say to upsert doc without providing doc"));
+            assertThat(e.getMessage(), containsString("can't say to upsert doc without providing doc"));
         }
     }
 


### PR DESCRIPTION
When posting a document for Update should be possible to tell the command to do an upsert of the same document. Something like upsert_doc: true. Reduces the amount of data sent over the wire significantly. This scenario happens a lot when having several data stores for the same document in the index. 
