### PR TITLE
Added IndicesAdminClient.getTemplates()

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -88,6 +88,8 @@ import org.elasticsearch.action.admin.indices.status.IndicesStatusAction;
 import org.elasticsearch.action.admin.indices.status.TransportIndicesStatusAction;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.delete.TransportDeleteIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
+import org.elasticsearch.action.admin.indices.template.get.TransportGetIndexTemplatesAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.validate.query.TransportValidateQueryAction;
@@ -206,6 +208,7 @@ public class ActionModule extends AbstractModule {
         registerAction(UpdateSettingsAction.INSTANCE, TransportUpdateSettingsAction.class);
         registerAction(AnalyzeAction.INSTANCE, TransportAnalyzeAction.class);
         registerAction(PutIndexTemplateAction.INSTANCE, TransportPutIndexTemplateAction.class);
+        registerAction(GetIndexTemplatesAction.INSTANCE, TransportGetIndexTemplatesAction.class);
         registerAction(DeleteIndexTemplateAction.INSTANCE, TransportDeleteIndexTemplateAction.class);
         registerAction(ValidateQueryAction.INSTANCE, TransportValidateQueryAction.class);
         registerAction(GatewaySnapshotAction.INSTANCE, TransportGatewaySnapshotAction.class);

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesAction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.template.get;
+
+import org.elasticsearch.action.admin.indices.IndicesAction;
+import org.elasticsearch.client.IndicesAdminClient;
+
+/**
+ *
+ */
+public class GetIndexTemplatesAction extends IndicesAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse, GetIndexTemplatesRequestBuilder> {
+
+    public static final GetIndexTemplatesAction INSTANCE = new GetIndexTemplatesAction();
+    public static final String NAME = "indices/template/get";
+
+    protected GetIndexTemplatesAction() {
+        super(NAME);
+    }
+
+    @Override
+    public GetIndexTemplatesResponse newResponse() {
+        return new GetIndexTemplatesResponse();
+    }
+
+    @Override
+    public GetIndexTemplatesRequestBuilder newRequestBuilder(IndicesAdminClient client) {
+        return new GetIndexTemplatesRequestBuilder(client);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.template.get;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+/**
+ *
+ */
+public class GetIndexTemplatesRequest extends ClusterInfoRequest<GetIndexTemplatesRequest> {
+
+    private String name;
+
+    public GetIndexTemplatesRequest() {}
+
+    public GetIndexTemplatesRequest(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (name == null) {
+            validationException = addValidationError("name is missing", validationException);
+        }
+        return validationException;
+    }
+
+    /**
+     * Sets the name of the index template.
+     */
+    public GetIndexTemplatesRequest name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * The name of the index template.
+     */
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        name = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(name);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.template.get;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.client.internal.InternalIndicesAdminClient;
+
+/**
+ *
+ */
+public class GetIndexTemplatesRequestBuilder extends MasterNodeOperationRequestBuilder<GetIndexTemplatesRequest, GetIndexTemplatesResponse, GetIndexTemplatesRequestBuilder> {
+
+    public GetIndexTemplatesRequestBuilder(IndicesAdminClient indicesClient) {
+        super((InternalIndicesAdminClient) indicesClient, new GetIndexTemplatesRequest());
+    }
+
+    public GetIndexTemplatesRequestBuilder(IndicesAdminClient indicesClient, String name) {
+        super((InternalIndicesAdminClient) indicesClient, new GetIndexTemplatesRequest(name));
+    }
+
+    @Override
+    protected void doExecute(ActionListener<GetIndexTemplatesResponse> listener) {
+        ((IndicesAdminClient) client).getTemplates(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.template.get;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ *
+ */
+public class GetIndexTemplatesResponse extends ActionResponse {
+
+    private List<IndexTemplateMetaData> indexTemplates;
+
+    GetIndexTemplatesResponse() {
+    }
+
+    GetIndexTemplatesResponse(List<IndexTemplateMetaData> indexTemplates) {
+        this.indexTemplates = indexTemplates;
+    }
+
+    public List<IndexTemplateMetaData> getIndexTemplates() {
+        return indexTemplates;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        int size = in.readVInt();
+        indexTemplates = Lists.newArrayListWithExpectedSize(size);
+        for (int i = 0 ; i < size ; i++) {
+            indexTemplates.add(0, IndexTemplateMetaData.Builder.readFrom(in));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(indexTemplates.size());
+        for (IndexTemplateMetaData indexTemplate : indexTemplates) {
+            IndexTemplateMetaData.Builder.writeTo(indexTemplate, out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.template.get;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.info.TransportClusterInfoAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaDataIndexTemplateService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class TransportGetIndexTemplatesAction extends TransportClusterInfoAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
+
+    @Inject
+    public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
+        super(settings, transportService, clusterService, threadPool);
+    }
+
+    @Override
+    protected String transportAction() {
+        return GetIndexTemplatesAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected GetIndexTemplatesRequest newRequest() {
+        return new GetIndexTemplatesRequest();
+    }
+
+    @Override
+    protected GetIndexTemplatesResponse newResponse() {
+        return new GetIndexTemplatesResponse();
+    }
+
+    @Override
+    protected void doMasterOperation(final GetIndexTemplatesRequest request, final ClusterState state, final ActionListener<GetIndexTemplatesResponse> listener) throws ElasticSearchException {
+        List<IndexTemplateMetaData> results = Lists.newArrayList();
+
+        if (Regex.isSimpleMatchPattern(request.name())) {
+            for (Map.Entry<String, IndexTemplateMetaData> entry : state.metaData().templates().entrySet()) {
+                if (Regex.simpleMatch(request.name(), entry.getKey())) {
+                    results.add(entry.getValue());
+                }
+            }
+        } else if (state.metaData().templates().containsKey(request.name())) {
+            results.add(state.metaData().templates().get(request.name()));
+        }
+
+        listener.onResponse(new GetIndexTemplatesResponse(results));
+    }
+}

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -89,6 +89,9 @@ import org.elasticsearch.action.admin.indices.status.IndicesStatusResponse;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequestBuilder;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
@@ -635,6 +638,23 @@ public interface IndicesAdminClient {
      * @param name The name of the template.
      */
     DeleteIndexTemplateRequestBuilder prepareDeleteTemplate(String name);
+
+    /**
+     * Gets index template.
+     */
+    ActionFuture<GetIndexTemplatesResponse> getTemplates(GetIndexTemplatesRequest request);
+
+    /**
+     * Gets an index template.
+     */
+    void getTemplates(GetIndexTemplatesRequest request, ActionListener<GetIndexTemplatesResponse> listener);
+
+    /**
+     * Gets an index template.
+     *
+     * @param name The name of the template.
+     */
+    GetIndexTemplatesRequestBuilder prepareGetTemplates(String name);
 
     /**
      * Validate a query for correctness.

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -112,6 +112,10 @@ import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplat
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequestBuilder;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
@@ -493,6 +497,21 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
     @Override
     public PutIndexTemplateRequestBuilder preparePutTemplate(String name) {
         return new PutIndexTemplateRequestBuilder(this, name);
+    }
+
+    @Override
+    public ActionFuture<GetIndexTemplatesResponse> getTemplates(final GetIndexTemplatesRequest request) {
+        return execute(GetIndexTemplatesAction.INSTANCE, request);
+    }
+
+    @Override
+    public void getTemplates(final GetIndexTemplatesRequest request, final ActionListener<GetIndexTemplatesResponse> listener) {
+        execute(GetIndexTemplatesAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public GetIndexTemplatesRequestBuilder prepareGetTemplates(String name) {
+        return new GetIndexTemplatesRequestBuilder(this, name);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -20,22 +20,19 @@
 package org.elasticsearch.rest.action.admin.indices.template.get;
 
 import com.google.common.collect.Maps;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -47,47 +44,36 @@ import static org.elasticsearch.rest.RestStatus.OK;
  */
 public class RestGetIndexTemplateAction extends BaseRestHandler {
 
-    private final SettingsFilter settingsFilter;
-
     @Inject
-    public RestGetIndexTemplateAction(Settings settings, Client client, RestController controller,
-                                      SettingsFilter settingsFilter) {
+    public RestGetIndexTemplateAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
-        this.settingsFilter = settingsFilter;
 
         controller.registerHandler(GET, "/_template/{name}", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
-                .filterRoutingTable(true)
-                .filterNodes(true)
-                .filteredIndexTemplates(request.param("name"))
-                .filterOutIndices();
+        GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
+        getIndexTemplatesRequest.listenerThreaded(false);
 
-        clusterStateRequest.listenerThreaded(false);
-
-        client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
+        client.admin().indices().getTemplates(getIndexTemplatesRequest, new ActionListener<GetIndexTemplatesResponse>() {
             @Override
-            public void onResponse(ClusterStateResponse response) {
-                Map<String, String> paramsMap = Maps.newHashMap();
-                paramsMap.put("reduce_mappings", "true");
-                ToXContent.Params params = new ToXContent.DelegatingMapParams(paramsMap, request);
-
+            public void onResponse(GetIndexTemplatesResponse getIndexTemplatesResponse) {
                 try {
-                    MetaData metaData = response.getState().metaData();
+                    boolean templateExists = getIndexTemplatesResponse.getIndexTemplates().size() > 0;
 
-                    if (metaData.templates().values().size() == 0) {
+                    if (!templateExists) {
                         channel.sendResponse(new StringRestResponse(NOT_FOUND));
                     } else {
+                        Map<String, String> paramsMap = Maps.newHashMap();
+                        paramsMap.put("reduce_mappings", "true");
+                        ToXContent.Params params = new ToXContent.DelegatingMapParams(paramsMap, request);
+
                         XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                         builder.startObject();
-
-                        for (IndexTemplateMetaData indexMetaData : metaData.templates().values()) {
-                            IndexTemplateMetaData.Builder.toXContent(indexMetaData, builder, params);
+                        for (IndexTemplateMetaData indexTemplateMetaData : getIndexTemplatesResponse.getIndexTemplates()) {
+                            IndexTemplateMetaData.Builder.toXContent(indexTemplateMetaData, builder, params);
                         }
-
                         builder.endObject();
 
                         channel.sendResponse(new XContentRestResponse(request, OK, builder));
@@ -100,8 +86,8 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
             @Override
             public void onFailure(Throwable e) {
                 try {
-                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
-                } catch (IOException e1) {
+                    channel.sendResponse(new StringRestResponse(ExceptionsHelper.status(e)));
+                } catch (Exception e1) {
                     logger.error("Failed to send failure response", e1);
                 }
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -20,10 +20,9 @@ package org.elasticsearch.rest.action.admin.indices.template.head;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
@@ -46,19 +45,12 @@ public class RestHeadIndexTemplateAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
-                .filterRoutingTable(true)
-                .filterNodes(true)
-                .filteredIndexTemplates(request.param("name"))
-                .filterOutIndices();
-
-        clusterStateRequest.listenerThreaded(false);
-
-        client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
+        GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
+        client.admin().indices().getTemplates(getIndexTemplatesRequest, new ActionListener<GetIndexTemplatesResponse>() {
             @Override
-            public void onResponse(ClusterStateResponse response) {
+            public void onResponse(GetIndexTemplatesResponse getIndexTemplatesResponse) {
                 try {
-                    boolean templateExists = response.getState().metaData().templates().size() > 0;
+                    boolean templateExists = getIndexTemplatesResponse.getIndexTemplates().size() > 0;
 
                     if (templateExists) {
                         channel.sendResponse(new StringRestResponse(OK));


### PR DESCRIPTION
In addition to creating and removing a template, one can now receive the template as well, even receiving multiple templates using simple regexes.

Closes #3439
