### PR TITLE
Terms Lookup by Query/Filter (aka. Join Filter)

### DIFF
--- a/docs/reference/query-dsl/filters/terms-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/terms-filter.asciidoc
@@ -30,7 +30,7 @@ them in the more compact model that terms filter provides.
 The `execution` option now has the following options :
 
 [horizontal]
-`plain`:: 
+`plain`::
     The default. Works as today. Iterates over all the terms,
     building a bit set matching it, and filtering. The total filter is
     cached.
@@ -38,22 +38,22 @@ The `execution` option now has the following options :
 `fielddata`::
     Generates a terms filters that uses the fielddata cache to
     compare terms.  This execution mode is great to use when filtering
-    on a field that is already loaded into the fielddata cache from 
+    on a field that is already loaded into the fielddata cache from
     faceting, sorting, or index warmers.  When filtering on
     a large number of terms, this execution can be considerably faster
     than the other modes.  The total filter is not cached unless
     explicitly configured to do so.
 
-`bool`:: 
+`bool`::
     Generates a term filter (which is cached) for each term, and
     wraps those in a bool filter. The bool filter itself is not cached as it
     can operate very quickly on the cached term filters.
 
-`and`:: 
+`and`::
     Generates a term filter (which is cached) for each term, and
     wraps those in an and filter. The and filter itself is not cached.
 
-`or`:: 
+`or`::
     Generates a term filter (which is cached) for each term, and
     wraps those in an or filter. The or filter itself is not cached.
     Generally, the `bool` execution mode should be preferred.
@@ -102,25 +102,25 @@ lookup mechanism.
 The terms lookup mechanism supports the following options:
 
 [horizontal]
-`index`:: 
+`index`::
     The index to fetch the term values from. Defaults to the
     current index.
 
-`type`:: 
+`type`::
     The type to fetch the term values from.
 
-`id`:: 
+`id`::
     The id of the document to fetch the term values from.
 
-`path`:: 
+`path`::
     The field specified as path to fetch the actual values for the
     `terms` filter.
 
-`routing`:: 
+`routing`::
     A custom routing value to be used when retrieving the
     external terms doc.
 
-`cache`:: 
+`cache`::
     Whether to cache the filter built from the retrieved document
     (`true` - default) or whether to fetch and rebuild the filter on every
     request (`false`). See "<<query-dsl-terms-filter-lookup-caching,Terms lookup caching>>" below
@@ -148,62 +148,68 @@ over multiple indices, shards, and types.
 The terms lookup by query mechanism supports the following options:
 
 [horizontal]
-`indices` or `index`:: 
+`indices` or `index`::
     One or more indices to execute the lookup query against. Default's
     to all indices if not specified.
 
-`types` or `type`:: 
+`types` or `type`::
     One or more types to execute against.  Default's to all types of
     the configured indices.
 
-`path`:: 
+`path`::
     The field to fetch the actual values from the documents matching
     the lookup query.
 
 `filter`::
     The query filter documents must match for their terms to be collected
     as part of the query lookup.
-    
-`routing`:: 
+
+`max_terms_per_shard`::
+    The maximum number of terms to collect from each shard.  Default's to
+    all terms.
+
+`routing`::
     A custom routing value to be used when executing the lookup query.
 
-`cache`:: 
+`cache`::
     Whether to cache the filter built from the retrieved terms
     (`true` - default) or whether to fetch and rebuild the filter on every
-    request (`false`). See "<<query-dsl-terms-filter-lookup-bloom,Terms lookup caching>>" 
+    request (`false`). See "<<query-dsl-terms-filter-lookup-bloom,Terms lookup caching>>"
     below.
 
 `bloom_filter`::
     Configures the query lookup to gather terms within a bloom filter for
-    more compact term representation at the cost of lookup precision.  See 
+    more compact term representation at the cost of lookup precision.  See
     the "<<query-dsl-terms-filter-lookup-caching,Bloom Filter>>" section below.
-    
-The values for the `terms` filter will be fetched from the `path` field of 
-documents matching the lookup filter.  If the source field is a text based field,
-the cost of gathering a large number of terms can be quite expensive due to
-network latency.  In this situation it is best to use numeric fields or configure
-the lookup to use a "<<query-dsl-terms-filter-lookup-bloom,Bloom Filter>>".
 
-The terms lookup currently only uses the `fielddata` exection mode so proper "<<indices-warmers,Warming>>" is recommended.  Since the filter uses the 
-fielddata cache by default, the resulting filter is not cached unless configured
-to do so.
+The values for the `terms` filter will be fetched from the `path` field of
+documents matching the lookup filter.  If `max_terms_per_shard` is set, then
+the number of terms gathered will be at most `max_terms_per_shard` * NUM_SHARDS.
+If the source field is a text based field, the cost of gathering a large number
+of terms can be quite expensive due to network latency.  In this situation it is
+best to use numeric fields or configure the lookup to use a
+"<<query-dsl-terms-filter-lookup-bloom,Bloom Filter>>".
+
+The terms lookup currently only uses the `fielddata` exection mode so proper "<<indices-warmers,Warming>>" is
+recommended.  Since the filter uses the fielddata cache by default, the resulting filter is not cached unless
+configured to do so.
 
 ["float",id="query-dsl-terms-filter-lookup-bloom"]
 ==== Bloom filter support
 
-When performing a lookup query against a set of text based terms with a high 
+When performing a lookup query against a set of text based terms with a high
 cardinality the cost of transfering these terms over the network can be
 quite expensive resulting in slow response times.  If precision is not
-critical, performance can be considerably better by using a 
+critical, performance can be considerably better by using a
 http://en.wikipedia.org/wiki/Bloom_filter[Bloom Filter]
 for the lookup terms.  To enable the use of the bloom filter, set any of
 the following configuration options on the `bloom_filter` option:
 
 [horizontal]
-`expected_insertions`:: 
-    The expected number of terms to be inserted into the bloom filter.  This 
+`expected_insertions`::
+    The expected number of terms to be inserted into the bloom filter.  This
     value must be greater than 0 and is REQUIRED.
-    
+
 `fpp`::
     The false positive probability.  This is the acceptable percentage of
     terms that can potentially be considered a valid lookup term even though
@@ -214,11 +220,11 @@ the following configuration options on the `bloom_filter` option:
     The number of times a value should be hashed before being inserted into the
     bloom filter.  This value must be between 1 and 255 and by default has an
     optimal value calculated based on the `expected_insertions` and `fpp`.
-    
+
 The optimal bloom filter configuration is very dependent on the number of terms
 gathered from matching documents and the number of terms the filter will actually
 compare against the bloom filter.  For a higher precision (less false positives)
-you can increase the number of `expected_insertions`, lower the `fpp`, or increase 
+you can increase the number of `expected_insertions`, lower the `fpp`, or increase
 the number of `hash_functions`.  As you get a higher precision your response times
 will get slower due to resulting bloom filter getting larger and/or using more CPU
 to calculate the hashes.  Increasing the `fpp` value is typically the only thing
@@ -234,13 +240,13 @@ There is an additional cache involved, which caches the lookup of the
 lookup document to the actual terms. This lookup cache is a LRU cache.
 This cache has the following options:
 
-`indices.cache.filter.terms.size`:: 
+`indices.cache.filter.terms.size`::
     The size of the lookup cache. The default is `10mb`.
 
-`indices.cache.filter.terms.expire_after_access`:: 
+`indices.cache.filter.terms.expire_after_access`::
     The time after the last read an entry should expire. Disabled by default.
 
-`indices.cache.filter.terms.expire_after_write`:: 
+`indices.cache.filter.terms.expire_after_write`::
     The time after the last write an entry should expire. Disabled by default.
 
 All options for the lookup of the documents cache can only be configured
@@ -320,10 +326,10 @@ In which case, the lookup path will be `followers.id`.
 [float]
 ==== Terms lookup by query example
 
-In the following example we are replicating the 
-"<<query-dsl-has-child-filter,HasChild Filter>>" by looking up the 
-"pid" values from children documents with the tag "something" and 
-then filtering only parent documents that have an "id" matching one 
+In the following example we are replicating the
+"<<query-dsl-has-child-filter,HasChild Filter>>" by looking up the
+"pid" values from children documents with the tag "something" and
+then filtering only parent documents that have an "id" matching one
 of the children's "pid" values.
 
 In this example, parents and children are stored in their own indices.

--- a/docs/reference/query-dsl/filters/terms-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/terms-filter.asciidoc
@@ -139,6 +139,15 @@ possible, reducing the need for networking.
 [float]
 ==== Terms lookup by query mechanism
 
+added[1.2.0]
+
+.Experimental!
+[IMPORTANT]
+=====
+This feature is marked as experimental, and may be subject to change in the
+future.  If you use this feature, please let us know your experience with it!
+=====
+
 The terms filter by query feature allows the lookup of terms from
 documents matching a query/filter.  This functionality is similar to
 the "<<query-dsl-has-child-filter,HasChild>>" and "<<query-dsl-has-parent-filter,HasParent>>"

--- a/docs/reference/query-dsl/filters/terms-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/terms-filter.asciidoc
@@ -136,6 +136,97 @@ across all nodes if the "reference" terms data is not large. The lookup
 terms filter will prefer to execute the get request on a local node if
 possible, reducing the need for networking.
 
+[float]
+==== Terms lookup by query mechanism
+
+The terms filter by query feature allows the lookup of terms from
+documents matching a query/filter.  This functionality is similar to
+the "<<query-dsl-has-child-filter,HasChild>>" and "<<query-dsl-has-parent-filter,HasParent>>"
+functionality without the limiations.  The lookup query can be executed
+over multiple indices, shards, and types.
+
+The terms lookup by query mechanism supports the following options:
+
+[horizontal]
+`indices` or `index`:: 
+    One or more indices to execute the lookup query against. Default's
+    to all indices if not specified.
+
+`types` or `type`:: 
+    One or more types to execute against.  Default's to all types of
+    the configured indices.
+
+`path`:: 
+    The field to fetch the actual values from the documents matching
+    the lookup query.
+
+`filter`::
+    The query filter documents must match for their terms to be collected
+    as part of the query lookup.
+    
+`routing`:: 
+    A custom routing value to be used when executing the lookup query.
+
+`cache`:: 
+    Whether to cache the filter built from the retrieved terms
+    (`true` - default) or whether to fetch and rebuild the filter on every
+    request (`false`). See "<<query-dsl-terms-filter-lookup-bloom,Terms lookup caching>>" 
+    below.
+
+`bloom_filter`::
+    Configures the query lookup to gather terms within a bloom filter for
+    more compact term representation at the cost of lookup precision.  See 
+    the "<<query-dsl-terms-filter-lookup-caching,Bloom Filter>>" section below.
+    
+The values for the `terms` filter will be fetched from the `path` field of 
+documents matching the lookup filter.  If the source field is a text based field,
+the cost of gathering a large number of terms can be quite expensive due to
+network latency.  In this situation it is best to use numeric fields or configure
+the lookup to use a "<<query-dsl-terms-filter-lookup-bloom,Bloom Filter>>".
+
+The terms lookup currently only uses the `fielddata` exection mode so proper "<<indices-warmers,Warming>>" is recommended.  Since the filter uses the 
+fielddata cache by default, the resulting filter is not cached unless configured
+to do so.
+
+["float",id="query-dsl-terms-filter-lookup-bloom"]
+==== Bloom filter support
+
+When performing a lookup query against a set of text based terms with a high 
+cardinality the cost of transfering these terms over the network can be
+quite expensive resulting in slow response times.  If precision is not
+critical, performance can be considerably better by using a 
+http://en.wikipedia.org/wiki/Bloom_filter[Bloom Filter]
+for the lookup terms.  To enable the use of the bloom filter, set any of
+the following configuration options on the `bloom_filter` option:
+
+[horizontal]
+`expected_insertions`:: 
+    The expected number of terms to be inserted into the bloom filter.  This 
+    value must be greater than 0 and is REQUIRED.
+    
+`fpp`::
+    The false positive probability.  This is the acceptable percentage of
+    terms that can potentially be considered a valid lookup term even though
+    it was not found in any documents matching the lookup query.   This value
+    must be between 0 and 1 and defaults to 0.03 (3%).
+
+`hash_functions`::
+    The number of times a value should be hashed before being inserted into the
+    bloom filter.  This value must be between 1 and 255 and by default has an
+    optimal value calculated based on the `expected_insertions` and `fpp`.
+    
+The optimal bloom filter configuration is very dependent on the number of terms
+gathered from matching documents and the number of terms the filter will actually
+compare against the bloom filter.  For a higher precision (less false positives)
+you can increase the number of `expected_insertions`, lower the `fpp`, or increase 
+the number of `hash_functions`.  As you get a higher precision your response times
+will get slower due to resulting bloom filter getting larger and/or using more CPU
+to calculate the hashes.  Increasing the `fpp` value is typically the only thing
+required to get faster response times.
+
+The bloom filter support is an advanced feature and will require some trial and error
+to find optimal values.
+
 ["float",id="query-dsl-terms-filter-lookup-caching"]
 ==== Terms lookup caching
 
@@ -225,3 +316,96 @@ curl -XPUT localhost:9200/users/user/2 -d '{
 --------------------------------------------------
 
 In which case, the lookup path will be `followers.id`.
