### PR TITLE
Added version support to update requests

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -155,6 +156,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> {
         }
         return this;
     }
+
     /**
      * Adds an {@link DeleteRequest} to the list of actions to execute.
      */
@@ -272,7 +274,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> {
                 String timestamp = null;
                 Long ttl = null;
                 String opType = null;
-                long version = 0;
+                long version = Versions.MATCH_ANY;
                 VersionType versionType = VersionType.INTERNAL;
                 String percolate = null;
                 int retryOnConflict = 0;
@@ -345,6 +347,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> {
                                 .percolate(percolate), payload);
                     } else if ("update".equals(action)) {
                         internalAdd(new UpdateRequest(index, type, id).routing(routing).parent(parent).retryOnConflict(retryOnConflict)
+                                .version(version).versionType(versionType)
                                 .source(data.slice(from, nextMarker - from))
                                 .percolate(percolate), payload);
                     }

--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
@@ -130,7 +131,7 @@ public class IndexRequest extends ShardReplicationOperationRequest<IndexRequest>
     private OpType opType = OpType.INDEX;
 
     private boolean refresh = false;
-    private long version = 0;
+    private long version = Versions.MATCH_ANY;
     private VersionType versionType = VersionType.INTERNAL;
     private String percolate;
 

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -29,6 +29,7 @@ import org.elasticsearch.client.internal.InternalClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.VersionType;
 
 import java.util.Map;
 
@@ -125,6 +126,24 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
     }
 
     /**
+     * Sets the version, which will cause the index operation to only be performed if a matching
+     * version exists and no changes happened on the doc since then.
+     */
+    public UpdateRequestBuilder setVersion(long version) {
+        request.version(version);
+        return this;
+    }
+
+    /**
+     * Sets the versioning type. Defaults to {@link org.elasticsearch.index.VersionType#INTERNAL}.
+     */
+    public UpdateRequestBuilder setVersionType(VersionType versionType) {
+        request.versionType(versionType);
+        return this;
+    }
+
+
+    /**
      * Should a refresh be executed post this update operation causing the operation to
      * be searchable. Note, heavy indexing should not set this to <tt>true</tt>. Defaults
      * to <tt>false</tt>.
@@ -217,6 +236,14 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
     }
 
     /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequestBuilder setDoc(String field, Object value) {
+        request.doc(field, value);
+        return this;
+    }
+
+    /**
      * Sets the index request to be used if the document does not exists. Otherwise, a {@link org.elasticsearch.index.engine.DocumentMissingException}
      * is thrown.
      */
@@ -305,5 +332,4 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
     protected void doExecute(ActionListener<UpdateResponse> listener) {
         ((Client) client).update(request, listener);
     }
-
 }

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -86,6 +86,9 @@ public class RestUpdateAction extends BaseRestHandler {
             }
         }
         updateRequest.retryOnConflict(request.paramAsInt("retry_on_conflict", updateRequest.retryOnConflict()));
