### PR TITLE
Add a "routing" parameter to the terms lookup filter. This resolves issue 3233

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -170,7 +170,7 @@ public class TermsFilterParser implements FilterParser {
             }
 
             // external lookup, use it
-            TermsLookup termsLookup = new TermsLookup(fieldMapper, lookupIndex, lookupType, lookupId, lookupPath, lookupRouting, parseContext);
+            TermsLookup termsLookup = new TermsLookup(fieldName, fieldMapper, lookupIndex, lookupType, lookupId, lookupPath, lookupRouting, parseContext);
             if (cacheKey == null) {
                 cacheKey = new CacheKeyFilter.Key(termsLookup.toString());
             }

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -76,6 +76,7 @@ public class TermsFilterParser implements FilterParser {
         String lookupType = null;
         String lookupId = null;
         String lookupPath = null;
+        String lookupRouting = null;
 
         CacheKeyFilter.Key cacheKey = null;
         XContentParser.Token token;
@@ -108,7 +109,9 @@ public class TermsFilterParser implements FilterParser {
                         } else if ("id".equals(currentFieldName)) {
                             lookupId = parser.text();
                         } else if ("path".equals(currentFieldName)) {
-                            lookupPath = parser.text();
+                          lookupPath = parser.text();
+                        } else if ("routing".equals(currentFieldName)) {
+                          lookupRouting = parser.text();
                         } else {
                             throw new QueryParsingException(parseContext.index(), "[terms] filter does not support [" + currentFieldName + "] within lookup element");
                         }
@@ -122,6 +125,9 @@ public class TermsFilterParser implements FilterParser {
                 }
                 if (lookupPath == null) {
                     throw new QueryParsingException(parseContext.index(), "[terms] filter lookup element requires specifying the path");
+                }
+                if (lookupRouting == null) {
+                    lookupRouting = lookupId;
                 }
             } else if (token.isValue()) {
                 if ("execution".equals(currentFieldName)) {
@@ -164,7 +170,7 @@ public class TermsFilterParser implements FilterParser {
             }
 
             // external lookup, use it
-            TermsLookup termsLookup = new TermsLookup(fieldMapper, lookupIndex, lookupType, lookupId, lookupPath, parseContext);
+            TermsLookup termsLookup = new TermsLookup(fieldMapper, lookupIndex, lookupType, lookupId, lookupPath, lookupRouting, parseContext);
             if (cacheKey == null) {
                 cacheKey = new CacheKeyFilter.Key(termsLookup.toString());
             }

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/IndicesTermsFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/IndicesTermsFilterCache.java
@@ -95,7 +95,7 @@ public class IndicesTermsFilterCache extends AbstractComponent {
             return cache.get(cacheKey, new Callable<TermsFilterValue>() {
                 @Override
                 public TermsFilterValue call() throws Exception {
-                    GetResponse getResponse = client.get(new GetRequest(lookup.getIndex(), lookup.getType(), lookup.getId()).preference("_local")).actionGet();
+                    GetResponse getResponse = client.get(new GetRequest(lookup.getIndex(), lookup.getType(), lookup.getId()).routing(lookup.getRouting()).preference("_local")).actionGet();
                     if (!getResponse.isExists()) {
                         return NO_TERMS;
                     }

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
@@ -29,6 +29,7 @@ public class TermsLookup {
 
     private final FieldMapper fieldMapper;
 
+    private final String fieldName;
     private final String index;
     private final String type;
     private final String id;
@@ -38,8 +39,9 @@ public class TermsLookup {
     @Nullable
     private final QueryParseContext queryParseContext;
 
-    public TermsLookup(FieldMapper fieldMapper, String index, String type, String id, String path, String routing, @Nullable QueryParseContext queryParseContext) {
+    public TermsLookup(String fieldName, FieldMapper fieldMapper, String index, String type, String id, String path, String routing, @Nullable QueryParseContext queryParseContext) {
         this.fieldMapper = fieldMapper;
+        this.fieldName = fieldName;
         this.index = index;
         this.type = type;
         this.id = id;
@@ -48,8 +50,11 @@ public class TermsLookup {
         this.queryParseContext = queryParseContext;
     }
 
+    public String getFieldName() {
+      return fieldName;
+    }
     public FieldMapper getFieldMapper() {
-        return fieldMapper;
+      return fieldMapper;
     }
 
     public String getIndex() {

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
@@ -32,17 +32,19 @@ public class TermsLookup {
     private final String index;
     private final String type;
     private final String id;
+    private final String routing;
     private final String path;
 
     @Nullable
     private final QueryParseContext queryParseContext;
 
-    public TermsLookup(FieldMapper fieldMapper, String index, String type, String id, String path, @Nullable QueryParseContext queryParseContext) {
+    public TermsLookup(FieldMapper fieldMapper, String index, String type, String id, String path, String routing, @Nullable QueryParseContext queryParseContext) {
         this.fieldMapper = fieldMapper;
         this.index = index;
         this.type = type;
         this.id = id;
         this.path = path;
+        this.routing = routing;
         this.queryParseContext = queryParseContext;
     }
 
@@ -64,6 +66,10 @@ public class TermsLookup {
 
     public String getPath() {
         return path;
+    }
+
+    public String getRouting() {
+      return routing;
     }
 
     @Nullable


### PR DESCRIPTION
https://github.com/elasticsearch/elasticsearch/issues/3233

This allows a custom routing parameter for the document lookup when using the "terms lookup" filter. Previously, only the document_id could be used.