+
+[float]
+==== Terms lookup by query example
+
+In the following example we are replicating the 
+"<<query-dsl-has-child-filter,HasChild Filter>>" by looking up the 
+"pid" values from children documents with the tag "something" and 
+then filtering only parent documents that have an "id" matching one 
+of the children's "pid" values.
+
+In this example, parents and children are stored in their own indices.
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'http://localhost:9200/parentIndex/_search' -d '{
+  "query": {
+    "constant_score": {
+      "filter": {
+        "terms": {
+          "id": {
+            "index": "childIndex",
+            "type": "childType",
+            "path": "pid",
+            "filter": {
+              "term": {
+                "tag": "something"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+--------------------------------------------------
+
+Using the "<<query-dsl-terms-filter-lookup-bloom,Bloom Filter>>" support:
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'http://localhost:9200/parentIndex/_search' -d '{
+  "query": {
+    "constant_score": {
+      "filter": {
+        "terms": {
+          "id": {
+            "index": "childIndex",
+            "type": "childType",
+            "path": "pid",
+            "filter": {
+              "term": {
+                "tag": "something"
+              }
+            },
+            "bloom_filter": {
+              "expected_insertions": 10000
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+--------------------------------------------------
+
+Here is another example where we are searching for products or services
+mentioning "elasticsearch".  Products, Services, and Companies are all stored
+in their own index and contain a numeric "company_id" field.  Both products
+and services have a "description" field.
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'http://localhost:9200/companies/_search' -d '{
+  "query": {
+    "constant_score": {
+      "filter": {
+        "terms": {
+          "company_id": {
+            "indices": ["products", "services"],
+            "path": "company_id",
+            "filter": {
+              "term": {
+                "description": "elasticsearch"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+--------------------------------------------------
+

--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.action;
 
+import org.elasticsearch.action.terms.TermsByQueryAction;
+import org.elasticsearch.action.terms.TransportTermsByQueryAction;
+
 import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
@@ -258,6 +261,7 @@ public class ActionModule extends AbstractModule {
         registerAction(DeleteAction.INSTANCE, TransportDeleteAction.class,
                 TransportIndexDeleteAction.class, TransportShardDeleteAction.class);
         registerAction(CountAction.INSTANCE, TransportCountAction.class);
+        registerAction(TermsByQueryAction.INSTANCE, TransportTermsByQueryAction.class);
         registerAction(SuggestAction.INSTANCE, TransportSuggestAction.class);
         registerAction(UpdateAction.INSTANCE, TransportUpdateAction.class);
         registerAction(MultiGetAction.INSTANCE, TransportMultiGetAction.class,

--- a/src/main/java/org/elasticsearch/action/terms/ResponseTerms.java
+++ b/src/main/java/org/elasticsearch/action/terms/ResponseTerms.java
@@ -939,7 +939,7 @@ public abstract class ResponseTerms implements Streamable {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(maxTerms);
             out.writeVLong(termsHash.size());
-            for (long i = 0; i < termsHash.capacity(); i++) {
+            for (long i = 0; i < termsHash.size(); i++) {
                 out.writeLong(termsHash.get(i));
             }
         }

--- a/src/main/java/org/elasticsearch/action/terms/ResponseTerms.java
+++ b/src/main/java/org/elasticsearch/action/terms/ResponseTerms.java
@@ -1,0 +1,911 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import com.carrotsearch.hppc.DoubleOpenHashSet;
+import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.ObjectOpenHashSet;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.action.terms.TransportTermsByQueryAction.HitSetCollector;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.util.BloomFilter;
+import org.elasticsearch.index.fielddata.*;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Gathers and stores terms for a {@link TermsByQueryRequest}.
+ */
+public abstract class ResponseTerms implements Streamable {
+
+    protected transient final HitSetCollector collector;
+
+    /**
+     * Default constructor
+     */
+    ResponseTerms() {
+        this.collector = null;
+    }
+
+    /**
+     * Constructor used before term collection
+     *
+     * @param collector the collector used during the lookup query execution
+     */
+    public ResponseTerms(HitSetCollector collector) {
+        this.collector = collector;
+    }
+
+    /**
+     * Deserialize to correct {@link ResponseTerms} implementation.
+     */
+    public static ResponseTerms deserialize(StreamInput in) throws IOException {
+        Type type = Type.fromOrd(in.readVInt());
+        ResponseTerms rt;
+        switch (type) {
+            case LONGS:
+                rt = new LongsResponseTerms();
+                break;
+            case DOUBLES:
+                rt = new DoublesResponseTerms();
+                break;
+            case BLOOM:
+                rt = new BloomResponseTerms();
+                break;
+            default:
+                rt = new BytesResponseTerms();
+        }
+
+        rt.readFrom(in);
+        return rt;
+    }
+
+    /**
+     * Serialize a {@link ResponseTerms}.
+     */
+    public static void serialize(ResponseTerms rt, StreamOutput out) throws IOException {
+        out.writeVInt(rt.getType().ordinal());
+        rt.writeTo(out);
+    }
+
+    /**
+     * Creates a new {@link ResponseTerms} based on the fielddata type and request settings.  Returns a
+     * {@link LongsResponseTerms} for non-floating point numeric fields, {@link DoublesResponseTerms} for floating point
+     * numeric fields, and a {@link BytesResponseTerms} for all other field types.  If
+     * {@link TermsByQueryRequest#useBloomFilter} is set, then a {@link BloomResponseTerms} is returned for
+     * non-numeric fields.
+     *
+     * @param collector      the collector used during the lookup query execution
+     * @param indexFieldData the fielddata for the lookup field
+     * @param request        the lookup request
+     * @return {@link ResponseTerms} for the fielddata type
+     */
+    public static ResponseTerms get(HitSetCollector collector, IndexFieldData indexFieldData, TermsByQueryRequest request) {
+        if (indexFieldData instanceof IndexNumericFieldData) {
+            IndexNumericFieldData numFieldData = (IndexNumericFieldData) indexFieldData;
+            if (numFieldData.getNumericType().isFloatingPoint()) {
+                return new DoublesResponseTerms(collector, numFieldData);
+            } else {
+                return new LongsResponseTerms(collector, numFieldData);
+            }
+        } else {
+            // use bytes or bloom for all non-numeric fields types
+            if (request.useBloomFilter()) {
+                BloomResponseTerms bloomTerms =
+                        new BloomResponseTerms(collector, indexFieldData, request.bloomFpp(),
+                                request.bloomExpectedInsertions(), request.bloomHashFunctions());
+                return bloomTerms;
+            } else {
+                return new BytesResponseTerms(collector, indexFieldData);
+            }
+        }
+    }
+
+    /**
+     * Gets a {@link ResponseTerms} for a specified type and initial size.
+     *
+     * @param type The {@link ResponseTerms.Type} to return
+     * @param size The number of expected terms.
+     * @return {@link ResponseTerms} of the specified type.
+     */
+    public static ResponseTerms get(Type type, int size) {
+        switch (type) {
+            case LONGS:
+                return new LongsResponseTerms(size);
+            case DOUBLES:
+                return new DoublesResponseTerms(size);
+            case BLOOM:
+                return new BloomResponseTerms();
+            default:
+                return new BytesResponseTerms(size);
+        }
+    }
+
+    /**
+     * Called before gathering terms on a new {@link AtomicReaderContext}. Should be used to perform operations such
+     * as loading fielddata, etc.
+     *
+     * @param context The {@link AtomicReaderContext} we are about to process
+     */
+    protected abstract void load(AtomicReaderContext context);
+
+    /**
+     * Called for each hit in the current {@link AtomicReaderContext}.  Should be used to extract terms.
+     *
+     * @param docId The internal lucene docid for the hit in the current {@link AtomicReaderContext}.
+     */
+    protected abstract void processDoc(int docId);
+
+    /**
+     * Returns the type.
+     *
+     * @return The {@link ResponseTerms.Type}
+     */
+    public abstract Type getType();
+
+    /**
+     * Called to merging {@link ResponseTerms} from other shards.
+     *
+     * @param other The {@link ResponseTerms} to merge with
+     */
+    public abstract void merge(ResponseTerms other);
+
+    /**
+     * The number of terms in the {@link ResponseTerms}.
+     *
+     * @return The number of terms
+     */
+    public abstract int size();
+
+    /**
+     * The size of the {@link ResponseTerms} in bytes.
+     *
+     * @return The size in bytes
+     */
+    public abstract long getSizeInBytes();
+
+    /**
+     * Returns the the terms.
+     *
+     * @return The terms
+     */
+    public abstract Object getTerms();
+
+    /**
+     * Process the terms lookup query.
+     *
+     * @param leaves a list of {@link AtomicReaderContext} the lookup query was executed against.
+     * @throws IOException
+     */
+    public void process(List<AtomicReaderContext> leaves) throws IOException {
+        FixedBitSet[] bitSets = collector.getFixedSets();
+        for (int i = 0; i < leaves.size(); i++) {
+            AtomicReaderContext readerContext = leaves.get(i);
+            load(readerContext);
+            DocIdSetIterator iterator = bitSets[i].iterator();
+            int docId = 0;
+            while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                processDoc(docId);
+            }
+        }
+    }
+
+    /**
+     * The various types of {@link ResponseTerms}.
+     */
+    public static enum Type {
+        BYTES, LONGS, DOUBLES, BLOOM;
+
+        public static Type fromOrd(int ord) {
+            switch (ord) {
+                case 1:
+                    return LONGS;
+                case 2:
+                    return DOUBLES;
+                case 3:
+                    return BLOOM;
+                default:
+                    return BYTES;
+            }
+        }
+    }
+
+    /**
+     * A {@link ResponseTerms} implementation that creates a {@link BloomFilter} while collecting terms.  The {@link BloomFilter}
+     * is less expensive to serialize over the network resulting in much better response times.  The trade off is the
+     * possibility of false positives.  The {@link BloomFilter} can be tuned to for size (faster) or accuracy (slower) depending
+     * on the user's needs.
+     */
+    public static class BloomResponseTerms extends ResponseTerms {
+
+        private transient final IndexFieldData indexFieldData;
+        private transient BytesValues values;
+        private BloomFilter bloomFilter;
+        private int size = 0;
+
+        /**
+         * Default constructor
+         */
+        BloomResponseTerms() {
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used before term collection and to specify custom {@link BloomFilter} settings.
+         *
+         * @param collector          the collector used during terms lookup query
+         * @param indexFieldData     the fielddata for the lookup field
+         * @param fpp                false positive probability, must be between value between 0 and 1.
+         * @param expectedInsertions the expected number of terms to be inserted into the bloom filter
+         * @param numHashFunctions   the number of hash functions to use
+         */
+        BloomResponseTerms(HitSetCollector collector, IndexFieldData indexFieldData,
+                           Double fpp, Integer expectedInsertions, Integer numHashFunctions) {
+            super(collector);
+            this.indexFieldData = indexFieldData;
+
+            if (fpp == null) {
+                fpp = 0.03;
+            }
+
+            if (expectedInsertions == null) {
+                expectedInsertions = 100;
+            }
+
+            if (numHashFunctions != null) {
+                bloomFilter = BloomFilter.create(expectedInsertions, fpp, numHashFunctions);
+            } else {
+                bloomFilter = BloomFilter.create(expectedInsertions, fpp);
+            }
+        }
+
+        /**
+         * Load the fielddata
+         *
+         * @param context The {@link AtomicReaderContext} we are about to process
+         */
+        @Override
+        protected void load(AtomicReaderContext context) {
+            values = indexFieldData.load(context).getBytesValues(false); // load field data cache
+        }
+
+        /**
+         * Extracts all values from the fielddata for the lookup field and inserts them in the bloom filter.
+         *
+         * @param docId The internal lucene docid for the hit in the current {@link AtomicReaderContext}.
+         */
+        @Override
+        protected void processDoc(int docId) {
+            final int numVals = values.setDocument(docId);
+            for (int i = 0; i < numVals; i++) {
+                final BytesRef term = values.nextValue();
+                bloomFilter.put(term);
+                size += 1;
+            }
+        }
+
+        /**
+         * The type.
+         *
+         * @return {@link BloomResponseTerms.Type#BLOOM}
+         */
+        @Override
+        public Type getType() {
+            return Type.BLOOM;
+        }
+
+        /**
+         * Merge with another {@link BloomResponseTerms}
+         *
+         * @param other The {@link ResponseTerms} to merge with
+         */
+        @Override
+        public void merge(ResponseTerms other) {
+            assert other.getType() == Type.BLOOM; // must be a bloom
+
+            BloomResponseTerms ot = (BloomResponseTerms) other;
+            size += ot.size;
+
+            if (bloomFilter == null) {
+                bloomFilter = ot.bloomFilter;
+            } else if (ot.bloomFilter != null) {
+                bloomFilter.merge(ot.bloomFilter);
+            }
+        }
+
+        /**
+         * The number of terms represented in the bloom filter.
+         *
+         * @return the number of terms.
+         */
+        @Override
+        public int size() {
+            return size;
+        }
+
+        /**
+         * The size of the bloom filter.
+         *
+         * @return The size of the bloom filter in bytes.
+         */
+        @Override
+        public long getSizeInBytes() {
+            return bloomFilter != null ? bloomFilter.getSizeInBytes() : 0;
+        }
+
+        /**
+         * Returns the bloom filter.
+         *
+         * @return the {@link BloomFilter}
+         */
+        @Override
+        public Object getTerms() {
+            return bloomFilter;
+        }
+
+        /**
+         * Deserialize
+         *
+         * @param in the input
+         * @throws IOException
+         */
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            if (in.readBoolean()) {
+                bloomFilter = BloomFilter.readFrom(in);
+            }
+
+            size = in.readVInt();
+        }
+
+        /**
+         * Serialize
+         *
+         * @param out the output
+         * @throws IOException
+         */
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            if (bloomFilter != null) {
+                out.writeBoolean(true);
+                BloomFilter.writeTo(bloomFilter, out);
+            } else {
+                out.writeBoolean(false);
+            }
+
+            out.writeVInt(size);
+        }
+    }
+
+    /**
+     * A {@link ResponseTerms} implementation for non-numeric fields that collects all terms into a set.  All terms
+     * are serialized and transferred over the network which could lead to slower response times if performing a lookup
+     * on a field with a high-cardinality and a large result set.
+     */
+    public static class BytesResponseTerms extends ResponseTerms {
+
+        private transient final IndexFieldData indexFieldData;
+        private long sizeInBytes;
+        private transient BytesValues values;
+        private ObjectOpenHashSet<BytesRef> terms;
+
+        /**
+         * Default constructor
+         */
+        BytesResponseTerms() {
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used before merging.  Initializes the set with the correct size to avoid rehashing during
+         * the merge.
+         *
+         * @param size the number of terms that will be in the resulting set
+         */
+        BytesResponseTerms(int size) {
+            // create terms set, size is known so adjust for load factor so no rehashing is needed
+            this.terms = new ObjectOpenHashSet<BytesRef>(optimalSetSize(size));
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used for term collection on each shard.
+         *
+         * @param collector      the collector used during the lookup query execution
+         * @param indexFieldData the fielddata for the lookup field.
+         */
+        BytesResponseTerms(HitSetCollector collector, IndexFieldData indexFieldData) {
+            super(collector);
+            this.indexFieldData = indexFieldData;
+            this.terms = new ObjectOpenHashSet<BytesRef>(optimalSetSize(collector.getHits()));
+        }
+
+        /**
+         * Calculates the optimal set size to avoid rehashing
+         *
+         * @param size the number of items being inserted
+         * @return the optimal size
+         */
+        protected int optimalSetSize(int size) {
+            return (int) (size / ObjectOpenHashSet.DEFAULT_LOAD_FACTOR) + 1;
+        }
+
+        /**
+         * Load the fielddata.
+         *
+         * @param context The {@link AtomicReaderContext} we are about to process
+         */
+        @Override
+        protected void load(AtomicReaderContext context) {
+            values = indexFieldData.load(context).getBytesValues(false); // load field data cache
+        }
+
+        /**
+         * Extracts all values from the fielddata for the lookup field and inserts them in the terms set.
+         *
+         * @param docId The internal lucene docid for the hit in the current {@link AtomicReaderContext}.
+         */
+        @Override
+        protected void processDoc(int docId) {
+            final int numVals = values.setDocument(docId);
+            for (int i = 0; i < numVals; i++) {
+                final BytesRef term = values.nextValue();
+                terms.add(values.copyShared());  // so it is safe to be placed in set
+                sizeInBytes += term.length + 8;  // 8 additional bytes for the 2 ints in a BytesRef
+            }
+        }
+
+        /**
+         * Merge with another {@link BytesResponseTerms}
+         *
+         * @param other The {@link ResponseTerms} to merge with
+         */
+        @Override
+        public void merge(ResponseTerms other) {
+            assert other.getType() == Type.BYTES;
+            BytesResponseTerms ot = (BytesResponseTerms) other;
+            sizeInBytes += ot.sizeInBytes;  // update size and hashcode
+            if (terms == null) {
+                // probably never hit this since we init terms to known size before merge
+                terms = new ObjectOpenHashSet<BytesRef>(ot.terms);
+            } else {
+                // TODO: maybe make it an option not to merge and just store all the sets (to avoid internal hashing)
+                // this would use more memory due to duplicate terms but might be faster?
+                terms.addAll(ot.terms);
+            }
+        }
+
+        /**
+         * The type.
+         *
+         * @return {@link ResponseTerms.Type#BYTES}
+         */
+        @Override
+        public Type getType() {
+            return Type.BYTES;
+        }
+
+        /**
+         * Deserialize
+         *
+         * @param in the input
+         * @throws IOException
+         */
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            int size = in.readVInt();
+            sizeInBytes = in.readVLong();
+            // init set to account large enough to avoid rehashing during insert
+            terms = new ObjectOpenHashSet<BytesRef>(optimalSetSize(size));
+            for (int i = 0; i < size; i++) {
+                BytesRef term = in.readBytesRef();
+                terms.add(term);
+            }
+        }
+
+        /**
+         * Serialize
+         *
+         * @param out the output
+         * @throws IOException
+         */
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(terms.size());
+            out.writeVLong(sizeInBytes);
+
+            final boolean[] allocated = terms.allocated;
+            final Object[] keys = terms.keys;
+            for (int i = 0; i < allocated.length; i++) {
+                if (allocated[i]) {
+                    out.writeBytesRef((BytesRef) keys[i]);
+                }
+            }
+        }
+
+        /**
+         * The number of collected terms.
+         *
+         * @return the number of terms.
+         */
+        @Override
+        public int size() {
+            return terms.size();
+        }
+
+        /**
+         * The size of the terms.
+         *
+         * @return the size in bytes.
+         */
+        @Override
+        public long getSizeInBytes() {
+            return sizeInBytes;
+        }
+
+        /**
+         * Returns the terms.
+         *
+         * @return {@link ObjectOpenHashSet} of {@link BytesRef}
+         */
+        @Override
+        public Object getTerms() {
+            return terms;
+        }
+    }
+
+    /**
+     * A {@link ResponseTerms} implementation for non-floating point numeric fields that collects all terms into a set.
+     * All terms are gathered and serialized as primitive longs.
+     */
+    public static class LongsResponseTerms extends ResponseTerms {
+
+        private transient final IndexNumericFieldData indexFieldData;
+        private transient LongValues values;
+        private LongOpenHashSet terms;
+
+        /**
+         * Default constructor
+         */
+        LongsResponseTerms() {
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used before merging.  Initializes the set with the correct size to avoid rehashing during
+         * the merge.
+         *
+         * @param size the number of terms that will be in the resulting set
+         */
+        LongsResponseTerms(int size) {
+            // create terms set, size is known so adjust for load factor so no rehashing is needed
+            this.terms = new LongOpenHashSet(optimalSetSize(size));
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used for term collection on each shard.
+         *
+         * @param collector      the collector used during the lookup query execution
+         * @param indexFieldData the fielddata for the lookup field.
+         */
+        LongsResponseTerms(HitSetCollector collector, IndexNumericFieldData indexFieldData) {
+            super(collector);
+            this.indexFieldData = indexFieldData;
+            this.terms = new LongOpenHashSet(optimalSetSize(collector.getHits()));
+        }
+
+        /**
+         * Calculates the optimal set size to avoid rehashing
+         *
+         * @param size the number of items being inserted
+         * @return the optimal size
+         */
+        protected int optimalSetSize(int size) {
+            return (int) (size / LongOpenHashSet.DEFAULT_LOAD_FACTOR) + 1;
+        }
+
+        /**
+         * Load the fielddata
+         *
+         * @param context The {@link AtomicReaderContext} we are about to process
+         */
+        @Override
+        protected void load(AtomicReaderContext context) {
+            values = indexFieldData.load(context).getLongValues(); // load field data cache
+        }
+
+        /**
+         * Extracts all values from the fielddata for the lookup field and inserts them in the terms set.
+         *
+         * @param docId The internal lucene docid for the hit in the current {@link AtomicReaderContext}.
+         */
+        @Override
+        protected void processDoc(int docId) {
+            final int numVals = values.setDocument(docId);
+            for (int i = 0; i < numVals; i++) {
+                final long term = values.nextValue();
+                terms.add(term);
+            }
+        }
+
+        /**
+         * Merge with another {@link LongsResponseTerms}.
+         *
+         * @param other The {@link ResponseTerms} to merge with
+         */
+        @Override
+        public void merge(ResponseTerms other) {
+            assert other.getType() == Type.LONGS;
+            LongsResponseTerms ot = (LongsResponseTerms) other;
+            if (terms == null) {
+                terms = new LongOpenHashSet(ot.terms);
+            } else {
+                terms.addAll(ot.terms);
+            }
+        }
+
+        /**
+         * The type
+         *
+         * @return {@link ResponseTerms.Type#LONGS}
+         */
+        @Override
+        public Type getType() {
+            return Type.LONGS;
+        }
+
+        /**
+         * Deserialize
+         *
+         * @param in the input
+         * @throws IOException
+         */
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            int size = in.readVInt();
+            terms = new LongOpenHashSet(optimalSetSize(size));
+            for (int i = 0; i < size; i++) {
+                terms.add(in.readVLong());
+            }
+        }
+
+        /**
+         * Serialize
+         *
+         * @param out the output
+         * @throws IOException
+         */
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(terms.size());
+
+            final boolean[] allocated = terms.allocated;
+            final long[] keys = terms.keys;
+            for (int i = 0; i < allocated.length; i++) {
+                if (allocated[i]) {
+                    out.writeVLong(keys[i]);
+                }
+            }
+        }
+
+        /**
+         * The number of terms.
+         *
+         * @return the number of terms collected.
+         */
+        @Override
+        public int size() {
+            return terms.size();
+        }
+
+        /**
+         * The size of the gathered terms
+         *
+         * @return The size in bytes
+         */
+        @Override
+        public long getSizeInBytes() {
+            return terms.size() * 8;
+        }
+
+        /**
+         * Returns the terms.
+         *
+         * @return {@link LongOpenHashSet}
+         */
+        @Override
+        public Object getTerms() {
+            return terms;
+        }
+    }
+
+    /**
+     * A {@link ResponseTerms} implementation for floating point numeric fields that collects all terms into a set.
+     * All terms are gathered and serialized as primitive doubles.
+     */
+    public static class DoublesResponseTerms extends ResponseTerms {
+
+        private transient final IndexNumericFieldData indexFieldData;
+        private transient DoubleValues values;
+        private DoubleOpenHashSet terms;
+
+        /**
+         * Default constructor
+         */
+        DoublesResponseTerms() {
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used before merging.  Initializes the set with the correct size to avoid rehashing during
+         * the merge.
+         *
+         * @param size the number of terms that will be in the resulting set
+         */
+        DoublesResponseTerms(int size) {
+            // create terms set, size is known so adjust for load factor so no rehashing is needed
+            this.terms = new DoubleOpenHashSet(optimalSetSize(size));
+            this.indexFieldData = null;
+        }
+
+        /**
+         * Constructor to be used for term collection on each shard.
+         *
+         * @param collector      the collector used during the lookup query execution
+         * @param indexFieldData the fielddata for the lookup field.
+         */
+        DoublesResponseTerms(HitSetCollector collector, IndexNumericFieldData indexFieldData) {
+            super(collector);
+            this.indexFieldData = indexFieldData;
+            this.terms = new DoubleOpenHashSet(optimalSetSize(collector.getHits()));
+        }
+
+        /**
+         * Calculates the optimal set size to avoid rehashing
+         *
+         * @param size the number of items being inserted
+         * @return the optimal size
+         */
+        protected int optimalSetSize(int size) {
+            return (int) (size / DoubleOpenHashSet.DEFAULT_LOAD_FACTOR) + 1;
+        }
+
+        /**
+         * Load the fielddata
+         *
+         * @param context The {@link AtomicReaderContext} we are about to process
+         */
+        @Override
+        protected void load(AtomicReaderContext context) {
+            values = indexFieldData.load(context).getDoubleValues(); // load field data cache
+        }
+
+        /**
+         * Extracts all values from the fielddata for the lookup field and inserts them in the terms set.
+         *
+         * @param docId The internal lucene docid for the hit in the current {@link AtomicReaderContext}.
+         */
+        @Override
+        protected void processDoc(int docId) {
+            final int numVals = values.setDocument(docId);
+            for (int i = 0; i < numVals; i++) {
+                final double term = values.nextValue();
+                final long longTerm = Double.doubleToLongBits(term);
+                terms.add(term);
+            }
+        }
+
+        /**
+         * Merge with another {@link DoublesResponseTerms}
+         *
+         * @param other The {@link ResponseTerms} to merge with
+         */
+        @Override
+        public void merge(ResponseTerms other) {
+            assert other.getType() == Type.DOUBLES;
+            DoublesResponseTerms ot = (DoublesResponseTerms) other;
+            if (terms == null) {
+                terms = new DoubleOpenHashSet(ot.terms);
+            } else {
+                terms.addAll(ot.terms);
+            }
+        }
+
+        /**
+         * The type
+         *
+         * @return {@link ResponseTerms.Type#DOUBLES}
+         */
+        @Override
+        public Type getType() {
+            return Type.DOUBLES;
+        }
+
+        /**
+         * Deserialize
+         *
+         * @param in the input
+         * @throws IOException
+         */
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            int size = in.readVInt();
+            terms = new DoubleOpenHashSet(optimalSetSize(size));
+            for (int i = 0; i < size; i++) {
+                terms.add(in.readDouble());
+            }
+        }
+
+        /**
+         * Serialize
+         *
+         * @param out the output
+         * @throws IOException
+         */
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(terms.size());
+            final boolean[] allocated = terms.allocated;
+            final double[] keys = terms.keys;
+            for (int i = 0; i < allocated.length; i++) {
+                if (allocated[i]) {
+                    out.writeDouble(keys[i]);
+                }
+            }
+        }
+
+        /**
+         * The number of collected terms
+         *
+         * @return the number of terms.
+         */
+        @Override
+        public int size() {
+            return terms.size();
+        }
+
+        /**
+         * The size of the collected terms
+         *
+         * @return The size of the terms in bytes.
+         */
+        @Override
+        public long getSizeInBytes() {
+            return terms.size() * 8;
+        }
+
+        /**
+         * Returns the terms.
+         *
+         * @return {@link DoubleOpenHashSet}
+         */
+        @Override
+        public Object getTerms() {
+            return terms;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Internal terms by query request executed directly against a specific index shard.
+ */
+class ShardTermsByQueryRequest extends BroadcastShardOperationRequest {
+
+    @Nullable
+    private String[] filteringAliases;
+    private TermsByQueryRequest request;
+
+    /**
+     * Default constructor
+     */
+    ShardTermsByQueryRequest() {
+    }
+
+    /**
+     * Main Constructor
+     *
+     * @param index            the index of the shard request
+     * @param shardId          the id of the shard the request is for
+     * @param filteringAliases optional aliases
+     * @param request          the original {@link TermsByQueryRequest}
+     */
+    public ShardTermsByQueryRequest(String index, int shardId, @Nullable String[] filteringAliases, TermsByQueryRequest request) {
+        super(index, shardId, request);
+        this.filteringAliases = filteringAliases;
+        this.request = request;
+    }
+
+    /**
+     * Gets the filtering aliases
+     *
+     * @return the filtering aliases
+     */
+    public String[] filteringAliases() {
+        return filteringAliases;
+    }
+
+    /**
+     * Gets the original {@link TermsByQueryRequest}
+     *
+     * @return the request
+     */
+    public TermsByQueryRequest request() {
+        return request;
+    }
+
+    /**
+     * Deserialize
+     *
+     * @param in the input
+     * @throws IOException
+     */
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+
+        if (in.readBoolean()) {
+            request = new TermsByQueryRequest();
+            request.readFrom(in);
+        }
+
+        if (in.readBoolean()) {
+            filteringAliases = in.readStringArray();
+        }
+    }
+
+    /**
+     * Serialize
+     *
+     * @param out the output
+     * @throws IOException
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+
+        if (request == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            request.writeTo(out);
+        }
+
+        if (filteringAliases == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeStringArray(filteringAliases);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryRequest.java
@@ -82,11 +82,8 @@ class ShardTermsByQueryRequest extends BroadcastShardOperationRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-
-        if (in.readBoolean()) {
-            request = new TermsByQueryRequest();
-            request.readFrom(in);
-        }
+        request = new TermsByQueryRequest();
+        request.readFrom(in);
 
         if (in.readBoolean()) {
             filteringAliases = in.readStringArray();
@@ -102,13 +99,7 @@ class ShardTermsByQueryRequest extends BroadcastShardOperationRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-
-        if (request == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            request.writeTo(out);
-        }
+        request.writeTo(out);
 
         if (filteringAliases == null) {
             out.writeBoolean(false);

--- a/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryResponse.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Internal terms by query response of a shard terms by query request executed directly against a specific shard.
+ */
+class ShardTermsByQueryResponse extends BroadcastShardOperationResponse {
+
+    private ResponseTerms responseTerms;
+
+    /**
+     * Default constructor
+     */
+    ShardTermsByQueryResponse() {
+    }
+
+    /**
+     * Main constructor
+     *
+     * @param index         the index the request executed against
+     * @param shardId       the id of the shard the request executed on
+     * @param responseTerms the terms gathered from the shard
+     */
+    public ShardTermsByQueryResponse(String index, int shardId, ResponseTerms responseTerms) {
+        super(index, shardId);
+        this.responseTerms = responseTerms;
+    }
+
+    /**
+     * Gets the gathered terms.
+     *
+     * @return the {@link ResponseTerms}
+     */
+    public ResponseTerms getResponseTerms() {
+        return this.responseTerms;
+    }
+
+    /**
+     * Deserialize
+     *
+     * @param in the input
+     * @throws IOException
+     */
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        if (in.readBoolean()) {
+            responseTerms = ResponseTerms.deserialize(in);
+        }
+    }
+
+    /**
+     * Serialize
+     *
+     * @param out the output
+     * @throws IOException
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (responseTerms != null) {
+            out.writeBoolean(true);
+            ResponseTerms.serialize(responseTerms, out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/terms/ShardTermsByQueryResponse.java
@@ -68,9 +68,7 @@ class ShardTermsByQueryResponse extends BroadcastShardOperationResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.readBoolean()) {
-            responseTerms = ResponseTerms.deserialize(in);
-        }
+        responseTerms = ResponseTerms.deserialize(in);
     }
 
     /**
@@ -82,11 +80,6 @@ class ShardTermsByQueryResponse extends BroadcastShardOperationResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (responseTerms != null) {
-            out.writeBoolean(true);
-            ResponseTerms.serialize(responseTerms, out);
-        } else {
-            out.writeBoolean(false);
-        }
+        ResponseTerms.serialize(responseTerms, out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryAction.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportRequestOptions;
+
+/**
+ * The action to request terms by query
+ */
+public class TermsByQueryAction extends Action<TermsByQueryRequest, TermsByQueryResponse, TermsByQueryRequestBuilder> {
+
+    public static final TermsByQueryAction INSTANCE = new TermsByQueryAction();
+    public static final String NAME = "termsbyquery";
+
+    /**
+     * Default constructor
+     */
+    private TermsByQueryAction() {
+        super(NAME);
+    }
+
+    /**
+     * Gets a new {@link TermsByQueryResponse} object
+     *
+     * @return the new {@link TermsByQueryResponse}.
+     */
+    @Override
+    public TermsByQueryResponse newResponse() {
+        return new TermsByQueryResponse();
+    }
+
+    /**
+     * Set transport options specific to a terms by query request.
+     *
+     * @param settings node settings
+     * @return the request options.
+     */
+    @Override
+    public TransportRequestOptions transportOptions(Settings settings) {
+        TransportRequestOptions opts = new TransportRequestOptions();
+        opts.withType(TransportRequestOptions.Type.BULK);  // TODO: just stick with default of REG?
+        opts.withCompress(true);
+
+        // return TransportRequestOptions.EMPTY;
+        return opts;
+    }
+
+    /**
+     * Get a new {@link TermsByQueryRequestBuilder}
+     *
+     * @param client the client responsible for executing the request.
+     * @return the new {@link TermsByQueryRequestBuilder}
+     */
+    @Override
+    public TermsByQueryRequestBuilder newRequestBuilder(Client client) {
+        return new TermsByQueryRequestBuilder(client);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.FilterBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A request to get the values from a specific field for documents matching a specific query.
+ * <p/>
+ * The request requires the filter source to be set either using {@link #filter(org.elasticsearch.index.query.FilterBuilder)}, or
+ * {@link #filter(byte[])}.
+ *
+ * @see TermsByQueryResponse
+ */
+public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryRequest> {
+
+    private static final XContentType contentType = Requests.CONTENT_TYPE;
+    @Nullable
+    protected String routing;
+    private long nowInMillis;
+    private Float minScore;
+    @Nullable
+    private String preference;
+    private BytesReference filterSource;
+    private boolean filterSourceUnsafe;
+    @Nullable
+    private String[] types = Strings.EMPTY_ARRAY;
+    private String field;
+    private boolean useBloomFilter = false;
+    private Double bloomFpp;         // false positive probability
+    private Integer bloomExpectedInsertions;
+    private Integer bloomHashFunctions;
+
+    TermsByQueryRequest() {
+    }
+
+    /**
+     * Constructs a new terms by query request against the provided indices. No indices provided means it will run against all indices.
+     */
+    public TermsByQueryRequest(String... indices) {
+        super(indices);
+    }
+
+    /**
+     * Validates the request
+     *
+     * @return null if valid, exception otherwise
+     */
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = super.validate();
+        return validationException;
+    }
+
+    /**
+     * Makes the filter source safe before the request is executed.
+     */
+    @Override
+    protected void beforeStart() {
+        if (filterSource != null && filterSourceUnsafe) {
+            filterSource = filterSource.copyBytesArray();
+            filterSourceUnsafe = false;
+        }
+    }
+
+    /**
+     * The minimum score of the documents to include in the terms by query request.
+     */
+    public Float minScore() {
+        return minScore;
+    }
+
+    /**
+     * The minimum score of the documents to include in the terms by query. Defaults to <tt>null</tt> which means all
+     * documents will be included in the terms by query request.
+     */
+    public TermsByQueryRequest minScore(float minScore) {
+        this.minScore = minScore;
+        return this;
+    }
+
+    /**
+     * The field to extract terms from.
+     */
+    public String field() {
+        return field;
+    }
+
+    /**
+     * The field to extract terms from.
+     */
+    public TermsByQueryRequest field(String field) {
+        this.field = field;
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public BytesReference filterSource() {
+        return filterSource;
+    }
+
+    /**
+     * The filter source to execute.
+     *
+     * @see {@link org.elasticsearch.index.query.FilterBuilders}
+     */
+    public TermsByQueryRequest filter(FilterBuilder filterBuilder) {
+        this.filterSource = filterBuilder.buildAsBytes();
+        this.filterSourceUnsafe = false;
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequest filter(XContentBuilder builder) {
+        this.filterSource = builder.bytes();
+        this.filterSourceUnsafe = false;
+        return this;
+    }
+
+    /**
+     * The filter source to execute. It is preferable to use {@link #filter(byte[])}
+     */
+    public TermsByQueryRequest filter(String filterSource) {
+        this.filterSource = new BytesArray(filterSource);
+        this.filterSourceUnsafe = false;
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequest filter(byte[] filterSource) {
+        return filter(filterSource, 0, filterSource.length, false);
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequest filter(byte[] filterSource, int offset, int length, boolean unsafe) {
+        return filter(new BytesArray(filterSource, offset, length), unsafe);
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequest filter(BytesReference filterSource, boolean unsafe) {
+        this.filterSource = filterSource;
+        this.filterSourceUnsafe = unsafe;
+        return this;
+    }
+
+    /**
+     * The types of documents the query will run against. Defaults to all types.
+     */
+    public String[] types() {
+        return this.types;
+    }
+
+    /**
+     * The types of documents the query will run against. Defaults to all types.
+     */
+    public TermsByQueryRequest types(String... types) {
+        this.types = types;
+        return this;
+    }
+
+    /**
+     * A comma separated list of routing values to control the shards the search will be executed on.
+     */
+    public String routing() {
+        return this.routing;
+    }
+
+    /**
+     * A comma separated list of routing values to control the shards the search will be executed on.
+     */
+    public TermsByQueryRequest routing(String routing) {
+        this.routing = routing;
+        return this;
+    }
+
+    /**
+     * The current time in milliseconds
+     */
+    public long nowInMillis() {
+        return nowInMillis;
+    }
+
+    /**
+     * Sets the current time in milliseconds
+     */
+    public TermsByQueryRequest nowInMillis(long nowInMillis) {
+        this.nowInMillis = nowInMillis;
+        return this;
+    }
+
+    /**
+     * The routing values to control the shards that the request will be executed on.
+     */
+    public TermsByQueryRequest routing(String... routings) {
+        this.routing = Strings.arrayToCommaDelimitedString(routings);
+        return this;
+    }
+
+    /**
+     * The preference value to control what node the request will be executed on
+     */
+    public TermsByQueryRequest preference(String preference) {
+        this.preference = preference;
+        return this;
+    }
+
+    /**
+     * The current preference value
+     */
+    public String preference() {
+        return this.preference;
+    }
+
+    /**
+     * If the bloom filter should be used.
+     */
+    public TermsByQueryRequest useBloomFilter(boolean useBloomFilter) {
+        this.useBloomFilter = useBloomFilter;
+        return this;
+    }
+
+    /**
+     * If the bloom filter will be used.
+     */
+    public boolean useBloomFilter() {
+        return useBloomFilter;
+    }
+
+    /**
+     * The bloom filter false positive probability
+     */
+    public TermsByQueryRequest bloomFpp(double bloomFpp) {
+        this.bloomFpp = bloomFpp;
+        return this;
+    }
+
+    /**
+     * The bloom filter false positive probability
+     */
+    public Double bloomFpp() {
+        return bloomFpp;
+    }
+
+    /**
+     * The expected insertions size for the bloom filter
+     */
+    public TermsByQueryRequest bloomExpectedInsertions(int bloomExpectedInsertions) {
+        this.bloomExpectedInsertions = bloomExpectedInsertions;
+        return this;
+    }
+
+    /**
+     * The expected insertions for the bloom filter
+     */
+    public Integer bloomExpectedInsertions() {
+        return bloomExpectedInsertions;
+    }
+
+    /**
+     * The number of hash functions for the bloom filter
+     */
+    public TermsByQueryRequest bloomHashFunctions(int bloomHashFunctions) {
+        this.bloomHashFunctions = bloomHashFunctions;
+        return this;
+    }
+
+    /**
+     * The number of hash functions for the bloom filter
+     */
+    public Integer bloomHashFunctions() {
+        return bloomHashFunctions;
+    }
+
+    /**
+     * Deserialize
+     *
+     * @param in the input
+     * @throws IOException
+     */
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+
+        if (in.readBoolean()) {
+            minScore = in.readFloat();
+        }
+
+        routing = in.readOptionalString();
+        preference = in.readOptionalString();
+
+        filterSourceUnsafe = false;
+        if (in.readBoolean()) {
+            filterSource = in.readBytesReference();
+        } else {
+            filterSource = null;
+        }
+
+        if (in.readBoolean()) {
+            types = in.readStringArray();
+        }
+
+        field = in.readString();
+        nowInMillis = in.readVLong();
+        useBloomFilter = in.readBoolean();
+
+        if (in.readBoolean()) {
+            bloomFpp = in.readDouble();
+        }
+
+        if (in.readBoolean()) {
+            bloomExpectedInsertions = in.readVInt();
+        }
+
+        if (in.readBoolean()) {
+            bloomHashFunctions = in.readVInt();
+        }
+    }
+
+    /**
+     * Serialize
+     *
+     * @param out the output
+     * @throws IOException
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+
+        if (minScore == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeFloat(minScore);
+        }
+
+        out.writeOptionalString(routing);
+        out.writeOptionalString(preference);
+
+        if (filterSource != null) {
+            out.writeBoolean(true);
+            out.writeBytesReference(filterSource);
+        } else {
+            out.writeBoolean(false);
+        }
+
+        if (types == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeStringArray(types);
+        }
+
+        out.writeString(field);
+        out.writeVLong(nowInMillis);
+        out.writeBoolean(useBloomFilter);
+
+        if (bloomFpp == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeDouble(bloomFpp);
+        }
+
+        if (bloomExpectedInsertions == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(bloomExpectedInsertions);
+        }
+
+        if (bloomHashFunctions == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(bloomHashFunctions);
+        }
+    }
+
+    /**
+     * String representation of the request
+     *
+     * @return
+     */
+    @Override
+    public String toString() {
+        String sSource = "_na_";
+        try {
+            sSource = XContentHelper.convertToJson(filterSource, false);
+        } catch (Exception e) {
+            // ignore
+        }
+        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", filterSource[" + sSource + "]";
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
@@ -59,7 +59,7 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
     private Double bloomFpp;         // false positive probability
     private Integer bloomExpectedInsertions;
     private Integer bloomHashFunctions;
-    private Integer maxTermsPerShard;
+    private Long maxTermsPerShard;
 
     TermsByQueryRequest() {
     }
@@ -314,7 +314,7 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
     /**
      * The max number of terms to gather per shard
      */
-    public TermsByQueryRequest maxTermsPerShard(int maxTermsPerShard) {
+    public TermsByQueryRequest maxTermsPerShard(long maxTermsPerShard) {
         this.maxTermsPerShard = maxTermsPerShard;
         return this;
     }
@@ -322,7 +322,7 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
     /**
      * The max number of terms to gather per shard
      */
-    public Integer maxTermsPerShard() {
+    public Long maxTermsPerShard() {
         return maxTermsPerShard;
     }
 
@@ -371,7 +371,7 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
         }
 
         if (in.readBoolean()) {
-            maxTermsPerShard = in.readVInt();
+            maxTermsPerShard = in.readVLong();
         }
     }
 
@@ -438,7 +438,7 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeVInt(maxTermsPerShard);
+            out.writeVLong(maxTermsPerShard);
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.terms;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
-import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -30,7 +29,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.FilterBuilder;
 
 import java.io.IOException;
@@ -46,7 +44,6 @@ import java.util.Arrays;
  */
 public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryRequest> {
 
-    private static final XContentType contentType = Requests.CONTENT_TYPE;
     @Nullable
     protected String routing;
     private long nowInMillis;

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequest.java
@@ -62,6 +62,7 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
     private Double bloomFpp;         // false positive probability
     private Integer bloomExpectedInsertions;
     private Integer bloomHashFunctions;
+    private Integer maxTermsPerShard;
 
     TermsByQueryRequest() {
     }
@@ -314,6 +315,21 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
     }
 
     /**
+     * The max number of terms to gather per shard
+     */
+    public TermsByQueryRequest maxTermsPerShard(int maxTermsPerShard) {
+        this.maxTermsPerShard = maxTermsPerShard;
+        return this;
+    }
+
+    /**
+     * The max number of terms to gather per shard
+     */
+    public Integer maxTermsPerShard() {
+        return maxTermsPerShard;
+    }
+
+    /**
      * Deserialize
      *
      * @param in the input
@@ -355,6 +371,10 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
 
         if (in.readBoolean()) {
             bloomHashFunctions = in.readVInt();
+        }
+
+        if (in.readBoolean()) {
+            maxTermsPerShard = in.readVInt();
         }
     }
 
@@ -415,6 +435,13 @@ public class TermsByQueryRequest extends BroadcastOperationRequest<TermsByQueryR
         } else {
             out.writeBoolean(true);
             out.writeVInt(bloomHashFunctions);
+        }
+
+        if (maxTermsPerShard == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(maxTermsPerShard);
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
@@ -155,7 +155,7 @@ public class TermsByQueryRequestBuilder extends BroadcastOperationRequestBuilder
     /**
      * The max number of terms collected per shard
      */
-    public TermsByQueryRequestBuilder setMaxTermsPerShard(int maxTermsPerShard) {
+    public TermsByQueryRequestBuilder setMaxTermsPerShard(long maxTermsPerShard) {
         request.maxTermsPerShard(maxTermsPerShard);
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.query.FilterBuilder;
 
 /**
- * A terms by query action request builder.
+ * A terms by query action request builder.  This is an internal api.
  */
 public class TermsByQueryRequestBuilder extends BroadcastOperationRequestBuilder<TermsByQueryRequest, TermsByQueryResponse, TermsByQueryRequestBuilder> {
 

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.internal.InternalClient;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.query.FilterBuilder;
+
+/**
+ * A terms by query action request builder.
+ */
+public class TermsByQueryRequestBuilder extends BroadcastOperationRequestBuilder<TermsByQueryRequest, TermsByQueryResponse, TermsByQueryRequestBuilder> {
+
+    public TermsByQueryRequestBuilder(Client client) {
+        super((InternalClient) client, new TermsByQueryRequest());
+    }
+
+    /**
+     * The types of documents the query will run against. Defaults to all types.
+     */
+    public TermsByQueryRequestBuilder setTypes(String... types) {
+        request.types(types);
+        return this;
+    }
+
+    /**
+     * The minimum score of the documents to include in the terms by query. Defaults to <tt>-1</tt> which means all documents will be
+     * included in the terms by query.
+     */
+    public TermsByQueryRequestBuilder setMinScore(float minScore) {
+        request.minScore(minScore);
+        return this;
+    }
+
+    /**
+     * A comma separated list of routing values to control the shards the search will be executed on.
+     */
+    public TermsByQueryRequestBuilder setRouting(String routing) {
+        request.routing(routing);
+        return this;
+    }
+
+    /**
+     * Sets the preference to execute the search. Defaults to randomize across shards. Can be set to <tt>_local</tt> to prefer local
+     * shards, <tt>_primary</tt> to execute only on primary shards, _shards:x,y to operate on shards x & y, or a custom value, which
+     * guarantees that the same order will be used across different requests.
+     */
+    public TermsByQueryRequestBuilder setPreference(String preference) {
+        request.preference(preference);
+        return this;
+    }
+
+    /**
+     * The routing values to control the shards that the search will be executed on.
+     */
+    public TermsByQueryRequestBuilder setRouting(String... routing) {
+        request.routing(routing);
+        return this;
+    }
+
+    /**
+     * The field to extract terms from.
+     */
+    public TermsByQueryRequestBuilder setField(String field) {
+        request.field(field);
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     *
+     * @see org.elasticsearch.index.query.FilterBuilders
+     */
+    public TermsByQueryRequestBuilder setFilter(FilterBuilder filterBuilder) {
+        request.filter(filterBuilder);
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequestBuilder setFilter(BytesReference filterSource) {
+        request.filter(filterSource, false);
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequestBuilder setFilter(BytesReference filterSource, boolean unsafe) {
+        request.filter(filterSource, unsafe);
+        return this;
+    }
+
+    /**
+     * The filter source to execute.
+     */
+    public TermsByQueryRequestBuilder setFilter(byte[] filterSource) {
+        request.filter(filterSource);
+        return this;
+    }
+
+    /**
+     * If we should use a bloom filter to gather terms
+     */
+    public TermsByQueryRequestBuilder setUseBloomFilter(boolean useBloomFilter) {
+        request.useBloomFilter(useBloomFilter);
+        return this;
+    }
+
+    /**
+     * The BloomFilter false positive probability
+     */
+    public TermsByQueryRequestBuilder setBloomFpp(double bloomFpp) {
+        request.bloomFpp(bloomFpp);
+        return this;
+    }
+
+    /**
+     * The expected insertions for the BloomFilter
+     */
+    public TermsByQueryRequestBuilder setExpectedInsertions(int bloomExpectedInsertions) {
+        request.bloomExpectedInsertions(bloomExpectedInsertions);
+        return this;
+    }
+
+    /**
+     * The number of hashes to use in the BloomFilter
+     */
+    public TermsByQueryRequestBuilder setBloomHashFunctions(int bloomHashFunctions) {
+        request.bloomHashFunctions(bloomHashFunctions);
+        return this;
+    }
+
+    /**
+     * Executes the the request
+     */
+    @Override
+    protected void doExecute(ActionListener<TermsByQueryResponse> listener) {
+        ((InternalClient) client).execute(TermsByQueryAction.INSTANCE, request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryRequestBuilder.java
@@ -153,6 +153,14 @@ public class TermsByQueryRequestBuilder extends BroadcastOperationRequestBuilder
     }
 
     /**
+     * The max number of terms collected per shard
+     */
+    public TermsByQueryRequestBuilder setMaxTermsPerShard(int maxTermsPerShard) {
+        request.maxTermsPerShard(maxTermsPerShard);
+        return this;
+    }
+
+    /**
      * Executes the the request
      */
     @Override

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryResponse.java
@@ -73,9 +73,7 @@ public class TermsByQueryResponse extends BroadcastOperationResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.readBoolean()) {
-            responseTerms = ResponseTerms.deserialize(in);
-        }
+        responseTerms = ResponseTerms.deserialize(in);
     }
 
     /**
@@ -87,11 +85,6 @@ public class TermsByQueryResponse extends BroadcastOperationResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (responseTerms == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            ResponseTerms.serialize(responseTerms, out);
-        }
+        ResponseTerms.serialize(responseTerms, out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/terms/TermsByQueryResponse.java
+++ b/src/main/java/org/elasticsearch/action/terms/TermsByQueryResponse.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The response of the terms by query action.
+ */
+public class TermsByQueryResponse extends BroadcastOperationResponse {
+
+    private ResponseTerms responseTerms;
+
+    /**
+     * Default constructor
+     */
+    TermsByQueryResponse() {
+    }
+
+    /**
+     * Main constructor
+     *
+     * @param responseTerms    the merged terms
+     * @param totalShards      the number of shards the request executed on
+     * @param successfulShards the number of shards the request executed on successfully
+     * @param failedShards     the number of failed shards
+     * @param shardFailures    the failures
+     */
+    TermsByQueryResponse(ResponseTerms responseTerms, int totalShards, int successfulShards, int failedShards,
+                         List<ShardOperationFailedException> shardFailures) {
+        super(totalShards, successfulShards, failedShards, shardFailures);
+        this.responseTerms = responseTerms;
+    }
+
+    /**
+     * Gets the merged terms
+     *
+     * @return the terms
+     */
+    public ResponseTerms getResponseTerms() {
+        return responseTerms;
+    }
+
+    /**
+     * Deserialize
+     *
+     * @param in the input
+     * @throws IOException
+     */
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        if (in.readBoolean()) {
+            responseTerms = ResponseTerms.deserialize(in);
+        }
+    }
+
+    /**
+     * Serialize
+     *
+     * @param out the output
+     * @throws IOException
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (responseTerms == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            ResponseTerms.serialize(responseTerms, out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/terms/TransportTermsByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/terms/TransportTermsByQueryAction.java
@@ -72,9 +72,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * The terms by query transport operation
  */
-public class TransportTermsByQueryAction
-        extends
-        TransportBroadcastOperationAction<TermsByQueryRequest, TermsByQueryResponse, ShardTermsByQueryRequest, ShardTermsByQueryResponse> {
+public class TransportTermsByQueryAction extends TransportBroadcastOperationAction<TermsByQueryRequest, TermsByQueryResponse, ShardTermsByQueryRequest, ShardTermsByQueryResponse> {
 
     private final IndicesService indicesService;
     private final ScriptService scriptService;
@@ -306,7 +304,7 @@ public class TransportTermsByQueryAction
             throw new QueryPhaseExecutionException(context, "failed to execute termsByQuery", e);
         } finally {
             // this will also release the index searcher
-            context.release();
+            context.clearAndRelease();
             SearchContext.removeCurrent();
         }
     }

--- a/src/main/java/org/elasticsearch/action/terms/TransportTermsByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/terms/TransportTermsByQueryAction.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.*;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.cache.recycler.CacheRecycler;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.shard.service.IndexShard;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.SearchContextException;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.internal.DefaultSearchContext;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.query.QueryPhaseExecutionException;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * The terms by query transport operation
+ */
+public class TransportTermsByQueryAction
+        extends
+        TransportBroadcastOperationAction<TermsByQueryRequest, TermsByQueryResponse, ShardTermsByQueryRequest, ShardTermsByQueryResponse> {
+
+    private final IndicesService indicesService;
+    private final ScriptService scriptService;
+    private final CacheRecycler cacheRecycler;
+    private final PageCacheRecycler pageCacheRecycler;
+    private final BigArrays bigArrays;
+
+    /**
+     * Constructor
+     */
+    @Inject
+    public TransportTermsByQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                       TransportService transportService, IndicesService indicesService,
+                                       ScriptService scriptService, CacheRecycler cacheRecycler,
+                                       PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
+        super(settings, threadPool, clusterService, transportService);
+        this.indicesService = indicesService;
+        this.scriptService = scriptService;
+        this.cacheRecycler = cacheRecycler;
+        this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
+    }
+
+    /**
+     * Executes the actions.
+     */
+    @Override
+    protected void doExecute(TermsByQueryRequest request, ActionListener<TermsByQueryResponse> listener) {
+        request.nowInMillis(System.currentTimeMillis()); // set time to be used in scripts
+        super.doExecute(request, listener);
+    }
+
+    /**
+     * The threadpool this request will execute against
+     */
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SEARCH;
+    }
+
+    /**
+     * The action name
+     */
+    @Override
+    protected String transportAction() {
+        return TermsByQueryAction.NAME;
+    }
+
+    /**
+     * Creates a new {@link TermsByQueryRequest}
+     */
+    @Override
+    protected TermsByQueryRequest newRequest() {
+        return new TermsByQueryRequest();
+    }
+
+    /**
+     * Creates a new {@link ShardTermsByQueryRequest}
+     */
+    @Override
+    protected ShardTermsByQueryRequest newShardRequest() {
+        return new ShardTermsByQueryRequest();
+    }
+
+    /**
+     * Creates a new {@link ShardTermsByQueryRequest}
+     */
+    @Override
+    protected ShardTermsByQueryRequest newShardRequest(ShardRouting shard, TermsByQueryRequest request) {
+        String[] filteringAliases = clusterService.state().metaData().filteringAliases(shard.index(), request.indices());
+        return new ShardTermsByQueryRequest(shard.index(), shard.id(), filteringAliases, request);
+    }
+
+    /**
+     * Creates a new {@link ShardTermsByQueryResponse}
+     */
+    @Override
+    protected ShardTermsByQueryResponse newShardResponse() {
+        return new ShardTermsByQueryResponse();
+    }
+
+    /**
+     * The shards this request will execute against.
+     */
+    @Override
+    protected GroupShardsIterator shards(ClusterState clusterState, TermsByQueryRequest request, String[] concreteIndices) {
+        Map<String, Set<String>> routingMap = clusterState.metaData().resolveSearchRouting(request.routing(), request.indices());
+        return clusterService.operationRouting().searchShards(clusterState,
+                request.indices(),
+                concreteIndices,
+                routingMap,
+                request.preference());
+    }
+
+    @Override
+    protected ClusterBlockException checkGlobalBlock(ClusterState state, TermsByQueryRequest request) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
+    }
+
+    @Override
+    protected ClusterBlockException checkRequestBlock(ClusterState state, TermsByQueryRequest request, String[] concreteIndices) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, concreteIndices);
+    }
+
+    /**
+     * Merges the individual shard responses and returns the final {@link TermsByQueryResponse}.
+     */
+    @Override
+    protected TermsByQueryResponse newResponse(TermsByQueryRequest request, AtomicReferenceArray shardsResponses, ClusterState clusterState) {
+        int successfulShards = 0;
+        int failedShards = 0;
+        int numTerms = 0;
+        ResponseTerms responseTerms = null;
+        ResponseTerms[] responses = new ResponseTerms[shardsResponses.length()];
+        List<ShardOperationFailedException> shardFailures = null;
+
+        // we check each shard response
+        for (int i = 0; i < shardsResponses.length(); i++) {
+            Object shardResponse = shardsResponses.get(i);
+            if (shardResponse == null) {
+                failedShards++;
+            } else if (shardResponse instanceof BroadcastShardOperationFailedException) {
+                failedShards++;
+                if (shardFailures == null) {
+                    shardFailures = newArrayList();
+                }
+                logger.info("shard operation failed", (BroadcastShardOperationFailedException) shardResponse);
+                shardFailures.add(new DefaultShardOperationFailedException((BroadcastShardOperationFailedException) shardResponse));
+            } else {
+                // on successful shard response, just add to the array or responses so we can process them below
+                // we calculate the total number of terms gathered across each shard so we can use it during
+                // initialization of the final ResponseTerms below (to avoid rehashing during merging)
+                ShardTermsByQueryResponse shardResp = ((ShardTermsByQueryResponse) shardResponse);
+                ResponseTerms response = shardResp.getResponseTerms();
+                responses[i] = response;
+                numTerms += response.size();
+                successfulShards++;
+            }
+        }
+
+        // merge the responses
+        for (int i = 0; i < responses.length; i++) {
+            ResponseTerms response = responses[i];
+            if (response == null) {
+                continue;
+            }
+
+            // responseTerms is responsible for the merge, use first non-null response
+            // set size to avoid rehashing on certain implementations.
+            if (responseTerms == null) {
+                responseTerms = ResponseTerms.get(response.getType(), numTerms);
+            }
+
+            responseTerms.merge(response);
+        }
+
+        return new TermsByQueryResponse(responseTerms, shardsResponses.length(), successfulShards, failedShards, shardFailures);
+    }
+
+    /**
+     * The operation that executes the query and generates a {@link ShardTermsByQueryResponse} for each shard.
+     */
+    @Override
+    protected ShardTermsByQueryResponse shardOperation(ShardTermsByQueryRequest shardRequest) throws ElasticsearchException {
+        IndexService indexService = indicesService.indexServiceSafe(shardRequest.index());
+        IndexShard indexShard = indexService.shardSafe(shardRequest.shardId());
+        TermsByQueryRequest request = shardRequest.request();
+
+        SearchShardTarget shardTarget =
+                new SearchShardTarget(clusterService.localNode().id(), shardRequest.index(), shardRequest.shardId());
+
+        ShardSearchRequest shardSearchRequest = new ShardSearchRequest()
+                .types(request.types())
+                .filteringAliases(shardRequest.filteringAliases())
+                .nowInMillis(request.nowInMillis());
+
+        SearchContext context = new DefaultSearchContext(0, shardSearchRequest, shardTarget,
+                indexShard.acquireSearcher("termsByQuery"), indexService, indexShard, scriptService, cacheRecycler,
+                pageCacheRecycler, bigArrays);
+
+        try {
+            SearchContext.setCurrent(context);
+            FieldMapper fieldMapper = context.smartNameFieldMapper(request.field());
+            if (fieldMapper == null) {
+                throw new SearchContextException(context, "field not found");
+            }
+
+            IndexFieldData indexFieldData = context.fieldData().getForField(fieldMapper);
+
+            if (request.minScore() != null) {
+                context.minimumScore(request.minScore());
+            }
+
+            BytesReference filterSource = request.filterSource();
+            if (filterSource != null && filterSource.length() > 0) {
+                XContentParser filterParser = null;
+                try {
+                    filterParser = XContentFactory.xContent(filterSource).createParser(filterSource);
+                    QueryParseContext.setTypes(request.types());
+                    Filter filter = indexService.queryParserService().parseInnerFilter(filterParser).filter();
+                    context.parsedQuery(new ParsedQuery(new XConstantScoreQuery(filter), ImmutableMap.<String, Filter>of()));
+                } finally {
+                    QueryParseContext.removeTypes();
+                    if (filterParser != null) {
+                        filterParser.close();
+                    }
+                }
+            }
+
+            context.preProcess();
+
+            // execute the search only gathering the hit count and bitset for each segment
+            HitSetCollector termCollector = new HitSetCollector(context.searcher().getTopReaderContext().leaves().size());
+            Query query = context.query();
+            if (!(query instanceof ConstantScoreQuery)) {
+                query = new ConstantScoreQuery(query);
+            }
+
+            context.searcher().search(query, termCollector);
+
+            // gather the terms reading the values from the field data cache
+            // the number of terms will be less than or equal to the total hits from the collector
+            ResponseTerms responseTerms = ResponseTerms.get(termCollector, indexFieldData, request);
+            responseTerms.process(context.searcher().getTopReaderContext().leaves());
+
+            return new ShardTermsByQueryResponse(shardRequest.index(), shardRequest.shardId(), responseTerms);
+        } catch (Throwable e) {
+            logger.info("error executing shard operation", e);
+            throw new QueryPhaseExecutionException(context, "failed to execute termsByQuery", e);
+        } finally {
+            // this will also release the index searcher
+            context.release();
+            SearchContext.removeCurrent();
+        }
+    }
+
+    /*
+     * Collector that tracks the total number of hits and the BitSet for each segment.
+     */
+    protected class HitSetCollector extends Collector {
+        private final FixedBitSet[] fixedBitSets;
+        private FixedBitSet current;
+        private int hits;
+
+        public HitSetCollector(int numSegments) {
+            this.fixedBitSets = new FixedBitSet[numSegments];
+        }
+
+        @Override
+        public void collect(int doc) throws IOException {
+            current.set(doc);
+            hits = hits + 1;
+        }
+
+        @Override
+        public void setNextReader(AtomicReaderContext context) throws IOException {
+            current = new FixedBitSet(context.reader().maxDoc());
+            fixedBitSets[context.ord] = current;
+        }
+
+        @Override
+        public void setScorer(Scorer scorer) throws IOException {
+        }
+
+        @Override
+        public boolean acceptsDocsOutOfOrder() {
+            return true;
+        }
+
+        /**
+         * The total hits
+         */
+        public int getHits() {
+            return hits;
+        }
+
+        /**
+         * The BitSets for each segment
+         */
+        public FixedBitSet[] getFixedSets() {
+            return fixedBitSets;
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/action/terms/TransportTermsByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/terms/TransportTermsByQueryAction.java
@@ -304,7 +304,7 @@ public class TransportTermsByQueryAction extends TransportBroadcastOperationActi
             throw new QueryPhaseExecutionException(context, "failed to execute termsByQuery", e);
         } finally {
             // this will also release the index searcher
-            context.clearAndRelease();
+            context.close();
             SearchContext.removeCurrent();
         }
     }

--- a/src/main/java/org/elasticsearch/common/util/AbstractPagedHashMap.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractPagedHashMap.java
@@ -32,13 +32,13 @@ abstract class AbstractPagedHashMap implements Releasable {
     // collisions may result into worse lookup performance.
     static final float DEFAULT_MAX_LOAD_FACTOR = 0.6f;
 
-    static long hash(long value) {
+    public static long hash(long value) {
         // Don't use the value directly. Under some cases eg dates, it could be that the low bits don't carry much value and we would like
         // all bits of the hash to carry as much value
         return MurmurHash3.hash(value);
     }
 
-    static long hash(double value) {
+    public static long hash(double value) {
         return hash(Double.doubleToLongBits(value));
     }
 

--- a/src/main/java/org/elasticsearch/common/util/BloomFilter.java
+++ b/src/main/java/org/elasticsearch/common/util/BloomFilter.java
@@ -258,9 +258,29 @@ public class BloomFilter {
         return bits.bitSize() + 8;
     }
 
+    public boolean isEmpty() {
+        return bits.bitCount == 0;
+    }
+
+    /**
+     * Merge with another {@link BloomFilter}.  The other bloom filter must have the same size, number of hash 
+     * functions, and hashing type.
+     *
+     * @param other the other {@link BloomFilter} to merge with.
+     */
+    public void merge(BloomFilter other) {
+        if (bits.data.length != other.bits.data.length ||
+                numHashFunctions != other.getNumHashFunctions() ||
+                hashing.type() != other.hashing.type()) {
+            throw new IllegalArgumentException("BloomFilters must have same size, number of hash functions, and hash type");
+        }
+
+        bits.or(other.bits);
+    }
+
     @Override
     public int hashCode() {
-        return bits.hashCode() + numHashFunctions;
+        return bits.hashCode() + numHashFunctions + hashing.type();
     }
 
   /*
@@ -336,6 +356,18 @@ public class BloomFilter {
                 return true;
             }
             return false;
+        }
+
+        /**
+         * Union.  BitArray's must be the same length.
+         */
+        void or(BitArray other) {
+            assert data.length == other.data.length : "BitArrays must be same length";
+            bitCount = 0;
+            for (int i = 0; i < data.length; i++) {
+                data[i] |= other.data[i];
+                bitCount += Long.bitCount(data[i]);
+            }
         }
 
         boolean get(long index) {

--- a/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -71,9 +71,9 @@ public final class BytesRefHash extends AbstractHash {
     }
 
     /**
-     * Get the id associated with <code>key</code>
+     * Get the id associated with <code>key</code> using the provided spare BytesRef
      */
-    public long find(BytesRef key, int code) {
+    public long find(BytesRef key, int code, BytesRef spare) {
         final long slot = slot(rehash(code), mask);
         for (long index = slot; ; index = nextSlot(index, mask)) {
             final long id = id(index);
@@ -81,6 +81,13 @@ public final class BytesRefHash extends AbstractHash {
                 return id;
             }
         }
+    }
+
+    /**
+     * Get the id associated with <code>key</code>
+     */
+    public long find(BytesRef key, int code) {
+        return find(key, code, spare);
     }
 
     /** Sugar for {@link #find(BytesRef, int) find(key, key.hashCode()} */
@@ -149,6 +156,13 @@ public final class BytesRefHash extends AbstractHash {
     /** Sugar to {@link #add(BytesRef, int) add(key, key.hashCode()}. */
     public long add(BytesRef key) {
         return add(key, key.hashCode());
+    }
+
+
+    /** Get the cached hashcode **/
+    public int code(long id) {
+        assert id >= 0;
+        return hashes.get(id);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -90,7 +90,7 @@ public class TermsFilterParser implements FilterParser {
         Double lookupBloomFpp = null;
         Integer lookupBloomExpectedInsertions = null;
         Integer lookupBloomHashFunctions = null;
-        Integer lookupMaxTermsPerShard = null;
+        Long lookupMaxTermsPerShard = null;
         boolean lookupCache = true;
 
         CacheKeyFilter.Key cacheKey = null;
@@ -179,7 +179,7 @@ public class TermsFilterParser implements FilterParser {
                         } else if ("path".equals(currentFieldName)) {
                             lookupPath = parser.text();
                         } else if ("max_terms_per_shard".equals(currentFieldName) || "maxTermsPerShard".equals(currentFieldName)) {
-                            lookupMaxTermsPerShard = parser.intValue();
+                            lookupMaxTermsPerShard = parser.longValue();
                         } else if ("routing".equals(currentFieldName)) {
                             lookupRouting = parser.textOrNull();
                         } else if ("cache".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -90,6 +90,7 @@ public class TermsFilterParser implements FilterParser {
         Double lookupBloomFpp = null;
         Integer lookupBloomExpectedInsertions = null;
         Integer lookupBloomHashFunctions = null;
+        Integer lookupMaxTermsPerShard = null;
         boolean lookupCache = true;
 
         CacheKeyFilter.Key cacheKey = null;
@@ -177,6 +178,8 @@ public class TermsFilterParser implements FilterParser {
                             lookupId = parser.text();
                         } else if ("path".equals(currentFieldName)) {
                             lookupPath = parser.text();
+                        } else if ("max_terms_per_shard".equals(currentFieldName) || "maxTermsPerShard".equals(currentFieldName)) {
+                            lookupMaxTermsPerShard = parser.intValue();
                         } else if ("routing".equals(currentFieldName)) {
                             lookupRouting = parser.textOrNull();
                         } else if ("cache".equals(currentFieldName)) {
@@ -253,8 +256,15 @@ public class TermsFilterParser implements FilterParser {
             TermsLookup termsLookup;
             if (lookupFilter != null) {
                 final TermsByQueryRequest termsByQueryReq = new TermsByQueryRequest(lookupIndices.toArray(new String[lookupIndices.size()]))
-                        .types(lookupTypes.toArray(new String[lookupTypes.size()])).field(lookupPath)
-                        .routing(lookupRouting).filter(lookupFilter).useBloomFilter(lookupUseBloomFilter);
+                        .types(lookupTypes.toArray(new String[lookupTypes.size()]))
+                        .field(lookupPath)
+                        .routing(lookupRouting)
+                        .filter(lookupFilter)
+                        .useBloomFilter(lookupUseBloomFilter);
+
+                if (lookupMaxTermsPerShard != null) {
+                    termsByQueryReq.maxTermsPerShard(lookupMaxTermsPerShard);
+                }
 
                 if (lookupUseBloomFilter && lookupBloomFpp != null) {
                     termsByQueryReq.bloomFpp(lookupBloomFpp);

--- a/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
@@ -42,6 +42,7 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
     private Double bloomFpp;
     private Integer bloomExpectedInsertions;
     private Integer bloomHashFunctions;
+    private Integer maxTermsPerShard;
 
     public TermsLookupFilterBuilder(String name) {
         this.name = name;
@@ -144,6 +145,14 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
     }
 
     /**
+     * Sets the max number of terms to collect per shard.
+     */
+    public TermsLookupFilterBuilder maxTermsPerShard(int maxTermsPerShard) {
+        this.maxTermsPerShard = maxTermsPerShard;
+        return this;
+    }
+
+    /**
      * Sets if the gathered terms should be cached or not
      */
     public TermsLookupFilterBuilder lookupCache(boolean lookupCache) {
@@ -197,6 +206,10 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
 
         if (path != null) {
             builder.field("path", path);
+        }
+
+        if (maxTermsPerShard != null) {
+            builder.field("max_terms_per_shard", maxTermsPerShard);
         }
 
         if (bloomFpp != null || bloomExpectedInsertions != null || bloomHashFunctions != null) {

--- a/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
@@ -24,21 +24,24 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * A filer for a field based on several terms matching on any of them.
+ * A filter for a field based on several terms matching on any of them.
  */
 public class TermsLookupFilterBuilder extends BaseFilterBuilder {
 
     private final String name;
-    private String lookupIndex;
-    private String lookupType;
-    private String lookupId;
-    private String lookupRouting;
-    private String lookupPath;
+    private String[] indices;
+    private String[] types;
+    private String id;
+    private String routing;
+    private String path;
     private Boolean lookupCache;
-
+    private FilterBuilder lookupFilter;
     private Boolean cache;
     private String cacheKey;
     private String filterName;
+    private Double bloomFpp;
+    private Integer bloomExpectedInsertions;
+    private Integer bloomHashFunctions;
 
     public TermsLookupFilterBuilder(String name) {
         this.name = name;
@@ -55,50 +58,110 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
     /**
      * Sets the index name to lookup the terms from.
      */
-    public TermsLookupFilterBuilder lookupIndex(String lookupIndex) {
-        this.lookupIndex = lookupIndex;
+    public TermsLookupFilterBuilder index(String index) {
+        this.indices = new String[]{index};
+        return this;
+    }
+
+    /**
+     * Sets the index name to lookup the terms from.
+     */
+    public TermsLookupFilterBuilder indices(String... indices) {
+        this.indices = indices;
         return this;
     }
 
     /**
      * Sets the index type to lookup the terms from.
      */
-    public TermsLookupFilterBuilder lookupType(String lookupType) {
-        this.lookupType = lookupType;
+    public TermsLookupFilterBuilder type(String type) {
+        this.types = new String[]{type};
+        return this;
+    }
+
+    /**
+     * Sets the index type to lookup the terms from.
+     */
+    public TermsLookupFilterBuilder types(String... types) {
+        this.types = types;
         return this;
     }
 
     /**
      * Sets the doc id to lookup the terms from.
      */
-    public TermsLookupFilterBuilder lookupId(String lookupId) {
-        this.lookupId = lookupId;
+    public TermsLookupFilterBuilder id(String id) {
+        this.id = id;
         return this;
     }
 
     /**
      * Sets the path within the document to lookup the terms from.
      */
-    public TermsLookupFilterBuilder lookupPath(String lookupPath) {
-        this.lookupPath = lookupPath;
+    public TermsLookupFilterBuilder path(String path) {
+        this.path = path;
         return this;
     }
 
-    public TermsLookupFilterBuilder lookupRouting(String lookupRouting) {
-        this.lookupRouting = lookupRouting;
+    /**
+     * Sets the filter used to lookup terms with
+     */
+    public TermsLookupFilterBuilder lookupFilter(FilterBuilder lookupFilter) {
+        this.lookupFilter = lookupFilter;
         return this;
     }
 
+    /**
+     * Sets the node routing used to control the shards the lookup request is executed on
+     */
+    public TermsLookupFilterBuilder routing(String routing) {
+        this.routing = routing;
+        return this;
+    }
+
+    /**
+     * Sets the BloomFilter false positive probability
+     */
+    public TermsLookupFilterBuilder bloomFpp(double bloomFpp) {
+        this.bloomFpp = bloomFpp;
+        return this;
+    }
+
+    /**
+     * Sets the expected insertions to create the BloomFilter with
+     */
+    public TermsLookupFilterBuilder bloomExpectedInsertions(int bloomExpectedInsertions) {
+        this.bloomExpectedInsertions = bloomExpectedInsertions;
+        return this;
+    }
+
+    /**
+     * Sets the number of hash functions used in the BloomFilter
+     */
+    public TermsLookupFilterBuilder bloomHashFunctions(int bloomHashFunctions) {
+        this.bloomHashFunctions = bloomHashFunctions;
+        return this;
+    }
+
+    /**
+     * Sets if the gathered terms should be cached or not
+     */
     public TermsLookupFilterBuilder lookupCache(boolean lookupCache) {
         this.lookupCache = lookupCache;
         return this;
     }
 
+    /**
+     * Sets if the resulting filter should be cached or not
+     */
     public TermsLookupFilterBuilder cache(boolean cache) {
         this.cache = cache;
         return this;
     }
 
+    /**
+     * Sets the filter cache key
+     */
     public TermsLookupFilterBuilder cacheKey(String cacheKey) {
         this.cacheKey = cacheKey;
         return this;
@@ -107,32 +170,66 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(TermsFilterParser.NAME);
-
         builder.startObject(name);
-        if (lookupIndex != null) {
-            builder.field("index", lookupIndex);
+        if (indices != null) {
+            builder.field("indices", indices);
         }
-        builder.field("type", lookupType);
-        builder.field("id", lookupId);
-        if (lookupRouting != null) {
-            builder.field("routing", lookupRouting);
+
+        if (types != null) {
+            builder.field("types", types);
         }
+
+        if (id != null) {
+            builder.field("id", id);
+        }
+
+        if (routing != null) {
+            builder.field("routing", routing);
+        }
+
         if (lookupCache != null) {
             builder.field("cache", lookupCache);
         }
-        builder.field("path", lookupPath);
+
+        if (lookupFilter != null) {
+            builder.field("filter", lookupFilter);
+        }
+
+        if (path != null) {
+            builder.field("path", path);
+        }
+
+        if (bloomFpp != null || bloomExpectedInsertions != null || bloomHashFunctions != null) {
+            builder.startObject("bloom_filter");
+
+            if (bloomFpp != null) {
+                builder.field("fpp", bloomFpp);
+            }
+
+            if (bloomExpectedInsertions != null) {
+                builder.field("expected_insertions", bloomExpectedInsertions);
+            }
+
+            if (bloomHashFunctions != null) {
+                builder.field("hash_functions", bloomHashFunctions);
+            }
+
+            builder.endObject();
+        }
+
         builder.endObject();
 
         if (filterName != null) {
             builder.field("_name", filterName);
         }
+
         if (cache != null) {
             builder.field("_cache", cache);
         }
+
         if (cacheKey != null) {
             builder.field("_cache_key", cacheKey);
         }
-
         builder.endObject();
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsLookupFilterBuilder.java
@@ -42,7 +42,7 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
     private Double bloomFpp;
     private Integer bloomExpectedInsertions;
     private Integer bloomHashFunctions;
-    private Integer maxTermsPerShard;
+    private Long maxTermsPerShard;
 
     public TermsLookupFilterBuilder(String name) {
         this.name = name;
@@ -147,7 +147,7 @@ public class TermsLookupFilterBuilder extends BaseFilterBuilder {
     /**
      * Sets the max number of terms to collect per shard.
      */
-    public TermsLookupFilterBuilder maxTermsPerShard(int maxTermsPerShard) {
+    public TermsLookupFilterBuilder maxTermsPerShard(long maxTermsPerShard) {
         this.maxTermsPerShard = maxTermsPerShard;
         return this;
     }

--- a/src/main/java/org/elasticsearch/index/search/BloomFieldDataTermsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/BloomFieldDataTermsFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.search;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.docset.MatchDocIdSet;
+import org.elasticsearch.common.util.BloomFilter;
+import org.elasticsearch.index.fielddata.BytesValues;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+
+import java.io.IOException;
+
+/**
+ * Filters on non-numeric field values that might be found in a {@link BloomFilter}.
+ */
+public class BloomFieldDataTermsFilter extends FieldDataTermsFilter {
+
+    final BloomFilter bloomFilter;
+    Integer hashCode;
+
+    /**
+     * Constructor accepting a {@link BloomFilter}.
+     */
+    public BloomFieldDataTermsFilter(IndexFieldData fieldData, BloomFilter bloomFilter) {
+        super(fieldData);
+        this.bloomFilter = bloomFilter;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || !(obj instanceof BloomFieldDataTermsFilter)) return false;
+
+        BloomFieldDataTermsFilter that = (BloomFieldDataTermsFilter) obj;
+        if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+        if (!bloomFilter.equals(that.bloomFilter)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == null) {
+            // calculate hashCode of each bloom filter
+            int hash = fieldData.getFieldNames().indexName().hashCode();
+            hash += bloomFilter != null ? bloomFilter.hashCode() : 0;
+
+            hashCode = hash;
+        }
+
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("BloomFieldDataTermsFilter:");
+        return sb
+                .append(fieldData.getFieldNames().indexName())
+                .append(":")
+                .append(bloomFilter.toString()) // TODO: what to use here? hashCode maybe?
+                .toString();
+    }
+
+    @Override
+    public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+        // make sure there are terms to filter on
+        if (bloomFilter == null || bloomFilter.isEmpty()) return null;
+
+        final BytesValues values = fieldData.load(context).getBytesValues(false); // load fielddata
+        return new MatchDocIdSet(context.reader().maxDoc(), acceptDocs) {
+            @Override
+            protected boolean matchDoc(int doc) {
+                final int numVals = values.setDocument(doc);
+                for (int i = 0; i < numVals; i++) {
+                    final BytesRef term = values.nextValue();
+                    if (bloomFilter != null ? bloomFilter.mightContain(term) : false) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        };
+    }
+}

--- a/src/main/java/org/elasticsearch/index/search/BloomFieldDataTermsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/BloomFieldDataTermsFilter.java
@@ -93,7 +93,7 @@ public class BloomFieldDataTermsFilter extends FieldDataTermsFilter {
                 final int numVals = values.setDocument(doc);
                 for (int i = 0; i < numVals; i++) {
                     final BytesRef term = values.nextValue();
-                    if (bloomFilter != null ? bloomFilter.mightContain(term) : false) {
+                    if (bloomFilter.mightContain(term)) {
                         return true;
                     }
                 }

--- a/src/main/java/org/elasticsearch/index/search/FieldDataTermsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/FieldDataTermsFilter.java
@@ -79,15 +79,7 @@ public abstract class FieldDataTermsFilter extends Filter {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || !(obj instanceof FieldDataTermsFilter)) return false;
-
-        FieldDataTermsFilter that = (FieldDataTermsFilter) obj;
-        if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
-        if (this.hashCode() != obj.hashCode()) return false;
-        return true;
-    }
+    public abstract boolean equals(Object obj);
 
     @Override
     public abstract int hashCode();
@@ -101,6 +93,7 @@ public abstract class FieldDataTermsFilter extends Filter {
     protected static class BytesFieldDataFilter extends FieldDataTermsFilter {
 
         final ObjectOpenHashSet<BytesRef> terms;
+        Integer hashCode;
 
         protected BytesFieldDataFilter(IndexFieldData fieldData, ObjectOpenHashSet<BytesRef> terms) {
             super(fieldData);
@@ -108,10 +101,24 @@ public abstract class FieldDataTermsFilter extends Filter {
         }
 
         @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || !(obj instanceof BytesFieldDataFilter)) return false;
+
+            BytesFieldDataFilter that = (BytesFieldDataFilter) obj;
+            if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+            if (!terms.equals(that.terms)) return false;
+
+            return true;
+        }
+
+        @Override
         public int hashCode() {
-            int hashcode = fieldData.getFieldNames().indexName().hashCode();
-            hashcode += terms != null ? terms.hashCode() : 0;
-            return hashcode;
+            if (hashCode == null) {
+                hashCode = fieldData.getFieldNames().indexName().hashCode() + (terms != null ? terms.hashCode() : 0);
+            }
+
+            return hashCode;
         }
 
         @Override
@@ -152,6 +159,7 @@ public abstract class FieldDataTermsFilter extends Filter {
     protected static class LongsFieldDataFilter extends FieldDataTermsFilter {
 
         final LongOpenHashSet terms;
+        Integer hashCode;
 
         protected LongsFieldDataFilter(IndexNumericFieldData fieldData, LongOpenHashSet terms) {
             super(fieldData);
@@ -159,10 +167,24 @@ public abstract class FieldDataTermsFilter extends Filter {
         }
 
         @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || !(obj instanceof LongsFieldDataFilter)) return false;
+
+            LongsFieldDataFilter that = (LongsFieldDataFilter) obj;
+            if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+            if (!terms.equals(that.terms)) return false;
+
+            return true;
+        }
+
+        @Override
         public int hashCode() {
-            int hashcode = fieldData.getFieldNames().indexName().hashCode();
-            hashcode += terms != null ? terms.hashCode() : 0;
-            return hashcode;
+            if (hashCode == null) {
+                hashCode = fieldData.getFieldNames().indexName().hashCode() + (terms != null ? terms.hashCode() : 0);
+            }
+
+            return hashCode;
         }
 
         @Override
@@ -210,6 +232,7 @@ public abstract class FieldDataTermsFilter extends Filter {
     protected static class DoublesFieldDataFilter extends FieldDataTermsFilter {
 
         final DoubleOpenHashSet terms;
+        Integer hashCode;
 
         protected DoublesFieldDataFilter(IndexNumericFieldData fieldData, DoubleOpenHashSet terms) {
             super(fieldData);
@@ -217,10 +240,24 @@ public abstract class FieldDataTermsFilter extends Filter {
         }
 
         @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || !(obj instanceof DoublesFieldDataFilter)) return false;
+
+            DoublesFieldDataFilter that = (DoublesFieldDataFilter) obj;
+            if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+            if (!terms.equals(that.terms)) return false;
+
+            return true;
+        }
+
+        @Override
         public int hashCode() {
-            int hashcode = fieldData.getFieldNames().indexName().hashCode();
-            hashcode += terms != null ? terms.hashCode() : 0;
-            return hashcode;
+            if (hashCode == null) {
+                hashCode = fieldData.getFieldNames().indexName().hashCode() + (terms != null ? terms.hashCode() : 0);
+            }
+
+            return hashCode;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/search/FieldDataTermsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/FieldDataTermsFilter.java
@@ -21,12 +21,15 @@ package org.elasticsearch.index.search;
 import com.carrotsearch.hppc.DoubleOpenHashSet;
 import com.carrotsearch.hppc.LongOpenHashSet;
 import com.carrotsearch.hppc.ObjectOpenHashSet;
+import com.google.common.primitives.Longs;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.docset.MatchDocIdSet;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.index.fielddata.*;
 
 import java.io.IOException;
@@ -55,6 +58,18 @@ public abstract class FieldDataTermsFilter extends Filter {
     }
 
     /**
+     * Get a {@link FieldDataTermsFilter} that filters on non-numeric terms found in a
+     * {@link org.elasticsearch.common.util.BytesRefHash}
+     *
+     * @param fieldData The fielddata for the field.
+     * @param terms     A {@link org.elasticsearch.common.util.BytesRefHash} of terms.
+     * @return the filter.
+     */
+    public static FieldDataTermsFilter newBytes(IndexFieldData fieldData, BytesRefHash terms) {
+        return new HashedBytesFieldDataFilter(fieldData, terms);
+    }
+
+    /**
      * Get a {@link FieldDataTermsFilter} that filters on non-floating point numeric terms found in a hppc
      * {@link LongOpenHashSet}.
      *
@@ -67,6 +82,18 @@ public abstract class FieldDataTermsFilter extends Filter {
     }
 
     /**
+     * Get a {@link FieldDataTermsFilter} that filters on non-floating point numeric terms found in a
+     * {@link org.elasticsearch.common.util.LongHash}.
+     *
+     * @param fieldData The fielddata for the field.
+     * @param terms     A {@link org.elasticsearch.common.util.LongHash} of terms.
+     * @return the filter.
+     */
+    public static FieldDataTermsFilter newLongs(IndexNumericFieldData fieldData, LongHash terms) {
+        return new HashedLongsFieldDataFilter(fieldData, terms);
+    }
+
+    /**
      * Get a {@link FieldDataTermsFilter} that filters on floating point numeric terms found in a hppc
      * {@link DoubleOpenHashSet}.
      *
@@ -76,6 +103,19 @@ public abstract class FieldDataTermsFilter extends Filter {
      */
     public static FieldDataTermsFilter newDoubles(IndexNumericFieldData fieldData, DoubleOpenHashSet terms) {
         return new DoublesFieldDataFilter(fieldData, terms);
+    }
+
+    /**
+     * Get a {@link FieldDataTermsFilter} that filters on floating point numeric terms found in a
+     * {@link org.elasticsearch.common.util.LongHash}.  Terms must be represented as long bits, ie. using
+     * Double.doubleToLongBits.
+     *
+     * @param fieldData The fielddata for the field.
+     * @param terms     A {@link org.elasticsearch.common.util.LongHash} of terms.
+     * @return the filter.
+     */
+    public static FieldDataTermsFilter newDoubles(IndexNumericFieldData fieldData, LongHash terms) {
+        return new HashedDoublesFieldDataFilter(fieldData, terms);
     }
 
     @Override
@@ -148,6 +188,89 @@ public abstract class FieldDataTermsFilter extends Filter {
                     }
 
                     return false;
+                }
+            };
+        }
+    }
+
+    /**
+     * Filters on non-numeric fields.
+     */
+    protected static class HashedBytesFieldDataFilter extends FieldDataTermsFilter {
+
+        final BytesRefHash terms;
+        Integer hashCode;
+
+        protected HashedBytesFieldDataFilter(IndexFieldData fieldData, BytesRefHash terms) {
+            super(fieldData);
+            this.terms = terms;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || !(obj instanceof HashedBytesFieldDataFilter)) return false;
+
+            HashedBytesFieldDataFilter that = (HashedBytesFieldDataFilter) obj;
+            if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+            if (terms.size() != that.terms.size()) return false;
+
+            // TODO: best way to do this?
+            BytesRef spare = new BytesRef();
+            for (long i = 0; i < terms.size(); i++) {
+                terms.get(i, spare);
+                if (that.terms.find(spare, spare.hashCode()) < 0) return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            if (hashCode == null) {
+                hashCode = fieldData.getFieldNames().indexName().hashCode();
+                if (terms != null) {
+                    for (long i = 0; i < terms.size(); i++) {
+                        hashCode += terms.code(i);
+                    }
+                }
+            }
+
+            return hashCode;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("HashedBytesFieldDataFilter:");
+            return sb
+                    .append(fieldData.getFieldNames().indexName())
+                    .append(":")
+                    .append(terms != null ? terms.toString() : "") // TODO: do better?
+                    .toString();
+        }
+
+        @Override
+        public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+            // make sure there are terms to filter on
+            if (terms == null || terms.size() == 0) return null;
+
+            final BytesValues values = fieldData.load(context).getBytesValues(true); // load fielddata
+            return new MatchDocIdSet(context.reader().maxDoc(), acceptDocs) {
+                private final BytesRef spare = new BytesRef();
+
+                @Override
+                protected boolean matchDoc(int doc) {
+
+                    final int numVals = values.setDocument(doc);
+                    for (int i = 0; i < numVals; i++) {
+                        BytesRef term = values.nextValue();
+                        if (terms.find(term, values.currentValueHash(), spare) >= 0) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+
                 }
             };
         }
@@ -227,6 +350,90 @@ public abstract class FieldDataTermsFilter extends Filter {
     }
 
     /**
+     * Filters on non-floating point numeric fields.
+     */
+    protected static class HashedLongsFieldDataFilter extends FieldDataTermsFilter {
+
+        final LongHash terms;
+        Integer hashCode;
+
+        protected HashedLongsFieldDataFilter(IndexNumericFieldData fieldData, LongHash terms) {
+            super(fieldData);
+            this.terms = terms;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || !(obj instanceof HashedLongsFieldDataFilter)) return false;
+
+            HashedLongsFieldDataFilter that = (HashedLongsFieldDataFilter) obj;
+            if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+            if (!terms.equals(that.terms)) return false;
+            if (terms.size() != that.terms.size()) return false;
+
+            // TODO: best way to do this?
+            for (long i = 0; i < terms.size(); i++) {
+                if (that.terms.find(i) < 0) return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            if (hashCode == null) {
+                hashCode = fieldData.getFieldNames().indexName().hashCode();
+                if (terms != null) {
+                    for (long i = 0; i < terms.size(); i++) {
+                        hashCode += Longs.hashCode(LongHash.hash(terms.get(i)));
+                    }
+                }
+            }
+
+            return hashCode;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("HashedLongsFieldDataFilter:");
+            return sb
+                    .append(fieldData.getFieldNames().indexName())
+                    .append(":")
+                    .append(terms != null ? terms.toString() : "") // TODO: do better
+                    .toString();
+        }
+
+        @Override
+        public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+            // make sure there are terms to filter on
+            if (terms == null || terms.size() == 0) return null;
+
+            IndexNumericFieldData numericFieldData = (IndexNumericFieldData) fieldData;
+            if (!numericFieldData.getNumericType().isFloatingPoint()) {
+                final LongValues values = numericFieldData.load(context).getLongValues(); // load fielddata
+                return new MatchDocIdSet(context.reader().maxDoc(), acceptDocs) {
+                    @Override
+                    protected boolean matchDoc(int doc) {
+                        final int numVals = values.setDocument(doc);
+                        for (int i = 0; i < numVals; i++) {
+                            if (terms.find(values.nextValue()) >= 0) {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+                };
+            }
+
+            // only get here if wrong fielddata type in which case
+            // no docs will match so we just return null.
+            return null;
+        }
+    }
+
+    /**
      * Filters on floating point numeric fields.
      */
     protected static class DoublesFieldDataFilter extends FieldDataTermsFilter {
@@ -286,6 +493,92 @@ public abstract class FieldDataTermsFilter extends Filter {
 
                         for (int i = 0; i < numVals; i++) {
                             if (terms.contains(values.nextValue())) {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+                };
+            }
+
+            // only get here if wrong fielddata type in which case
+            // no docs will match so we just return null.
+            return null;
+        }
+    }
+
+    /**
+     * Filters on floating point numeric fields.
+     */
+    protected static class HashedDoublesFieldDataFilter extends FieldDataTermsFilter {
+
+        final LongHash terms;
+        Integer hashCode;
+
+        protected HashedDoublesFieldDataFilter(IndexNumericFieldData fieldData, LongHash terms) {
+            super(fieldData);
+            this.terms = terms;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || !(obj instanceof HashedLongsFieldDataFilter)) return false;
+
+            HashedLongsFieldDataFilter that = (HashedLongsFieldDataFilter) obj;
+            if (!fieldData.getFieldNames().indexName().equals(that.fieldData.getFieldNames().indexName())) return false;
+            if (!terms.equals(that.terms)) return false;
+            if (terms.size() != that.terms.size()) return false;
+
+            // TODO: best way to do this?
+            for (long i = 0; i < terms.size(); i++) {
+                if (that.terms.find(i) < 0) return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            if (hashCode == null) {
+                hashCode = fieldData.getFieldNames().indexName().hashCode();
+                if (terms != null) {
+                    for (long i = 0; i < terms.size(); i++) {
+                        hashCode += Longs.hashCode(LongHash.hash(terms.get(i)));
+                    }
+                }
+            }
+
+            return hashCode;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("HashedDoublesFieldDataFilter:");
+            return sb
+                    .append(fieldData.getFieldNames().indexName())
+                    .append(":")
+                    .append(terms != null ? terms.toString() : "") // TODO: do better
+                    .toString();
+        }
+
+        @Override
+        public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+            // make sure there are terms to filter on
+            if (terms == null || terms.size() == 0) return null;
+
+            IndexNumericFieldData numericFieldData = (IndexNumericFieldData) fieldData;
+            if (numericFieldData.getNumericType().isFloatingPoint()) {
+                final DoubleValues values = numericFieldData.load(context).getDoubleValues(); // load fielddata
+                return new MatchDocIdSet(context.reader().maxDoc(), acceptDocs) {
+                    @Override
+                    protected boolean matchDoc(int doc) {
+                        final int numVals = values.setDocument(doc);
+                        for (int i = 0; i < numVals; i++) {
+                            final double dval = values.nextValue();
+                            final long lval = Double.doubleToLongBits(dval);
+                            if (terms.find(lval) >= 0) {
                                 return true;
                             }
                         }

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/FieldTermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/FieldTermsLookup.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.cache.filter.terms;
+
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.query.QueryParseContext;
+
+import java.util.List;
+
+/**
+ * A {@link TermsLookup} implementation that gathers the filter terms from the field of another document.
+ */
+public class FieldTermsLookup extends TermsLookup {
+
+    private final FieldMapper fieldMapper;
+    private final String index;
+    private final String type;
+    private final String id;
+    private final String routing;
+    private final String path;
+    @Nullable
+    private final QueryParseContext queryParseContext;
+    private List<Object> terms;
+
+    public FieldTermsLookup(FieldMapper fieldMapper, String index, String type, String id, String routing, String path,
+                            @Nullable QueryParseContext queryParseContext) {
+        this.fieldMapper = fieldMapper;
+        this.index = index;
+        this.type = type;
+        this.id = id;
+        this.routing = routing;
+        this.path = path;
+        this.queryParseContext = queryParseContext;
+    }
+
+    /**
+     * Performs a {@link GetRequest} for the document containing the lookup terms, extracts the terms from the specified
+     * field and generates an {@link org.apache.lucene.queries.TermsFilter}.
+     * @return the generated filter
+     */
+    @Override
+    public Filter getFilter() {
+        GetResponse getResponse = client.get(new GetRequest(index, type, id).preference("_local").routing(routing)).actionGet();
+        if (!getResponse.isExists()) {
+            return null;
+        }
+
+        terms = XContentMapValues.extractRawValues(path, getResponse.getSourceAsMap());
+        if (terms.isEmpty()) {
+            return null;
+        }
+
+        Filter filter = fieldMapper.termsFilter(terms, queryParseContext);
+        return filter;
+    }
+
+    /**
+     * Estimates the size of the filter.
+     * @return the estimated size in bytes.
+     */
+    @Override
+    public long estimateSizeInBytes() {
+        long size = 8;
+        for (Object term : terms) {
+            if (term instanceof BytesRef) {
+                size += ((BytesRef) term).length;
+            } else if (term instanceof String) {
+                size += ((String) term).length() / 2;
+            } else {
+                size += 4;
+            }
+        }
+
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return fieldMapper.names().fullName() + ":" + index + "/" + type + "/" + id + "/" + path;
+    }
+}

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/QueryTermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/QueryTermsLookup.java
@@ -19,24 +19,19 @@
 
 package org.elasticsearch.indices.cache.filter.terms;
 
-import com.carrotsearch.hppc.DoubleOpenHashSet;
-import com.carrotsearch.hppc.LongOpenHashSet;
-import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.google.common.base.Joiner;
-import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.Filter;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.terms.ResponseTerms;
 import org.elasticsearch.action.terms.TermsByQueryAction;
 import org.elasticsearch.action.terms.TermsByQueryRequest;
 import org.elasticsearch.action.terms.TermsByQueryResponse;
 import org.elasticsearch.common.util.BloomFilter;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.search.BloomFieldDataTermsFilter;
 import org.elasticsearch.index.search.FieldDataTermsFilter;
-
-import java.util.List;
 
 /**
  * A {@link TermsLookup} implementation that gathers the filter terms from the specified field of documents matching
@@ -75,13 +70,13 @@ public class QueryTermsLookup extends TermsLookup {
                 filter = new BloomFieldDataTermsFilter(fieldData, (BloomFilter) terms.getTerms());
                 break;
             case LONGS:
-                filter = FieldDataTermsFilter.newLongs((IndexNumericFieldData) fieldData, (LongOpenHashSet) terms.getTerms());
+                filter = FieldDataTermsFilter.newLongs((IndexNumericFieldData) fieldData, (LongHash) terms.getTerms());
                 break;
             case DOUBLES:
-                filter = FieldDataTermsFilter.newDoubles((IndexNumericFieldData) fieldData, (DoubleOpenHashSet) terms.getTerms());
+                filter = FieldDataTermsFilter.newDoubles((IndexNumericFieldData) fieldData, (LongHash) terms.getTerms());
                 break;
             default:
-                filter = FieldDataTermsFilter.newBytes(fieldData, (ObjectOpenHashSet<BytesRef>) terms.getTerms());
+                filter = FieldDataTermsFilter.newBytes(fieldData, (BytesRefHash) terms.getTerms());
         }
 
 

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/QueryTermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/QueryTermsLookup.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.cache.filter.terms;
+
+import com.carrotsearch.hppc.DoubleOpenHashSet;
+import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.ObjectOpenHashSet;
+import com.google.common.base.Joiner;
+import org.apache.lucene.queries.TermsFilter;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.terms.ResponseTerms;
+import org.elasticsearch.action.terms.TermsByQueryAction;
+import org.elasticsearch.action.terms.TermsByQueryRequest;
+import org.elasticsearch.action.terms.TermsByQueryResponse;
+import org.elasticsearch.common.util.BloomFilter;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.search.BloomFieldDataTermsFilter;
+import org.elasticsearch.index.search.FieldDataTermsFilter;
+
+import java.util.List;
+
+/**
+ * A {@link TermsLookup} implementation that gathers the filter terms from the specified field of documents matching
+ * the specified filter.
+ */
+public class QueryTermsLookup extends TermsLookup {
+
+    private final TermsByQueryRequest request;
+    private final IndexFieldData fieldData;
+    private ResponseTerms terms;
+
+    public QueryTermsLookup(TermsByQueryRequest request, IndexFieldData fieldData) {
+        super();
+        this.request = request;
+        this.fieldData = fieldData;
+    }
+
+    /**
+     * Executes the lookup query and gathers the terms.  It generates a {@link FieldDataTermsFilter} that uses the
+     * fielddata to lookup and filter values.
+     *
+     * @return the lookup filter
+     */
+    @Override
+    public Filter getFilter() {
+        TermsByQueryResponse termsByQueryResp = client.execute(TermsByQueryAction.INSTANCE, request).actionGet();
+        terms = termsByQueryResp.getResponseTerms();
+
+        if (terms.size() == 0) {
+            return null;
+        }
+
+        Filter filter;
+        switch (terms.getType()) {
+            case BLOOM:
+                filter = new BloomFieldDataTermsFilter(fieldData, (BloomFilter) terms.getTerms());
+                break;
+            case LONGS:
+                filter = FieldDataTermsFilter.newLongs((IndexNumericFieldData) fieldData, (LongOpenHashSet) terms.getTerms());
+                break;
+            case DOUBLES:
+                filter = FieldDataTermsFilter.newDoubles((IndexNumericFieldData) fieldData, (DoubleOpenHashSet) terms.getTerms());
+                break;
+            default:
+                filter = FieldDataTermsFilter.newBytes(fieldData, (ObjectOpenHashSet<BytesRef>) terms.getTerms());
+        }
+
+
+        return filter;
+    }
+
+    /**
+     * String representation of the query lookup.
+     *
+     * @return the string representation
+     */
+    @Override
+    public String toString() {
+        // to_field/index1,index2,.../type1,type2,.../from_field/filter(filter_bytes_hash)
+        Joiner joiner = Joiner.on(",");
+        StringBuilder repr = new StringBuilder(fieldData.getFieldNames().indexName())
+                .append(":").append(joiner.join(request.indices())).append("/")
+                .append(joiner.join(request.types())).append("/").append(request.field()).append("/");
+
+        if (request.filterSource() != null) {
+            repr.append("filter(");
+            try {
+                repr.append(request.filterSource().toBytesArray().hashCode());
+            } finally {
+                repr.append(")");
+            }
+        }
+
+        if (request.useBloomFilter()) {
+            repr.append("/bloom");
+        }
+
+        return repr.toString();
+    }
+
+    /**
+     * Deletages to {@link org.elasticsearch.action.terms.ResponseTerms#getSizeInBytes()}
+     *
+     * @return the estimated size of the filter in bytes.
+     */
+    @Override
+    public long estimateSizeInBytes() {
+        return terms.getSizeInBytes();
+    }
+}

--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/TermsLookup.java
@@ -19,65 +19,44 @@
 
 package org.elasticsearch.indices.cache.filter.terms;
 
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.query.QueryParseContext;
+import org.apache.lucene.search.Filter;
+import org.elasticsearch.client.Client;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 /**
+ * Abstract {@link TermsLookup}.
  */
-public class TermsLookup {
+public abstract class TermsLookup {
 
-    private final FieldMapper fieldMapper;
+    protected Client client;
 
-    private final String index;
-    private final String type;
-    private final String id;
-    private final String routing;
-    private final String path;
-
-    @Nullable
-    private final QueryParseContext queryParseContext;
-
-    public TermsLookup(FieldMapper fieldMapper, String index, String type, String id, String routing, String path, @Nullable QueryParseContext queryParseContext) {
-        this.fieldMapper = fieldMapper;
-        this.index = index;
-        this.type = type;
-        this.id = id;
-        this.routing = routing;
-        this.path = path;
-        this.queryParseContext = queryParseContext;
+    // TODO: Can this be injected?
+    /**
+     * Sets the client
+     * @param client the {@link Client}
+     */
+    public void setClient(Client client) {
+        this.client = client;
     }
 
-    public FieldMapper getFieldMapper() {
-        return fieldMapper;
-    }
+    /**
+     * Returns the lookup filter
+     * @return the filter
+     */
+    public abstract Filter getFilter();
 
-    public String getIndex() {
-        return index;
-    }
+    /**
+     * Used for cache key when not specified
+     * @return the lookup string representation
+     */
+    public abstract String toString();
 
-    public String getType() {
-        return type;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getRouting() {
-        return this.routing;
-    }
-
-    public String getPath() {
-        return path;
-    }
-
-    @Nullable
-    public QueryParseContext getQueryParseContext() {
-        return queryParseContext;
-    }
-
-    public String toString() {
-        return fieldMapper.names().fullName() + ":" + index + "/" + type + "/" + id + "/" + path;
-    }
+    /**
+     * The size of the lookup in bytes to be used in
+     * cache size calculations
+     * @return the size of the lookup in bytes
+     */
+    public abstract long estimateSizeInBytes();
 }

--- a/src/test/java/org/elasticsearch/action/terms/SimpleTermsByQueryActionTests.java
+++ b/src/test/java/org/elasticsearch/action/terms/SimpleTermsByQueryActionTests.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.terms;
+
+import com.carrotsearch.hppc.DoubleOpenHashSet;
+import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.ObjectOpenHashSet;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BloomFilter;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.junit.Test;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.FilterBuilders.matchAllFilter;
+import static org.elasticsearch.index.query.FilterBuilders.rangeFilter;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class SimpleTermsByQueryActionTests extends ElasticsearchIntegrationTest {
+
+    /**
+     * Tests that the terms by query action returns the correct terms against string fields
+     */
+    @Test
+    public void testTermsByQuery() throws Exception {
+        int numShards = randomIntBetween(1, 6);
+        int numDocs = randomIntBetween(100, 2000);
+
+        logger.info("--> creating index [idx] shards [" + numShards + "]");
+        client().admin().indices().prepareCreate("idx").setSettings("index.number_of_shards", numShards, "index.number_of_replicas", 0).execute().actionGet();
+        ensureGreen();
+
+        logger.info("--> indexing [" + numDocs + "] docs");
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex("idx", "type", "" + i)
+                    .setSource(jsonBuilder().startObject()
+                            .field("str", Integer.toString(i)).field("dbl", Double.valueOf(i)).field("int", i)
+                            .endObject()).execute().actionGet();
+        }
+
+        client().admin().indices().prepareRefresh("idx").execute().actionGet();
+
+        logger.info("--> lookup terms in field [str]");
+        TermsByQueryResponse resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("str")
+                .setFilter(matchAllFilter()).execute().actionGet();
+
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(numDocs));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.BytesResponseTerms, is(true));
+        assertThat(resp.getResponseTerms().getTerms() instanceof ObjectOpenHashSet, is(true)); // bloom doesn't store terms
+        ObjectOpenHashSet<BytesRef> bTerms = (ObjectOpenHashSet<BytesRef>) resp.getResponseTerms().getTerms();
+        assertThat(bTerms.size(), is(numDocs));
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(bTerms.contains(new BytesRef(Integer.toString(i))), is(true));
+        }
+
+        logger.info("--> lookup terms in field [str] with BloomFilter");
+        resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("str").setUseBloomFilter(true)
+                .setExpectedInsertions(numDocs).setFilter(matchAllFilter()).execute().actionGet();
+
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(numDocs));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.BloomResponseTerms, is(true));
+        assertThat(resp.getResponseTerms().getTerms() instanceof BloomFilter, is(true));
+        BloomFilter bloomFilter = (BloomFilter) resp.getResponseTerms().getTerms();
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(bloomFilter.mightContain(new BytesRef(Integer.toString(i))), is(true));
+        }
+
+        logger.info("--> lookup terms in field [int]");
+        resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("int")
+                .setFilter(matchAllFilter()).execute().actionGet();
+
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(numDocs));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.LongsResponseTerms, is(true));
+        assertThat(resp.getResponseTerms().getTerms() instanceof LongOpenHashSet, is(true)); // bloom doesn't store terms
+        LongOpenHashSet lTerms = (LongOpenHashSet) resp.getResponseTerms().getTerms();
+        assertThat(lTerms.size(), is(numDocs));
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(lTerms.contains(Long.valueOf(i)), is(true));
+        }
+
+        logger.info("--> lookup terms in field [dbl]");
+        resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("dbl")
+                .setFilter(matchAllFilter()).execute().actionGet();
+
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(numDocs));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.DoublesResponseTerms, is(true));
+        assertThat(resp.getResponseTerms().getTerms() instanceof DoubleOpenHashSet, is(true)); // bloom doesn't store terms
+        DoubleOpenHashSet dTerms = (DoubleOpenHashSet) resp.getResponseTerms().getTerms();
+        assertThat(dTerms.size(), is(numDocs));
+        for (int i = 0; i < numDocs; i++) {
+            assertThat(dTerms.contains(Double.valueOf(i)), is(true));
+        }
+
+        logger.info("--> lookup in field [str] with no docs");
+        resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("str")
+                .setFilter(rangeFilter("int").gt(numDocs)).execute().actionGet();
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(0));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.BytesResponseTerms, is(true));
+        bTerms = (ObjectOpenHashSet<BytesRef>) resp.getResponseTerms().getTerms();
+        assertThat(bTerms.size(), is(0));
+
+        logger.info("--> lookup in field [int] with no docs");
+        resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("int")
+                .setFilter(rangeFilter("int").gt(numDocs)).execute().actionGet();
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(0));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.LongsResponseTerms, is(true));
+        lTerms = (LongOpenHashSet) resp.getResponseTerms().getTerms();
+        assertThat(lTerms.size(), is(0));
+
+        logger.info("--> lookup in field [dbl] with no docs");
+        resp = new TermsByQueryRequestBuilder(client()).setIndices("idx").setField("dbl")
+                .setFilter(rangeFilter("int").gt(numDocs)).execute().actionGet();
+        ElasticsearchAssertions.assertNoFailures(resp);
+        assertThat(resp.getResponseTerms(), notNullValue());
+        assertThat(resp.getResponseTerms().size(), is(0));
+        assertThat(resp.getResponseTerms() instanceof ResponseTerms.DoublesResponseTerms, is(true));
+        dTerms = (DoubleOpenHashSet) resp.getResponseTerms().getTerms();
+        assertThat(dTerms.size(), is(0));
+    }
+}

--- a/src/test/java/org/elasticsearch/benchmark/search/lookup/QueryTermsLookupBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/lookup/QueryTermsLookupBenchmark.java
@@ -1,0 +1,530 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.benchmark.search.lookup;
+
+import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.FilterBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermsLookupFilterBuilder;
+import org.elasticsearch.node.Node;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.elasticsearch.client.Requests.createIndexRequest;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.FilterBuilders.*;
+import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+import static org.elasticsearch.search.facet.FacetBuilders.termsFacet;
+
+/**
+ * Perform the parent/child search tests using terms query lookup.
+ * This should work across multiple shards and not need a special mapping
+ */
+public class QueryTermsLookupBenchmark {
+
+    // index settings
+    public static final int NUM_SHARDS = 3;
+    public static final int NUM_REPLICAS = 0;
+    public static final String PARENT_INDEX = "joinparent";
+    public static final String PARENT_TYPE = "p";
+    public static final String CHILD_INDEX = "joinchild";
+    public static final String CHILD_TYPE = "c";
+    // test settings
+    public static final int NUM_PARENTS = 1000000;
+    public static final int NUM_CHILDREN_PER_PARENT = 5;
+    public static final int BATCH_SIZE = 100;
+    public static final int NUM_QUERIES = 50;
+    private final Node node;
+    private final Client client;
+    private final Random random;
+
+    QueryTermsLookupBenchmark() {
+        Settings settings = settingsBuilder()
+                .put("index.engine.robin.refreshInterval", "-1")
+                .put("gateway.type", "local")
+                .put(SETTING_NUMBER_OF_SHARDS, NUM_SHARDS)
+                .put(SETTING_NUMBER_OF_REPLICAS, NUM_REPLICAS)
+                .build();
+
+        this.node = nodeBuilder().settings(settingsBuilder().put(settings).put("name", "node1")).node();
+        this.client = node.client();
+        this.random = new Random(System.currentTimeMillis());
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        QueryTermsLookupBenchmark bench = new QueryTermsLookupBenchmark();
+        bench.waitForGreen();
+        bench.setupIndex();
+        bench.memStatus();
+
+        // don't cache lookup
+        bench.benchHasChildSingleTerm(false);
+        bench.benchHasParentSingleTerm(false);
+        bench.benchHasParentMatchAll(false);
+        bench.benchHasChildMatchAll(false);
+        bench.benchHasParentRandomTerms(false);
+
+        System.gc();
+        bench.memStatus();
+        bench.shutdown();
+    }
+
+    public void waitForGreen() {
+        client.admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
+    }
+
+    public void shutdown() {
+        client.close();
+        node.close();
+    }
+
+    public void log(String msg) {
+        System.out.println("--> " + msg);
+    }
+
+    public void memStatus() {
+        NodeStats nodeStats = client.admin().cluster().prepareNodesStats().setJvm(true).setIndices(true).execute().actionGet().getNodes()[0];
+        log("==== MEMORY ====");
+        log("Committed heap size: " + nodeStats.getJvm().getMem().getHeapCommitted());
+        log("Used heap size: " + nodeStats.getJvm().getMem().getHeapUsed());
+        log("FieldData cache size: " + nodeStats.getIndices().getFieldData().getMemorySize());
+        log("");
+    }
+
+    public XContentBuilder parentSource(int id, String nameValue) throws IOException {
+        return jsonBuilder().startObject().field("id", Integer.toString(id)).field("num", id).field("name", nameValue).endObject();
+    }
+
+    public XContentBuilder childSource(String id, int parent, String tag) throws IOException {
+        return jsonBuilder().startObject().field("id", id).field("pid", Integer.toString(parent)).field("num", parent).field("tag", tag)
+                .endObject();
+    }
+
+    public void setupIndex() {
+        log("==== INDEX SETUP ====");
+        try {
+            client.admin().indices().create(createIndexRequest(PARENT_INDEX)).actionGet();
+            client.admin().indices().create(createIndexRequest(CHILD_INDEX)).actionGet();
+            Thread.sleep(5000);
+
+            StopWatch stopWatch = new StopWatch().start();
+
+            log("Indexing [" + NUM_PARENTS + "] parent documents into [" + PARENT_INDEX + "]");
+            log("Indexing [" + (NUM_PARENTS * NUM_CHILDREN_PER_PARENT) + "] child documents into [" + CHILD_INDEX + "]");
+            int ITERS = NUM_PARENTS / BATCH_SIZE;
+            int i = 1;
+            int counter = 0;
+            for (; i <= ITERS; i++) {
+                BulkRequestBuilder request = client.prepareBulk();
+                for (int j = 0; j < BATCH_SIZE; j++) {
+                    String parentId = Integer.toString(counter);
+                    counter++;
+                    request.add(Requests.indexRequest(PARENT_INDEX)
+                            .type(PARENT_TYPE)
+                            .id(parentId)
+                            .source(parentSource(counter, "test" + counter)));
+
+                    for (int k = 0; k < NUM_CHILDREN_PER_PARENT; k++) {
+                        String childId = parentId + "_" + k;
+                        request.add(Requests.indexRequest(CHILD_INDEX)
+                                .type(CHILD_TYPE)
+                                .id(childId)
+                                .source(childSource(childId, counter, "tag" + k)));
+                    }
+                }
+
+                BulkResponse response = request.execute().actionGet();
+                if (response.hasFailures()) {
+                    log("Index Failures...");
+                }
+
+                if (((i * BATCH_SIZE) % 10000) == 0) {
+                    log("Indexed [" + (i * BATCH_SIZE) * (1 + NUM_CHILDREN_PER_PARENT) + "] took [" + stopWatch.stop().lastTaskTime() + "]");
+                    stopWatch.start();
+                }
+            }
+
+            log("Indexing took [" + stopWatch.totalTime() + "]");
+            log("TPS [" + (((double) (NUM_PARENTS * (1 + NUM_CHILDREN_PER_PARENT))) / stopWatch.totalTime().secondsFrac()) + "]");
+        } catch (Exception e) {
+            log("Indices exist, wait for green");
+            waitForGreen();
+        }
+
+        client.admin().indices().prepareRefresh().execute().actionGet();
+        log("Number of docs in index: " + client.prepareCount(PARENT_INDEX, CHILD_INDEX).setQuery(matchAllQuery()).execute().actionGet().getCount());
+        log("");
+    }
+
+    public void warmFieldData(String parentField, String childField) {
+        ListenableActionFuture<SearchResponse> parentSearch = null;
+        ListenableActionFuture<SearchResponse> childSearch = null;
+
+        if (parentField != null) {
+            parentSearch = client
+                    .prepareSearch(PARENT_INDEX)
+                    .setQuery(matchAllQuery()).addFacet(termsFacet("parentfield").field(parentField)).execute();
+        }
+
+        if (childField != null) {
+            childSearch = client
+                    .prepareSearch(CHILD_INDEX)
+                    .setQuery(matchAllQuery()).addFacet(termsFacet("childfield").field(childField)).execute();
+        }
+
+        if (parentSearch != null) parentSearch.actionGet();
+        if (childSearch != null) childSearch.actionGet();
+    }
+
+    public long runQuery(String name, int testNum, String index, long expectedHits, QueryBuilder query) {
+        SearchResponse searchResponse = client
+                .prepareSearch(index)
+                .setQuery(query)
+                .execute().actionGet();
+
+        if (searchResponse.getFailedShards() > 0) {
+            log("Search Failures " + Arrays.toString(searchResponse.getShardFailures()));
+        }
+
+        long hits = searchResponse.getHits().totalHits();
+        if (hits != expectedHits) {
+            log("[" + name + "][#" + testNum + "] Hits Mismatch:  expected [" + expectedHits + "], got [" + hits + "]");
+        }
+
+        return searchResponse.getTookInMillis();
+    }
+
+    /**
+     * Search for parent documents that have children containing a specified tag.
+     * Expect all parents returned since one child from each parent will match the lookup.
+     * <p/>
+     * Parent string field = "id"
+     * Parent numeric field = "num"
+     * Child string field = "pid"
+     * Child numeric field = "num"
+     */
+    public void benchHasChildSingleTerm(boolean cacheLookup) {
+        FilterBuilder lookupFilter;
+        QueryBuilder mainQuery = matchAllQuery();
+
+        TermsLookupFilterBuilder stringFilter = termsLookupFilter("id")
+                .index(CHILD_INDEX)
+                .type(CHILD_TYPE)
+                .path("pid")
+                .lookupCache(cacheLookup);
+
+        TermsLookupFilterBuilder bloomFilter = termsLookupFilter("id")
+                .index(CHILD_INDEX)
+                .type(CHILD_TYPE)
+                .path("pid")
+                .bloomExpectedInsertions(NUM_PARENTS)
+                .lookupCache(cacheLookup);
+
+        TermsLookupFilterBuilder numericFilter = termsLookupFilter("num")
+                .index(CHILD_INDEX)
+                .type(CHILD_TYPE)
+                .path("num")
+                .lookupCache(cacheLookup);
+
+        long tookString = 0;
+        long tookNumeric = 0;
+        long tookBloom = 0;
+        long expected = NUM_PARENTS;
+        warmFieldData("id", "pid");     // for string fields
+        warmFieldData("num", "num");    // for numeric fields
+
+        log("==== HAS CHILD SINGLE TERM (cache: " + cacheLookup + ") ====");
+        for (int i = 0; i < NUM_QUERIES; i++) {
+            lookupFilter = termFilter("tag", "tag" + random.nextInt(NUM_CHILDREN_PER_PARENT));
+
+            stringFilter.lookupFilter(lookupFilter);
+            numericFilter.lookupFilter(lookupFilter);
+            bloomFilter.lookupFilter(lookupFilter);
+
+            tookString += runQuery("string", i, PARENT_INDEX, expected, filteredQuery(mainQuery, stringFilter));
+            tookNumeric += runQuery("numeric", i, PARENT_INDEX, expected, filteredQuery(mainQuery, numericFilter));
+            tookBloom += runQuery("bloom", i, PARENT_INDEX, expected, filteredQuery(mainQuery, bloomFilter));
+        }
+
+        log("string: " + (tookString / NUM_QUERIES) + "ms avg");
+        log("numeric: " + (tookNumeric / NUM_QUERIES) + "ms avg");
+        log("bloom: " + (tookBloom / NUM_QUERIES) + "ms avg");
+        log("");
+    }
+
+    /**
+     * Search for parent documents that have any child.
+     * Expect all parent documents returned.
+     * <p/>
+     * Parent string field = "id"
+     * Parent numeric field = "num"
+     * Child string field = "pid"
+     * Child numeric field = "num"
+     */
+    public void benchHasChildMatchAll(boolean cacheLookup) {
+        FilterBuilder lookupFilter = matchAllFilter();
+        QueryBuilder mainQuery = matchAllQuery();
+
+        TermsLookupFilterBuilder stringFilter = termsLookupFilter("id")
+                .index(CHILD_INDEX)
+                .type(CHILD_TYPE)
+                .path("pid")
+                .lookupCache(cacheLookup)
+                .lookupFilter(lookupFilter);
+
+        TermsLookupFilterBuilder bloomFilter = termsLookupFilter("id")
+                .index(CHILD_INDEX)
+                .type(CHILD_TYPE)
+                .path("pid")
+                .bloomExpectedInsertions(NUM_PARENTS)
+                .lookupCache(cacheLookup)
+                .lookupFilter(lookupFilter);
+
+        TermsLookupFilterBuilder numericFilter = termsLookupFilter("num")
+                .index(CHILD_INDEX)
+                .type(CHILD_TYPE)
+                .path("num")
+                .lookupCache(cacheLookup)
+                .lookupFilter(lookupFilter);
+
+        long tookString = 0;
+        long tookNumeric = 0;
+        long tookBloom = 0;
+        long expected = NUM_PARENTS;
+        warmFieldData("id", "pid");     // for string fields
+        warmFieldData("num", "num");    // for numeric fields
+
+        log("==== HAS CHILD MATCH-ALL (cache: " + cacheLookup + ") ====");
+        for (int i = 0; i < NUM_QUERIES; i++) {
+            tookString += runQuery("string", i, PARENT_INDEX, expected, filteredQuery(mainQuery, stringFilter));
+            tookNumeric += runQuery("numeric", i, PARENT_INDEX, expected, filteredQuery(mainQuery, numericFilter));
+            tookBloom += runQuery("bloom", i, PARENT_INDEX, expected, filteredQuery(mainQuery, bloomFilter));
+        }
+
+        log("string: " + (tookString / NUM_QUERIES) + "ms avg");
+        log("numeric: " + (tookNumeric / NUM_QUERIES) + "ms avg");
+        log("bloom: " + (tookBloom / NUM_QUERIES) + "ms avg");
+        log("");
+    }
+
+    /**
+     * Search for children that have a parent with the specified name.
+     * Expect NUM_CHILDREN_PER_PARENT since only one parent matching lookup.
+     * <p/>
+     * Parent string field = "id"
+     * Parent numeric field = "num"
+     * Child string field = "pid"
+     * Child numeric field = "num"
+     */
+    public void benchHasParentSingleTerm(boolean cacheLookup) {
+        FilterBuilder lookupFilter;
+        QueryBuilder mainQuery = matchAllQuery();
+
+        TermsLookupFilterBuilder stringFilter = termsLookupFilter("pid")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("id")
+                .lookupCache(cacheLookup);
+
+        TermsLookupFilterBuilder bloomFilter = termsLookupFilter("pid")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("id")
+                .bloomExpectedInsertions(NUM_PARENTS)
+                .lookupCache(cacheLookup);
+
+        TermsLookupFilterBuilder numericFilter = termsLookupFilter("num")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("num")
+                .lookupCache(cacheLookup);
+
+        long tookString = 0;
+        long tookNumeric = 0;
+        long tookBloom = 0;
+        long expected = NUM_CHILDREN_PER_PARENT;
+        warmFieldData("id", "pid");     // for string fields
+        warmFieldData("num", "num");    // for numeric fields
+
+        log("==== HAS PARENT SINGLE TERM (cache: " + cacheLookup + ") ====");
+        for (int i = 0; i < NUM_QUERIES; i++) {
+            lookupFilter = termFilter("name", "test" + (random.nextInt(NUM_PARENTS) + 1));
+
+            stringFilter.lookupFilter(lookupFilter);
+            numericFilter.lookupFilter(lookupFilter);
+            bloomFilter.lookupFilter(lookupFilter);
+
+            tookString += runQuery("string", i, CHILD_INDEX, expected, filteredQuery(mainQuery, stringFilter));
+            tookNumeric += runQuery("numeric", i, CHILD_INDEX, expected, filteredQuery(mainQuery, numericFilter));
+            tookBloom += runQuery("bloom", i, CHILD_INDEX, expected, filteredQuery(mainQuery, bloomFilter));
+        }
+
+        log("string: " + (tookString / NUM_QUERIES) + "ms avg");
+        log("numeric: " + (tookNumeric / NUM_QUERIES) + "ms avg");
+        log("bloom: " + (tookBloom / NUM_QUERIES) + "ms avg");
+        log("");
+    }
+
+    /**
+     * Search for children that have a parent.
+     * Expect all children to be returned.
+     * <p/>
+     * Parent string field = "id"
+     * Parent numeric field = "num"
+     * Child string field = "pid"
+     * Child numeric field = "num"
+     */
+    public void benchHasParentMatchAll(boolean cacheLookup) {
+        FilterBuilder lookupFilter = matchAllFilter();
+        QueryBuilder mainQuery = matchAllQuery();
+
+        TermsLookupFilterBuilder stringFilter = termsLookupFilter("pid")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("id")
+                .lookupCache(cacheLookup)
+                .lookupFilter(lookupFilter);
+
+        TermsLookupFilterBuilder bloomFilter = termsLookupFilter("pid")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("id")
+                .bloomExpectedInsertions(NUM_PARENTS * NUM_CHILDREN_PER_PARENT)
+                .lookupCache(cacheLookup)
+                .lookupFilter(lookupFilter);
+
+        TermsLookupFilterBuilder numericFilter = termsLookupFilter("num")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("num")
+                .lookupCache(cacheLookup)
+                .lookupFilter(lookupFilter);
+
+        long tookString = 0;
+        long tookNumeric = 0;
+        long tookBloom = 0;
+        long expected = NUM_CHILDREN_PER_PARENT * NUM_PARENTS;
+        warmFieldData("id", "pid");     // for string fields
+        warmFieldData("num", "num");    // for numeric fields
+
+        log("==== HAS PARENT MATCH-ALL (cache: " + cacheLookup + ") ====");
+        for (int i = 0; i < NUM_QUERIES; i++) {
+            tookString += runQuery("string", i, CHILD_INDEX, expected, filteredQuery(mainQuery, stringFilter));
+            tookNumeric += runQuery("numeric", i, CHILD_INDEX, expected, filteredQuery(mainQuery, numericFilter));
+            tookBloom += runQuery("bloom", i, CHILD_INDEX, expected, filteredQuery(mainQuery, bloomFilter));
+        }
+
+        log("string: " + (tookString / NUM_QUERIES) + "ms avg");
+        log("numeric: " + (tookNumeric / NUM_QUERIES) + "ms avg");
+        log("bloom: " + (tookBloom / NUM_QUERIES) + "ms avg");
+        log("");
+    }
+
+    /**
+     * Search for children that have a parent with any of the specified names.
+     * Expect NUM_CHILDREN_PER_PARENT * # of names.
+     * <p/>
+     * Parent string field = "id"
+     * Parent numeric field = "num"
+     * Child string field = "pid"
+     * Child numeric field = "num"
+     */
+    public void benchHasParentRandomTerms(boolean cacheLookup) {
+        FilterBuilder lookupFilter;
+        QueryBuilder mainQuery = matchAllQuery();
+        Set<String> names = new HashSet<String>(NUM_PARENTS);
+
+        TermsLookupFilterBuilder stringFilter = termsLookupFilter("pid")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("id")
+                .lookupCache(cacheLookup);
+
+        TermsLookupFilterBuilder bloomFilter = termsLookupFilter("pid")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("id")
+
+                /*
+                    Tune the bloom filter to give acceptable false positives for this test.
+                 */
+                .bloomHashFunctions(10)
+                .bloomFpp(0.01)
+                .lookupCache(cacheLookup);
+
+        TermsLookupFilterBuilder numericFilter = termsLookupFilter("num")
+                .index(PARENT_INDEX)
+                .type(PARENT_TYPE)
+                .path("num")
+                .lookupCache(cacheLookup);
+
+        long tookString = 0;
+        long tookNumeric = 0;
+        long tookBloom = 0;
+        int expected = 0;
+        warmFieldData("id", "pid");     // for string fields
+        warmFieldData("num", "num");    // for numeric fields
+        warmFieldData("name", null);    // for field data terms filter
+
+        log("==== HAS PARENT RANDOM TERMS (cache: " + cacheLookup + ") ====");
+        for (int i = 0; i < NUM_QUERIES; i++) {
+
+            // add a random number of terms to the set on each iteration
+            int randNum = random.nextInt(NUM_PARENTS / NUM_QUERIES) + 1;
+            for (int j = 0; j < randNum; j++) {
+                names.add("test" + (random.nextInt(NUM_PARENTS) + 1));
+            }
+
+            lookupFilter = termsFilter("name", names).execution("fielddata");
+            expected = NUM_CHILDREN_PER_PARENT * names.size();
+            stringFilter.lookupFilter(lookupFilter);
+            numericFilter.lookupFilter(lookupFilter);
+            bloomFilter.lookupFilter(lookupFilter).bloomExpectedInsertions(expected); // part of bloom filter tuning
+
+            tookString += runQuery("string", i, CHILD_INDEX, expected, filteredQuery(mainQuery, stringFilter));
+            tookNumeric += runQuery("numeric", i, CHILD_INDEX, expected, filteredQuery(mainQuery, numericFilter));
+            tookBloom += runQuery("bloom", i, CHILD_INDEX, expected, filteredQuery(mainQuery, bloomFilter));
+        }
+
+        log("string: " + (tookString / NUM_QUERIES) + "ms avg");
+        log("numeric: " + (tookNumeric / NUM_QUERIES) + "ms avg");
+        log("bloom: " + (tookBloom / NUM_QUERIES) + "ms avg");
+        log("");
+    }
+}

--- a/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
@@ -631,47 +631,46 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test", "type", "4").setSource("term", "4"));
 
         CountResponse countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup").lookupType("type").lookupId("1").lookupPath("terms"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup").type("type").id("1").path("terms"))).get();
         assertHitCount(countResponse, 2l);
 
         // same as above, just on the _id...
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("_id").lookupIndex("lookup").lookupType("type").lookupId("1").lookupPath("terms"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("_id").index("lookup").type("type").id("1").path("terms"))).get();
         assertHitCount(countResponse, 2l);
 
         // another search with same parameters...
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup").lookupType("type").lookupId("1").lookupPath("terms"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup").type("type").id("1").path("terms"))).get();
         assertHitCount(countResponse, 2l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup").lookupType("type").lookupId("2").lookupPath("terms"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup").type("type").id("2").path("terms"))).get();
         assertHitCount(countResponse, 1l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup").lookupType("type").lookupId("3").lookupPath("terms"))
-                ).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup").type("type").id("3").path("terms"))).get();
         assertNoFailures(countResponse);
         assertHitCount(countResponse, 2l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup").lookupType("type").lookupId("4").lookupPath("terms"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup").type("type").id("4").path("terms"))).get();
         assertHitCount(countResponse, 0l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup2").lookupType("type").lookupId("1").lookupPath("arr.term"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup2").type("type").id("1").path("arr.term"))).get();
         assertHitCount(countResponse, 2l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup2").lookupType("type").lookupId("2").lookupPath("arr.term"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup2").type("type").id("2").path("arr.term"))).get();
         assertHitCount(countResponse, 1l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").lookupIndex("lookup2").lookupType("type").lookupId("3").lookupPath("arr.term"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("term").index("lookup2").type("type").id("3").path("arr.term"))).get();
         assertHitCount(countResponse, 2l);
 
         countResponse = client().prepareCount("test")
-                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("not_exists").lookupIndex("lookup2").lookupType("type").lookupId("3").lookupPath("arr.term"))).get();
+                .setQuery(filteredQuery(matchAllQuery(), termsLookupFilter("not_exists").index("lookup2").type("type").id("3").path("arr.term"))).get();
         assertHitCount(countResponse, 0l);
     }
 


### PR DESCRIPTION
This PR adds support for generating a terms filter based on the field values
of documents matching a specified lookup query/filter.  The value of the 
configurable "path" field is collected from the field data cache for each 
document matching the lookup query/filter and is then used to filter the main 
query.  This is can also be called a join filter.

This PR abstracts the TermsLookup functionality in order to support multiple
lookup methods.  The existing functionality is moved into FieldTermsLookup and
the new query based lookup is in QueryTermsLookup.  All existing caching 
functionality works with the new query based lookup for increased performance.

During testing of I found that one of the performance bottlenecks was 
generating the Lucene TermsFilter on large sets of terms (probably since
it sorts the terms).  I have created a FieldDataTermsFilter that uses the
field data cache to lookup value of the field being filtered and compare it to
the set of gathered terms.  This significantly increased performance at the 
cost of higher memory usage.  Currently a TermsFilter is used when the number
of filtering terms is less than 1024 and the FieldDataTermsFilter is used
for everything else.  This should eventually be configurable or we need to
perform some test to find the optimal value.

Examples:

Replicate a has_child query by joining on the child's "pid" field to the
parent's "id" field for each child that has the tag "something".

```
curl -XPOST 'http://localhost:9200/parentIndex/_search' -d '{
    "query": {
        "constant_score": {
            "filter": {
                "terms": {
                    "id": {
                        "index": "childIndex",
                        "type": "childType",
                        "path": "pid",
                        "query": {
                            "term": {
                                "tag": "something"
                            }
                        }
                    }
                }
            }
        }
    }
}'
```

Lookup companies that offer products or services mentioning elasticsearch.
Notice that products and services are kept in their own indices.

```
curl -XPOST 'http://localhost:9200/companies/_search' -d '{
    "query": {
        "constant_score": {
            "filter": {
                "terms": {
                    "company_id": {
                        "indices": ["products", "services"],
                        "path": "company_id",
                        "filter": {
                            "term": {
                                "description": "elasticsearch"
                            }
                        }
                    }
                }
            }
        }
    }
}'
```
