### PR TITLE
Fix search shards count method when targeting concrete and aliased indices

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/operation/plain/PlainOperationRouting.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/operation/plain/PlainOperationRouting.java
@@ -131,6 +131,10 @@ public class PlainOperationRouting extends AbstractComponent implements Operatio
                         // we might get duplicates, but that's ok, its an estimated count? (we just want to know if its 1 or not)
                         set.add(indexShard.shardId());
                     }
+                } else {
+                    for (IndexShardRoutingTable indexShard : indexRouting) {
+                        set.add(indexShard.shardId());
+                    }
                 }
             }
             return set.size();


### PR DESCRIPTION
This is related to the same example as issue #2682.

This bug can lead to a forced query_and_fetch search type which might not be the expected behavior.

I propose to fix it this way because it is a quick 2 lines patch. But maybe we should refactor a bit and add a shared method for searchShards and searchShardsCount to avoid divergent behavior in the future.

Reading the code it seems like searchShardsCount is mainly implemented to test if we are hitting 1 shard or more than 1 shards so maybe it could be renamed and optimized for that specific use case.

Feel free to fix the problem otherwise or to tell me what do you prefer and I will be happy to change this pull request.
