### PR TITLE
Don't reset TokenStreams twice when highlighting.

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -127,7 +127,6 @@ public class PlainHighlighter implements Highlighter {
                 String text = textToHighlight.toString();
                 Analyzer analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();
                 TokenStream tokenStream = analyzer.tokenStream(mapper.names().indexName(), new FastStringReader(text));
-                tokenStream.reset();
                 if (!tokenStream.hasAttribute(CharTermAttribute.class) || !tokenStream.hasAttribute(OffsetAttribute.class)) {
                     // can't perform highlighting if the stream has no terms (binary token stream) or no offsets
                     continue;


### PR DESCRIPTION
When using PlainHighlighter, TokenStreams are resetted both before highlighting
and at the beginning of highlighting, causing issues with analyzers that read
in reset() such as PatternAnalyzer. This commit removes the call to reset which
was performed before passing the TokenStream to the highlighter.
