### PR TITLE
Don't allow unallocated indexes to be closed.

### DIFF
--- a/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
+++ b/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexException;
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ * Thrown when some action cannot be performed because the primary shard of
+ * some shard group in an index has not been allocated post api action.
+ */
+public class IndexPrimaryShardNotAllocatedException extends IndexException {
+
+    public IndexPrimaryShardNotAllocatedException(Index index) {
+        super(index, "primary not allocated post api");
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.CONFLICT;
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/indices/settings/UpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/settings/UpdateSettingsTests.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.test.integration.indices.settings;
 
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.test.integration.AbstractSharedClusterTest;
 import org.testng.annotations.Test;
@@ -62,6 +64,10 @@ public class UpdateSettingsTests extends AbstractSharedClusterTest {
         assertThat(indexMetaData.settings().get("index.refresh_interval"), equalTo("-1"));
 
         // now close the index, change the non dynamic setting, and see that it applies
+
+        // Wait for the index to turn green before attempting to close it
+        ClusterHealthResponse health = client().admin().cluster().prepareHealth().setTimeout("30s").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertThat(health.isTimedOut(), equalTo(false));
 
         client().admin().indices().prepareClose("test").execute().actionGet();
 


### PR DESCRIPTION
Refuse to close indexes that have not had their primary shard shard allocated post api action because this leaves the index in an un-openable state.

Closes #3313
