### PR TITLE
Added index templates REST support for HEAD and proper 404

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -62,6 +62,7 @@ import org.elasticsearch.rest.action.admin.indices.stats.RestIndicesStatsAction;
 import org.elasticsearch.rest.action.admin.indices.status.RestIndicesStatusAction;
 import org.elasticsearch.rest.action.admin.indices.template.delete.RestDeleteIndexTemplateAction;
 import org.elasticsearch.rest.action.admin.indices.template.get.RestGetIndexTemplateAction;
+import org.elasticsearch.rest.action.admin.indices.template.head.RestHeadIndexTemplateAction;
 import org.elasticsearch.rest.action.admin.indices.template.put.RestPutIndexTemplateAction;
 import org.elasticsearch.rest.action.admin.indices.validate.query.RestValidateQueryAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.delete.RestDeleteWarmerAction;
@@ -147,6 +148,7 @@ public class RestActionModule extends AbstractModule {
         bind(RestGetIndexTemplateAction.class).asEagerSingleton();
         bind(RestPutIndexTemplateAction.class).asEagerSingleton();
         bind(RestDeleteIndexTemplateAction.class).asEagerSingleton();
+        bind(RestHeadIndexTemplateAction.class).asEagerSingleton();
 
         bind(RestPutWarmerAction.class).asEagerSingleton();
         bind(RestDeleteWarmerAction.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -1,13 +1,13 @@
 /*
- * Licensed to Elastic Search and Shay Banon under one
+ * Licensed to ElasticSearch and Shay Banon under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership. Elastic Search licenses this
+ * regarding copyright ownership. ElasticSearch licenses this
  * file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,46 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.elasticsearch.rest.action.admin.indices.template.head;
 
-package org.elasticsearch.rest.action.admin.indices.template.get;
-
-import com.google.common.collect.Maps;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
-import java.io.IOException;
-import java.util.Map;
-
-import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  *
  */
-public class RestGetIndexTemplateAction extends BaseRestHandler {
-
-    private final SettingsFilter settingsFilter;
+public class RestHeadIndexTemplateAction extends BaseRestHandler {
 
     @Inject
-    public RestGetIndexTemplateAction(Settings settings, Client client, RestController controller,
-                                      SettingsFilter settingsFilter) {
+    public RestHeadIndexTemplateAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
-        this.settingsFilter = settingsFilter;
 
-        controller.registerHandler(GET, "/_template/{name}", this);
+        controller.registerHandler(HEAD, "/_template/{name}", this);
     }
 
     @Override
@@ -71,26 +57,13 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
             public void onResponse(ClusterStateResponse response) {
-                Map<String, String> paramsMap = Maps.newHashMap();
-                paramsMap.put("reduce_mappings", "true");
-                ToXContent.Params params = new ToXContent.DelegatingMapParams(paramsMap, request);
-
                 try {
-                    MetaData metaData = response.getState().metaData();
+                    boolean templateExists = response.getState().metaData().templates().size() > 0;
 
-                    if (metaData.templates().values().size() == 0) {
-                        channel.sendResponse(new StringRestResponse(NOT_FOUND));
+                    if (templateExists) {
+                        channel.sendResponse(new StringRestResponse(OK));
                     } else {
-                        XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
-                        builder.startObject();
-
-                        for (IndexTemplateMetaData indexMetaData : metaData.templates().values()) {
-                            IndexTemplateMetaData.Builder.toXContent(indexMetaData, builder, params);
-                        }
-
-                        builder.endObject();
-
-                        channel.sendResponse(new XContentRestResponse(request, OK, builder));
+                        channel.sendResponse(new StringRestResponse(NOT_FOUND));
                     }
                 } catch (Throwable e) {
                     onFailure(e);
@@ -100,8 +73,8 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
             @Override
             public void onFailure(Throwable e) {
                 try {
-                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
-                } catch (IOException e1) {
+                    channel.sendResponse(new StringRestResponse(ExceptionsHelper.status(e)));
+                } catch (Exception e1) {
                     logger.error("Failed to send failure response", e1);
                 }
             }


### PR DESCRIPTION
- Added HEAD support for index templates to find out of they exist
- Returning a 404 instead of a 200 if a GET hits on a non-existing index template

Closes #3434
