### PR TITLE
Added a depth count to XContentParser and uses it to verify query/filter/search elements parsers adhere to the contract of consuming all elements in their scope.

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -117,6 +117,15 @@ public interface XContentParser extends Closeable {
 
     Token currentToken();
 
+    /**
+     * returns the current depth in the xcontent structure. Note that the counter is increased when
+     * stepping into a scope (calling next when standing on a START element) and decreased when you step out
+     * (when next returns an END element).
+     *
+     * @return
+     */
+    int currentDepth();
+
     String currentName() throws IOException;
 
     Map<String, Object> map() throws IOException;
@@ -172,4 +181,10 @@ public interface XContentParser extends Closeable {
     byte[] binaryValue() throws IOException;
 
     void close();
+
+    /**
+     * Method that returns the location of the last processed character;
+     * usually for error reporting purposes.
+     */
+    String getCurrentLocationDescription();
 }

--- a/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisFieldQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FuzzyLikeThisFieldQueryParser.java
@@ -131,6 +131,10 @@ public class FuzzyLikeThisFieldQueryParser implements QueryParser {
             if (failOnUnsupportedField) {
                 throw new ElasticSearchIllegalArgumentException("fuzzy_like_this_field doesn't support binary/numeric fields: [" + fieldName + "]");
             } else {
+                token = parser.nextToken(); // move to close the field name
+                if (token != XContentParser.Token.END_OBJECT) {
+                    throw new QueryParsingException(parseContext.index(), "[flt_field] query malformed, no end_object");
+                }
                 return null;
             }
         }

--- a/src/main/java/org/elasticsearch/index/query/MatchAllFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MatchAllFilterParser.java
@@ -47,9 +47,7 @@ public class MatchAllFilterParser implements FilterParser {
     public Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
-        XContentParser.Token token;
-        while (((token = parser.nextToken()) != XContentParser.Token.END_OBJECT && token != XContentParser.Token.END_ARRAY)) {
-        }
+        parser.skipChildren();
 
         return Queries.MATCH_ALL_FILTER;
     }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -199,11 +199,16 @@ public class QueryParseContext {
         if (queryParser == null) {
             throw new QueryParsingException(index, "No query registered for [" + queryName + "]");
         }
+        int preDepth = parser.currentDepth();
         Query result = queryParser.parse(this);
-        if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
-            // if we are at END_OBJECT, move to the next one...
-            parser.nextToken();
+        if (parser.currentDepth() != preDepth) {
+            String msg = parser.currentDepth() > preDepth ? "didn't consume all tokens in scope" : "consumed too many tokens";
+            throw new QueryParsingException(index, "inner query parsing " + msg + " (type: " + queryName + ", at " + parser.getCurrentLocationDescription() + ")");
         }
+        // move to the END_OBJECT of query name
+        parser.nextToken();
+        assert parser.currentToken() == XContentParser.Token.END_OBJECT;
+
         return result;
     }
 
@@ -236,11 +241,16 @@ public class QueryParseContext {
         if (filterParser == null) {
             throw new QueryParsingException(index, "No filter registered for [" + filterName + "]");
         }
+        int preDepth = parser.currentDepth();
         Filter result = filterParser.parse(this);
-        if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
-            // if we are at END_OBJECT, move to the next one...
-            parser.nextToken();
+        if (parser.currentDepth() != preDepth) {
+            String msg = parser.currentDepth() > preDepth ? "didn't consume all tokens in scope" : "consumed too many tokens";
+            throw new QueryParsingException(index, "inner filter parsing " + msg + " (type: " + filterName + ", at " + parser.getCurrentLocationDescription() + ")");
         }
+        // move to the END_OBJECT of filter name
+        parser.nextToken();
+        assert parser.currentToken() == XContentParser.Token.END_OBJECT;
+
         return result;
     }
 
@@ -249,7 +259,13 @@ public class QueryParseContext {
         if (filterParser == null) {
             throw new QueryParsingException(index, "No filter registered for [" + filterName + "]");
         }
+        int preDepth = parser.currentDepth();
         Filter result = filterParser.parse(this);
+        if (parser.currentDepth() != preDepth) {
+            String msg = parser.currentDepth() > preDepth ? "didn't consume all tokens in scope" : "consumed too many tokens";
+            throw new QueryParsingException(index, "inner filter parsing " + msg + " (type: " + filterName + ", at " + parser.getCurrentLocationDescription() + ")");
+        }
+
         // don't move to the nextToken in this case...
 //        if (parser.currentToken() == XContentParser.Token.END_OBJECT || parser.currentToken() == XContentParser.Token.END_ARRAY) {
 //            // if we are at END_OBJECT, move to the next one...

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
@@ -562,7 +563,12 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     if (element == null) {
                         throw new SearchParseException(context, "No parser for element [" + fieldName + "]");
                     }
+                    int preDepth = parser.currentDepth();
                     element.parse(parser, context);
+                    if (parser.currentDepth() != preDepth) {
+                        String msg = parser.currentDepth() > preDepth ? "didn't consume all tokens in scope" : "consumed too many tokens";
+                        throw new ElasticSearchParseException("search element parsing " + msg + " (type: " + fieldName + ", at " + parser.getCurrentLocationDescription() + ")");
+                    }
                 } else if (token == null) {
                     break;
                 }

--- a/src/test/java/org/elasticsearch/test/unit/common/xcontent/XContentParserTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/xcontent/XContentParserTests.java
@@ -1,0 +1,93 @@
+package org.elasticsearch.test.unit.common.xcontent;
+/*
+ * Licensed to ElasticSearch under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class XContentParserTests {
+
+    @Test
+    public void testDepthCounter() throws IOException {
+        for (XContentType type : XContentType.values()) {
+            testDepthCounterForType(type);
+        }
+
+    }
+
+
+    private void testDepthCounterForType(XContentType type) throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(type);
+        builder.startObject();
+        builder.field("field1", "value1");
+        builder.startObject("obj");
+        builder.field("obj_field", "v3");
+        builder.startObject("obj_obj");
+        builder.field("obj_obj_field", "v4");
+        builder.endObject();
+        builder.endObject();
+        builder.field("field2", "value2");
+        builder.endObject();
+
+        XContentParser parser = XContentFactory.xContent(type).createParser(builder.bytes());
+        assertThat(parser.currentDepth(), equalTo(0));
+        parser.nextToken(); // start root
+        assertThat(parser.currentDepth(), equalTo(0));
+        parser.nextToken(); // field1
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // field1 value
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // obj key
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // start obj
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // obj_field
+        assertThat(parser.currentDepth(), equalTo(2));
+        parser.nextToken(); // obj_field value
+        assertThat(parser.currentDepth(), equalTo(2));
+        parser.nextToken(); //  obj_obj key
+        assertThat(parser.currentDepth(), equalTo(2));
+        parser.nextToken(); //  start obj_obj
+        assertThat(parser.currentDepth(), equalTo(2));
+        parser.nextToken(); // obj_obj_field
+        assertThat(parser.currentDepth(), equalTo(3));
+        parser.nextToken(); // obj_obj_field value
+        assertThat(parser.currentDepth(), equalTo(3));
+        parser.nextToken(); // end obj_obj
+        assertThat(parser.currentDepth(), equalTo(2));
+        parser.nextToken(); // end obj
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // field2
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // field2 value
+        assertThat(parser.currentDepth(), equalTo(1));
+        parser.nextToken(); // end root
+        assertThat(parser.currentDepth(), equalTo(0));
+
+    }
+}


### PR DESCRIPTION
Fixed an issue with FuzzLikeThisFieldQueryParser discovered by the above check.
Match all filter parser now correctly skips all the children of its scope.
Match all query parser correctly deals with wrong internal structures and reports the deprecation of norms_field (which was silently ignored).

Closes #3292
