### PR TITLE
Add PATCH-based update

### DIFF
--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -438,6 +438,25 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         return this;
     }
 
+    /**
+     * Sets the doc to use for updates when a script is not specified.
+     */
+    public UpdateRequest doc(BytesReference doc) throws Exception {
+        XContentType xContentType = XContentFactory.xContentType(doc);
+        XContentParser parser = XContentFactory.xContent(xContentType).createParser(doc);
+        try {
+            XContentParser.Token t = parser.nextToken();
+            if (t != null) {
+                XContentBuilder docBuilder = XContentFactory.contentBuilder(xContentType);
+                docBuilder.copyCurrentStructure(parser);
+                safeDoc().source(docBuilder);
+            }
+        } finally {
+            parser.close();
+        }
+        return this;
+    }
+
     public IndexRequest doc() {
         return this.doc;
     }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -81,7 +81,7 @@ public class NettyHttpChannel implements HttpChannel {
                 if (request.getMethod() == HttpMethod.OPTIONS) {
                     // Allow Ajax requests based on the CORS "preflight" request
                     resp.addHeader("Access-Control-Max-Age", transport.settings().getAsInt("http.cors.max-age", 1728000));
-                    resp.addHeader("Access-Control-Allow-Methods", transport.settings().get("http.cors.allow-methods", "OPTIONS, HEAD, GET, POST, PUT, DELETE"));
+                    resp.addHeader("Access-Control-Allow-Methods", transport.settings().get("http.cors.allow-methods", "OPTIONS, HEAD, GET, POST, PUT, PATCH, DELETE"));
                     resp.addHeader("Access-Control-Allow-Headers", transport.settings().get("http.cors.allow-headers", "X-Requested-With, Content-Type, Content-Length"));
                 }
             }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpRequest.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpRequest.java
@@ -74,6 +74,9 @@ public class NettyHttpRequest extends AbstractRestRequest implements HttpRequest
         if (httpMethod == HttpMethod.PUT)
             return Method.PUT;
 
+        if (httpMethod == HttpMethod.PATCH)
+            return Method.PATCH;
+
         if (httpMethod == HttpMethod.DELETE)
             return Method.DELETE;
 

--- a/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/src/main/java/org/elasticsearch/rest/RestController.java
@@ -44,6 +44,7 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
     private final PathTrie<RestHandler> getHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> postHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> putHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
+    private final PathTrie<RestHandler> patchHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> deleteHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> headHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> optionsHandlers = new PathTrie<RestHandler>(RestUtils.REST_DECODER);
@@ -105,6 +106,9 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
                 break;
             case PUT:
                 putHandlers.insert(path, handler);
+                break;
+            case PATCH:
+                patchHandlers.insert(path, handler);
                 break;
             case OPTIONS:
                 optionsHandlers.insert(path, handler);
@@ -177,6 +181,8 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
             return postHandlers.retrieve(path, request.params());
         } else if (method == RestRequest.Method.PUT) {
             return putHandlers.retrieve(path, request.params());
+        } else if (method == RestRequest.Method.PATCH) {
+            return patchHandlers.retrieve(path, request.params());
         } else if (method == RestRequest.Method.DELETE) {
             return deleteHandlers.retrieve(path, request.params());
         } else if (method == RestRequest.Method.HEAD) {

--- a/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public interface RestRequest extends ToXContent.Params {
 
     enum Method {
-        GET, POST, PUT, DELETE, OPTIONS, HEAD
+        GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD
     }
 
     Method method();

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -52,6 +52,7 @@ public class RestUpdateAction extends BaseRestHandler {
     public RestUpdateAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
         controller.registerHandler(POST, "/{index}/{type}/{id}/_update", this);
+        controller.registerHandler(PATCH, "/{index}/{type}/{id}", this);
     }
 
     @Override
@@ -94,7 +95,11 @@ public class RestUpdateAction extends BaseRestHandler {
         // see if we have it in the body
         if (request.hasContent()) {
             try {
-                updateRequest.source(request.content());
+                if (request.method() == PATCH) {
+                    updateRequest.doc(request.content());
+                } else {
+                    updateRequest.source(request.content());
+                }
                 IndexRequest upsertRequest = updateRequest.upsertRequest();
                 if (upsertRequest != null) {
                     upsertRequest.routing(request.param("routing"));

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestRequest.Method.PATCH;
 import static org.elasticsearch.rest.RestStatus.CREATED;
 import static org.elasticsearch.rest.RestStatus.OK;
 


### PR DESCRIPTION
This simplifies the way a document can be updated. It changes the syntax to, for example:

``` sh
$ curl -XPATCH ":9200/foo/user/1" -d '{"first_name":"Stephen"}'
```

Instead of the more verbosely-nested:

``` sh
$ curl -XPOST ":9200/foo/user/1/_update" -d '{"doc":{"first_name":"Stephen"}}'
```

Adding PATCH support is a relatively big change for the project, but I wanted to at least start a discussion. I think the request format for the update example is cleaner than nesting the update in a "doc" node (and more predictable/consistent with the PUT method).
