### PR TITLE
Support for parent in multi get request

### DIFF
--- a/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -94,6 +94,13 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
             return this.routing;
         }
 
+        public Item parent(String parent) {
+            if (routing == null) {
+                this.routing = parent;
+            }
+            return this;
+        }
+
         public Item fields(String... fields) {
             this.fields = fields;
             return this;
@@ -246,6 +253,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
                             String type = defaultType;
                             String id = null;
                             String routing = null;
+                            String parent = null;
                             List<String> fields = null;
                             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                                 if (token == XContentParser.Token.FIELD_NAME) {
@@ -259,6 +267,8 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
                                         id = parser.text();
                                     } else if ("_routing".equals(currentFieldName) || "routing".equals(currentFieldName)) {
                                         routing = parser.text();
+                                    } else if ("_parent".equals(currentFieldName) || "parent".equals(currentFieldName)) {
+                                        parent = parser.text();
                                     } else if ("fields".equals(currentFieldName)) {
                                         fields = new ArrayList<String>();
                                         fields.add(parser.text());
@@ -278,7 +288,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
                             } else {
                                 aFields = defaultFields;
                             }
-                            add(new Item(index, type, id).routing(routing).fields(aFields));
+                            add(new Item(index, type, id).routing(routing).fields(aFields).parent(parent));
                         }
                     } else if ("ids".equals(currentFieldName)) {
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {


### PR DESCRIPTION
When specifying the docs to be returned in a multi get request, a parent
field could not be specified, so that some docs seemingly did not exist,
even though they did.

This fix behaves like the normal GetRequest and simply overwrites the
routing value if it has not yet been set.

Also a test for routing with mget has been added.

Closes #3274
