### PR TITLE
Added support for multiple indices in open/close index apis

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.close;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,9 +37,9 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  */
 public class CloseIndexRequest extends MasterNodeOperationRequest<CloseIndexRequest> {
 
-    private String index;
-
+    private String[] indices;
     private TimeValue timeout = timeValueSeconds(10);
+    private IgnoreIndices ignoreIndices = IgnoreIndices.DEFAULT;
 
     CloseIndexRequest() {
     }
@@ -46,28 +47,34 @@ public class CloseIndexRequest extends MasterNodeOperationRequest<CloseIndexRequ
     /**
      * Constructs a new delete index request for the specified index.
      */
-    public CloseIndexRequest(String index) {
-        this.index = index;
+    public CloseIndexRequest(String... indices) {
+        this.indices = indices;
     }
 
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (index == null) {
+        if (indices == null || indices.length == 0) {
             validationException = addValidationError("index is missing", validationException);
         }
         return validationException;
     }
 
     /**
-     * The index to delete.
+     * The indices to be closed
+     * @return the indices to be closed
      */
-    String index() {
-        return index;
+    String[] indices() {
+        return indices;
     }
 
-    public CloseIndexRequest index(String index) {
-        this.index = index;
+    /**
+     * Sets the indices to be closed
+     * @param indices the indices to be closed
+     * @return the request itself
+     */
+    public CloseIndexRequest indices(String... indices) {
+        this.indices = indices;
         return this;
     }
 
@@ -96,17 +103,38 @@ public class CloseIndexRequest extends MasterNodeOperationRequest<CloseIndexRequ
         return timeout(TimeValue.parseTimeValue(timeout, null));
     }
 
+
+    /**
+     * Specifies what type of requested indices to ignore. For example indices that don't exist.
+     * @return the desired behaviour regarding indices to ignore
+     */
+    public IgnoreIndices ignoreIndices() {
+        return ignoreIndices;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore. For example indices that don't exist.
+     * @param ignoreIndices the desired behaviour regarding indices to ignore
+     * @return the request itself
+     */
+    public CloseIndexRequest ignoreIndices(IgnoreIndices ignoreIndices) {
+        this.ignoreIndices = ignoreIndices;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
+        indices = in.readStringArray();
         timeout = readTimeValue(in);
+        ignoreIndices = IgnoreIndices.fromId(in.readByte());
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
+        out.writeStringArray(indices);
         timeout.writeTo(out);
+        out.writeByte(ignoreIndices.id());
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.close;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
@@ -34,12 +35,17 @@ public class CloseIndexRequestBuilder extends MasterNodeOperationRequestBuilder<
         super((InternalIndicesAdminClient) indicesClient, new CloseIndexRequest());
     }
 
-    public CloseIndexRequestBuilder(IndicesAdminClient indicesClient, String index) {
-        super((InternalIndicesAdminClient) indicesClient, new CloseIndexRequest(index));
+    public CloseIndexRequestBuilder(IndicesAdminClient indicesClient, String... indices) {
+        super((InternalIndicesAdminClient) indicesClient, new CloseIndexRequest(indices));
     }
 
-    public CloseIndexRequestBuilder setIndex(String index) {
-        request.index(index);
+    /**
+     * Sets the indices to be closed
+     * @param indices the indices to be closed
+     * @return the request itself
+     */
+    public CloseIndexRequestBuilder setIndices(String... indices) {
+        request.indices(indices);
         return this;
     }
 
@@ -58,6 +64,16 @@ public class CloseIndexRequestBuilder extends MasterNodeOperationRequestBuilder<
      */
     public CloseIndexRequestBuilder setTimeout(String timeout) {
         request.timeout(timeout);
+        return this;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore. For example indices that don't exist.
+     * @param ignoreIndices the desired behaviour regarding indices to ignore
+     * @return the request itself
+     */
+    public CloseIndexRequestBuilder setIgnoreIndices(IgnoreIndices ignoreIndices) {
+        request.ignoreIndices(ignoreIndices);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.open;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
@@ -34,12 +35,17 @@ public class OpenIndexRequestBuilder extends MasterNodeOperationRequestBuilder<O
         super((InternalIndicesAdminClient) indicesClient, new OpenIndexRequest());
     }
 
-    public OpenIndexRequestBuilder(IndicesAdminClient indicesClient, String index) {
-        super((InternalIndicesAdminClient) indicesClient, new OpenIndexRequest(index));
+    public OpenIndexRequestBuilder(IndicesAdminClient indicesClient, String... indices) {
+        super((InternalIndicesAdminClient) indicesClient, new OpenIndexRequest(indices));
     }
 
-    public OpenIndexRequestBuilder setIndex(String index) {
-        request.index(index);
+    /**
+     * Sets the indices to be opened
+     * @param indices the indices to be opened
+     * @return the request itself
+     */
+    public OpenIndexRequestBuilder setIndices(String... indices) {
+        request.indices(indices);
         return this;
     }
 
@@ -58,6 +64,16 @@ public class OpenIndexRequestBuilder extends MasterNodeOperationRequestBuilder<O
      */
     public OpenIndexRequestBuilder setTimeout(String timeout) {
         request.timeout(timeout);
+        return this;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore. For example indices that don't exist.
+     * @param ignoreIndices the desired behaviour regarding indices to ignore
+     * @return the request itself
+     */
+    public OpenIndexRequestBuilder setIgnoreIndices(IgnoreIndices ignoreIndices) {
+        request.ignoreIndices(ignoreIndices);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -295,14 +295,14 @@ public interface IndicesAdminClient {
     void close(CloseIndexRequest request, ActionListener<CloseIndexResponse> listener);
 
     /**
-     * Closes an index based on the index name.
+     * Closes one or more indices based on their index name.
      *
-     * @param index The index name to close
+     * @param indices The name of the indices to close
      */
-    CloseIndexRequestBuilder prepareClose(String index);
+    CloseIndexRequestBuilder prepareClose(String... indices);
 
     /**
-     * OPen an index based on the index name.
+     * Open an index based on the index name.
      *
      * @param request The close index request
      * @return The result future
@@ -320,11 +320,11 @@ public interface IndicesAdminClient {
     void open(OpenIndexRequest request, ActionListener<OpenIndexResponse> listener);
 
     /**
-     * Opens an index based on the index name.
+     * Opens one or more indices based on their index name.
      *
-     * @param index The index name to close
+     * @param indices The name of the indices to close
      */
-    OpenIndexRequestBuilder prepareOpen(String index);
+    OpenIndexRequestBuilder prepareOpen(String... indices);
 
     /**
      * Explicitly refresh one or more indices (making the content indexed since the last refresh searchable).

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -276,8 +276,8 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
     }
 
     @Override
-    public CloseIndexRequestBuilder prepareClose(String index) {
-        return new CloseIndexRequestBuilder(this, index);
+    public CloseIndexRequestBuilder prepareClose(String... indices) {
+        return new CloseIndexRequestBuilder(this, indices);
     }
 
     @Override
@@ -291,8 +291,8 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
     }
 
     @Override
-    public OpenIndexRequestBuilder prepareOpen(String index) {
-        return new OpenIndexRequestBuilder(this, index);
+    public OpenIndexRequestBuilder prepareOpen(String... indices) {
+        return new OpenIndexRequestBuilder(this, indices);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.rest.action.admin.indices.close;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
+import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -34,6 +35,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
 
 /**
  *
@@ -43,14 +45,18 @@ public class RestCloseIndexAction extends BaseRestHandler {
     @Inject
     public RestCloseIndexAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
+        controller.registerHandler(RestRequest.Method.POST, "/_close", this);
         controller.registerHandler(RestRequest.Method.POST, "/{index}/_close", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        CloseIndexRequest closeIndexRequest = new CloseIndexRequest(request.param("index"));
+        CloseIndexRequest closeIndexRequest = new CloseIndexRequest(splitIndices(request.param("index")));
         closeIndexRequest.listenerThreaded(false);
         closeIndexRequest.timeout(request.paramAsTime("timeout", timeValueSeconds(10)));
+        if (request.hasParam("ignore_indices")) {
+            closeIndexRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
+        }
         client.admin().indices().close(closeIndexRequest, new ActionListener<CloseIndexResponse>() {
             @Override
             public void onResponse(CloseIndexResponse response) {

--- a/src/test/java/org/elasticsearch/test/integration/AbstractNodesTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/AbstractNodesTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.network.NetworkUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.node.Node;
 
 import java.util.Map;
@@ -140,5 +141,19 @@ public abstract class AbstractNodesTests extends ElasticsearchTestCase {
         }
         while (!blocks.isEmpty() && (System.currentTimeMillis() - start) < timeout.millis());
         return blocks;
+    }
+
+    public void createIndices(Client client, String... indices) {
+        for (String index : indices) {
+            client.admin().indices().prepareCreate(index).execute().actionGet();
+        }
+    }
+
+    public void wipeIndices(Client client, String... names) {
+        try {
+            client.admin().indices().prepareDelete(names).execute().actionGet();
+        } catch (IndexMissingException e) {
+            // ignore
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/test/integration/indices/state/CloseIndexDisableCloseAllTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/state/CloseIndexDisableCloseAllTests.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.integration.indices.state;
+
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.test.integration.AbstractNodesTests;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class CloseIndexDisableCloseAllTests extends AbstractNodesTests {
+
+    @BeforeClass
+    public void createNodes() {
+        ImmutableSettings.Builder settings = ImmutableSettings.builder().put("action.disable_close_all_indices", true);
+        startNode("server1", settings);
+        startNode("server2", settings);
+    }
+
+    @AfterClass
+    public void closeNodes() {
+        closeAllNodes();
+    }
+
+    @AfterMethod
+    public void wipeAllIndices() {
+        wipeIndices(client("server1"), "_all");
+    }
+
+    @Test(expectedExceptions = ElasticSearchIllegalArgumentException.class)
+    public void testCloseAllExplicitly() {
+        Client client = client("server1");
+        createIndices(client, "test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        client.admin().indices().prepareClose("_all").execute().actionGet();
+    }
+
+    @Test(expectedExceptions = ElasticSearchIllegalArgumentException.class)
+    public void testCloseAllWildcard() {
+        Client client = client("server2");
+        createIndices(client, "test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        client.admin().indices().prepareClose("*").execute().actionGet();
+    }
+
+    @Test(expectedExceptions = ElasticSearchIllegalArgumentException.class)
+    public void testCloseAllWildcard2() {
+        Client client = client("server2");
+        createIndices(client, "test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        client.admin().indices().prepareClose("test*").execute().actionGet();
+    }
+
+    @Test
+    public void testCloseWildcardNonMatchingAll() {
+        Client client = client("server1");
+        createIndices(client, "test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("*", "-test1").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test2", "test3");
+    }
+
+    @Test(expectedExceptions = ElasticSearchIllegalArgumentException.class)
+    public void testCloseWildcardMatchingAll() {
+        Client client = client("server2");
+        createIndices(client, "test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        client.admin().indices().prepareClose("*", "-test1", "+test1").execute().actionGet();
+    }
+
+    @Test
+    public void testCloseWildcardNonMatchingAll2() {
+        Client client = client("server1");
+        createIndices(client, "test1", "test2", "test3", "a");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test*").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2", "test3");
+    }
+
+    private void assertIndexIsClosed(String... indices) {
+        checkIndexState(IndexMetaData.State.CLOSE, indices);
+    }
+
+    private void checkIndexState(IndexMetaData.State state, String... indices) {
+        ClusterStateResponse clusterStateResponse = client("server1").admin().cluster().prepareState().execute().actionGet();
+        for (String index : indices) {
+            IndexMetaData indexMetaData = clusterStateResponse.getState().metaData().indices().get(index);
+            assertThat(indexMetaData, notNullValue());
+            assertThat(indexMetaData.getState(), equalTo(state));
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/indices/state/OpenCloseIndexTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/state/OpenCloseIndexTests.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.indices.state;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
+import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
+import org.elasticsearch.action.support.IgnoreIndices;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.test.integration.AbstractSharedClusterTest;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class OpenCloseIndexTests extends AbstractSharedClusterTest {
+
+    @Test
+    public void testSimpleCloseOpen() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test1").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1");
+    }
+
+    @Test(expectedExceptions = IndexMissingException.class)
+    public void testSimpleCloseMissingIndex() {
+        Client client = client();
+        client.admin().indices().prepareClose("test1").execute().actionGet();
+    }
+
+    @Test(expectedExceptions = IndexMissingException.class)
+    public void testSimpleOpenMissingIndex() {
+        Client client = client();
+        client.admin().indices().prepareOpen("test1").execute().actionGet();
+    }
+
+    @Test(expectedExceptions = IndexMissingException.class)
+    public void testCloseOneMissingIndex() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        client.admin().indices().prepareClose("test1", "test2").execute().actionGet();
+    }
+
+    @Test
+    public void testCloseOneMissingIndexIgnoreMissing() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test1", "test2")
+                .setIgnoreIndices(IgnoreIndices.MISSING).execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1");
+    }
+
+    @Test(expectedExceptions = IndexMissingException.class)
+    public void testOpenOneMissingIndex() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        client.admin().indices().prepareOpen("test1", "test2").execute().actionGet();
+    }
+
+    @Test
+    public void testOpenOneMissingIndexIgnoreMissing() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1", "test2")
+                .setIgnoreIndices(IgnoreIndices.MISSING).execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1");
+    }
+
+    @Test
+    public void testCloseOpenMultipleIndices() {
+        Client client = client();
+        createIndex("test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        CloseIndexResponse closeIndexResponse1 = client.admin().indices().prepareClose("test1").execute().actionGet();
+        assertThat(closeIndexResponse1.isAcknowledged(), equalTo(true));
+        CloseIndexResponse closeIndexResponse2 = client.admin().indices().prepareClose("test2").execute().actionGet();
+        assertThat(closeIndexResponse2.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2");
+        assertIndexIsOpened("test3");
+
+        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        assertThat(openIndexResponse1.isAcknowledged(), equalTo(true));
+        OpenIndexResponse openIndexResponse2 = client.admin().indices().prepareOpen("test2").execute().actionGet();
+        assertThat(openIndexResponse2.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1", "test2", "test3");
+    }
+
+    @Test
+    public void testCloseOpenWildcard() {
+        Client client = client();
+        createIndex("test1", "test2", "a");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test*").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2");
+        assertIndexIsOpened("a");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test*").execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1", "test2", "a");
+    }
+
+    @Test
+    public void testCloseOpenAll() {
+        Client client = client();
+        createIndex("test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("_all").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2", "test3");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("_all").execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1", "test2", "test3");
+    }
+
+    @Test
+    public void testCloseOpenAllWildcard() {
+        Client client = client();
+        createIndex("test1", "test2", "test3");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("*").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2", "test3");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("*").execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1", "test2", "test3");
+    }
+
+    @Test(expectedExceptions = ActionRequestValidationException.class)
+    public void testCloseNoIndex() {
+        Client client = client();
+        client.admin().indices().prepareClose().execute().actionGet();
+    }
+
+    @Test(expectedExceptions = ActionRequestValidationException.class)
+    public void testCloseNullIndex() {
+        Client client = client();
+        client.admin().indices().prepareClose(null).execute().actionGet();
+    }
+
+    @Test(expectedExceptions = ActionRequestValidationException.class)
+    public void testOpenNoIndex() {
+        Client client = client();
+        client.admin().indices().prepareOpen().execute().actionGet();
+    }
+
+    @Test(expectedExceptions = ActionRequestValidationException.class)
+    public void testOpenNullIndex() {
+        Client client = client();
+        client.admin().indices().prepareOpen(null).execute().actionGet();
+    }
+
+    @Test
+    public void testOpenAlreadyOpenedIndex() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        //no problem if we try to open an index that's already in open state
+        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        assertThat(openIndexResponse1.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1");
+    }
+
+    @Test
+    public void testCloseAlreadyClosedIndex() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        //closing the index
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test1").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1");
+
+        //no problem if we try to close an index that's already in close state
+        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        assertThat(openIndexResponse1.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1");
+    }
+
+    @Test
+    public void testSimpleCloseOpenAlias() {
+        Client client = client();
+        createIndex("test1");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        IndicesAliasesResponse aliasesResponse = client.admin().indices().prepareAliases().addAlias("test1", "test1-alias").execute().actionGet();
+        assertThat(aliasesResponse.isAcknowledged(), equalTo(true));
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test1-alias").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1-alias").execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1");
+    }
+
+    @Test
+    public void testCloseOpenAliasMultipleIndices() {
+        Client client = client();
+        createIndex("test1", "test2");
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        IndicesAliasesResponse aliasesResponse1 = client.admin().indices().prepareAliases().addAlias("test1", "test-alias").execute().actionGet();
+        assertThat(aliasesResponse1.isAcknowledged(), equalTo(true));
+        IndicesAliasesResponse aliasesResponse2 = client.admin().indices().prepareAliases().addAlias("test2", "test-alias").execute().actionGet();
+        assertThat(aliasesResponse2.isAcknowledged(), equalTo(true));
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test-alias").execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test-alias").execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1", "test2");
+    }
+
+    private void assertIndexIsOpened(String... indices) {
+        checkIndexState(IndexMetaData.State.OPEN, indices);
+    }
+
+    private void assertIndexIsClosed(String... indices) {
+        checkIndexState(IndexMetaData.State.CLOSE, indices);
+    }
+
+    private void checkIndexState(IndexMetaData.State state, String... indices) {
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        for (String index : indices) {
+            IndexMetaData indexMetaData = clusterStateResponse.getState().metaData().indices().get(index);
+            assertThat(indexMetaData, notNullValue());
+            assertThat(indexMetaData.getState(), equalTo(state));
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/unit/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/cluster/metadata/MetaDataTests.java
@@ -104,4 +104,157 @@ public class MetaDataTests {
          MetaData md = mdBuilder.build();
         assertThat(newHashSet(md.concreteIndices(new String[]{}, IgnoreIndices.MISSING, true)), equalTo(Sets.<String>newHashSet("kuku","testXXX")));
     }
+
+    @Test
+    public void testIsAllIndices_null() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isAllIndices(null), equalTo(true));
+    }
+
+    @Test
+    public void testIsAllIndices_empty() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isAllIndices(new String[0]), equalTo(true));
+    }
+
+    @Test
+    public void testIsAllIndices_explicitAll() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isAllIndices(new String[]{"_all"}), equalTo(true));
+    }
+
+    @Test
+    public void testIsAllIndices_explicitAllPlusOther() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isAllIndices(new String[]{"_all", "other"}), equalTo(false));
+    }
+
+    @Test
+    public void testIsAllIndices_normalIndexes() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isAllIndices(new String[]{"index1", "index2", "index3"}), equalTo(false));
+    }
+
+    @Test
+    public void testIsAllIndices_wildcard() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isAllIndices(new String[]{"*"}), equalTo(false));
+    }
+
+    @Test
+    public void testIsExplicitAllIndices_null() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isExplicitAllIndices(null), equalTo(false));
+    }
+
+    @Test
+    public void testIsExplicitAllIndices_empty() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isExplicitAllIndices(new String[0]), equalTo(false));
+    }
+
+    @Test
+    public void testIsExplicitAllIndices_explicitAll() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isExplicitAllIndices(new String[]{"_all"}), equalTo(true));
+    }
+
+    @Test
+    public void testIsExplicitAllIndices_explicitAllPlusOther() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isExplicitAllIndices(new String[]{"_all", "other"}), equalTo(false));
+    }
+
+    @Test
+    public void testIsExplicitAllIndices_normalIndexes() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isExplicitAllIndices(new String[]{"index1", "index2", "index3"}), equalTo(false));
+    }
+
+    @Test
+    public void testIsExplicitAllIndices_wildcard() throws Exception {
+        MetaData metaData = MetaData.builder().build();
+        assertThat(metaData.isExplicitAllIndices(new String[]{"*"}), equalTo(false));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_explicitList() throws Exception {
+        //even though it does identify all indices, it's not a pattern but just an explicit list of them
+        String[] concreteIndices = new String[]{"index1", "index2", "index3"};
+        String[] indicesOrAliases = concreteIndices;
+        String[] allConcreteIndices = concreteIndices;
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(false));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_onlyWildcard() throws Exception {
+        String[] indicesOrAliases = new String[]{"*"};
+        String[] concreteIndices = new String[]{"index1", "index2", "index3"};
+        String[] allConcreteIndices = concreteIndices;
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_matchingTrailingWildcard() throws Exception {
+        String[] indicesOrAliases = new String[]{"index*"};
+        String[] concreteIndices = new String[]{"index1", "index2", "index3"};
+        String[] allConcreteIndices = concreteIndices;
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_nonMatchingTrailingWildcard() throws Exception {
+        String[] indicesOrAliases = new String[]{"index*"};
+        String[] concreteIndices = new String[]{"index1", "index2", "index3"};
+        String[] allConcreteIndices = new String[]{"index1", "index2", "index3", "a", "b"};
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(false));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_matchingSingleExclusion() throws Exception {
+        String[] indicesOrAliases = new String[]{"-index1", "+index1"};
+        String[] concreteIndices = new String[]{"index1", "index2", "index3"};
+        String[] allConcreteIndices = concreteIndices;
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_nonMatchingSingleExclusion() throws Exception {
+        String[] indicesOrAliases = new String[]{"-index1"};
+        String[] concreteIndices = new String[]{"index2", "index3"};
+        String[] allConcreteIndices = new String[]{"index1", "index2", "index3"};
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(false));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_matchingTrailingWildcardAndExclusion() throws Exception {
+        String[] indicesOrAliases = new String[]{"index*", "-index1", "+index1"};
+        String[] concreteIndices = new String[]{"index1", "index2", "index3"};
+        String[] allConcreteIndices = concreteIndices;
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
+    }
+
+    @Test
+    public void testIsPatternMatchingAllIndices_nonMatchingTrailingWildcardAndExclusion() throws Exception {
+        String[] indicesOrAliases = new String[]{"index*", "-index1"};
+        String[] concreteIndices = new String[]{"index2", "index3"};
+        String[] allConcreteIndices = new String[]{"index1", "index2", "index3"};
+        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(false));
+    }
+
+    private MetaData metaDataBuilder(String... indices) {
+        MetaData.Builder mdBuilder = MetaData.builder();
+        for (String concreteIndex : indices) {
+            mdBuilder.put(indexBuilder(concreteIndex));
+        }
+        return mdBuilder.build();
+    }
 }


### PR DESCRIPTION
Open/Close index api supports now multiple indices the same way as the delete index api works. The only exception is when dealing with all indices: it's required to explicitly use _all or a pattern that identifies all the indices, not just an empty array of indices.

Closes #3217