+        updateRequest.version(RestActions.parseVersion(request));
+        updateRequest.versionType(VersionType.fromString(request.param("version_type"), updateRequest.versionType()));
+
 
         // see if we have it in the body
         if (request.hasContent()) {

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -20,9 +20,10 @@ package org.elasticsearch.test.hamcrest;
 
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
 import org.elasticsearch.search.SearchHit;
@@ -65,14 +66,14 @@ public class ElasticsearchAssertions {
     public static void assertSearchHit(SearchResponse searchResponse, int number, Matcher<SearchHit> matcher) {
         assert number > 0;
         assertThat("SearchHit number must be greater than 0", number, greaterThan(0));
-        assertThat(searchResponse.getHits().totalHits(), greaterThanOrEqualTo((long)number));
-        assertSearchHit(searchResponse.getHits().getAt(number-1), matcher);
+        assertThat(searchResponse.getHits().totalHits(), greaterThanOrEqualTo((long) number));
+        assertSearchHit(searchResponse.getHits().getAt(number - 1), matcher);
     }
-    
+
     public static void assertNoFailures(SearchResponse searchResponse) {
         assertThat("Unexpectd ShardFailures: " + Arrays.toString(searchResponse.getShardFailures()), searchResponse.getShardFailures().length, equalTo(0));
     }
-    
+
     public static void assertNoFailures(BroadcastOperationResponse response) {
         assertThat("Unexpectd ShardFailures: " + Arrays.toString(response.getShardFailures()), response.getFailedShards(), equalTo(0));
     }
@@ -88,16 +89,16 @@ public class ElasticsearchAssertions {
         assertThat(resp.getHits().hits()[hit].getHighlightFields().get(field).fragments().length, greaterThan(fragment));
         assertThat(resp.getHits().hits()[hit].highlightFields().get(field).fragments()[fragment].string(), matcher);
     }
-    
+
     public static void assertSuggestionSize(Suggest searchSuggest, int entry, int size, String key) {
         assertThat(searchSuggest, notNullValue());
-        assertThat(searchSuggest.size(),greaterThanOrEqualTo(1));
+        assertThat(searchSuggest.size(), greaterThanOrEqualTo(1));
         assertThat(searchSuggest.getSuggestion(key).getName(), equalTo(key));
         assertThat(searchSuggest.getSuggestion(key).getEntries().size(), greaterThanOrEqualTo(entry));
         assertThat(searchSuggest.getSuggestion(key).getEntries().get(entry).getOptions().size(), equalTo(size));
 
     }
-    
+
     public static void assertSuggestion(Suggest searchSuggest, int entry, int ord, String key, String text) {
         assertThat(searchSuggest, notNullValue());
         assertThat(searchSuggest.size(), greaterThanOrEqualTo(1));
@@ -121,31 +122,34 @@ public class ElasticsearchAssertions {
     public static Matcher<SearchHit> hasIndex(final String index) {
         return new ElasticsearchMatchers.SearchHitHasIndexMatcher(index);
     }
-    
+
     public static <T extends Query> T assertBooleanSubQuery(Query query, Class<T> subqueryType, int i) {
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery q = (BooleanQuery) query;
         assertThat(q.getClauses().length, greaterThan(i));
         assertThat(q.getClauses()[i].getQuery(), instanceOf(subqueryType));
-        return  (T)q.getClauses()[i].getQuery();
+        return (T) q.getClauses()[i].getQuery();
     }
 
-    public static <E extends Throwable> void assertThrows(ActionFuture future, Class<E> exceptionClass)  {
-        boolean fail=false;
+    public static <E extends Throwable> void assertThrows(ActionRequestBuilder<?, ?, ?> builder, Class<E> exceptionClass) {
+        assertThrows(builder.execute(), exceptionClass);
+    }
+
+    public static <E extends Throwable> void assertThrows(ActionFuture future, Class<E> exceptionClass) {
+        boolean fail = false;
         try {
             future.actionGet();
-            fail=true;
+            fail = true;
 
-        }
-        catch (ElasticSearchException esException) {
+        } catch (ElasticSearchException esException) {
             assertThat(esException.unwrapCause(), instanceOf(exceptionClass));
-        }
-        catch (Throwable e) {
+        } catch (Throwable e) {
             assertThat(e, instanceOf(exceptionClass));
         }
         // has to be outside catch clause to get a proper message
-        if (fail)
+        if (fail) {
             throw new AssertionError("Expected a " + exceptionClass + " exception to be thrown");
+        }
     }
 
 }

--- a/src/test/java/org/elasticsearch/test/integration/AbstractSharedClusterTest.java
+++ b/src/test/java/org/elasticsearch/test/integration/AbstractSharedClusterTest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRespon
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.admin.indices.optimize.OptimizeResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
@@ -46,7 +47,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.merge.policy.AbstractMergePolicyProvider;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
@@ -58,7 +58,6 @@ import org.testng.annotations.BeforeMethod;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Random;
 import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -317,6 +316,10 @@ public abstract class AbstractSharedClusterTest extends ElasticsearchTestCase {
     // utils
     protected IndexResponse index(String index, String type, XContentBuilder source) {
         return client().prepareIndex(index, type).setSource(source).execute().actionGet();
+    }
+
+    protected GetResponse get(String index, String type, String id) {
+        return client().prepareGet(index, type, id).execute().actionGet();
     }
 
     protected IndexResponse index(String index, String type, String id, String field, Object value) {

--- a/src/test/java/org/elasticsearch/test/unit/index/VersionTypeTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/VersionTypeTests.java
@@ -1,0 +1,115 @@
+package org.elasticsearch.test.unit.index;
+/*
+ * Licensed to ElasticSearch under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.index.VersionType;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class VersionTypeTests {
+    @Test
+    public void testInternalVersionConflict() throws Exception {
+
+        assertFalse(VersionType.INTERNAL.isVersionConflict(10, Versions.MATCH_ANY));
+        // if we don't have a version in the index we accept everything
+        assertFalse(VersionType.INTERNAL.isVersionConflict(Versions.NOT_SET, 10));
+        assertFalse(VersionType.INTERNAL.isVersionConflict(Versions.NOT_SET, Versions.MATCH_ANY));
+
+        // if we didn't find a version (but the index does support it), we don't like it unless MATCH_ANY
+        assertTrue(VersionType.INTERNAL.isVersionConflict(Versions.NOT_FOUND, Versions.NOT_FOUND));
+        assertTrue(VersionType.INTERNAL.isVersionConflict(Versions.NOT_FOUND, 10));
+        assertFalse(VersionType.INTERNAL.isVersionConflict(Versions.NOT_FOUND, Versions.MATCH_ANY));
+
+        // and the stupid usual case
+        assertFalse(VersionType.INTERNAL.isVersionConflict(10, 10));
+        assertTrue(VersionType.INTERNAL.isVersionConflict(9, 10));
+        assertTrue(VersionType.INTERNAL.isVersionConflict(10, 9));
+
+// Old indexing code, dictating behavior
+//        if (expectedVersion != Versions.MATCH_ANY && currentVersion != Versions.NOT_SET) {
+//            // an explicit version is provided, see if there is a conflict
+//            // if we did not find anything, and a version is provided, so we do expect to find a doc under that version
+//            // this is important, since we don't allow to preset a version in order to handle deletes
+//            if (currentVersion == Versions.NOT_FOUND) {
+//                throw new VersionConflictEngineException(shardId, index.type(), index.id(), Versions.NOT_FOUND, expectedVersion);
+//            } else if (expectedVersion != currentVersion) {
+//                throw new VersionConflictEngineException(shardId, index.type(), index.id(), currentVersion, expectedVersion);
+//            }
+//        }
+//        updatedVersion = (currentVersion == Versions.NOT_SET || currentVersion == Versions.NOT_FOUND) ? 1 : currentVersion + 1;
+    }
+
+    @Test
+    public void testExternalVersionConflict() throws Exception {
+
+        assertFalse(VersionType.EXTERNAL.isVersionConflict(Versions.NOT_FOUND, 10));
+        assertFalse(VersionType.EXTERNAL.isVersionConflict(Versions.NOT_SET, 10));
+        // MATCH_ANY must throw an exception in the case of external version, as the version must be set! it used as the new value
+        assertTrue(VersionType.EXTERNAL.isVersionConflict(10, Versions.MATCH_ANY));
+
+        // if we didn't find a version (but the index does support it), we always accept
+        assertFalse(VersionType.EXTERNAL.isVersionConflict(Versions.NOT_FOUND, Versions.NOT_FOUND));
+        assertFalse(VersionType.EXTERNAL.isVersionConflict(Versions.NOT_FOUND, 10));
+        assertFalse(VersionType.EXTERNAL.isVersionConflict(Versions.NOT_FOUND, Versions.MATCH_ANY));
+
+        // and the standard behavior
+        assertTrue(VersionType.EXTERNAL.isVersionConflict(10, 10));
+        assertFalse(VersionType.EXTERNAL.isVersionConflict(9, 10));
+        assertTrue(VersionType.EXTERNAL.isVersionConflict(10, 9));
+
+
+// Old indexing code, dictating behavior
+//        // an external version is provided, just check, if a local version exists, that its higher than it
+//        // the actual version checking is one in an external system, and we just want to not index older versions
+//        if (currentVersion >= 0) { // we can check!, its there
+//            if (currentVersion >= index.version()) {
+//                throw new VersionConflictEngineException(shardId, index.type(), index.id(), currentVersion, index.version());
+//            }
+//        }
+//        updatedVersion = index.version();
+    }
+
+
+    @Test
+    public void testUpdateVersion() {
+
+        assertThat(VersionType.INTERNAL.updateVersion(Versions.NOT_SET, 10), equalTo(1l));
+        assertThat(VersionType.INTERNAL.updateVersion(Versions.NOT_FOUND, 10), equalTo(1l));
+        assertThat(VersionType.INTERNAL.updateVersion(1, 1), equalTo(2l));
+        assertThat(VersionType.INTERNAL.updateVersion(2, Versions.MATCH_ANY), equalTo(3l));
+
+
+        assertThat(VersionType.EXTERNAL.updateVersion(Versions.NOT_SET, 10), equalTo(10l));
+        assertThat(VersionType.EXTERNAL.updateVersion(Versions.NOT_FOUND, 10), equalTo(10l));
+        assertThat(VersionType.EXTERNAL.updateVersion(1, 10), equalTo(10l));
+
+// Old indexing code
+//        if (index.versionType() == VersionType.INTERNAL) { // internal version type
+//            updatedVersion = (currentVersion == Versions.NOT_SET || currentVersion == Versions.NOT_FOUND) ? 1 : currentVersion + 1;
+//        } else { // external version type
+//            updatedVersion = expectedVersion;
+//        }
+    }
+}


### PR DESCRIPTION
Moved version handling from RobinEngine into VersionType. This avoids code re-use and makes it cleaner and easier to read.

Closes #3111
