### PR TITLE
XML format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,13 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.2.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.2.2</version>
             <scope>compile</scope>
@@ -433,6 +440,7 @@
                             <include>org.mvel:mvel2</include>
                             <include>com.fasterxml.jackson.core:jackson-core</include>
                             <include>com.fasterxml.jackson.dataformat:jackson-dataformat-smile</include>
+                            <include>com.fasterxml.jackson.dataformat:jackson-dataformat-xml</include>
                             <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
                             <include>joda-time:joda-time</include>
                             <include>io.netty:netty</include>

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.compress.CompressedStreamInput;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.xcontent.xml.XmlXParams;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,7 +39,6 @@ import java.util.Map;
 /**
  *
  */
-@SuppressWarnings("unchecked")
 public class XContentHelper {
 
     public static XContentParser createParser(BytesReference bytes) throws IOException {
@@ -168,6 +168,37 @@ public class XContentHelper {
             parser = XContentFactory.xContent(xContentType).createParser(data, offset, length);
             parser.nextToken();
             XContentBuilder builder = XContentFactory.jsonBuilder();
+            if (prettyPrint) {
+                builder.prettyPrint();
+            }
+            builder.copyCurrentStructure(parser);
+            return builder.string();
+        } finally {
+            if (parser != null) {
+                parser.close();
+            }
+        }
+    }
+
+    public static String convertToXml(byte[] data, int offset, int length) throws IOException {
+        return convertToXml(XmlXParams.getDefaultParams(), data, offset, length, false);
+    }
+
+    public static String convertToXml(byte[] data, int offset, int length, boolean prettyprint) throws IOException {
+        return convertToXml(XmlXParams.getDefaultParams(), data, offset, length, prettyprint);
+    }
+
+    public static String convertToXml(XmlXParams params, byte[] data, int offset, int length) throws IOException {
+        return convertToXml(params, data, offset, length, false);
+    }
+
+    public static String convertToXml(XmlXParams params, byte[] data, int offset, int length, boolean prettyPrint) throws IOException {
+        XContentType xContentType = XContentFactory.xContentType(data, offset, length);
+        XContentParser parser = null;
+        try {
+            parser = XContentFactory.xContent(xContentType).createParser(data, offset, length);
+            parser.nextToken();
+            XContentBuilder builder = XContentFactory.xmlBuilder(params);
             if (prettyPrint) {
                 builder.prettyPrint();
             }

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentType.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentType.java
@@ -21,10 +21,11 @@ package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.smile.SmileXContent;
+import org.elasticsearch.common.xcontent.xml.XmlXContent;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 
 /**
- * The content type of {@link org.elasticsearch.common.xcontent.XContent}.
+ * The content type of {@link XContent}.
  */
 public enum XContentType {
 
@@ -67,7 +68,7 @@ public enum XContentType {
         }
     },
     /**
-     * The jackson based smile binary format. Fast and compact binary format.
+     * The YAML format.
      */
     YAML(2) {
         @Override
@@ -83,6 +84,25 @@ public enum XContentType {
         @Override
         public XContent xContent() {
             return YamlXContent.yamlXContent;
+        }
+    },
+    /**
+     * The XML format.
+     */
+    XML(3) {
+        @Override
+        public String restContentType() {
+            return "application/xml";
+        }
+
+        @Override
+        public String shortName() {
+            return "xml";
+        }
+
+        @Override
+        public XContent xContent() {
+            return XmlXContent.xmlXContent();
         }
     };
 
@@ -100,6 +120,10 @@ public enum XContentType {
 
         if ("application/yaml".equals(contentType) || "yaml".equalsIgnoreCase(contentType)) {
             return YAML;
+        }
+
+        if ("application/xml".equals(contentType) || "xml".equalsIgnoreCase(contentType)) {
+            return XML;
         }
 
         return null;

--- a/src/main/java/org/elasticsearch/common/xcontent/xml/ToQName.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/xml/ToQName.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.xcontent.xml;
+
+/**
+ * Helper class to create a qualified name for XML from a field name
+ */
+import javax.xml.namespace.QName;
+
+public class ToQName {
+
+    public static QName toQName(QName root, XmlNamespaceContext context, String name) {
+        String nsPrefix = root.getPrefix();
+        String nsURI = root.getNamespaceURI();
+        if (name.startsWith("_")) {
+            name = name.substring(1);
+        } else if (name.startsWith("@")) {
+            name = name.substring(1);
+        }
+        int pos = name.indexOf(':');
+        if (pos > 0) {
+            nsPrefix = name.substring(0, pos);
+            nsURI = context.getNamespaceURI(nsPrefix);
+            if (nsURI == null) {
+                throw new IllegalArgumentException("unknown namespace prefix: " + nsPrefix);
+            }
+            name = name.substring(pos + 1);
+        }
+        return new QName(nsURI, name, nsPrefix);
+    }
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/xml/XmlNamespaceContext.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/xml/XmlNamespaceContext.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.xml;
+
+import com.google.common.collect.Maps;
+
+import javax.xml.namespace.NamespaceContext;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.SortedMap;
+
+/**
+ * Contains a simple context for XML namespaces
+ *
+ */
+public class XmlNamespaceContext implements NamespaceContext {
+
+    private static final String DEFAULT_RESOURCE = "xml-namespaces";
+
+    private final SortedMap<String, String> namespaces = Maps.newTreeMap();
+
+    private final SortedMap<String, Set<String>> prefixes = Maps.newTreeMap();
+
+    protected XmlNamespaceContext() {
+    }
+
+    protected XmlNamespaceContext(ResourceBundle bundle) {
+        Enumeration<String> en = bundle.getKeys();
+        while (en.hasMoreElements()) {
+            String prefix = en.nextElement();
+            String namespace = bundle.getString(prefix);
+            addNamespace(prefix, namespace);
+        }
+    }
+
+    protected static String bundleName() {
+        return DEFAULT_RESOURCE;
+    }
+
+
+    /**
+     * Empty namespace context.
+     *
+     * @return
+     */
+    public static XmlNamespaceContext newInstance() {
+        return new XmlNamespaceContext();
+    }
+
+    public static XmlNamespaceContext getDefaultInstance() {
+        return newInstance(bundleName());
+    }
+
+    public static XmlNamespaceContext newInstance(String bundleName) {
+        try {
+            return new XmlNamespaceContext(ResourceBundle.getBundle(bundleName));
+        } catch (MissingResourceException e) {
+            //logger.warn("bundle name {} not found, namespace will be empty", bundleName);
+            return new XmlNamespaceContext();
+        }
+    }
+
+    public final synchronized void addNamespace(String prefix, String namespace) {
+        namespaces.put(prefix, namespace);
+        if (prefixes.containsKey(namespace)) {
+            prefixes.get(namespace).add(prefix);
+        } else {
+            Set<String> set = new HashSet<String>();
+            set.add(prefix);
+            prefixes.put(namespace, set);
+        }
+    }
+
+    public Map<String, String> getNamespaces() {
+        return namespaces;
+    }
+
+    @Override
+    public String getNamespaceURI(String prefix) {
+        if (prefix == null) {
+            return null;
+        }
+        return namespaces.containsKey(prefix) ? namespaces.get(prefix) : null;
+    }
+
+    @Override
+    public String getPrefix(String namespaceURI) {
+        Iterator<String> it = getPrefixes(namespaceURI);
+        return it != null && it.hasNext() ? it.next() : null;
+    }
+
+    @Override
+    public Iterator<String> getPrefixes(String namespace) {
+        if (namespace == null) {
+            throw new IllegalArgumentException("namespace URI cannot be null");
+        }
+        return prefixes.containsKey(namespace) ?
+                prefixes.get(namespace).iterator() : null;
+    }
+
+    public String toString() {
+        return namespaces.toString();
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXContent.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXContent.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.xml;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.FastStringReader;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentGenerator;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+
+/**
+ * A XML based content implementation using Jackson XML dataformat
+ *
+ */
+public class XmlXContent implements XContent {
+
+    private final static XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+
+    private final static XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
+
+    static {
+        inputFactory.setProperty("javax.xml.stream.isNamespaceAware", Boolean.TRUE);
+        inputFactory.setProperty("javax.xml.stream.isValidating", Boolean.FALSE);
+        inputFactory.setProperty("javax.xml.stream.isCoalescing", Boolean.TRUE);
+        inputFactory.setProperty("javax.xml.stream.isReplacingEntityReferences", Boolean.FALSE);
+        inputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", Boolean.FALSE);
+
+        outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
+
+        xmlFactory = new XmlFactory(inputFactory, outputFactory);
+
+        xmlXContent = new XmlXContent();
+    }
+
+
+    public static XContentBuilder contentBuilder() throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(xmlXContent);
+        if (builder.generator() instanceof XmlXContentGenerator) {
+            ((XmlXContentGenerator) builder.generator()).setParams(XmlXParams.getDefaultParams());
+        }
+        return builder;
+    }
+
+    public static XContentBuilder contentBuilder(XmlXParams params) throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(xmlXContent);
+        if (builder.generator() instanceof XmlXContentGenerator) {
+            ((XmlXContentGenerator) builder.generator()).setParams(params);
+        }
+        return builder;
+    }
+
+    private final static XmlFactory xmlFactory;
+
+    private final static XmlXContent xmlXContent;
+
+
+    private XmlXContent() {
+    }
+
+    public static XmlXContent xmlXContent() {
+        return xmlXContent;
+    }
+
+    protected static XmlFactory xmlFactory() {
+        return xmlFactory;
+    }
+
+    public XContentType type() {
+        return XContentType.XML;
+    }
+
+    @Override
+    public byte streamSeparator() {
+        throw new UnsupportedOperationException("xml does not support stream parsing...");
+    }
+
+    @Override
+    public XContentGenerator createGenerator(OutputStream os) throws IOException {
+        return new XmlXContentGenerator(xmlFactory.createGenerator(os, JsonEncoding.UTF8));
+    }
+
+    @Override
+    public XContentGenerator createGenerator(Writer writer) throws IOException {
+        return new XmlXContentGenerator(xmlFactory.createGenerator(writer));
+    }
+
+    @Override
+    public XContentParser createParser(String content) throws IOException {
+        return new XmlXContentParser(xmlFactory.createParser(new FastStringReader(content)));
+    }
+
+    @Override
+    public XContentParser createParser(InputStream is) throws IOException {
+        return new XmlXContentParser(xmlFactory.createParser(is));
+    }
+
+    @Override
+    public XContentParser createParser(byte[] data) throws IOException {
+        return new XmlXContentParser(xmlFactory.createParser(data));
+    }
+
+    @Override
+    public XContentParser createParser(byte[] data, int offset, int length) throws IOException {
+        return new XmlXContentParser(xmlFactory.createParser(data, offset, length));
+    }
+
+    @Override
+    public XContentParser createParser(BytesReference bytes) throws IOException {
+        if (bytes.hasArray()) {
+            return createParser(bytes.array(), bytes.arrayOffset(), bytes.length());
+        }
+        return createParser(bytes.streamInput());
+    }
+
+    @Override
+    public XContentParser createParser(Reader reader) throws IOException {
+        return new XmlXContentParser(xmlFactory.createParser(reader));
+    }
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXContentGenerator.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXContentGenerator.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.xml;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.google.common.base.Charsets;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentGenerator;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentString;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ *
+ * Content generator for XML format
+ *
+ */
+public class XmlXContentGenerator implements XContentGenerator {
+
+    protected final ToXmlGenerator generator;
+
+    private XmlXParams params = XmlXParams.getDefaultParams();
+
+    private boolean started = false;
+
+    public XmlXContentGenerator(ToXmlGenerator generator) {
+        this.generator = generator;
+        generator.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, false);
+    }
+
+    public XmlXContentGenerator setParams(XmlXParams params) {
+        this.params = params;
+        return this;
+    }
+
+    public XmlXParams getParams() {
+        return params;
+    }
+
+    public XmlNamespaceContext getNamespaceContext() {
+        return params.getNamespaceContext();
+    }
+
+    @Override
+    public XContentType contentType() {
+        return XContentType.XML;
+    }
+
+    @Override
+    public void usePrettyPrint() {
+        generator.useDefaultPrettyPrinter();
+    }
+
+    @Override
+    public void writeStartArray() throws IOException {
+        generator.writeStartArray();
+    }
+
+    @Override
+    public void writeEndArray() throws IOException {
+        generator.writeEndArray();
+    }
+
+    @Override
+    public void writeStartObject() throws IOException {
+        try {
+            if (!started) {
+                generator.getStaxWriter().setDefaultNamespace(params.getQName().getNamespaceURI());
+                generator.startWrappedValue(null, params.getQName());
+            }
+            generator.writeStartObject();
+            if (!started) {
+                for (String prefix : getNamespaceContext().getNamespaces().keySet()) {
+                    generator.getStaxWriter().writeNamespace(prefix, getNamespaceContext().getNamespaceURI(prefix));
+                }
+                started = true;
+            }
+        } catch (XMLStreamException e) {
+            //
+        }
+    }
+
+    @Override
+    public void writeEndObject() throws IOException {
+        generator.writeEndObject();
+    }
+
+    @Override
+    public void writeFieldName(String name) throws IOException {
+        writeFieldNameXml(name);
+    }
+
+    @Override
+    public void writeFieldName(XContentString name) throws IOException {
+        writeFieldNameXml(name.getValue());
+    }
+
+    @Override
+    public void writeString(String text) throws IOException {
+        generator.writeString(text);
+    }
+
+    @Override
+    public void writeString(char[] text, int offset, int len) throws IOException {
+        generator.writeString(text, offset, len);
+    }
+
+    @Override
+    public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
+        // writeUTF8String not yet implemented in jackson-dataformat-xml
+        //generator.writeUTF8String(text, offset, length);
+        generator.writeString(new String(text, offset, length, Charsets.UTF_8));
+    }
+
+    @Override
+    public void writeBinary(byte[] data, int offset, int len) throws IOException {
+        generator.writeBinary(data, offset, len);
+    }
+
+    @Override
+    public void writeBinary(byte[] data) throws IOException {
+        generator.writeBinary(data);
+    }
+
+    @Override
+    public void writeNumber(int v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(long v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(double d) throws IOException {
+        generator.writeNumber(d);
+    }
+
+    @Override
+    public void writeNumber(float f) throws IOException {
+        generator.writeNumber(f);
+    }
+
+    @Override
+    public void writeBoolean(boolean state) throws IOException {
+        generator.writeBoolean(state);
+    }
+
+    @Override
+    public void writeBooleanField(XContentString fieldName, boolean value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeBoolean(value);
+    }
+
+    @Override
+    public void writeNull() throws IOException {
+        generator.writeNull();
+    }
+
+    @Override
+    public void writeNullField(XContentString fieldName) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeNull();
+    }
+
+    @Override
+    public void writeStringField(String fieldName, String value) throws IOException {
+        generator.writeStringField(fieldName, value);
+    }
+
+    @Override
+    public void writeStringField(XContentString fieldName, String value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeString(value);
+    }
+
+    @Override
+    public void writeBooleanField(String fieldName, boolean value) throws IOException {
+        generator.writeBooleanField(fieldName, value);
+    }
+
+    @Override
+    public void writeNullField(String fieldName) throws IOException {
+        generator.writeNullField(fieldName);
+    }
+
+    public void writeNumberField(String fieldName, int value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(XContentString fieldName, int value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeNumber(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, long value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(XContentString fieldName, long value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeNumber(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, double value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, float value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeBinaryField(String fieldName, byte[] data) throws IOException {
+        generator.writeBinaryField(fieldName, data);
+    }
+
+    @Override
+    public void writeBinaryField(XContentString fieldName, byte[] value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeBinary(value);
+    }
+
+    @Override
+    public void writeNumberField(XContentString fieldName, double value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeNumber(value);
+    }
+
+    @Override
+    public void writeNumberField(XContentString fieldName, float value) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeNumber(value);
+    }
+
+    @Override
+    public void writeArrayFieldStart(String fieldName) throws IOException {
+        generator.writeArrayFieldStart(fieldName);
+    }
+
+    @Override
+    public void writeArrayFieldStart(XContentString fieldName) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeStartArray();
+    }
+
+    @Override
+    public void writeObjectFieldStart(String fieldName) throws IOException {
+        generator.writeObjectFieldStart(fieldName);
+    }
+
+    @Override
+    public void writeObjectFieldStart(XContentString fieldName) throws IOException {
+        writeFieldName(fieldName);
+        generator.writeStartObject();
+    }
+
+    @Override
+    public void writeRawField(String fieldName, InputStream content, OutputStream bos) throws IOException {
+        writeFieldNameXml(fieldName);
+        JsonParser parser = XmlXContent.xmlFactory().createParser(content);
+        try {
+            parser.nextToken();
+            generator.copyCurrentStructure(parser);
+        } finally {
+            parser.close();
+        }
+    }
+
+    @Override
+    public void writeRawField(String fieldName, byte[] content, OutputStream bos) throws IOException {
+        writeFieldNameXml(fieldName);
+        JsonParser parser = XmlXContent.xmlFactory().createParser(content);
+        try {
+            parser.nextToken();
+            generator.copyCurrentStructure(parser);
+        } finally {
+            parser.close();
+        }
+    }
+
+    @Override
+    public void writeRawField(String fieldName, BytesReference content, OutputStream bos) throws IOException {
+        writeFieldNameXml(fieldName);
+        JsonParser parser;
+        if (content.hasArray()) {
+            parser = XmlXContent.xmlFactory().createParser(content.array(), content.arrayOffset(), content.length());
+        } else {
+            parser = XmlXContent.xmlFactory().createParser(content.streamInput());
+        }
+        try {
+            parser.nextToken();
+            generator.copyCurrentStructure(parser);
+        } finally {
+            parser.close();
+        }
+    }
+
+    @Override
+    public void writeRawField(String fieldName, byte[] content, int offset, int length, OutputStream bos) throws IOException {
+        writeFieldNameXml(fieldName);
+        JsonParser parser = XmlXContent.xmlFactory().createParser(content, offset, length);
+        try {
+            parser.nextToken();
+            generator.copyCurrentStructure(parser);
+        } finally {
+            parser.close();
+        }
+    }
+
+    @Override
+    public void copyCurrentStructure(XContentParser parser) throws IOException {
+        if (parser.currentToken() == null) {
+            parser.nextToken();
+        }
+        if (parser instanceof XmlXContentParser) {
+            generator.copyCurrentStructure(((XmlXContentParser) parser).parser);
+        } else {
+            XContentHelper.copyCurrentStructure(this, parser);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        generator.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        generator.close();
+    }
+
+    private void writeFieldNameXml(String name) throws IOException {
+        if (name.startsWith("@")) {
+            generator.setNextIsAttribute(true);
+        }
+        QName qname = ToQName.toQName(params.getQName(), params.getNamespaceContext(), name);
+        generator.setNextName(qname);
+        generator.writeFieldName(qname.getLocalPart());
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXContentParser.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.xml;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class XmlXContentParser extends AbstractXContentParser {
+
+    final JsonParser parser;
+
+    public XmlXContentParser(JsonParser parser) {
+        this.parser = parser;
+    }
+
+
+    @Override
+    public XContentType contentType() {
+        return XContentType.XML;
+    }
+
+
+    @Override
+    public XContentParser.Token nextToken() throws IOException {
+        return convertToken(parser.nextToken());
+    }
+
+
+    @Override
+    public void skipChildren() throws IOException {
+        parser.skipChildren();
+    }
+
+
+    @Override
+    public XContentParser.Token currentToken() {
+        return convertToken(parser.getCurrentToken());
+    }
+
+
+    @Override
+    public XContentParser.NumberType numberType() throws IOException {
+        return convertNumberType(parser.getNumberType());
+    }
+
+
+    @Override
+    public boolean estimatedNumberType() {
+        return true;
+    }
+
+
+    @Override
+    public String currentName() throws IOException {
+        return parser.getCurrentName();
+    }
+
+
+    @Override
+    protected boolean doBooleanValue() throws IOException {
+        return parser.getBooleanValue();
+    }
+
+
+    @Override
+    public String text() throws IOException {
+        return parser.getText();
+    }
+
+    @Override
+    public BytesRef bytes() throws IOException {
+        BytesRef bytes = new BytesRef();
+        UnicodeUtil.UTF16toUTF8(parser.getTextCharacters(), parser.getTextOffset(), parser.getTextLength(), bytes);
+        return bytes;
+    }
+
+    @Override
+    public Object objectText() throws IOException {
+        JsonToken currentToken = parser.getCurrentToken();
+        if (currentToken == JsonToken.VALUE_STRING) {
+            return text();
+        } else if (currentToken == JsonToken.VALUE_NUMBER_INT || currentToken == JsonToken.VALUE_NUMBER_FLOAT) {
+            return parser.getNumberValue();
+        } else if (currentToken == JsonToken.VALUE_TRUE) {
+            return Boolean.TRUE;
+        } else if (currentToken == JsonToken.VALUE_FALSE) {
+            return Boolean.FALSE;
+        } else if (currentToken == JsonToken.VALUE_NULL) {
+            return null;
+        } else {
+            return text();
+        }
+    }
+
+    @Override
+    public Object objectBytes() throws IOException {
+        JsonToken currentToken = parser.getCurrentToken();
+        if (currentToken == JsonToken.VALUE_STRING) {
+            return bytes();
+        } else if (currentToken == JsonToken.VALUE_NUMBER_INT || currentToken == JsonToken.VALUE_NUMBER_FLOAT) {
+            return parser.getNumberValue();
+        } else if (currentToken == JsonToken.VALUE_TRUE) {
+            return Boolean.TRUE;
+        } else if (currentToken == JsonToken.VALUE_FALSE) {
+            return Boolean.FALSE;
+        } else if (currentToken == JsonToken.VALUE_NULL) {
+            return null;
+        } else {
+            return bytes();
+        }
+    }
+
+    @Override
+    public boolean hasTextCharacters() {
+        return parser.hasTextCharacters();
+    }
+
+
+    @Override
+    public char[] textCharacters() throws IOException {
+        return parser.getTextCharacters();
+    }
+
+
+    @Override
+    public int textLength() throws IOException {
+        return parser.getTextLength();
+    }
+
+
+    @Override
+    public int textOffset() throws IOException {
+        return parser.getTextOffset();
+    }
+
+
+    @Override
+    public Number numberValue() throws IOException {
+        return parser.getNumberValue();
+    }
+
+
+    @Override
+    public short doShortValue() throws IOException {
+        return parser.getShortValue();
+    }
+
+
+    @Override
+    public int doIntValue() throws IOException {
+        return parser.getIntValue();
+    }
+
+
+    @Override
+    public long doLongValue() throws IOException {
+        return parser.getLongValue();
+    }
+
+
+    @Override
+    public float doFloatValue() throws IOException {
+        return parser.getFloatValue();
+    }
+
+
+    @Override
+    public double doDoubleValue() throws IOException {
+        return parser.getDoubleValue();
+    }
+
+
+    @Override
+    public byte[] binaryValue() throws IOException {
+        return parser.getBinaryValue();
+    }
+
+
+    @Override
+    public void close() {
+        try {
+            parser.close();
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+
+    private NumberType convertNumberType(JsonParser.NumberType numberType) {
+        switch (numberType) {
+            case INT:
+                return NumberType.INT;
+            case LONG:
+                return NumberType.LONG;
+            case FLOAT:
+                return NumberType.FLOAT;
+            case DOUBLE:
+                return NumberType.DOUBLE;
+        }
+        throw new IllegalStateException("No matching token for number_type [" + numberType + "]");
+    }
+
+    private Token convertToken(JsonToken token) {
+        if (token == null) {
+            return null;
+        }
+        switch (token) {
+            case FIELD_NAME:
+                return Token.FIELD_NAME;
+            case VALUE_FALSE:
+            case VALUE_TRUE:
+                return Token.VALUE_BOOLEAN;
+            case VALUE_STRING:
+                return Token.VALUE_STRING;
+            case VALUE_NUMBER_INT:
+            case VALUE_NUMBER_FLOAT:
+                return Token.VALUE_NUMBER;
+            case VALUE_NULL:
+                return Token.VALUE_NULL;
+            case START_OBJECT:
+                return Token.START_OBJECT;
+            case END_OBJECT:
+                return Token.END_OBJECT;
+            case START_ARRAY:
+                return Token.START_ARRAY;
+            case END_ARRAY:
+                return Token.END_ARRAY;
+            case VALUE_EMBEDDED_OBJECT:
+                return Token.VALUE_EMBEDDED_OBJECT;
+        }
+        throw new IllegalStateException("No matching token for json_token [" + token + "]");
+    }
+}

--- a/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXParams.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/xml/XmlXParams.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.xml;
+
+import javax.xml.namespace.QName;
+
+/**
+ * XML parameters for XML XContent
+ *
+ */
+public class XmlXParams {
+
+    private final static XmlXParams instance = new XmlXParams();
+
+    private final QName root;
+
+    private final XmlNamespaceContext namespaceContext;
+
+    public XmlXParams() {
+        this(null, null);
+    }
+
+    public XmlXParams(QName root) {
+        this(root, null);
+    }
+
+    public XmlXParams(XmlNamespaceContext namespaceContext) {
+        this(null, namespaceContext);
+    }
+
+    public XmlXParams(QName root, XmlNamespaceContext namespaceContext) {
+        this.root = root != null ? root : getDefaultRoot();
+        if (namespaceContext != null) {
+            namespaceContext.addNamespace(getDefaultRoot().getPrefix(), getDefaultRoot().getNamespaceURI());
+        } else {
+            namespaceContext = getDefaultNamespaceContext();
+        }
+        this.namespaceContext = namespaceContext;
+    }
+
+    public static XmlXParams getDefaultParams() {
+        return instance;
+    }
+
+    public QName getQName() {
+        return root;
+    }
+
+    public XmlNamespaceContext getNamespaceContext() {
+        return namespaceContext;
+    }
+
+    private final static QName getDefaultRoot() {
+        return new QName("http://elasticsearch.org/ns/1.0/", "root", "es");
+    }
+
+    private final static XmlNamespaceContext getDefaultNamespaceContext() {
+        XmlNamespaceContext namespaceContext = XmlNamespaceContext.newInstance();
+        namespaceContext.addNamespace(getDefaultRoot().getPrefix(), getDefaultRoot().getNamespaceURI());
+        return namespaceContext;
+    }
+}


### PR DESCRIPTION
To support Elasticsearch in legacy environments, it would be nice to have XML as an output option in the core. For example, applying XSL stylesheets to Elasticsearch output for XML/XHTML formatting is more convenient with XML present, it avoids transforming JSON to XML.

The XML format is realized by adding another jackson dependency, jackson-dataformat-xml.

Extra XML namespaces can be added in a properties file named `xml-namespaces.properties` in the class path, e.g. `dc = http://purl.org/dc/elements/1.1/`. Field names could then start with `dc:` to get resolved.

The JSON output is wrapped into a `root` element with default namespace `http://elasticsearch.org/ns/1.0/` and preferred prefix `es`/
