### PR TITLE
Expose timeout for nodes_info requests in the REST interface

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -101,6 +101,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
         nodesInfoRequest.transport(request.paramAsBoolean("transport", nodesInfoRequest.transport()));
         nodesInfoRequest.http(request.paramAsBoolean("http", nodesInfoRequest.http()));
         nodesInfoRequest.plugin(request.paramAsBoolean("plugin", nodesInfoRequest.plugin()));
+        nodesInfoRequest.timeout( request.paramAsTime("timeout", nodesInfoRequest.timeout()));
 
         executeNodeRequest(request, channel, nodesInfoRequest);
     }


### PR DESCRIPTION
The nodes_info action accepts a timeout parameter, but it isn't exposed in the REST interface. It is useful to have to avoid long request when sniffing for nodes.

Closes #3191
