### PR TITLE
Allow bin/plugin to set -D JVM parameters

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -28,4 +28,23 @@ else
     JAVA=`which java`
 fi
 
-exec $JAVA $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $*
+# this is a poor mans getopt replacement
+# real getopt cannot be used because we need to hand options over to the PluginManager
+while [ $# -gt 0 ]; do
+  case $1 in
+    -D*=*)
+      properties="$properties $1"
+      ;;
+    -D*)
+      var=$1
+      shift
+      properties="$properties $var=$1"
+      ;;
+    *)
+      args="$args $1"
+  esac
+  shift
+done
+
+exec $JAVA $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $args
+

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -214,7 +214,7 @@ public class PluginManager {
         // extract the plugin
         File extractLocation = new File(environment.pluginsFile(), name);
         if (extractLocation.exists()) {
-            throw new IOException("plugin directory already exists. To update the plugin, uninstall it first using -remove " + name + " command");
+            throw new IOException("plugin directory " + extractLocation.getAbsolutePath() + " already exists. To update the plugin, uninstall it first using -remove " + name + " command");
         }
         ZipFile zipFile = null;
         try {
@@ -235,6 +235,7 @@ public class PluginManager {
                 FileSystemUtils.mkdirs(target.getParentFile());
                 Streams.copy(zipFile.getInputStream(zipEntry), new FileOutputStream(target));
             }
+            System.out.println("Installed " + name + " into " + extractLocation.getAbsolutePath());
         } catch (Exception e) {
             System.err.println("failed to extract plugin [" + pluginFile + "]: " + ExceptionsHelper.detailedMessage(e));
             return;
@@ -261,6 +262,7 @@ public class PluginManager {
             System.out.println("Found bin, moving to " + toLocation.getAbsolutePath());
             FileSystemUtils.deleteRecursively(toLocation);
             binFile.renameTo(toLocation);
+            System.out.println("Installed " + name + " into " + toLocation.getAbsolutePath());
         }
 
         // try and identify the plugin type, see if it has no .class or .jar files in it
@@ -273,10 +275,9 @@ public class PluginManager {
                 extractLocation.renameTo(tmpLocation);
                 FileSystemUtils.mkdirs(extractLocation);
                 tmpLocation.renameTo(site);
+                System.out.println("Installed " + name + " into " + site.getAbsolutePath());
             }
         }
-
-        System.out.println("Installed " + name);
     }
 
     public void removePlugin(String name) throws IOException {


### PR DESCRIPTION
Currently the bin/plugin command did not allow one to set jvm parameters
for startup. Usually this parameters are not needed (no need to configure
heap sizes for such a short running process), but one could not set the
configuration path. And that one is important for plugins in order find
out, where the plugin directory is.

This is especially problematic when elasticsearch is installed as
debian/rpm package, because the configuration file is not placed in the
same directory structure the plugin shell script is put.

This pull request allows to call bin/plugin like this

bin/plugin -Des.default.config=/etc/elasticsearch/elasticsearch.yml -install mobz/elasticsearch-head

As a last small improvement, the PluginManager now outputs the directort
the plugin was installed to in order to avoid confusion.

Closes #3304
