### PR TITLE
Fixed nullshape indexing

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -213,6 +213,9 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
     public void parse(ParseContext context) throws IOException {
         try {
             ShapeBuilder shape = ShapeBuilder.parse(context.parser());
+            if(shape == null) {
+                return;
+            }
             Field[] fields = defaultStrategy.createIndexableFields(shape.build());
             if (fields == null || fields.length == 0) {
                 return;


### PR DESCRIPTION
The current shape builders allow parsing `null` shapes but if these values get indexed a parsing exception (nullpointer) is thrown. This commit catches the actual `null` shape and ignored any field creation.

Closes #3310
