### PR TITLE
Set max open files for systemd startup

### DIFF
--- a/src/rpm/systemd/elasticsearch.service
+++ b/src/rpm/systemd/elasticsearch.service
@@ -5,6 +5,7 @@ Documentation=http://www.elasticsearch.org
 [Service]
 Type=forking
 EnvironmentFile=/etc/sysconfig/elasticsearch
+LimitNOFILE=65535
 User=elasticsearch
 Group=elasticsearch
 PIDFile=/var/run/elasticsearch/elasticsearch.pid


### PR DESCRIPTION
...elasticsearch

Note that EnfironmentFile isn't loaded in time for:

LimitNOFILE=$MAX_OPEN_FILES

to work. Without this elasticsearch has the system default limit (likely
1-4K).
