### PR TITLE
Added support for readable_format parameter when printing out time and size values

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -126,8 +126,7 @@ public class IndicesSegmentResponse extends BroadcastOperationResponse implement
                         builder.field(Fields.GENERATION, segment.getGeneration());
                         builder.field(Fields.NUM_DOCS, segment.getNumDocs());
                         builder.field(Fields.DELETED_DOCS, segment.getDeletedDocs());
-                        builder.field(Fields.SIZE, segment.getSize().toString());
-                        builder.field(Fields.SIZE_IN_BYTES, segment.getSizeInBytes());
+                        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, segment.getSizeInBytes());
                         builder.field(Fields.COMMITTED, segment.isCommitted());
                         builder.field(Fields.SEARCH, segment.isSearch());
                         if (segment.getVersion() != null) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/status/IndicesStatusResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/IndicesStatusResponse.java
@@ -126,10 +126,8 @@ public class IndicesStatusResponse extends BroadcastOperationResponse implements
 
             builder.startObject(Fields.INDEX);
             if (indexStatus.getStoreSize() != null) {
-                builder.field(Fields.PRIMARY_SIZE, indexStatus.getPrimaryStoreSize().toString());
-                builder.field(Fields.PRIMARY_SIZE_IN_BYTES, indexStatus.getPrimaryStoreSize().bytes());
-                builder.field(Fields.SIZE, indexStatus.getStoreSize().toString());
-                builder.field(Fields.SIZE_IN_BYTES, indexStatus.getStoreSize().bytes());
+                builder.byteSizeField(Fields.PRIMARY_SIZE, Fields.PRIMARY_SIZE_IN_BYTES, indexStatus.getPrimaryStoreSize());
+                builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, indexStatus.getStoreSize());
             }
             builder.endObject();
             if (indexStatus.getTranslogOperations() != -1) {
@@ -177,8 +175,7 @@ public class IndicesStatusResponse extends BroadcastOperationResponse implements
                     builder.field(Fields.STATE, shardStatus.getState());
                     if (shardStatus.getStoreSize() != null) {
                         builder.startObject(Fields.INDEX);
-                        builder.field(Fields.SIZE, shardStatus.getStoreSize().toString());
-                        builder.field(Fields.SIZE_IN_BYTES, shardStatus.getStoreSize().bytes());
+                        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, shardStatus.getStoreSize());
                         builder.endObject();
                     }
                     if (shardStatus.getTranslogId() != -1) {
@@ -215,19 +212,14 @@ public class IndicesStatusResponse extends BroadcastOperationResponse implements
                         builder.startObject(Fields.PEER_RECOVERY);
                         builder.field(Fields.STAGE, peerRecoveryStatus.getStage());
                         builder.field(Fields.START_TIME_IN_MILLIS, peerRecoveryStatus.getStartTime());
-                        builder.field(Fields.TIME, peerRecoveryStatus.getTime());
-                        builder.field(Fields.TIME_IN_MILLIS, peerRecoveryStatus.getTime().millis());
+                        builder.timeValueField(Fields.TIME, Fields.TIME_IN_MILLIS, peerRecoveryStatus.getTime());
 
                         builder.startObject(Fields.INDEX);
                         builder.field(Fields.PROGRESS, peerRecoveryStatus.getIndexRecoveryProgress());
-                        builder.field(Fields.SIZE, peerRecoveryStatus.getIndexSize());
-                        builder.field(Fields.SIZE_IN_BYTES, peerRecoveryStatus.getIndexSize().bytes());
-                        builder.field(Fields.REUSED_SIZE, peerRecoveryStatus.getReusedIndexSize());
-                        builder.field(Fields.REUSED_SIZE_IN_BYTES, peerRecoveryStatus.getReusedIndexSize().bytes());
-                        builder.field(Fields.EXPECTED_RECOVERED_SIZE, peerRecoveryStatus.getExpectedRecoveredIndexSize());
-                        builder.field(Fields.EXPECTED_RECOVERED_SIZE_IN_BYTES, peerRecoveryStatus.getExpectedRecoveredIndexSize().bytes());
-                        builder.field(Fields.RECOVERED_SIZE, peerRecoveryStatus.getRecoveredIndexSize());
-                        builder.field(Fields.RECOVERED_SIZE_IN_BYTES, peerRecoveryStatus.getRecoveredIndexSize().bytes());
+                        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, peerRecoveryStatus.getIndexSize());
+                        builder.byteSizeField(Fields.REUSED_SIZE, Fields.REUSED_SIZE_IN_BYTES, peerRecoveryStatus.getReusedIndexSize());
+                        builder.byteSizeField(Fields.EXPECTED_RECOVERED_SIZE, Fields.EXPECTED_RECOVERED_SIZE_IN_BYTES, peerRecoveryStatus.getExpectedRecoveredIndexSize());
+                        builder.byteSizeField(Fields.RECOVERED_SIZE, Fields.RECOVERED_SIZE_IN_BYTES, peerRecoveryStatus.getRecoveredIndexSize());
                         builder.endObject();
 
                         builder.startObject(Fields.TRANSLOG);
