### PR TITLE
Geohash filter enhancement

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
@@ -170,7 +170,12 @@ public class GeoHashUtils {
             if (nx >= 0 && nx <= xLimit && ny >= 0 && ny < yLimit) {
                 return geohash.substring(0, level - 1) + encode(nx, ny);
             } else {
-                return neighbor(geohash, level - 1, dx, dy) + encode(nx, ny);
+                String neighbor = neighbor(geohash, level - 1, dx, dy);
+                if(neighbor != null) {
+                    return neighbor + encode(nx, ny); 
+                } else {
+                    return null;
+                }
             }
         }
     }

--- a/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -19,11 +19,21 @@
 
 package org.elasticsearch.common.geo;
 
+import java.io.IOException;
+
+import org.elasticsearch.ElasticSearchParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+
 /**
  *
  */
 public class GeoPoint {
 
+    public static final String LATITUDE = GeoPointFieldMapper.Names.LAT;
+    public static final String LONGITUDE = GeoPointFieldMapper.Names.LON;
+    
     private double lat;
     private double lon;
 
@@ -122,5 +132,93 @@ public class GeoPoint {
 
     public String toString() {
         return "[" + lat + ", " + lon + "]";
+    }
+    
+    /**
+     * Parse a {@link GeoPoint} with a {@link XContentParser}:
+     * 
+     * @param parser {@link XContentParser} to parse the value from
+     * @return new {@link GeoPoint} parsed from the parse
+     * 
+     * @throws IOException
+     * @throws ElasticSearchParseException
+     */
+    public static GeoPoint parse(XContentParser parser) throws IOException, ElasticSearchParseException {
+        return parse(parser, new GeoPoint());
+    }
+
+    /**
+     * Parse a {@link GeoPoint} with a {@link XContentParser}. A geopoint has one of the following forms:
+     * 
+     * <ul>
+     *     <li>Object: <pre>{&quot;lat&quot;: <i>&lt;latitude&gt;</i>, &quot;lon&quot;: <i>&lt;longitude&gt;</i>}</pre></li>
+     *     <li>String: <pre>&quot;<i>&lt;latitude&gt;</i>,<i>&lt;longitude&gt;</i>&quot;</pre></li>
+     *     <li>Geohash: <pre>&quot;<i>&lt;geohash&gt;</i>&quot;</pre></li>
+     *     <li>Array: <pre>[<i>&lt;longitude&gt;</i>,<i>&lt;latitude&gt;</i>]</pre></li>
+     * </ul>
+     * 
+     * @param parser {@link XContentParser} to parse the value from
+     * @param point A {@link GeoPoint} that will be reset by the values parsed
+     * @return new {@link GeoPoint} parsed from the parse
+     * 
+     * @throws IOException
+     * @throws ElasticSearchParseException
+     */
+    public static GeoPoint parse(XContentParser parser, GeoPoint point) throws IOException, ElasticSearchParseException {
+        if(parser.currentToken() == Token.START_OBJECT) {
+            while(parser.nextToken() != Token.END_OBJECT) {
+                if(parser.currentToken() == Token.FIELD_NAME) {
+                    String field = parser.text();
+                    if(LATITUDE.equals(field)) {
+                        if(parser.nextToken() == Token.VALUE_NUMBER) {
+                            point.resetLat(parser.doubleValue());
+                        } else {
+                            throw new ElasticSearchParseException("latitude must be a number");
+                        }
+                    } else if (LONGITUDE.equals(field)) {
+                        if(parser.nextToken() == Token.VALUE_NUMBER) {
+                            point.resetLon(parser.doubleValue());
+                        } else {
+                            throw new ElasticSearchParseException("latitude must be a number");
+                        }
+                    } else {
+                        throw new ElasticSearchParseException("field must be either '"+LATITUDE+"' or '"+LONGITUDE+"'");
+                    }
+                } else {
+                    throw new ElasticSearchParseException("Token '"+parser.currentToken()+"' not allowed");
+                }
+            }
+            return point;
+        } else if(parser.currentToken() == Token.START_ARRAY) {
+            int element = 0;
+            while(parser.nextToken() != Token.END_ARRAY) {
+                if(parser.currentToken() == Token.VALUE_NUMBER) {
+                    element++;
+                    if(element == 1) {
+                        point.resetLon(parser.doubleValue());
+                    } else if(element == 2) {
+                        point.resetLat(parser.doubleValue());
+                    } else {
+                        throw new ElasticSearchParseException("only two values allowed");
+                    }
+                } else {
+                    throw new ElasticSearchParseException("Numeric value expected");
+                }
+            }
+            return point;
+        } else if(parser.currentToken() == Token.VALUE_STRING) {
+            String data = parser.text();
+            int comma = data.indexOf(',');
+            if(comma > 0) {
+                double lat = Double.parseDouble(data.substring(0, comma).trim());
+                double lon = Double.parseDouble(data.substring(comma+1).trim());
+                return point.reset(lat, lon);
+            } else {
+                point.resetFromGeoHash(data);
+                return point;
+            }
+        } else {
+            throw new ElasticSearchParseException("geo_point expected");
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import com.spatial4j.core.shape.Shape;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.ShapeRelation;
 
 /**
@@ -370,6 +371,18 @@ public abstract class FilterBuilders {
      */
     public static GeohashFilter.Builder geoHashFilter(String fieldname, String geohash) {
         return new GeohashFilter.Builder(fieldname, geohash);
+    }
+
+    /**
+     * A filter based on a bounding box defined by geohash. The field this filter is applied to
+     * must have <code>{&quot;type&quot;:&quot;geo_point&quot;, &quot;geohash&quot;:true}</code>
+     * to work.
+     *
+     * @param fieldname The geopoint field name.
+     * @param point a geopoint within the geohash bucket
+     */
+    public static GeohashFilter.Builder geoHashFilter(String fieldname, GeoPoint point) {
+        return new GeohashFilter.Builder(fieldname, point);
     }
 
     /**


### PR DESCRIPTION
The `geohash_cell` filter now adapts the format of other geo-filters. The oject fieldnames match the fieldnames document names automatically. This invalidates the `field` field in previeous versions. The value these fields value is a `geo_point` value (all formats supported) which is internally translated to a geohash. Since those points alway have a maximum precision (level 12) a `precision` definition has been included. This precision can either be defined as _length_ of the geohash-string or as _distance_. It's assumed the a distance without any unit is a geohash-length.

```
GET 'http://127.0.0.1:9200/locations/_search?pretty=true' -d '{
    "query": {
        "match_all":{}
    },
    "filter": {
        "geohash_cell": {
            "pin": {
                "lat": 13.4080,
                "lon": 52.5186
            },
            "precision": 3,
            "neighbors": true
        }
    }
}'
```

Closes #3229
