### PR TITLE
Overwriting pidfile on startup

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -37,6 +37,7 @@ import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.node.internal.InternalSettingsPerparer;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.RandomAccessFile;
 import java.util.Locale;
 import java.util.Set;
@@ -151,9 +152,9 @@ public class Bootstrap {
                 if (fPidFile.getParentFile() != null) {
                     FileSystemUtils.mkdirs(fPidFile.getParentFile());
                 }
-                RandomAccessFile rafPidFile = new RandomAccessFile(fPidFile, "rw");
-                rafPidFile.writeBytes(Long.toString(JvmInfo.jvmInfo().pid()));
-                rafPidFile.close();
+                FileOutputStream outputStream = new FileOutputStream(fPidFile);
+                outputStream.write(Long.toString(JvmInfo.jvmInfo().pid()).getBytes());
+                outputStream.close();
 
                 fPidFile.deleteOnExit();
             } catch (Exception e) {


### PR DESCRIPTION
The current implementation does not overwrite, but only prepend the new PID into the pidfile.
So if the process is 4 digits long, but the file is already there with a 5 digit number, the file will contain 5 digits after the write.

Note: If the pidfile still exists this usually means, there either is already an instance running using this pidfile or the process has not finished correctly.

Closes #3425
