### PR TITLE
Add isolation support for plugins

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginClassLoader.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginClassLoader.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * ClassLoader with a delegation to parent last. Classes into added libraries
+ * URL should be used first.
+ * 
+ * @author Laurent Broudoux
+ */
+public class PluginClassLoader extends URLClassLoader {
+
+    private ClassLoader system;
+
+    public PluginClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+        system = getSystemClassLoader();
+    }
+
+    @Override
+    protected synchronized Class<?> loadClass(String name, boolean resolve)
+            throws ClassNotFoundException {
+        // First, check if the class has already been loaded
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+            if (system != null) {
+                try {
+                    // Checking system: jvm classes, endorsed, cmd classpath,
+                    // etc.
+                    c = system.loadClass(name);
+                } catch (ClassNotFoundException ignored) {
+                }
+            }
+            if (c == null) {
+                try {
+                    // Checking local.
+                    c = findClass(name);
+                } catch (ClassNotFoundException e) {
+                    // Checking parent
+                    // This call to loadClass may eventually call findClass
+                    // again, in
+                    // case the parent doesn't find anything.
+                    c = super.loadClass(name, resolve);
+                }
+            }
+        }
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = null;
+        if (system != null) {
+            url = system.getResource(name);
+        }
+        if (url == null) {
+            url = findResource(name);
+            if (url == null) {
+                // This call to getResource may eventually call findResource
+                // again, in case the parent doesn't find anything.
+                url = super.getResource(name);
+            }
+        }
+        return url;
+    }
+
+    /**
+     * Similar to super, but local resources are enumerated before parent
+     * resources
+     */
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Enumeration<URL> systemUrls = null;
+        if (system != null) {
+            systemUrls = system.getResources(name);
+        }
+        Enumeration<URL> localUrls = findResources(name);
+        Enumeration<URL> parentUrls = null;
+        if (getParent() != null) {
+            parentUrls = getParent().getResources(name);
+        }
+        final List<URL> urls = new ArrayList<URL>();
+        if (systemUrls != null) {
+            while (systemUrls.hasMoreElements()) {
+                urls.add(systemUrls.nextElement());
+            }
+        }
+        if (localUrls != null) {
+            while (localUrls.hasMoreElements()) {
+                urls.add(localUrls.nextElement());
+            }
+        }
+        if (parentUrls != null) {
+            while (parentUrls.hasMoreElements()) {
+                urls.add(parentUrls.nextElement());
+            }
+        }
+        return new Enumeration<URL>() {
+            Iterator<URL> iter = urls.iterator();
+
+            public boolean hasMoreElements() {
+                return iter.hasNext();
+            }
+
+            public URL nextElement() {
+                return iter.next();
+            }
+        };
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        URL url = getResource(name);
+        try {
+            return url != null ? url.openStream() : null;
+        } catch (IOException e) {
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginInvocationHandler.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginInvocationHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+/**
+ * 
+ * @author Laurent Broudoux
+ */
+public class PluginInvocationHandler implements InvocationHandler {
+
+    private final ESLogger logger = Loggers.getLogger(PluginInvocationHandler.class);
+    
+    private Plugin targetPlugin;
+    
+    
+    public PluginInvocationHandler(Plugin targetPlugin){
+        this.targetPlugin = targetPlugin;
+        logger.trace("PluginInvocationHandler built for {}", targetPlugin.getClass().getName());
+    }
+    
+    @Override
+    public Object invoke(Object target, Method method, Object[] args) throws Throwable {
+        ClassLoader clBackup = Thread.currentThread().getContextClassLoader();
+        logger.trace("ClassLoader before plugin invocation is {}", clBackup);
+        try{
+            // Change thread context classloader to the plugin classloader. 
+            Thread.currentThread().setContextClassLoader(targetPlugin.getClass().getClassLoader());
+            logger.trace("ClassLoader is set to {0} for plugin invocation", targetPlugin.getClass().getClassLoader());
+            return method.invoke(targetPlugin, args);
+        } finally {
+            // Restore thread context classloader to the original one. 
+            Thread.currentThread().setContextClassLoader(clBackup);
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginInvocationHandler.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginInvocationHandler.java
@@ -26,7 +26,8 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 
 /**
- * 
+ * An invocation handler that sets the current Thread classloader to be the plugin one
+ * during its invocation. 
  * @author Laurent Broudoux
  */
 public class PluginInvocationHandler implements InvocationHandler {

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -498,7 +498,7 @@ public class PluginsService extends AbstractComponent {
                     pluginProps.load(is);
                     String pluginClassName = pluginProps.getProperty("plugin");
                     Plugin plugin = loadPluginFromClassLoader(pluginClassName,settings, pluginCL);
-                    plugins.put(pluginName, plugin);
+                    plugins.put(plugin.name(), plugin);
                 } catch (Exception e) {
                     logger.warn("failed to load plugin from [" + pluginURL
                             + "]", e);


### PR DESCRIPTION
When loaded from /plugins directory, plugins main jars and libraries are all added to main ClassLoader during the PluginsService initialisation. As a consequence, plugins share same resources and classes and thus could not use different, maybe conflicting versions of the same dependency.

This pull request adds support for loading each plugins in its own isolated ClassLoader that uses local class definitions first. This feature may be activated using the "plugin.isolate" boolean setting.

More details on the discovery case and on a working demo here : http://lbroudoux.wordpress.com/2013/06/13/plugin-isolation-support-in-elasticsearch/

Regards, 