@@ -242,19 +234,14 @@ public class IndicesStatusResponse extends BroadcastOperationResponse implements
                         builder.startObject(Fields.GATEWAY_RECOVERY);
                         builder.field(Fields.STAGE, gatewayRecoveryStatus.getStage());
                         builder.field(Fields.START_TIME_IN_MILLIS, gatewayRecoveryStatus.getStartTime());
-                        builder.field(Fields.TIME, gatewayRecoveryStatus.getTime());
-                        builder.field(Fields.TIME_IN_MILLIS, gatewayRecoveryStatus.getTime().millis());
+                        builder.timeValueField(Fields.TIME, Fields.TIME_IN_MILLIS, gatewayRecoveryStatus.getTime());
 
                         builder.startObject(Fields.INDEX);
                         builder.field(Fields.PROGRESS, gatewayRecoveryStatus.getIndexRecoveryProgress());
-                        builder.field(Fields.SIZE, gatewayRecoveryStatus.getIndexSize());
-                        builder.field(Fields.SIZE_IN_BYTES, gatewayRecoveryStatus.getIndexSize().bytes());
-                        builder.field(Fields.REUSED_SIZE, gatewayRecoveryStatus.getReusedIndexSize());
-                        builder.field(Fields.REUSED_SIZE_IN_BYTES, gatewayRecoveryStatus.getReusedIndexSize().bytes());
-                        builder.field(Fields.EXPECTED_RECOVERED_SIZE, gatewayRecoveryStatus.getExpectedRecoveredIndexSize());
-                        builder.field(Fields.EXPECTED_RECOVERED_SIZE_IN_BYTES, gatewayRecoveryStatus.getExpectedRecoveredIndexSize().bytes());
-                        builder.field(Fields.RECOVERED_SIZE, gatewayRecoveryStatus.getRecoveredIndexSize());
-                        builder.field(Fields.RECOVERED_SIZE_IN_BYTES, gatewayRecoveryStatus.getRecoveredIndexSize().bytes());
+                        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, gatewayRecoveryStatus.getIndexSize());
+                        builder.byteSizeField(Fields.REUSED_SIZE, Fields.REUSED_SIZE_IN_BYTES, gatewayRecoveryStatus.getReusedIndexSize());
+                        builder.byteSizeField(Fields.EXPECTED_RECOVERED_SIZE, Fields.EXPECTED_RECOVERED_SIZE_IN_BYTES, gatewayRecoveryStatus.getExpectedRecoveredIndexSize());
+                        builder.byteSizeField(Fields.RECOVERED_SIZE, Fields.RECOVERED_SIZE_IN_BYTES, gatewayRecoveryStatus.getRecoveredIndexSize());
                         builder.endObject();
 
                         builder.startObject(Fields.TRANSLOG);
@@ -269,12 +256,10 @@ public class IndicesStatusResponse extends BroadcastOperationResponse implements
                         builder.startObject(Fields.GATEWAY_SNAPSHOT);
                         builder.field(Fields.STAGE, gatewaySnapshotStatus.getStage());
                         builder.field(Fields.START_TIME_IN_MILLIS, gatewaySnapshotStatus.getStartTime());
-                        builder.field(Fields.TIME, gatewaySnapshotStatus.getTime());
-                        builder.field(Fields.TIME_IN_MILLIS, gatewaySnapshotStatus.getTime().millis());
+                        builder.timeValueField(Fields.TIME, Fields.TIME_IN_MILLIS, gatewaySnapshotStatus.getTime());
 
                         builder.startObject(Fields.INDEX);
-                        builder.field(Fields.SIZE, gatewaySnapshotStatus.getIndexSize());
-                        builder.field(Fields.SIZE_IN_BYTES, gatewaySnapshotStatus.getIndexSize().bytes());
+                        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, gatewaySnapshotStatus.getIndexSize());
                         builder.endObject();
 
                         builder.startObject(Fields.TRANSLOG);

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.BytesStream;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadableInstant;
 import org.joda.time.format.DateTimeFormatter;
