### PR TITLE
Fix xcontent serialization of timestamp index field

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -238,7 +238,7 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
         }
         builder.startObject(CONTENT_TYPE);
         if (fieldType.indexed() != Defaults.FIELD_TYPE.indexed()) {
-            builder.field("index", fieldType.indexed());
+            builder.field("index", indexTokenizeOptionToString(fieldType.indexed(), fieldType.tokenized()));
         }
         if (fieldType.stored() != Defaults.FIELD_TYPE.stored()) {
             builder.field("store", fieldType.stored());

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -226,7 +226,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
         }
         if (enabledState.enabled) {
             if (fieldType.indexed() != Defaults.FIELD_TYPE.indexed()) {
-                builder.field("index", fieldType.indexed());
+                builder.field("index", indexTokenizeOptionToString(fieldType.indexed(), fieldType.tokenized()));
             }
             if (fieldType.stored() != Defaults.FIELD_TYPE.stored()) {
                 builder.field("store", fieldType.stored());


### PR DESCRIPTION
The index field was serialized as a boolean instead of showing the
'analyed', 'not_analzyed', 'no' options. Fixed by calling
indexTokenizeOptionToString() in the builder.

Closes #3174
