### PR TITLE
Optimize parent/child queries and filters if possible

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/child/HasParentFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/HasParentFilter.java
@@ -80,6 +80,11 @@ public class HasParentFilter extends Filter implements SearchContext.Rewrite {
             throw new ElasticSearchIllegalStateException("has_parent filter hasn't executed properly");
         }
 
+        // no parents to match
+        if (parents.size() == 0) {
+            return null;
+        }
+        
         DocIdSet childrenDocIdSet = childrenFilter.getDocIdSet(readerContext, null);
         if (DocIdSets.isEmpty(childrenDocIdSet)) {
             return null;

--- a/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -227,10 +227,15 @@ public class ParentQuery extends Query implements SearchContext.Rewrite {
 
         @Override
         public Scorer scorer(AtomicReaderContext context, boolean scoreDocsInOrder, boolean topScorer, Bits acceptDocs) throws IOException {
+            if (uidToScore.size() == 0) {
+                return null;
+            }
+            
             DocIdSet childrenDocSet = childrenFilter.getDocIdSet(context, acceptDocs);
             if (childrenDocSet == null || childrenDocSet == DocIdSet.EMPTY_DOCIDSET) {
                 return null;
             }
+            
             IdReaderTypeCache idTypeCache = searchContext.idCache().reader(context.reader()).type(parentType);
             if (idTypeCache == null) {
                 return null;
@@ -298,7 +303,7 @@ public class ParentQuery extends Query implements SearchContext.Rewrite {
             if (currentChildDoc == DocIdSetIterator.NO_MORE_DOCS) {
                 return currentChildDoc;
             }
-            BytesReference uid = typeCache.idByDoc(currentChildDoc);
+            BytesReference uid = typeCache.parentIdByDoc(currentChildDoc);
             if (uid == null) {
                 return nextDoc();
             }


### PR DESCRIPTION
This is for #3190.  The main optimization is in has_child queries and filters by short-circuiting the parent processing once all known parents have been.  Other small updates to has_child query/filter to not execute the internal children filter when we know there are going to be no hits (no parents found).
