### PR TITLE
Proposed fix for the issue #1284 - A new river may not be found immediate...

### DIFF
--- a/src/main/java/org/elasticsearch/river/RiversService.java
+++ b/src/main/java/org/elasticsearch/river/RiversService.java
@@ -216,7 +216,7 @@ public class RiversService extends AbstractLifecycleComponent<RiversService> {
                     closeRiver(riverName);
                     // also, double check and delete the river content if it was deleted (_meta does not exists)
                     try {
-                        client.prepareGet(riverIndexName, riverName.name(), "_meta").setListenerThreaded(true).execute(new ActionListener<GetResponse>() {
+                        client.prepareGet(riverIndexName, riverName.name(), "_meta").setPreference("_primary").setListenerThreaded(true).execute(new ActionListener<GetResponse>() {
                             @Override
                             public void onResponse(GetResponse getResponse) {
                                 if (!getResponse.isExists()) {
@@ -261,7 +261,7 @@ public class RiversService extends AbstractLifecycleComponent<RiversService> {
                 if (rivers.containsKey(routing.riverName())) {
                     continue;
                 }
-                client.prepareGet(riverIndexName, routing.riverName().name(), "_meta").setListenerThreaded(true).execute(new ActionListener<GetResponse>() {
+                client.prepareGet(riverIndexName, routing.riverName().name(), "_meta").setPreference("_primary").setListenerThreaded(true).execute(new ActionListener<GetResponse>() {
                     @Override
                     public void onResponse(GetResponse getResponse) {
                         if (!rivers.containsKey(routing.riverName())) {
@@ -284,7 +284,7 @@ public class RiversService extends AbstractLifecycleComponent<RiversService> {
                             threadPool.schedule(TimeValue.timeValueSeconds(5), ThreadPool.Names.SAME, new Runnable() {
                                 @Override
                                 public void run() {
-                                    client.prepareGet(riverIndexName, routing.riverName().name(), "_meta").setListenerThreaded(true).execute(listener);
+                                    client.prepareGet(riverIndexName, routing.riverName().name(), "_meta").setPreference("_primary").setListenerThreaded(true).execute(listener);
                                 }
                             });
                         } else {

--- a/src/main/java/org/elasticsearch/river/routing/RiversRouter.java
+++ b/src/main/java/org/elasticsearch/river/routing/RiversRouter.java
@@ -106,7 +106,7 @@ public class RiversRouter extends AbstractLifecycleComponent<RiversRouter> imple
                     if (!currentState.routing().hasRiverByName(mappingType)) {
                         // no river, we need to add it to the routing with no node allocation
                         try {
-                            GetResponse getResponse = client.prepareGet(riverIndexName, mappingType, "_meta").execute().actionGet();
+                            GetResponse getResponse = client.prepareGet(riverIndexName, mappingType, "_meta").setPreference("_primary").execute().actionGet();
                             if (getResponse.isExists()) {
                                 String riverType = XContentMapValues.nodeStringValue(getResponse.getSourceAsMap().get("type"), null);
                                 if (riverType == null) {


### PR DESCRIPTION
Proposed fix for the issue #1284 - A new river may not be found immediately. The proposed fix is to get the river metadata from the primary shard, so that it does not wait for the metadata to propagate.
