### PR TITLE
Change default values for "low/high_freq_operator" to "or" for "common" queries

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -51,9 +51,9 @@ public class CommonTermsQueryParser implements QueryParser {
 
     static final float DEFAULT_MAX_TERM_DOC_FREQ = 0.01f;
 
-    static final Occur DEFAULT_HIGH_FREQ_OCCUR = Occur.MUST;
+    static final Occur DEFAULT_HIGH_FREQ_OCCUR = Occur.SHOULD;
 
-    static final Occur DEFAULT_LOW_FREQ_OCCUR = Occur.MUST;
+    static final Occur DEFAULT_LOW_FREQ_OCCUR = Occur.SHOULD;
 
     static final boolean DEFAULT_DISABLE_COORDS = true;
 
@@ -81,7 +81,7 @@ public class CommonTermsQueryParser implements QueryParser {
         String minimumShouldMatch = null;
         boolean disableCoords = DEFAULT_DISABLE_COORDS;
         Occur highFreqOccur = DEFAULT_HIGH_FREQ_OCCUR;
-        Occur lowFreqOccur = DEFAULT_HIGH_FREQ_OCCUR;
+        Occur lowFreqOccur = DEFAULT_LOW_FREQ_OCCUR;
         float maxTermFrequency = DEFAULT_MAX_TERM_DOC_FREQ;
         token = parser.nextToken();
         if (token == XContentParser.Token.START_OBJECT) {

--- a/src/test/java/org/elasticsearch/test/integration/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/query/SimpleQueryTests.java
@@ -95,13 +95,19 @@ public class SimpleQueryTests extends AbstractSharedClusterTest {
         client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree").execute().actionGet();
         client().prepareIndex("test", "type1", "3").setSource("field1", "quick lazy huge brown", "field2", "the quick lazy huge brown fox jumps over the tree").setRefresh(true).execute().actionGet();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3)).execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.OR)).execute().actionGet();
+        assertThat(searchResponse.getHits().totalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getHits()[0].getId(), equalTo("1"));
+        assertThat(searchResponse.getHits().getHits()[1].getId(), equalTo("2"));
+        assertThat(searchResponse.getHits().getHits()[2].getId(), equalTo("3"));
+
+        searchResponse = client().prepareSearch().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.AND)).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
         assertThat(searchResponse.getHits().getHits()[0].getId(), equalTo("1"));
         assertThat(searchResponse.getHits().getHits()[1].getId(), equalTo("2"));
 
-
-        searchResponse = client().prepareSearch().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.OR)).execute().actionGet();
+        // Default
+        searchResponse = client().prepareSearch().setQuery(QueryBuilders.commonTerms("field1", "the quick brown").cutoffFrequency(3)).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(3l));
         assertThat(searchResponse.getHits().getHits()[0].getId(), equalTo("1"));
         assertThat(searchResponse.getHits().getHits()[1].getId(), equalTo("2"));


### PR DESCRIPTION
It seems more logical to me rather than keep "and"

Closes #3178
