### PR TITLE
Use CFS in any case if index.compound_format is set to true

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/policy/AbstractMergePolicyProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/AbstractMergePolicyProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.merge.policy;
+
+import org.apache.lucene.index.MergePolicy;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.index.shard.AbstractIndexShardComponent;
+import org.elasticsearch.index.store.Store;
+
+public abstract class AbstractMergePolicyProvider<MP extends MergePolicy> extends AbstractIndexShardComponent implements MergePolicyProvider<MP> {
+    
+    public static final String INDEX_COMPOUND_FORMAT = "index.compound_format";
+
+    protected volatile boolean compoundFormat;
+    protected volatile double noCFSRatio;
+
+    protected AbstractMergePolicyProvider(Store store) {
+        super(store.shardId(), store.indexSettings());
+        this.noCFSRatio = parseNoCFSRatio(indexSettings.get(INDEX_COMPOUND_FORMAT, Boolean.toString(store.suggestUseCompoundFile())));
+        this.compoundFormat = noCFSRatio != 0.0;
+    }
+
+    public static double parseNoCFSRatio(String noCFSRatio) {
+        noCFSRatio = noCFSRatio.trim();
+        if (noCFSRatio.equalsIgnoreCase("true")) {
+            return 1.0d;
+        } else if (noCFSRatio.equalsIgnoreCase("false")) {
+            return 0.0;
+        } else {
+            try {
+                double value = Double.parseDouble(noCFSRatio);
+                if (value < 0.0 || value > 1.0) {
+                    throw new ElasticSearchIllegalArgumentException("NoCFSRatio must be in the interval [0..1] but was: [" + value + "]");
+                }
+                return value;
+            } catch (NumberFormatException ex) {
+                throw new ElasticSearchIllegalArgumentException("Expected a boolean or a value in the interval [0..1] but was: [" + noCFSRatio + "]", ex);
+            }
+        }
+    }
+
+    public static String formatNoCFSRatio(double ratio) {
+        if (ratio == 1.0) {
+            return Boolean.TRUE.toString();
+        } else if (ratio == 0.0) {
+            return Boolean.FALSE.toString();
+        } else {
+            return Double.toString(ratio);
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/merge/policy/TieredMergePolicyProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/TieredMergePolicyProvider.java
@@ -32,16 +32,16 @@ import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.store.Store;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-public class TieredMergePolicyProvider extends AbstractIndexShardComponent implements MergePolicyProvider<TieredMergePolicy> {
+public class TieredMergePolicyProvider extends AbstractMergePolicyProvider<TieredMergePolicy> {
 
     private final IndexSettingsService indexSettingsService;
 
     private final Set<CustomTieredMergePolicyProvider> policies = new CopyOnWriteArraySet<CustomTieredMergePolicyProvider>();
 
-    private volatile boolean compoundFormat;
     private volatile double forceMergeDeletesPctAllowed;
     private volatile ByteSizeValue floorSegment;
     private volatile int maxMergeAtOnce;
@@ -53,12 +53,12 @@ public class TieredMergePolicyProvider extends AbstractIndexShardComponent imple
 
     private final ApplySettings applySettings = new ApplySettings();
 
+    
+
     @Inject
     public TieredMergePolicyProvider(Store store, IndexSettingsService indexSettingsService) {
-        super(store.shardId(), store.indexSettings());
+        super(store);
         this.indexSettingsService = indexSettingsService;
-
-        this.compoundFormat = indexSettings.getAsBoolean(INDEX_COMPOUND_FORMAT, store.suggestUseCompoundFile());
         this.asyncMerge = indexSettings.getAsBoolean("index.merge.async", true);
         this.forceMergeDeletesPctAllowed = componentSettings.getAsDouble("expunge_deletes_allowed", 10d); // percentage
         this.floorSegment = componentSettings.getAsBytesSize("floor_segment", new ByteSizeValue(2, ByteSizeUnit.MB));
@@ -76,7 +76,7 @@ public class TieredMergePolicyProvider extends AbstractIndexShardComponent imple
 
         indexSettingsService.addListener(applySettings);
     }
-
+    
     private void fixSettingsIfNeeded() {
         // fixing maxMergeAtOnce, see TieredMergePolicy#setMaxMergeAtOnce
         if (!(segmentsPerTier >= maxMergeAtOnce)) {
@@ -100,6 +100,7 @@ public class TieredMergePolicyProvider extends AbstractIndexShardComponent imple
             mergePolicy = new CustomTieredMergePolicyProvider(this);
         }
         mergePolicy.setUseCompoundFile(compoundFormat);
+        mergePolicy.setNoCFSRatio(noCFSRatio);
         mergePolicy.setForceMergeDeletesPctAllowed(forceMergeDeletesPctAllowed);
         mergePolicy.setFloorSegmentMB(floorSegment.mbFrac());
         mergePolicy.setMaxMergeAtOnce(maxMergeAtOnce);
@@ -122,7 +123,6 @@ public class TieredMergePolicyProvider extends AbstractIndexShardComponent imple
     public static final String INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT = "index.merge.policy.max_merged_segment";
     public static final String INDEX_MERGE_POLICY_SEGMENTS_PER_TIER = "index.merge.policy.segments_per_tier";
     public static final String INDEX_MERGE_POLICY_RECLAIM_DELETES_WEIGHT = "index.merge.policy.reclaim_deletes_weight";
-    public static final String INDEX_COMPOUND_FORMAT = "index.compound_format";
 
     class ApplySettings implements IndexSettingsService.Listener {
         @Override
@@ -190,11 +190,14 @@ public class TieredMergePolicyProvider extends AbstractIndexShardComponent imple
                 }
             }
 
-            boolean compoundFormat = settings.getAsBoolean(INDEX_COMPOUND_FORMAT, TieredMergePolicyProvider.this.compoundFormat);
-            if (compoundFormat != TieredMergePolicyProvider.this.compoundFormat) {
-                logger.info("updating index.compound_format from [{}] to [{}]", TieredMergePolicyProvider.this.compoundFormat, compoundFormat);
+            final double noCFSRatio = parseNoCFSRatio(settings.get(INDEX_COMPOUND_FORMAT, Double.toString(TieredMergePolicyProvider.this.noCFSRatio)));
+            final boolean compoundFormat = noCFSRatio != 0.0;
+            if (noCFSRatio != TieredMergePolicyProvider.this.noCFSRatio) {
+                logger.info("updating index.compound_format from [{}] to [{}]", formatNoCFSRatio(TieredMergePolicyProvider.this.noCFSRatio), formatNoCFSRatio(noCFSRatio));
                 TieredMergePolicyProvider.this.compoundFormat = compoundFormat;
+                TieredMergePolicyProvider.this.noCFSRatio = noCFSRatio;
                 for (CustomTieredMergePolicyProvider policy : policies) {
+                    policy.setNoCFSRatio(noCFSRatio);
                     policy.setUseCompoundFile(compoundFormat);
                 }
             }

--- a/src/test/java/org/elasticsearch/test/integration/AbstractSharedClusterTest.java
+++ b/src/test/java/org/elasticsearch/test/integration/AbstractSharedClusterTest.java
@@ -45,6 +45,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.merge.policy.AbstractMergePolicyProvider;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
@@ -56,6 +57,7 @@ import org.testng.annotations.BeforeMethod;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Random;
 import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -132,6 +134,7 @@ public abstract class AbstractSharedClusterTest extends ElasticsearchTestCase {
         // TODO RANDOMIZE
         return ImmutableSettings.builder();
     }
+    // TODO Randomize MergePolicyProviderBase.INDEX_COMPOUND_FORMAT [true|false|"true"|"false"|[0..1]| toString([0..1])]
 
     public Settings getSettings() {
         return randomSettingsBuilder().build();

--- a/src/test/java/org/elasticsearch/test/unit/index/merge/policy/MergePolicySettingsTest.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/merge/policy/MergePolicySettingsTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Elastic Search licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.index.merge.policy;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
+
+import java.io.IOException;
+
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.merge.policy.LogByteSizeMergePolicyProvider;
+import org.elasticsearch.index.merge.policy.LogDocMergePolicyProvider;
+import org.elasticsearch.index.merge.policy.AbstractMergePolicyProvider;
+import org.elasticsearch.index.merge.policy.TieredMergePolicyProvider;
+import org.elasticsearch.index.settings.IndexSettingsService;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.index.store.distributor.LeastUsedDistributor;
+import org.elasticsearch.index.store.ram.RamDirectoryService;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class MergePolicySettingsTest {
+
+    protected final ShardId shardId = new ShardId(new Index("index"), 1);
+
+    @Test
+    public void testCompoundFileSettings() throws IOException {
+        IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
+
+        assertThat(new TieredMergePolicyProvider(createStore(EMPTY_SETTINGS), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new TieredMergePolicyProvider(createStore(EMPTY_SETTINGS), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build(true)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new TieredMergePolicyProvider(createStore(build(true)), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build(0.5)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new TieredMergePolicyProvider(createStore(build(0.5)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.5));
+        assertThat(new TieredMergePolicyProvider(createStore(build(1.0)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new TieredMergePolicyProvider(createStore(build(1.0)), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build("true")), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new TieredMergePolicyProvider(createStore(build("true")), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build("True")), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new TieredMergePolicyProvider(createStore(build("True")), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build("False")), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new TieredMergePolicyProvider(createStore(build("False")), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build("false")), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new TieredMergePolicyProvider(createStore(build("false")), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build(false)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new TieredMergePolicyProvider(createStore(build(false)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build(0)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new TieredMergePolicyProvider(createStore(build(0)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new TieredMergePolicyProvider(createStore(build(0.0)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new TieredMergePolicyProvider(createStore(build(0.0)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(EMPTY_SETTINGS), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(EMPTY_SETTINGS), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(true)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(true)), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0.5)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0.5)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.5));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(1.0)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(1.0)), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("true")), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("true")), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("True")), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("True")), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("False")), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("False")), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("false")), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build("false")), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(false)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(false)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0.0)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogByteSizeMergePolicyProvider(createStore(build(0.0)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+
+        assertThat(new LogDocMergePolicyProvider(createStore(EMPTY_SETTINGS), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogDocMergePolicyProvider(createStore(EMPTY_SETTINGS), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(true)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(true)), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(0.5)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(0.5)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.5));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(1.0)), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(1.0)), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("true")), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("true")), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("True")), service).newMergePolicy().getUseCompoundFile(), equalTo(true));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("True")), service).newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("False")), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("False")), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("false")), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogDocMergePolicyProvider(createStore(build("false")), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(false)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(false)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(0)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(0)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(0.0)), service).newMergePolicy().getUseCompoundFile(), equalTo(false));
+        assertThat(new LogDocMergePolicyProvider(createStore(build(0.0)), service).newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+
+    }
+    
+    @Test
+    public void testInvalidValue() throws IOException {
+        IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
+        try {
+            new LogDocMergePolicyProvider(createStore(build(-0.1)), service).newMergePolicy().getNoCFSRatio();
+            assertThat("exception expected", false);
+        } catch (ElasticSearchIllegalArgumentException ex) {
+
+        }
+        try {
+            new LogDocMergePolicyProvider(createStore(build(1.1)), service).newMergePolicy().getNoCFSRatio();
+            assertThat("exception expected", false);
+        } catch (ElasticSearchIllegalArgumentException ex) {
+
+        }
+        try {
+            new LogDocMergePolicyProvider(createStore(build("Falsch")), service).newMergePolicy().getNoCFSRatio();
+            assertThat("exception expected", false);
+        } catch (ElasticSearchIllegalArgumentException ex) {
+
+        }
+
+    }
+
+    @Test
+    public void testUpdateSettings() throws IOException {
+        {
+            IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
+            TieredMergePolicyProvider mp = new TieredMergePolicyProvider(createStore(EMPTY_SETTINGS), service);
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(false));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+
+            service.refreshSettings(build(1.0));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(true));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+
+            service.refreshSettings(build(0.1));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(true));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.1));
+
+            service.refreshSettings(build(0.0));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(false));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        }
+
+        {
+            IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
+            LogByteSizeMergePolicyProvider mp = new LogByteSizeMergePolicyProvider(createStore(EMPTY_SETTINGS), service);
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(false));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+
+            service.refreshSettings(build(1.0));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(true));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+
+            service.refreshSettings(build(0.1));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(true));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.1));
+
+            service.refreshSettings(build(0.0));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(false));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        }
+
+        {
+            IndexSettingsService service = new IndexSettingsService(new Index("test"), EMPTY_SETTINGS);
+            LogDocMergePolicyProvider mp = new LogDocMergePolicyProvider(createStore(EMPTY_SETTINGS), service);
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(false));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+
+            service.refreshSettings(build(1.0));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(true));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(1.0));
+
+            service.refreshSettings(build(0.1));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(true));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.1));
+
+            service.refreshSettings(build(0.0));
+            assertThat(mp.newMergePolicy().getUseCompoundFile(), equalTo(false));
+            assertThat(mp.newMergePolicy().getNoCFSRatio(), equalTo(0.0));
+        }
+    }
+
+    public Settings build(String value) {
+        return ImmutableSettings.builder().put(AbstractMergePolicyProvider.INDEX_COMPOUND_FORMAT, value).build();
+    }
+
+    public Settings build(double value) {
+        return ImmutableSettings.builder().put(AbstractMergePolicyProvider.INDEX_COMPOUND_FORMAT, value).build();
+    }
+
+    public Settings build(int value) {
+        return ImmutableSettings.builder().put(AbstractMergePolicyProvider.INDEX_COMPOUND_FORMAT, value).build();
+    }
+
+    public Settings build(boolean value) {
+        return ImmutableSettings.builder().put(AbstractMergePolicyProvider.INDEX_COMPOUND_FORMAT, value).build();
+    }
+
+    protected Store createStore(Settings settings) throws IOException {
+        DirectoryService directoryService = new RamDirectoryService(shardId, EMPTY_SETTINGS);
+        return new Store(shardId, settings, null, directoryService, new LeastUsedDistributor(directoryService));
+    }
+
+}


### PR DESCRIPTION
Lucenes MergePolicies support a noCFSRatio. This commit introduces
support for this ratio via `index.compound_format`. This setting
can parse a boolean value or a value in the interval [0..1] that
is equivalent to the noCFSRatio. The setting `1`, `1.0` and `true`
are equivalent as well as `0`, `0.0` and `false`.

Closes #3166
