### PR TITLE
Distance scoring

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.index.query;
 
+
+import org.elasticsearch.index.query.distancescoring.FunctionScoreQueryBuilder;
+import org.elasticsearch.index.query.distancescoring.ScoreFunctionBuilder;
+
 import java.util.Collection;
 
 import org.elasticsearch.common.Nullable;
@@ -530,6 +534,17 @@ public abstract class QueryBuilders {
         return new CustomScoreQueryBuilder(filterBuilder);
     }
 
+     /**
+     * A query that multiplies the score of the query with a factor computed from the distance of user given field values from a user given reference.
+     *
+     * @param queryBuilder The original query.
+     * @param scoreBuilder The builder for computing the distance dependent multiplier.
+     */
+    public static FunctionScoreQueryBuilder distanceScoreQuery(QueryBuilder queryBuilder, ScoreFunctionBuilder scoreBuilder) {
+        return new FunctionScoreQueryBuilder(queryBuilder, scoreBuilder);
+    }
+    
+    
     public static CustomFiltersScoreQueryBuilder customFiltersScoreQuery(QueryBuilder queryBuilder) {
         return new CustomFiltersScoreQueryBuilder(queryBuilder);
     }

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/DistanceScoringModule.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/DistanceScoringModule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.query.distancescoring;
+
+import java.util.List;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.ExponentialDecayFunctionParser;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.GaussDecayFunctionParser;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.LinearDecayFunctionParser;
+
+import com.google.common.collect.Lists;
+
+/**
+ *
+ */
+public class DistanceScoringModule extends AbstractModule {
+
+    private List<Class<? extends ScoreFunctionParser>> parsers = Lists.newArrayList();
+
+    public DistanceScoringModule() {
+        registerParser(LinearDecayFunctionParser.class);
+        registerParser(GaussDecayFunctionParser.class);
+        registerParser(ExponentialDecayFunctionParser.class);
+    }
+
+    public void registerParser(Class<? extends ScoreFunctionParser> parser) {
+        parsers.add(parser);
+    }
+
+    @Override
+    protected void configure() {
+        Multibinder<ScoreFunctionParser> parserMapBinder = Multibinder.newSetBinder(binder(), ScoreFunctionParser.class);
+        for (Class<? extends ScoreFunctionParser> clazz : parsers) {
+            parserMapBinder.addBinding().to(clazz);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/FunctionScoreQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/FunctionScoreQueryBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.BaseQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+
+public class FunctionScoreQueryBuilder extends BaseQueryBuilder {
+
+    private final QueryBuilder queryBuilder;
+
+    private ScoreFunctionBuilder scoreBuilder;
+
+    /**
+     * A query that multiplies the score computed by another query with a
+     * function centered about a user given reference. The farther the numeric
+     * values of the document are from the user given reference, the lower the
+     * score is weighted.
+     * 
+     * @param queryBuilder
+     *            The query to apply the boost factor to.
+     * @param scoreBuilder
+     */
+    public FunctionScoreQueryBuilder(QueryBuilder queryBuilder, ScoreFunctionBuilder scoreBuilder) {
+        this.queryBuilder = queryBuilder;
+        this.scoreBuilder = scoreBuilder;
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(FunctionScoreQueryParser.NAME);
+        builder.field("query");
+        queryBuilder.toXContent(builder, params);
+        builder.field(((ScoreFunctionBuilder) scoreBuilder).getName());
+        scoreBuilder.toXContent(builder, params);
+        builder.endObject();
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/FunctionScoreQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/FunctionScoreQueryParser.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Set;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParser;
+import org.elasticsearch.index.query.QueryParsingException;
+
+/**
+ *
+ */
+public class FunctionScoreQueryParser implements QueryParser {
+
+    public static final String NAME = "distance_score";
+
+    protected HashMap<String, ScoreFunctionParser> functionParsers;
+
+    @Inject
+    public FunctionScoreQueryParser(Set<ScoreFunctionParser> parsers) {
+
+        functionParsers = new HashMap<String, ScoreFunctionParser>();
+        for (ScoreFunctionParser scoreFunctionParser : parsers) {
+            addParser(scoreFunctionParser);
+        }
+    }
+
+    private void addParser(ScoreFunctionParser scoreFunctionParser) {
+        functionParsers.put(scoreFunctionParser.getName(), scoreFunctionParser);
+    }
+
+    @Override
+    public String[] names() {
+        return new String[] { NAME, Strings.toCamelCase(NAME) };
+    }
+
+    @Override
+    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        XContentParser parser = parseContext.parser();
+
+        Query query = null;
+        String currentFieldName = null;
+        ScoreFunction scoreFunction = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if ("query".equals(currentFieldName)) {
+                    query = parseContext.parseInnerQuery();
+                } else {
+                    ScoreFunctionParser scoreFunctionParser = functionParsers.get(currentFieldName);
+                    if (scoreFunctionParser == null) {
+                        throw new QueryParsingException(parseContext.index(), "[distance_score] query does not support ["
+                                + currentFieldName + "]");
+                    } else {
+                        scoreFunction = scoreFunctionParser.parse(parseContext, parser);
+                    }
+                }
+            }
+        }
+
+        if (scoreFunction == null) {
+            throw new QueryParsingException(parseContext.index(), "[distance_score] requires a function");
+        }
+        if (query == null) {
+            throw new QueryParsingException(parseContext.index(), "[distance_score] requires a 'query'");
+        }
+        FunctionScoreQuery fQuery = new FunctionScoreQuery(query, scoreFunction);
+        fQuery.setBoost(1);
+        return fQuery;
+
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/ScoreFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/ScoreFunctionBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+
+public interface ScoreFunctionBuilder extends ToXContent {
+
+    public String getName();
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/ScoreFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/ScoreFunctionParser.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParsingException;
+
+public interface ScoreFunctionParser {
+
+    public ScoreFunction parse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException;
+
+    /**
+     * Returns the name of the function, for example "linear", "gauss" etc. This
+     * name is used for registering the parser in
+     * {@link FunctionScoreQueryParser}.
+     * */
+    public String getName();
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/CustomDecayFuntion.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/CustomDecayFuntion.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+import org.apache.lucene.search.Explanation;
+
+/**
+ * Implement this interface to provide a decay function that is executed on a
+ * distance. For example, this could be an exponential drop of, a triangle
+ * function or something of the kind. This is used, for example, by
+ * {@link GaussDecayFunctionParser}.
+ * 
+ * */
+
+public interface CustomDecayFuntion {
+    public double evaluate(double value, double scale);
+
+    public Explanation explainFunction(String distance, double distanceVal, double scale);
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/ExponentialDecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/ExponentialDecayFunctionBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+public class ExponentialDecayFunctionBuilder extends MultiplyingFunctionBuilder {
+
+    private static String NAME = new String("exp");
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/ExponentialDecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/ExponentialDecayFunctionParser.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+import org.apache.lucene.search.ComplexExplanation;
+import org.apache.lucene.search.Explanation;
+
+public class ExponentialDecayFunctionParser extends MultiplyingFunctionParser {
+
+    public static String NAME = "exp";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    static CustomDecayFuntion distanceFunction = new ExponentialDecayScoreFunction();
+
+    @Override
+    public CustomDecayFuntion getDecayFunction() {
+        return distanceFunction;
+    }
+
+    static class ExponentialDecayScoreFunction implements CustomDecayFuntion {
+
+        @Override
+        public double evaluate(double value, double scale) {
+            return Math.exp(-Math.abs(value) / scale);
+        }
+
+        @Override
+        public Explanation explainFunction(String distance, double distanceVal, double scale) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setValue((float) evaluate(distanceVal, scale));
+            ce.setDescription("exp(- abs(" + distance + ")/" + scale + ")");
+            return ce;
+        }
+
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/GaussDecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/GaussDecayFunctionBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+public class GaussDecayFunctionBuilder extends MultiplyingFunctionBuilder {
+
+    private static String NAME = new String("gauss");
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/GaussDecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/GaussDecayFunctionParser.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+import org.apache.lucene.search.ComplexExplanation;
+import org.apache.lucene.search.Explanation;
+
+public class GaussDecayFunctionParser extends MultiplyingFunctionParser {
+
+    static CustomDecayFuntion distanceFunction = new GaussScoreFunction();
+    public static String NAME = "gauss";
+
+    @Override
+    public CustomDecayFuntion getDecayFunction() {
+        return distanceFunction;
+    }
+
+    static class GaussScoreFunction implements CustomDecayFuntion {
+
+        @Override
+        public double evaluate(double value, double scale) {
+            return (float) Math.exp(-0.5 * (value * value) / Math.pow(scale, 2.0));
+        }
+
+        @Override
+        public Explanation explainFunction(String distance, double distanceVal, double scale) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setValue((float) evaluate(distanceVal, scale));
+            ce.setDescription("exp(-0.5*pow(" + distance + ",2.0)/" + scale + ")");
+            return ce;
+
+        }
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/LinearDecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/LinearDecayFunctionBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+public class LinearDecayFunctionBuilder extends MultiplyingFunctionBuilder {
+
+    private static String NAME = new String("lin");
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/LinearDecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/LinearDecayFunctionParser.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+import org.apache.lucene.search.ComplexExplanation;
+import org.apache.lucene.search.Explanation;
+
+public class LinearDecayFunctionParser extends MultiplyingFunctionParser {
+
+    public static String NAME = "lin";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    static CustomDecayFuntion distanceFunction = new LinearDecayScoreFunction();
+
+    @Override
+    public CustomDecayFuntion getDecayFunction() {
+        return distanceFunction;
+    }
+
+    static class LinearDecayScoreFunction implements CustomDecayFuntion {
+
+        @Override
+        public double evaluate(double value, double scale) {
+            return Math.max(0.0, (scale - Math.abs(value)) / scale);
+        }
+
+        @Override
+        public Explanation explainFunction(String distance, double distanceVal, double scale) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setValue((float) evaluate(distanceVal, scale));
+            ce.setDescription("max(0.0, ((" + scale + " - abs(" + distance + "))/" + scale + ")");
+            return ce;
+        }
+
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/MultiplyingFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/MultiplyingFunctionBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.distancescoring.ScoreFunctionBuilder;
+
+public abstract class MultiplyingFunctionBuilder implements ScoreFunctionBuilder {
+
+    List<Var> vars = null;
+
+    public void addVariable(String fieldName, String scale, String reference) {
+        if (vars == null) {
+            vars = new ArrayList<Var>();
+        }
+        vars.add(new Var(fieldName, reference, scale));
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        for (Var var : vars) {
+            builder.field(var.fieldName);
+            builder.startObject();
+            builder.field("reference", var.reference);
+            builder.field("scale", var.scale);
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    class Var {
+        String fieldName;
+        String reference;
+        String scale;
+
+        public Var(String fieldName, String reference, String scale) {
+            this.fieldName = fieldName;
+            this.reference = reference;
+            this.scale = scale;
+        }
+    }
+
+    public void addGeoVariable(String fieldName, double lat, double lon, String scale) {
+
+        String geoLoc = Double.toString(lat) + ", " + Double.toString(lon);
+        addVariable(fieldName, scale, geoLoc);
+
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/MultiplyingFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/distancescoring/simplemultiply/MultiplyingFunctionParser.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.distancescoring.simplemultiply;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.ComplexExplanation;
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.ElasticSearchParseException;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.DoubleValues;
+import org.elasticsearch.index.fielddata.GeoPointValues;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper.GeoStringFieldMapper;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.distancescoring.ScoreFunctionParser;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ * This class provides the basic functionality needed for adding a multiplying
+ * scoring function. Suppose you have several numeric fields and you want to
+ * score the documents according to some decay function from a reference point.
+ * 
+ * This parser accepts input of the form
+ * 
+ * <pre>
+ * {@code}
+ * { 
+ *      "fieldname1" : {"reference" = "someValue", "scale" = "someValue"} 
+ *      "fieldname2" : {"reference" = "someValue", "scale" = "someValue"} 
+ * }
+ * </pre>
+ * 
+ * "reference" here refers to the reference point and "scale" to the level of
+ * uncertainty you have in your reference.
+ * <p>
+ * 
+ * For example, you might want to retrieve an event that took place around the
+ * 20 May 2010 somewhere near Berlin. You are mainly interested in events that
+ * are close to the 20 May 2010 but you are unsure about your guess, maybe it
+ * was a week before or after that. Your "reference" for the date field would be
+ * "20 May 2010" and your "scale" would be "7d".
+ * 
+ * This class parses the input and creates a scoring function that multiplies a
+ * custom scoring function for each field given.
+ * <p>
+ * To write a new scoring function, create a new class that inherits from this
+ * one and implement the getDistanceFuntion(). Furthermore, you might need a
+ * Builder to support the java API. To do so, override the getName() in
+ * {@link MultiplyingFunctionBuilder}.
+ * <p>
+ * See {@link GaussDecayFunctionBuilder} and {@link GaussDecayFunctionParser}
+ * for an example. The parser furthermore needs to be registered in the
+ * {@link org.elasticsearch.index.query.distancescoring.DistanceScoringModule
+ * DistanceScoringModule}. See
+ * {@link org.elasticsearch.test.integration.search.distancescore.CustomDistanceScorePlugin
+ * CustomDistanceScorePlugin} and
+ * {@link org.elasticsearch.test.integration.search.distancescore.CustomDistanceScorePlugin
+ * DistanceScorePluginTest DistanceScorePluginTest} for an example on how to
+ * write your own function and plugin.
+ * 
+ * **/
+
+public abstract class MultiplyingFunctionParser implements ScoreFunctionParser {
+
+    /**
+     * Override this function if you want to produce your own scorer.
+     * */
+    public abstract CustomDecayFuntion getDecayFunction();
+
+    /**
+     * Parses bodies of the kind
+     * 
+     * <pre>
+     * {@code}
+     * { 
+     *      "fieldname1" : {"reference" = "someValue","scale" = "someValue"},
+     *      "fieldname1" : {"reference" = "someValue","scale" = "someValue"} 
+     * }
+     * </pre>
+     * 
+     * For each field, an Abstract score function is created. From these the
+     * MultplyingScoreFunction is created.
+     * 
+     * */
+    @Override
+    public ScoreFunction parse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {
+        String currentFieldName = null;
+        XContentParser.Token token;
+        List<ScoreFunction> vars = new ArrayList<ScoreFunction>();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+
+                // parse per field the reference and scale value
+                ScoreFunction var = parseVariable(currentFieldName, parser, parseContext);
+                vars.add(var);
+            } else {
+                throw new ElasticSearchParseException("must start an object here!");
+            }
+        }
+        ScoreFunction[] functions = new ScoreFunction[vars.size()];
+        return new MultplyingScoreFunction(vars.toArray(functions));
+    }
+
+    // parses a single field with reference and scale parameter
+    private ScoreFunction parseVariable(String fieldName, XContentParser parser, QueryParseContext parseContext) throws IOException {
+
+        // now, the field must exist, else we later cannot read the value for
+        // the doc
+        MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
+        if (smartMappers == null || !smartMappers.hasMapper()) {
+            throw new QueryParsingException(parseContext.index(), "failed to find field [" + fieldName + "]");
+        }
+        FieldMapper<?> mapper = smartMappers.mapper();
+
+        // dates and time need special handling
+        if (mapper instanceof DateFieldMapper) {
+            return parseDateVariable(fieldName, parser, parseContext, (DateFieldMapper) mapper);
+        } else if (mapper instanceof GeoStringFieldMapper) {
+            return parseGeoVariable(fieldName, parser, parseContext, (GeoStringFieldMapper) mapper);
+        } else if (mapper instanceof NumberFieldMapper<?>) {
+            return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper<?>) mapper);
+        } else {
+            throw new QueryParsingException(parseContext.index(), "field of type " + mapper.fieldType() + " not supported");
+        }
+    }
+
+    private ScoreFunction parseNumberVariable(String fieldName, XContentParser parser, QueryParseContext parseContext,
+            NumberFieldMapper<?> mapper) throws IOException {
+        XContentParser.Token token;
+        String parameterName = null;
+        String scaleString = null;
+        String referenceString = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                parameterName = parser.currentName();
+            } else if (parameterName.equals("scale")) {
+                scaleString = parser.text();
+            } else if (parameterName.equals("reference")) {
+                referenceString = parser.text();
+            } else {
+                throw new ElasticSearchParseException("Parameter " + parameterName + " not supported!");
+            }
+        }
+        double reference = mapper.value(referenceString).doubleValue();
+        double scale = mapper.value(scaleString).doubleValue();
+        IndexNumericFieldData<?> numericFieldData = parseContext.fieldData().getForField(mapper);
+        return new NumericFieldDataScoreFunction(scale, getDecayFunction(), reference, numericFieldData);
+    }
+
+    private ScoreFunction parseGeoVariable(String fieldName, XContentParser parser, QueryParseContext parseContext,
+            GeoStringFieldMapper mapper) throws IOException {
+        XContentParser.Token token;
+        String parameterName = null;
+        GeoPoint reference = new GeoPoint();
+        String scaleString = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                parameterName = parser.currentName();
+            } else if (parameterName.equals("scale")) {
+                scaleString = parser.text();
+            } else if (parameterName.equals("reference")) {
+                reference = GeoPoint.parse(parser);
+            } else {
+                throw new ElasticSearchParseException("Parameter " + parameterName + " not supported!");
+            }
+        }
+
+        if (scaleString == null) {
+            scaleString = "1km";
+        }
+        if (reference == null) {
+            throw new ElasticSearchParseException("Need a geo point that gives the loacation!");
+        }
+        double scale = DistanceUnit.parse(scaleString, DistanceUnit.METERS, DistanceUnit.METERS);
+
+        IndexGeoPointFieldData<?> indexFieldData = parseContext.fieldData().getForField(mapper);
+        return new GeoFieldDataScoreFunction(scale, getDecayFunction(), reference, indexFieldData);
+
+    }
+
+    private ScoreFunction parseDateVariable(String fieldName, XContentParser parser, QueryParseContext parseContext,
+            DateFieldMapper dateFieldMapper) throws IOException {
+        XContentParser.Token token;
+        String parameterName = null;
+        String scaleString = null;
+        String referenceString = null;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                parameterName = parser.currentName();
+            } else if (parameterName.equals("scale")) {
+                scaleString = parser.text();
+            } else if (parameterName.equals("reference")) {
+                referenceString = parser.text();
+            } else {
+                throw new ElasticSearchParseException("Parameter " + parameterName + " not supported!");
+            }
+        }
+        long reference = SearchContext.current().nowInMillis();
+        if (referenceString != null) {
+            reference = dateFieldMapper.value(referenceString).longValue();
+        }
+        double scale = 1.e7;
+        if (scaleString != null) {
+            TimeValue val = TimeValue.parseTimeValue(scaleString, TimeValue.timeValueHours(24));
+            scale = val.getMillis();
+        }
+        IndexNumericFieldData<?> numericFieldData = parseContext.fieldData().getForField(dateFieldMapper);
+        return new NumericFieldDataScoreFunction(scale, getDecayFunction(), reference, numericFieldData);
+    }
+
+    /**
+     * This class does the actual scoring. It gathers scores for each field that
+     * the user provided and multiplies them.
+     * 
+     * */
+    public static class MultplyingScoreFunction implements ScoreFunction {
+
+        private final ScoreFunction[] functions;
+
+        public MultplyingScoreFunction(ScoreFunction[] functions) {
+            this.functions = functions;
+        }
+
+        @Override
+        public void setNextReader(AtomicReaderContext context) {
+            for (ScoreFunction scoreFunction : functions) {
+                scoreFunction.setNextReader(context);
+            }
+        }
+
+        @Override
+        public float score(int docId, float subQueryScore) {
+            return subQueryScore * factor(docId);
+        }
+
+        @Override
+        public float factor(int docId) {
+            float multScore = 1.0f;
+            for (ScoreFunction scoreFunction : functions) {
+                multScore *= scoreFunction.factor(docId);
+            }
+            return multScore;
+        }
+
+        @Override
+        public Explanation explainScore(int docId, Explanation subQueryExpl) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setMatch(true);
+            ce.setValue(factor(docId) * subQueryExpl.getValue());
+            ce.setDescription(subQueryExpl.getValue() + "*Product of field functions for doc " + docId + ":");
+            for (ScoreFunction sf : functions) {
+                ce.addDetail(sf.explainFactor(docId));
+            }
+            return ce;
+        }
+
+        @Override
+        public Explanation explainFactor(int docId) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setMatch(true);
+            ce.setValue(factor(docId));
+            ce.setDescription("Product of field functions for doc " + docId + ":");
+            for (ScoreFunction sf : functions) {
+                ce.addDetail(sf.explainFactor(docId));
+            }
+            return ce;
+        }
+    }
+
+    static class GeoFieldDataScoreFunction extends AbstractDistanceScoreFunction {
+
+        GeoPoint reference = null;
+        IndexGeoPointFieldData<?> fieldData = null;
+        GeoPointValues geoPointValues = null;
+
+        private GeoDistance distFunction;
+
+        public GeoFieldDataScoreFunction(double scale, CustomDecayFuntion func, GeoPoint reference, IndexGeoPointFieldData<?> fieldData) {
+            super(scale, func);
+            this.reference = reference;
+            this.distFunction = GeoDistance.fromString("arc");
+            this.fieldData = fieldData;
+        }
+
+        @Override
+        public void setNextReader(AtomicReaderContext context) {
+            geoPointValues = fieldData.load(context).getGeoPointValues();
+        }
+
+        @Override
+        protected double distance(int docId) {
+            if (geoPointValues.hasValue(docId)) {
+                final GeoPoint other = geoPointValues.getValue(docId);
+                return distFunction.calculate(reference.lat(), reference.lon(), other.lat(), other.lon(), DistanceUnit.METERS);
+            } else {
+                return Float.MAX_VALUE;
+            }
+        }
+
+        @Override
+        protected String getDistanceString(int docId) {
+            final GeoPoint other = geoPointValues.getValue(docId);
+            return "arcDistance(" + other + "(=doc value), " + reference + ") = " + distance(docId);
+
+        }
+
+        @Override
+        protected String getFieldName() {
+
+            return fieldData.getFieldNames().fullName();
+
+        }
+    }
+
+    static class NumericFieldDataScoreFunction extends AbstractDistanceScoreFunction {
+
+        IndexNumericFieldData<?> fieldData = null;
+        private DoubleValues valueOfDoc;
+
+        double reference = 0;
+
+        public NumericFieldDataScoreFunction(double scale, CustomDecayFuntion func, double reference, IndexNumericFieldData<?> valueOfDoc) {
+            super(scale, func);
+            this.fieldData = valueOfDoc;
+            this.reference = reference;
+        }
+
+        public void setNextReader(AtomicReaderContext context) {
+            this.valueOfDoc = this.fieldData.load(context).getDoubleValues();
+        }
+
+        @Override
+        protected double distance(int docId) {
+
+            if (valueOfDoc.hasValue(docId)) {
+                return valueOfDoc.getValue(docId) - reference;
+
+            } else {
+                return Float.MAX_VALUE;
+            }
+
+        }
+
+        @Override
+        protected String getDistanceString(int docId) {
+
+            return "(" + valueOfDoc.getValue(docId) + "(=doc value) - " + reference + ")";
+        }
+
+        @Override
+        protected String getFieldName() {
+            return fieldData.getFieldNames().fullName();
+        }
+    }
+
+    /**
+     * This is the base class for scoring a single field.
+     * 
+     * */
+    public static abstract class AbstractDistanceScoreFunction implements ScoreFunction {
+
+        private final double scale;
+        private final CustomDecayFuntion func;
+
+        public AbstractDistanceScoreFunction(double scale, CustomDecayFuntion func) {
+            this.scale = scale;
+            this.func = func;
+        }
+
+        @Override
+        public float score(int docId, float subQueryScore) {
+            return subQueryScore * factor(docId);
+        }
+
+        @Override
+        public float factor(int docId) {
+            double value = distance(docId);
+            return (float) func.evaluate(value, scale);
+        }
+
+        /**
+         * This function computes the distance from a defined reference. Since
+         * the value of the document is read from the index, it cannot be
+         * guaranteed that the value actually exists. If it does not, we assume
+         * the user is not interested in the document since it cannot be scored
+         * and therefore this function should return Float.MAX_VALUE in this
+         * case.
+         * */
+        protected abstract double distance(int docId);
+
+        protected abstract String getDistanceString(int docId);
+
+        protected abstract String getFieldName();
+
+        @Override
+        public Explanation explainScore(int docId, Explanation subQueryExpl) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setValue(subQueryExpl.getValue() * factor(docId));
+            ce.setMatch(true);
+            ce.setDescription("subQueryScore*Function for field " + getFieldName() + ":");
+            ce.addDetail(func.explainFunction(getDistanceString(docId), distance(docId), scale));
+            return ce;
+        }
+
+        @Override
+        public Explanation explainFactor(int docId) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setValue(factor(docId));
+            ce.setMatch(true);
+            ce.setDescription("Function for field " + getFieldName() + ":");
+            ce.addDetail(func.explainFunction(getDistanceString(docId), distance(docId), scale));
+            return ce;
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
+++ b/src/main/java/org/elasticsearch/indices/query/IndicesQueriesModule.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.Multibinder;
 import org.elasticsearch.index.query.*;
+import org.elasticsearch.index.query.distancescoring.FunctionScoreQueryParser;
 
 import java.util.Set;
 
@@ -104,6 +105,7 @@ public class IndicesQueriesModule extends AbstractModule {
         qpBinders.addBinding().to(IndicesQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(CommonTermsQueryParser.class).asEagerSingleton();
         qpBinders.addBinding().to(SpanMultiTermQueryParser.class).asEagerSingleton();
+        qpBinders.addBinding().to(FunctionScoreQueryParser.class).asEagerSingleton();
 
         if (ShapesAvailability.JTS_AVAILABLE) {
             qpBinders.addBinding().to(GeoShapeQueryParser.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.inject.SpawnModules;
+import org.elasticsearch.index.query.distancescoring.DistanceScoringModule;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.dfs.DfsPhase;
@@ -45,7 +46,7 @@ public class SearchModule extends AbstractModule implements SpawnModules {
 
     @Override
     public Iterable<? extends Module> spawnModules() {
-        return ImmutableList.of(new TransportSearchModule(), new FacetModule(), new HighlightModule(), new SuggestModule());
+        return ImmutableList.of(new TransportSearchModule(), new FacetModule(), new HighlightModule(), new SuggestModule(), new DistanceScoringModule());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/integration/search/distancescore/CustomDistanceScoreBuilder.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/distancescore/CustomDistanceScoreBuilder.java
@@ -1,0 +1,14 @@
+package org.elasticsearch.test.integration.search.distancescore;
+
+import org.elasticsearch.index.query.distancescoring.simplemultiply.MultiplyingFunctionBuilder;
+
+public class CustomDistanceScoreBuilder extends MultiplyingFunctionBuilder {
+
+    private static String NAME = new String("linear_mult");
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/search/distancescore/CustomDistanceScoreParser.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/distancescore/CustomDistanceScoreParser.java
@@ -1,0 +1,44 @@
+package org.elasticsearch.test.integration.search.distancescore;
+
+import org.apache.lucene.search.ComplexExplanation;
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.CustomDecayFuntion;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.MultiplyingFunctionParser;
+
+public class CustomDistanceScoreParser extends MultiplyingFunctionParser {
+
+    public static String NAME = "linear_mult";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    static CustomDecayFuntion distanceFunction;
+
+    public CustomDistanceScoreParser() {
+        distanceFunction = new LinearMultScoreFunction();
+    }
+
+    @Override
+    public CustomDecayFuntion getDecayFunction() {
+        return distanceFunction;
+    }
+
+    static class LinearMultScoreFunction implements CustomDecayFuntion {
+        LinearMultScoreFunction() {
+        }
+
+        @Override
+        public double evaluate(double value, double scale) {
+            return (float) Math.abs(value);
+        }
+
+        @Override
+        public Explanation explainFunction(String distanceString, double distanceVal, double scale) {
+            ComplexExplanation ce = new ComplexExplanation();
+            ce.setDescription("No explanaition");
+            return ce;
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/search/distancescore/CustomDistanceScorePlugin.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/distancescore/CustomDistanceScorePlugin.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.integration.search.distancescore;
+
+import org.elasticsearch.index.query.distancescoring.DistanceScoringModule;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+/**
+ *
+ */
+public class CustomDistanceScorePlugin extends AbstractPlugin {
+
+    @Override
+    public String name() {
+        return "test-plugin-distance-score";
+    }
+
+    @Override
+    public String description() {
+        return "Distance score plugin to test pluggable implementation";
+    }
+
+    public void onModule(DistanceScoringModule scoreModule) {
+        scoreModule.registerParser(CustomDistanceScoreParser.class);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/search/distancescore/DistanceScorePluginTest.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/distancescore/DistanceScorePluginTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.search.distancescore;
+
+import static org.elasticsearch.client.Requests.indexRequest;
+import static org.elasticsearch.client.Requests.searchRequest;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.distanceScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.MultiplyingFunctionBuilder;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ *
+ */
+public class DistanceScorePluginTest extends AbstractNodesTests {
+
+    private Client client;
+
+    @BeforeClass
+    public void createNodes() throws Exception {
+        ImmutableSettings.Builder settings = settingsBuilder().put("plugin.types", CustomDistanceScorePlugin.class.getName());
+        startNode("server1", settings);
+        client = client("server1");
+        client.admin()
+                .indices()
+                .prepareCreate("test")
+                .addMapping(
+                        "type1",
+                        jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test")
+                                .field("type", "string").endObject().startObject("num1").field("type", "date").endObject().endObject()
+                                .endObject().endObject()).execute().actionGet();
+        client.admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+    }
+
+    @AfterClass
+    public void closeNodes() {
+        client.close();
+        closeAllNodes();
+    }
+
+    @Test
+    public void testPlugin() throws Exception {
+
+        client.index(
+                indexRequest("test").type("type1").id("1")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-26").endObject())).actionGet();
+        client.index(
+                indexRequest("test").type("type1").id("2")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-27").endObject())).actionGet();
+
+        client.admin().indices().prepareRefresh().execute().actionGet();
+        MultiplyingFunctionBuilder gfb = new CustomDistanceScoreBuilder();
+        gfb.addVariable("num1", "+1d", "2013-05-28");
+
+        ActionFuture<SearchResponse> response = client.search(searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
+                searchSource().explain(false).query(distanceScoreQuery(termQuery("test", "value"), gfb))));
+
+        SearchResponse sr = response.actionGet();
+        ElasticsearchAssertions.assertNoFailures(sr);
+        SearchHits sh = sr.getHits();
+
+        assertThat(sh.hits().length, equalTo(2));
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(1).getId(), equalTo("2"));
+        
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/integration/search/distancescore/DistanceScoreTest.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/distancescore/DistanceScoreTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.search.distancescore;
+
+import static org.elasticsearch.client.Requests.indexRequest;
+import static org.elasticsearch.client.Requests.searchRequest;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.distanceScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.GaussDecayFunctionBuilder;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.LinearDecayFunctionBuilder;
+import org.elasticsearch.index.query.distancescoring.simplemultiply.MultiplyingFunctionBuilder;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.test.integration.AbstractSharedClusterTest;
+import org.testng.annotations.Test;
+
+public class DistanceScoreTest extends AbstractSharedClusterTest {
+
+    @Test
+    public void testDistanceScoreTime() throws Exception {
+
+        createIndexMapped("test", "type1", "test", "string", "num1", "date");
+        ensureYellow();
+        client().index(
+                indexRequest("test").type("type1").id("1")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-27").endObject())).actionGet();
+        client().index(
+                indexRequest("test").type("type1").id("2")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-28").endObject())).actionGet();
+        refresh();
+
+        MultiplyingFunctionBuilder gfb = new GaussDecayFunctionBuilder();
+        gfb.addVariable("num1", "+1d", "2013-05-28");
+
+        ActionFuture<SearchResponse> response = client().search(
+                searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
+                        searchSource().explain(true).query(distanceScoreQuery(termQuery("test", "value"), gfb))));
+
+        SearchResponse sr = response.actionGet();
+        ElasticsearchAssertions.assertNoFailures(sr);
+        SearchHits sh = sr.getHits();
+        assertThat(sh.hits().length, equalTo(2));
+        assertThat(sh.getAt(0).getId(), equalTo("2"));
+        assertThat(sh.getAt(1).getId(), equalTo("1"));
+        System.out.println(sh.getAt(0).explanation());
+        System.out.println(sh.getAt(1).explanation());
+
+
+    }
+
+    @Test
+    public void testLinearScoring() throws Exception {
+
+        createIndexMapped("test", "type1", "test", "string", "num1", "date");
+        ensureYellow();
+        client().index(
+                indexRequest("test").type("type1").id("1")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-27").endObject())).actionGet();
+        client().index(
+                indexRequest("test").type("type1").id("2")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-28").endObject())).actionGet();
+        client().index(
+                indexRequest("test").type("type1").id("3")
+                        .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-30").endObject())).actionGet();
+
+        refresh();
+
+        MultiplyingFunctionBuilder gfb = new LinearDecayFunctionBuilder();
+        gfb.addVariable("num1", "+3d", "2013-05-28");
+
+        ActionFuture<SearchResponse> response = client().search(
+                searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
+                        searchSource().explain(true).query(distanceScoreQuery(termQuery("test", "value"), gfb))));
+
+        SearchResponse sr = response.actionGet();
+        ElasticsearchAssertions.assertNoFailures(sr);
+        SearchHits sh = sr.getHits();
+        assertThat(sh.hits().length, equalTo(3));
+        assertThat(sh.getAt(0).getId(), equalTo("2"));
+        assertThat(sh.getAt(1).getId(), equalTo("1"));
+        assertThat(sh.getAt(2).getId(), equalTo("3"));
+        System.out.println(sh.getAt(0).explanation());
+        System.out.println(sh.getAt(1).explanation());
+
+
+    }
+
+    @Test
+    public void testDistanceScoreGeo() throws Exception {
+
+        createIndexMapped("test", "type1", "test", "string", "loc", "geo_point");
+        ensureYellow();
+        client().index(
+                indexRequest("test").type("type1").id("1")
+                        .source(jsonBuilder().startObject().field("test", "value").array("loc", 10, 20).endObject())).actionGet();
+        client().index(
+                indexRequest("test").type("type1").id("2")
+                        .source(jsonBuilder().startObject().field("test", "value").array("loc", 20, 30).endObject())).actionGet();
+        refresh();
+
+        MultiplyingFunctionBuilder gfb = new GaussDecayFunctionBuilder();
+        gfb.addGeoVariable("loc", 11, 20, "100km");
+
+        ActionFuture<SearchResponse> response = client().search(
+                searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
+                        searchSource().explain(false).query(termQuery("test", "value"))));
+        SearchResponse sr = response.actionGet();
+        SearchHits sh = sr.getHits();
+        assertThat(sh.getTotalHits(), equalTo(2l));
+
+        response = client().search(
+                searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
+                        searchSource().explain(true).query(distanceScoreQuery(termQuery("test", "value"), gfb))));
+        sr = response.actionGet();
+        sh = sr.getHits();
+        assertThat(sh.getTotalHits(), equalTo(2l));
+        assertThat(sh.hits().length, equalTo(2));
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(1).getId(), equalTo("2"));
+        System.out.println(sh.getAt(0).explanation());
+        System.out.println(sh.getAt(1).explanation());
+
+
+    }
+
+}


### PR DESCRIPTION
# 

It might sometimes be desirable to have a tool available that allows to multiply the original score for a document with a function that decays depending on the distance of a numeric field value of the document from a user given reference.

To use distance scoring on a query that has numerical fields, the user has to define
1. a reference and
2. a scale

for each field you want the function applied on. A reference is needed to define a distance for the document and a scale to define the rate of decay.

For each field in each found document, a decay function is be computed. The original score of the query is then multiplied with the individual function values computed for the fields. Distance scoring in this case behaves like a range query with smoothed box edges.

Distance scoring can be applied for an arbitrary number of numeric fields.
## Example

Suppose you are searching for a hotel in a certain town. Your budget is limited. Also, you would like the hotel to be close to the town center, so the farther the hotel is from the desired location the less likely you are to check in.
You would like the query results that match your criterion (for example, "hotel, Nancy, non-smoker") to be scored with respect to distance to the town center and also the price.

Intuitively, you would like to define the town center as the origin and maybe you are willing to walk 2km to the town center from the hotel.
In this case your _reference_ for the location field is the town center and the _scale_ is ~2km.

If your budget is low, you would probably prefer something cheap above something expensive.
For the price field, the _reference_ would be 0 Euros and the _scale_ depends on how much you are willing to pay, for example 20 Euros.
## Usage

In the above example, the fields might be called "price" for the price of the hotel and "location" for the coordinates of this hotel.

To apply distance scoring, embed any query in a distance_score query like this:

```
curl 'localhost:9200/hotels/_search/' -d '{
    "query" : {
        "distance_score" : {
            "query" : {
                 "match": { "properties": "balcony" }
            },
            "gauss" : {
                "location" : {
                    "reference": "11, 12",
                    "scale" : "2km"
                },
                "price" : {
                    "reference": "0",
                    "scale" : "20"
                }
            }
        }
    }
}'
```

The parameters (reference and scale) for the function (here is is "gauss") are given after the query for each field. Three different functions can be applied: Gauss ("gauss"), linear decay ("lin") and exponential decay ("exp").
## Supported fields

Only single valued numeric fields, including time and geo locations, are be supported.
## What is a field is missing?

Is the numeric field is missing in the document, that field will not be taken into account at all for this document. The function value for this field is set to 1 for this document.

Closes #3307
