### PR TITLE
Check for packaged config file in plugin install script

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -21,6 +21,14 @@ ES_HOME=`dirname "$SCRIPT"`/..
 # make ELASTICSEARCH_HOME absolute
 ES_HOME=`cd "$ES_HOME"; pwd`
 
+# if there is no configuration file in ES_HOME, we might have a packaged version and use it for getting the correct plugin path
+if [ ! -e $ES_HOME/config/elasticsearch.yml ] && [ -e /etc/elasticsearch/elasticsearch.yml ]; then
+  if [ -z $JAVA_OPTS ] ; then
+    JAVA_OPTS="-Des.default.config=/etc/elasticsearch/elasticsearch.yml"
+  elif [ -n $JAVA_OPTS ] && [ ! $JAVA_OPTS =~ " -Des.default.config=" ] ; then
+    JAVA_OPTS="$JAVA_OPTS -Des.default.config=/etc/elasticsearch/elasticsearch.yml"
+  fi
+fi
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA=$JAVA_HOME/bin/java


### PR DESCRIPTION
In case you are running the plugin command from a packaged installation
like the debian or RPM package, a change of the path.plugins directory
in the elasticsearch.yml directory was ignored, because it was not loaded.

This change checks for the existence of /etc/elasticsearch/elasticsearch.yml
and the absence of $ES_HOME/config/elasticsearch.yml - in that case a package
installation is assumed and the -Des.default.config parameter is appended to
the JAVA_OPTS if it does not exist yet.

Closes #3304