@@ -48,7 +50,7 @@ public final class XContentBuilder implements BytesStream {
 
     public static enum FieldCaseConversion {
         /**
-         * No came conversion will occur.
+         * No conversion will occur.
          */
         NONE,
         /**
@@ -56,7 +58,7 @@ public final class XContentBuilder implements BytesStream {
          */
         UNDERSCORE,
         /**
-         * Underscore will be converted to Camel case conversion.
+         * Underscore will be converted to Camel case.
          */
         CAMELCASE
     }
@@ -73,7 +75,6 @@ public final class XContentBuilder implements BytesStream {
         return new XContentBuilder(xContent, new BytesStreamOutput());
     }
 
-
     private XContentGenerator generator;
 
     private final OutputStream bos;
@@ -82,6 +83,7 @@ public final class XContentBuilder implements BytesStream {
 
     private StringBuilder cachedStringBuilder;
 
+    private boolean readableFormat = false;
 
     /**
      * Constructs a new builder using the provided xcontent and an OutputStream. Make sure
@@ -104,6 +106,15 @@ public final class XContentBuilder implements BytesStream {
     public XContentBuilder prettyPrint() {
         generator.usePrettyPrint();
         return this;
+    }
+
+    public XContentBuilder readableFormat(boolean readableFormat) {
+        this.readableFormat = readableFormat;
+        return this;
+    }
+
+    public boolean readableFormat() {
+        return this.readableFormat;
     }
 
     public XContentBuilder field(String name, ToXContent xContent) throws IOException {
@@ -822,6 +833,38 @@ public final class XContentBuilder implements BytesStream {
 
     public XContentBuilder rawField(String fieldName, BytesReference content) throws IOException {
         generator.writeRawField(fieldName, content, bos);
+        return this;
+    }
+
+    public XContentBuilder timeValueField(XContentBuilderString rawFieldName, XContentBuilderString readableFieldName, TimeValue timeValue) throws IOException {
+        if (readableFormat) {
+            field(readableFieldName, timeValue.toString());
+        }
+        field(rawFieldName, timeValue.millis());
+        return this;
+    }
+
+    public XContentBuilder timeValueField(XContentBuilderString rawFieldName, XContentBuilderString readableFieldName, long rawTime) throws IOException {
+        if (readableFormat) {
+            field(readableFieldName, new TimeValue(rawTime).toString());
+        }
+        field(rawFieldName, rawTime);
+        return this;
+    }
+
+    public XContentBuilder byteSizeField(XContentBuilderString rawFieldName, XContentBuilderString readableFieldName, ByteSizeValue byteSizeValue) throws IOException {
+        if (readableFormat) {
+            field(readableFieldName, byteSizeValue.toString());
+        }
+        field(rawFieldName, byteSizeValue.bytes());
+        return this;
+    }
+
+    public XContentBuilder byteSizeField(XContentBuilderString rawFieldName, XContentBuilderString readableFieldName, long rawSize) throws IOException {
+        if (readableFormat) {
+            field(readableFieldName, new ByteSizeValue(rawSize).toString());
+        }
+        field(rawFieldName, rawSize);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -82,8 +82,7 @@ public class FilterCacheStats implements Streamable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject(Fields.FILTER_CACHE);
-        builder.field(Fields.MEMORY_SIZE, getMemorySize().toString());
-        builder.field(Fields.MEMORY_SIZE_IN_BYTES, memorySize);
+        builder.byteSizeField(Fields.MEMORY_SIZE, Fields.MEMORY_SIZE_IN_BYTES, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/index/cache/id/IdCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/id/IdCacheStats.java
@@ -73,8 +73,7 @@ public class IdCacheStats implements Streamable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.ID_CACHE);
-        builder.field(Fields.MEMORY_SIZE, getMemorySize().toString());
-        builder.field(Fields.MEMORY_SIZE_IN_BYTES, memorySize);
+        builder.byteSizeField(Fields.MEMORY_SIZE, Fields.MEMORY_SIZE_IN_BYTES, memorySize);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -119,16 +119,14 @@ public class FieldDataStats implements Streamable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.FIELDDATA);
-        builder.field(Fields.MEMORY_SIZE, getMemorySize().toString());
-        builder.field(Fields.MEMORY_SIZE_IN_BYTES, memorySize);
+        builder.byteSizeField(Fields.MEMORY_SIZE, Fields.MEMORY_SIZE_IN_BYTES, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
         if (fields != null) {
             builder.startObject(Fields.FIELDS);
             for (TObjectLongIterator<String> it = fields.iterator(); it.hasNext(); ) {
                 it.advance();
                 builder.startObject(it.key(), XContentBuilder.FieldCaseConversion.NONE);
-                builder.field(Fields.MEMORY_SIZE, new ByteSizeValue(it.value()).toString());
-                builder.field(Fields.MEMORY_SIZE_IN_BYTES, it.value());
+                builder.byteSizeField(Fields.MEMORY_SIZE, Fields.MEMORY_SIZE_IN_BYTES, it.value());
                 builder.endObject();
             }
             builder.endObject();

--- a/src/main/java/org/elasticsearch/index/flush/FlushStats.java
+++ b/src/main/java/org/elasticsearch/index/flush/FlushStats.java
@@ -88,8 +88,7 @@ public class FlushStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.FLUSH);
         builder.field(Fields.TOTAL, total);
-        builder.field(Fields.TOTAL_TIME, getTotalTime().toString());
-        builder.field(Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
+        builder.timeValueField(Fields.TOTAL_TIME, Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/index/get/GetStats.java
+++ b/src/main/java/org/elasticsearch/index/get/GetStats.java
@@ -105,14 +105,11 @@ public class GetStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.GET);
         builder.field(Fields.TOTAL, getCount());
-        builder.field(Fields.TIME, getTime().toString());
-        builder.field(Fields.TIME_IN_MILLIS, getTimeInMillis());
+        builder.timeValueField(Fields.TIME, Fields.TIME_IN_MILLIS, getTimeInMillis());
         builder.field(Fields.EXISTS_TOTAL, existsCount);
-        builder.field(Fields.EXISTS_TIME, getExistsTime().toString());
-        builder.field(Fields.EXISTS_TIME_IN_MILLIS, existsTimeInMillis);
+        builder.timeValueField(Fields.EXISTS_TIME, Fields.EXISTS_TIME_IN_MILLIS, existsTimeInMillis);
         builder.field(Fields.MISSING_TOTAL, missingCount);
-        builder.field(Fields.MISSING_TIME, getMissingTime().toString());
-        builder.field(Fields.MISSING_TIME_IN_MILLIS, missingTimeInMillis);
+        builder.timeValueField(Fields.MISSING_TIME, Fields.MISSING_TIME_IN_MILLIS, missingTimeInMillis);
         builder.field(Fields.CURRENT, current);
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
+++ b/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
@@ -132,13 +132,11 @@ public class IndexingStats implements Streamable, ToXContent {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.INDEX_TOTAL, indexCount);
-            builder.field(Fields.INDEX_TIME, getIndexTime().toString());
-            builder.field(Fields.INDEX_TIME_IN_MILLIS, indexTimeInMillis);
+            builder.timeValueField(Fields.INDEX_TIME, Fields.INDEX_TIME_IN_MILLIS, indexTimeInMillis);
             builder.field(Fields.INDEX_CURRENT, indexCurrent);
 
             builder.field(Fields.DELETE_TOTAL, deleteCount);
-            builder.field(Fields.DELETE_TIME, getDeleteTime().toString());
-            builder.field(Fields.DELETE_TIME_IN_MILLIS, deleteTimeInMillis);
+            builder.timeValueField(Fields.DELETE_TIME, Fields.DELETE_TIME_IN_MILLIS, deleteTimeInMillis);
             builder.field(Fields.DELETE_CURRENT, deleteCurrent);
 
             return builder;

--- a/src/main/java/org/elasticsearch/index/merge/MergeStats.java
+++ b/src/main/java/org/elasticsearch/index/merge/MergeStats.java
@@ -133,14 +133,11 @@ public class MergeStats implements Streamable, ToXContent {
         builder.startObject(Fields.MERGES);
         builder.field(Fields.CURRENT, current);
         builder.field(Fields.CURRENT_DOCS, currentNumDocs);
-        builder.field(Fields.CURRENT_SIZE, getCurrentSize().toString());
-        builder.field(Fields.CURRENT_SIZE_IN_BYTES, currentSizeInBytes);
+        builder.byteSizeField(Fields.CURRENT_SIZE, Fields.CURRENT_SIZE_IN_BYTES, currentSizeInBytes);
         builder.field(Fields.TOTAL, total);
-        builder.field(Fields.TOTAL_TIME, getTotalTime().toString());
-        builder.field(Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
+        builder.timeValueField(Fields.TOTAL_TIME, Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
         builder.field(Fields.TOTAL_DOCS, totalNumDocs);
-        builder.field(Fields.TOTAL_SIZE, getTotalSize().toString());
-        builder.field(Fields.TOTAL_SIZE_IN_BYTES, totalSizeInBytes);
+        builder.byteSizeField(Fields.TOTAL_SIZE, Fields.TOTAL_SIZE_IN_BYTES, totalSizeInBytes);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/index/percolator/stats/PercolateStats.java
+++ b/src/main/java/org/elasticsearch/index/percolator/stats/PercolateStats.java
@@ -47,8 +47,7 @@ public class PercolateStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.PERCOLATE);
         builder.field(Fields.TOTAL, percolateCount);
-        builder.field(Fields.TIME, getTime().toString());
-        builder.field(Fields.TIME_IN_MILLIS, percolateTimeInMillis);
+        builder.timeValueField(Fields.TIME, Fields.TIME_IN_MILLIS, percolateTimeInMillis);
         builder.field(Fields.CURRENT, current);
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
+++ b/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
@@ -88,8 +88,7 @@ public class RefreshStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.REFRESH);
         builder.field(Fields.TOTAL, total);
-        builder.field(Fields.TOTAL_TIME, getTotalTime().toString());
-        builder.field(Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
+        builder.timeValueField(Fields.TOTAL_TIME, Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -133,13 +133,11 @@ public class SearchStats implements Streamable, ToXContent {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.QUERY_TOTAL, queryCount);
-            builder.field(Fields.QUERY_TIME, getQueryTime().toString());
-            builder.field(Fields.QUERY_TIME_IN_MILLIS, queryTimeInMillis);
+            builder.timeValueField(Fields.QUERY_TIME, Fields.QUERY_TIME_IN_MILLIS, queryTimeInMillis);
             builder.field(Fields.QUERY_CURRENT, queryCurrent);
 
             builder.field(Fields.FETCH_TOTAL, fetchCount);
-            builder.field(Fields.FETCH_TIME, getFetchTime().toString());
-            builder.field(Fields.FETCH_TIME_IN_MILLIS, fetchTimeInMillis);
+            builder.timeValueField(Fields.FETCH_TIME, Fields.FETCH_TIME_IN_MILLIS, fetchTimeInMillis);
             builder.field(Fields.FETCH_CURRENT, fetchCurrent);
 
             return builder;

--- a/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -101,10 +101,8 @@ public class StoreStats implements Streamable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.STORE);
-        builder.field(Fields.SIZE, size().toString());
-        builder.field(Fields.SIZE_IN_BYTES, sizeInBytes);
-        builder.field(Fields.THROTTLE_TIME, throttleTime().toString());
-        builder.field(Fields.THROTTLE_TIME_IN_MILLIS, throttleTime().millis());
+        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, sizeInBytes);
+        builder.timeValueField(Fields.THROTTLE_TIME, Fields.THROTTLE_TIME_IN_MILLIS, throttleTime());
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
+++ b/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
@@ -98,8 +98,7 @@ public class WarmerStats implements Streamable, ToXContent {
         builder.startObject(Fields.WARMER);
         builder.field(Fields.CURRENT, current);
         builder.field(Fields.TOTAL, total);
-        builder.field(Fields.TOTAL_TIME, totalTime().toString());
-        builder.field(Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
+        builder.timeValueField(Fields.TOTAL_TIME, Fields.TOTAL_TIME_IN_MILLIS, totalTimeInMillis);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/monitor/fs/FsStats.java
+++ b/src/main/java/org/elasticsearch/monitor/fs/FsStats.java
@@ -217,16 +217,13 @@ public class FsStats implements Iterable<FsStats.Info>, Streamable, ToXContent {
             }
 
             if (info.total != -1) {
-                builder.field(Fields.TOTAL, info.getTotal().toString());
-                builder.field(Fields.TOTAL_IN_BYTES, info.total);
+                builder.byteSizeField(Fields.TOTAL, Fields.TOTAL_IN_BYTES, info.total);
             }
             if (info.free != -1) {
-                builder.field(Fields.FREE, info.getFree().toString());
-                builder.field(Fields.FREE_IN_BYTES, info.free);
+                builder.byteSizeField(Fields.FREE, Fields.FREE_IN_BYTES, info.free);
             }
             if (info.available != -1) {
-                builder.field(Fields.AVAILABLE, info.getAvailable().toString());
-                builder.field(Fields.AVAILABLE_IN_BYTES, info.available);
+                builder.byteSizeField(Fields.AVAILABLE, Fields.AVAILABLE_IN_BYTES, info.available);
             }
 
             if (info.diskReads != -1) {
@@ -237,12 +234,10 @@ public class FsStats implements Iterable<FsStats.Info>, Streamable, ToXContent {
             }
 
             if (info.diskReadBytes != -1) {
-                builder.field(Fields.DISK_READ_SIZE, info.getDiskReadSizeSize().toString());
-                builder.field(Fields.DISK_READ_SIZE_IN_BYTES, info.getDiskReadSizeInBytes());
+                builder.byteSizeField(Fields.DISK_READ_SIZE, Fields.DISK_READ_SIZE_IN_BYTES, info.getDiskReadSizeInBytes());
             }
             if (info.diskWriteBytes != -1) {
-                builder.field(Fields.DISK_WRITE_SIZE, info.getDiskWriteSizeSize().toString());
-                builder.field(Fields.DISK_WRITE_SIZE_IN_BYTES, info.getDiskWriteSizeInBytes());
+                builder.byteSizeField(Fields.DISK_WRITE_SIZE, Fields.DISK_WRITE_SIZE_IN_BYTES, info.getDiskWriteSizeInBytes());
             }
 
             if (info.diskQueue != -1) {

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -274,16 +274,11 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
         builder.field(Fields.START_TIME, startTime);
 
         builder.startObject(Fields.MEM);
-        builder.field(Fields.HEAP_INIT, mem.heapInit().toString());
-        builder.field(Fields.HEAP_INIT_IN_BYTES, mem.heapInit);
-        builder.field(Fields.HEAP_MAX, mem.heapMax().toString());
-        builder.field(Fields.HEAP_MAX_IN_BYTES, mem.heapMax);
-        builder.field(Fields.NON_HEAP_INIT, mem.nonHeapInit().toString());
-        builder.field(Fields.NON_HEAP_INIT_IN_BYTES, mem.nonHeapInit);
-        builder.field(Fields.NON_HEAP_MAX, mem.nonHeapMax().toString());
-        builder.field(Fields.NON_HEAP_MAX_IN_BYTES, mem.nonHeapMax);
-        builder.field(Fields.DIRECT_MAX, mem.directMemoryMax().toString());
-        builder.field(Fields.DIRECT_MAX_IN_BYTES, mem.directMemoryMax().bytes());
+        builder.byteSizeField(Fields.HEAP_INIT, Fields.HEAP_INIT_IN_BYTES, mem.heapInit);
+        builder.byteSizeField(Fields.HEAP_MAX, Fields.HEAP_MAX_IN_BYTES, mem.heapMax);
+        builder.byteSizeField(Fields.NON_HEAP_INIT, Fields.NON_HEAP_INIT_IN_BYTES, mem.nonHeapInit);
+        builder.byteSizeField(Fields.NON_HEAP_MAX, Fields.NON_HEAP_MAX_IN_BYTES, mem.nonHeapMax);
+        builder.byteSizeField(Fields.DIRECT_MAX, Fields.DIRECT_MAX_IN_BYTES, mem.directMemoryMax);
         builder.endObject();
 
         builder.endObject();

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -283,32 +283,23 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.JVM);
         builder.field(Fields.TIMESTAMP, timestamp);
-        builder.field(Fields.UPTIME, uptime().format());
-        builder.field(Fields.UPTIME_IN_MILLIS, uptime().millis());
+        builder.timeValueField(Fields.UPTIME, Fields.UPTIME_IN_MILLIS, uptime);
         if (mem != null) {
             builder.startObject(Fields.MEM);
-            builder.field(Fields.HEAP_USED, mem.heapUsed().toString());
-            builder.field(Fields.HEAP_USED_IN_BYTES, mem.heapUsed().bytes());
-            builder.field(Fields.HEAP_COMMITTED, mem.heapCommitted().toString());
-            builder.field(Fields.HEAP_COMMITTED_IN_BYTES, mem.heapCommitted().bytes());
 
-            builder.field(Fields.NON_HEAP_USED, mem.nonHeapUsed().toString());
-            builder.field(Fields.NON_HEAP_USED_IN_BYTES, mem.nonHeapUsed);
-            builder.field(Fields.NON_HEAP_COMMITTED, mem.nonHeapCommitted().toString());
-            builder.field(Fields.NON_HEAP_COMMITTED_IN_BYTES, mem.nonHeapCommitted);
+            builder.byteSizeField(Fields.HEAP_USED, Fields.HEAP_USED_IN_BYTES, mem.heapUsed);
+            builder.byteSizeField(Fields.HEAP_COMMITTED, Fields.HEAP_COMMITTED_IN_BYTES, mem.heapCommitted);
+            builder.byteSizeField(Fields.NON_HEAP_USED, Fields.NON_HEAP_USED_IN_BYTES, mem.nonHeapUsed);
+            builder.byteSizeField(Fields.NON_HEAP_COMMITTED, Fields.NON_HEAP_COMMITTED_IN_BYTES, mem.nonHeapCommitted);
 
             builder.startObject(Fields.POOLS);
             for (MemoryPool pool : mem) {
                 builder.startObject(pool.name(), XContentBuilder.FieldCaseConversion.NONE);
-                builder.field(Fields.USED, pool.used().toString());
-                builder.field(Fields.USED_IN_BYTES, pool.used);
-                builder.field(Fields.MAX, pool.max().toString());
-                builder.field(Fields.MAX_IN_BYTES, pool.max);
+                builder.byteSizeField(Fields.USED, Fields.USED_IN_BYTES, pool.used);
+                builder.byteSizeField(Fields.MAX, Fields.MAX_IN_BYTES, pool.max);
 
-                builder.field(Fields.PEAK_USED, pool.peakUsed().toString());
-                builder.field(Fields.PEAK_USED_IN_BYTES, pool.peakUsed);
-                builder.field(Fields.PEAK_MAX, pool.peakMax().toString());
-                builder.field(Fields.PEAK_MAX_IN_BYTES, pool.peakMax);
+                builder.byteSizeField(Fields.PEAK_USED, Fields.PEAK_USED_IN_BYTES, pool.peakUsed);
+                builder.byteSizeField(Fields.PEAK_MAX, Fields.PEAK_MAX_IN_BYTES, pool.peakMax);
 
                 builder.endObject();
             }
@@ -325,15 +316,13 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
         if (gc != null) {
             builder.startObject(Fields.GC);
             builder.field(Fields.COLLECTION_COUNT, gc.collectionCount());
-            builder.field(Fields.COLLECTION_TIME, gc.collectionTime().format());
-            builder.field(Fields.COLLECTION_TIME_IN_MILLIS, gc.collectionTime().millis());
+            builder.timeValueField(Fields.COLLECTION_TIME, Fields.COLLECTION_TIME_IN_MILLIS, gc.collectionTime());
 
             builder.startObject(Fields.COLLECTORS);
             for (GarbageCollector collector : gc) {
                 builder.startObject(collector.name(), XContentBuilder.FieldCaseConversion.NONE);
                 builder.field(Fields.COLLECTION_COUNT, collector.collectionCount());
-                builder.field(Fields.COLLECTION_TIME, collector.collectionTime().format());
-                builder.field(Fields.COLLECTION_TIME_IN_MILLIS, collector.collectionTime().millis());
+                builder.timeValueField(Fields.COLLECTION_TIME, Fields.COLLECTION_TIME_IN_MILLIS, collector.collectionTime);
                 builder.endObject();
             }
             builder.endObject();
@@ -346,10 +335,8 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
             for (BufferPool bufferPool : bufferPools) {
                 builder.startObject(bufferPool.name(), XContentBuilder.FieldCaseConversion.NONE);
                 builder.field(Fields.COUNT, bufferPool.count());
-                builder.field(Fields.USED, bufferPool.used().toString());
-                builder.field(Fields.USED_IN_BYTES, bufferPool.used);
-                builder.field(Fields.TOTAL_CAPACITY, bufferPool.totalCapacity().toString());
-                builder.field(Fields.TOTAL_CAPACITY_IN_BYTES, bufferPool.totalCapacity);
+                builder.byteSizeField(Fields.USED, Fields.USED_IN_BYTES, bufferPool.used);
+                builder.byteSizeField(Fields.TOTAL_CAPACITY, Fields.TOTAL_CAPACITY_IN_BYTES, bufferPool.totalCapacity);
                 builder.endObject();
             }
             builder.endObject();

--- a/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -121,20 +121,17 @@ public class OsInfo implements Streamable, Serializable, ToXContent {
             builder.field(Fields.TOTAL_CORES, cpu.totalCores());
             builder.field(Fields.TOTAL_SOCKETS, cpu.totalSockets());
             builder.field(Fields.CORES_PER_SOCKET, cpu.coresPerSocket());
-            builder.field(Fields.CACHE_SIZE, cpu.cacheSize().toString());
-            builder.field(Fields.CACHE_SIZE_IN_BYTES, cpu.cacheSize().bytes());
+            builder.byteSizeField(Fields.CACHE_SIZE, Fields.CACHE_SIZE_IN_BYTES, cpu.cacheSize);
             builder.endObject();
         }
         if (mem != null) {
             builder.startObject(Fields.MEM);
-            builder.field(Fields.TOTAL, mem.total().toString());
-            builder.field(Fields.TOTAL_IN_BYTES, mem.total);
+            builder.byteSizeField(Fields.TOTAL, Fields.TOTAL_IN_BYTES, mem.total);
             builder.endObject();
         }
         if (swap != null) {
             builder.startObject(Fields.SWAP);
-            builder.field(Fields.TOTAL, swap.total().toString());
-            builder.field(Fields.TOTAL_IN_BYTES, swap.total);
+            builder.byteSizeField(Fields.TOTAL, Fields.TOTAL_IN_BYTES, swap.total);
             builder.endObject();
         }
         builder.endObject();

--- a/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -138,8 +138,7 @@ public class OsStats implements Streamable, Serializable, ToXContent {
         builder.field(Fields.TIMESTAMP, timestamp);
 
         if (uptime != -1) {
-            builder.field(Fields.UPTIME, uptime().format());
-            builder.field(Fields.UPTIME_IN_MILLIS, uptime().millis());
+            builder.byteSizeField(Fields.UPTIME, Fields.UPTIME_IN_MILLIS, uptime);
         }
 
         if (loadAverage.length > 0) {
@@ -161,28 +160,22 @@ public class OsStats implements Streamable, Serializable, ToXContent {
 
         if (mem != null) {
             builder.startObject(Fields.MEM);
-            builder.field(Fields.FREE, mem.free().toString());
-            builder.field(Fields.FREE_IN_BYTES, mem.free);
-            builder.field(Fields.USED, mem.used().toString());
-            builder.field(Fields.USED_IN_BYTES, mem.used);
+            builder.byteSizeField(Fields.FREE, Fields.FREE_IN_BYTES, mem.free);
+            builder.byteSizeField(Fields.USED, Fields.USED_IN_BYTES, mem.used);
 
             builder.field(Fields.FREE_PERCENT, mem.freePercent());
             builder.field(Fields.USED_PERCENT, mem.usedPercent());
 
-            builder.field(Fields.ACTUAL_FREE, mem.actualFree().toString());
-            builder.field(Fields.ACTUAL_FREE_IN_BYTES, mem.actualFree);
-            builder.field(Fields.ACTUAL_USED, mem.actualUsed().toString());
-            builder.field(Fields.ACTUAL_USED_IN_BYTES, mem.actualUsed);
+            builder.byteSizeField(Fields.ACTUAL_FREE, Fields.ACTUAL_FREE_IN_BYTES, mem.actualFree);
+            builder.byteSizeField(Fields.ACTUAL_USED, Fields.ACTUAL_USED_IN_BYTES, mem.actualUsed);
 
             builder.endObject();
         }
 
         if (swap != null) {
             builder.startObject(Fields.SWAP);
-            builder.field(Fields.USED, swap.used().toString());
-            builder.field(Fields.USED_IN_BYTES, swap.used);
-            builder.field(Fields.FREE, swap.free().toString());
-            builder.field(Fields.FREE_IN_BYTES, swap.free);
+            builder.byteSizeField(Fields.USED, Fields.USED_IN_BYTES, swap.used);
+            builder.byteSizeField(Fields.FREE, Fields.FREE_IN_BYTES, swap.free);
             builder.endObject();
         }
 

--- a/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
+++ b/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
@@ -110,22 +110,16 @@ public class ProcessStats implements Streamable, Serializable, ToXContent {
         if (cpu != null) {
             builder.startObject(Fields.CPU);
             builder.field(Fields.PERCENT, cpu.percent());
-            builder.field(Fields.SYS, cpu.sys().format());
-            builder.field(Fields.SYS_IN_MILLIS, cpu.sys().millis());
-            builder.field(Fields.USER, cpu.user().format());
-            builder.field(Fields.USER_IN_MILLIS, cpu.user().millis());
-            builder.field(Fields.TOTAL, cpu.total().format());
-            builder.field(Fields.TOTAL_IN_MILLIS, cpu.total().millis());
+            builder.byteSizeField(Fields.SYS, Fields.SYS_IN_MILLIS, cpu.sys);
+            builder.byteSizeField(Fields.USER, Fields.USER_IN_MILLIS, cpu.user);
+            builder.byteSizeField(Fields.TOTAL, Fields.TOTAL_IN_MILLIS, cpu.total);
             builder.endObject();
         }
         if (mem != null) {
             builder.startObject(Fields.MEM);
-            builder.field(Fields.RESIDENT, mem.resident().toString());
-            builder.field(Fields.RESIDENT_IN_BYTES, mem.resident().bytes());
-            builder.field(Fields.SHARE, mem.share().toString());
-            builder.field(Fields.SHARE_IN_BYTES, mem.share().bytes());
-            builder.field(Fields.TOTAL_VIRTUAL, mem.totalVirtual().toString());
-            builder.field(Fields.TOTAL_VIRTUAL_IN_BYTES, mem.totalVirtual().bytes());
+            builder.byteSizeField(Fields.RESIDENT, Fields.RESIDENT_IN_BYTES, mem.resident);
+            builder.byteSizeField(Fields.SHARE, Fields.SHARE_IN_BYTES, mem.share);
+            builder.byteSizeField(Fields.TOTAL_VIRTUAL, Fields.TOTAL_VIRTUAL_IN_BYTES, mem.totalVirtual);
             builder.endObject();
         }
         builder.endObject();

--- a/src/main/java/org/elasticsearch/rest/action/support/RestXContentBuilder.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestXContentBuilder.java
@@ -57,6 +57,9 @@ public class RestXContentBuilder {
         if (request.paramAsBoolean("pretty", false)) {
             builder.prettyPrint();
         }
+
+        builder.readableFormat(request.paramAsBoolean("readable_format", builder.readableFormat()));
+
         String casing = request.param("case");
         if (casing != null && "camelCase".equals(casing)) {
             builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.CAMELCASE);

--- a/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -118,11 +118,9 @@ public class TransportStats implements Streamable, ToXContent {
         builder.startObject(Fields.TRANSPORT);
         builder.field(Fields.SERVER_OPEN, serverOpen);
         builder.field(Fields.RX_COUNT, rxCount);
-        builder.field(Fields.RX_SIZE, rxSize().toString());
-        builder.field(Fields.RX_SIZE_IN_BYTES, rxSize);
+        builder.byteSizeField(Fields.RX_SIZE, Fields.RX_SIZE_IN_BYTES, rxSize);
         builder.field(Fields.TX_COUNT, txCount);
-        builder.field(Fields.TX_SIZE, txSize().toString());
-        builder.field(Fields.TX_SIZE_IN_BYTES, txSize);
+        builder.byteSizeField(Fields.TX_SIZE, Fields.TX_SIZE_IN_BYTES, txSize);
         builder.endObject();
         return builder;
     }


### PR DESCRIPTION
The following are the API affected by this change and support now the readable_format flag (default false when not specified):
- indices segments
- indices stats
- indices status
- cluster nodes stats
- cluster nodes info

Closes #3432
