### PR TITLE
Make index.warmer.enabled setting dynamic

### DIFF
--- a/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.store.support.AbstractIndexStore;
 import org.elasticsearch.index.translog.TranslogService;
 import org.elasticsearch.index.translog.fs.FsTranslog;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
+import org.elasticsearch.indices.warmer.InternalIndicesWarmer;
 
 /**
  */
@@ -113,6 +114,7 @@ public class IndexDynamicSettingsModule extends AbstractModule {
         indexDynamicSettings.addDynamicSetting(TranslogService.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE, Validator.BYTES_SIZE);
         indexDynamicSettings.addDynamicSetting(TranslogService.INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD, Validator.TIME);
         indexDynamicSettings.addDynamicSetting(TranslogService.INDEX_TRANSLOG_DISABLE_FLUSH);
+        indexDynamicSettings.addDynamicSetting(InternalIndicesWarmer.INDEX_WARMER_ENABLED);
     }
 
     public void addDynamicSettings(String... settings) {

--- a/src/main/java/org/elasticsearch/indices/warmer/InternalIndicesWarmer.java
+++ b/src/main/java/org/elasticsearch/indices/warmer/InternalIndicesWarmer.java
@@ -38,6 +38,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class InternalIndicesWarmer extends AbstractComponent implements IndicesWarmer {
 
+    public static final String INDEX_WARMER_ENABLED = "index.warmer.enabled";
+
     private final ThreadPool threadPool;
 
     private final ClusterService clusterService;
@@ -69,7 +71,7 @@ public class InternalIndicesWarmer extends AbstractComponent implements IndicesW
         if (indexMetaData == null) {
             return;
         }
-        if (!indexMetaData.settings().getAsBoolean("index.warmer.enabled", settings.getAsBoolean("index.warmer.enabled", true))) {
+        if (!indexMetaData.settings().getAsBoolean(INDEX_WARMER_ENABLED, settings.getAsBoolean(INDEX_WARMER_ENABLED, true))) {
             return;
         }
         IndexService indexService = indicesService.indexService(context.shardId().index().name());


### PR DESCRIPTION
Even though proposed in the documentation, the realtime enabling/disabling of
index warmers was not supported. This commit adds support for
index.warmer.enabled as a dynamic setting.

Closes #3246
