### PR TITLE
Analysis: update ThaiAnalyzerProvider to use custom stopwords setting

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/ThaiAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ThaiAnalyzerProvider.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.th.ThaiAnalyzer;
+import org.apache.lucene.analysis.util.CharArraySet;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.settings.IndexSettings;
 
@@ -34,9 +36,9 @@ public class ThaiAnalyzerProvider extends AbstractIndexAnalyzerProvider<ThaiAnal
     private final ThaiAnalyzer analyzer;
 
     @Inject
-    public ThaiAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+    public ThaiAnalyzerProvider(Index index, @IndexSettings Settings indexSettings, Environment env, @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
-        analyzer = new ThaiAnalyzer(version);
+	analyzer = new ThaiAnalyzer(version, Analysis.parseStopWords(env, settings, ThaiAnalyzer.getDefaultStopSet(), version));
     }
 
     @Override


### PR DESCRIPTION
Modified ThaiAnalyzerProvider so it is now possible to set stopwords for the thai analyzer in index settings.

Issue: #3342
