### PR TITLE
Fix field number attribution to _version.

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/policy/IndexUpgraderMergePolicy.java
+++ b/src/main/java/org/elasticsearch/index/merge/policy/IndexUpgraderMergePolicy.java
@@ -94,7 +94,12 @@ public final class IndexUpgraderMergePolicy extends MergePolicy {
         // Build new field infos, doc values, and return a filter reader
         final FieldInfo newVersionInfo;
         if (versionInfo == null) {
-            newVersionInfo = new FieldInfo(UidFieldMapper.VERSION, false, fieldInfos.size(), false, true, false,
+            // Find a free field number
+            int fieldNumber = 0;
+            for (FieldInfo fi : fieldInfos) {
+                fieldNumber = Math.max(fieldNumber, fi.number + 1);
+            }
+            newVersionInfo = new FieldInfo(UidFieldMapper.VERSION, false, fieldNumber, false, true, false,
                     IndexOptions.DOCS_ONLY, DocValuesType.NUMERIC, DocValuesType.NUMERIC, Collections.<String, String>emptyMap());
         } else {
             newVersionInfo = new FieldInfo(UidFieldMapper.VERSION, versionInfo.isIndexed(), versionInfo.number,

--- a/src/test/java/org/elasticsearch/test/unit/common/lucene/uid/VersionsTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/lucene/uid/VersionsTests.java
@@ -211,6 +211,8 @@ public class VersionsTests {
 
         // 1st segment, no _version
         Document document = new Document();
+        // Add a dummy field (enough to trigger #3237)
+        document.add(new StringField("a", "b", Store.NO));
         StringField uid = new StringField(UidFieldMapper.NAME, "1", Store.YES);
         document.add(uid);
         iw.addDocument(document);


### PR DESCRIPTION
IndexUpgraderMergePolicy assumed that field numbers were dense and that
fieldInfos.size() was a free field number. This can however be wrong for a
segment which doesn't have one or more fields that some older segments have.
