### PR TITLE
Configurable sort order for missing string values

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefOrdValComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefOrdValComparator.java
@@ -137,16 +137,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
 
     @Override
     public int compareDocToValue(int doc, BytesRef value) {
-        BytesRef docValue = termsIndex.getValue(doc);
-        if (docValue == null) {
-            if (value == null) {
-                return 0;
-            }
-            return -1;
-        } else if (value == null) {
-            return 1;
-        }
-        return docValue.compareTo(value);
+        throw new UnsupportedOperationException();
     }
 
     class PerSegmentComparator extends NestedWrappableComparator<BytesRef> {
@@ -196,7 +187,9 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
 
         @Override
         public int compareDocToValue(int doc, BytesRef value) {
-            return BytesRefOrdValComparator.this.compareDocToValue(doc, value);
+            final long ord = getOrd(doc);
+            final BytesRef docValue = ord == 0 ? null : termsIndex.getValueByOrd(ord);
+            return compareValues(docValue, value);
         }
 
         protected long getOrd(int doc) {

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefValComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefValComparator.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
-import java.io.IOException;
-
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+
+import java.io.IOException;
 
 /**
  * Sorts by field's natural Term sort order.  All
@@ -33,19 +33,21 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
  * slow for medium to large result sets but possibly
  * very fast for very small results sets.
  */
-public final class BytesRefValComparator extends FieldComparator<BytesRef> {
+public final class BytesRefValComparator extends NestedWrappableComparator<BytesRef> {
 
     private final IndexFieldData<?> indexFieldData;
     private final SortMode sortMode;
+    private final BytesRef missingValue;
 
     private final BytesRef[] values;
     private BytesRef bottom;
     private BytesValues docTerms;
 
-    BytesRefValComparator(IndexFieldData<?> indexFieldData, int numHits, SortMode sortMode) {
+    BytesRefValComparator(IndexFieldData<?> indexFieldData, int numHits, SortMode sortMode, BytesRef missingValue) {
         this.sortMode = sortMode;
         values = new BytesRef[numHits];
         this.indexFieldData = indexFieldData;
+        this.missingValue = missingValue;
     }
 
     @Override
@@ -57,16 +59,23 @@ public final class BytesRefValComparator extends FieldComparator<BytesRef> {
 
     @Override
     public int compareBottom(int doc) throws IOException {
-        final BytesRef val2 = docTerms.getValue(doc);
+        BytesRef val2 = docTerms.getValue(doc);
+        if (val2 == null) {
+            val2 = missingValue;
+        }
         return compareValues(bottom, val2);
     }
 
     @Override
     public void copy(int slot, int doc) throws IOException {
-        if (values[slot] == null) {
-            values[slot] = new BytesRef();
+        if (!docTerms.hasValue(doc)) {
+            values[slot] = missingValue;
+        } else {
+            if (values[slot] == null | values[slot] == missingValue) {
+                values[slot] = new BytesRef();
+            }
+            docTerms.getValueScratch(doc, values[slot]);
         }
-        docTerms.getValueScratch(doc, values[slot]);
     }
 
     @Override
@@ -143,23 +152,27 @@ public final class BytesRefValComparator extends FieldComparator<BytesRef> {
         }
 
         @Override
-        public BytesRef getValueScratch(int docId, BytesRef scratch) {
+        public BytesRef getValueScratch(int docId, BytesRef relevantVal) {
             BytesValues.Iter iter = delegate.getIter(docId);
             if (!iter.hasNext()) {
-                return null;
+                relevantVal.length = 0;
+                return relevantVal;
             }
 
             BytesRef currentVal = iter.next();
-            BytesRef relevantVal = currentVal;
+            relevantVal.length = 0;
+            relevantVal.append(currentVal);
             while (true) {
                 int cmp = currentVal.compareTo(relevantVal);
                 if (sortMode == SortMode.MAX) {
                     if (cmp > 0) {
-                        relevantVal = currentVal;
+                        relevantVal.length = 0;
+                        relevantVal.append(currentVal);
                     }
                 } else {
                     if (cmp < 0) {
-                        relevantVal = currentVal;
+                        relevantVal.length = 0;
+                        relevantVal.append(currentVal);
                     }
                 }
                 if (!iter.hasNext()) {
@@ -170,6 +183,16 @@ public final class BytesRefValComparator extends FieldComparator<BytesRef> {
             return relevantVal;
         }
 
+    }
+
+    @Override
+    public void missing(int slot) {
+        values[slot] = missingValue;
+    }
+
+    @Override
+    public int compareBottomMissing() {
+        return compareValues(bottom, missingValue);
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/NestedWrappableComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/NestedWrappableComparator.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -19,27 +19,24 @@
 
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
+import org.apache.lucene.search.FieldComparator;
 
-/**
- * Base FieldComparator class for number fields.
- */
-// This is right now only used for sorting number based fields inside nested objects
-public abstract class NumberComparatorBase<T> extends NestedWrappableComparator<T> {
+/** Base comparator which allows for nested sorting. */
+public abstract class NestedWrappableComparator<T> extends FieldComparator<T> {
 
     /**
-     * Adds numeric value at the specified doc to the specified slot.
+     * Assigns the underlying missing value to the specified slot, if the actual implementation supports missing value.
      *
-     * @param slot  The specified slot
-     * @param doc   The specified doc
+     * @param slot The slot to assign the the missing value to.
      */
-    public abstract void add(int slot, int doc);
+    public abstract void missing(int slot);
 
     /**
-     * Divides the value at the specified slot with the specified divisor.
+     * Compares the missing value to the bottom.
      *
-     * @param slot      The specified slot
-     * @param divisor   The specified divisor
+     * @return any N < 0 if the bottom value is not competitive with the missing value, any N > 0 if the
+     * bottom value is competitive with the missing value and 0 if they are equal.
      */
-    public abstract void divide(int slot, int divisor);
+    public abstract int compareBottomMissing();
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractBytesIndexFieldData.java
@@ -59,8 +59,7 @@ public abstract class AbstractBytesIndexFieldData<FD extends AtomicFieldData.Wit
 
     @Override
     public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
-        // TODO support "missingValue" for sortMissingValue options here...
-        return new BytesRefFieldComparatorSource(this, sortMode);
+        return new BytesRefFieldComparatorSource(this, missingValue, sortMode);
     }
     
     protected TermsEnum filter(Terms terms, AtomicReader reader) throws IOException {

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/AbstractFieldDataImplTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/AbstractFieldDataImplTests.java
@@ -1,0 +1,460 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.index.fielddata;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.*;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.HashedBytesRef;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.BytesValues;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+
+public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests {
+
+    protected String one() {
+        return "1";
+    }
+
+    protected String two() {
+        return "2";
+    }
+
+    protected String three() {
+        return "3";
+    }
+
+    protected String four() {
+        return "4";
+    }
+
+    protected String toString(Object value) {
+        if (value instanceof BytesRef) {
+            return ((BytesRef) value).utf8ToString();
+        }
+        return value.toString();
+    }
+
+    protected abstract void fillSingleValueAllSet() throws Exception;
+
+    protected abstract void add2SingleValuedDocumentsAndDeleteOneOfThem() throws Exception;
+
+    @Test
+    public void testDeletedDocs() throws Exception {
+        add2SingleValuedDocumentsAndDeleteOneOfThem();
+        IndexFieldData indexFieldData = getForField("value");
+        AtomicReaderContext readerContext = refreshReader();
+        AtomicFieldData fieldData = indexFieldData.load(readerContext);
+        BytesValues values = fieldData.getBytesValues();
+        for (int i = 0; i < fieldData.getNumDocs(); ++i) {
+            assertThat(values.hasValue(i), equalTo(true));
+        }
+    }
+
+    @Test
+    public void testSingleValueAllSet() throws Exception {
+        fillSingleValueAllSet();
+        IndexFieldData indexFieldData = getForField("value");
+        AtomicReaderContext readerContext = refreshReader();
+        AtomicFieldData fieldData = indexFieldData.load(readerContext);
+        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
+
+        assertThat(fieldData.getNumDocs(), equalTo(3));
+
+        BytesValues bytesValues = fieldData.getBytesValues();
+
+        assertThat(bytesValues.isMultiValued(), equalTo(false));
+
+        assertThat(bytesValues.hasValue(0), equalTo(true));
+        assertThat(bytesValues.hasValue(1), equalTo(true));
+        assertThat(bytesValues.hasValue(2), equalTo(true));
+
+        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValue(1), equalTo(new BytesRef(one())));
+        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
+
+        BytesRef bytesRef = new BytesRef();
+        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
+        assertThat(bytesRef, equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef(one())));
+        assertThat(bytesRef, equalTo(new BytesRef(one())));
+        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
+        assertThat(bytesRef, equalTo(new BytesRef(three())));
+
+
+        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
+        assertThat(bytesValuesIter.hasNext(), equalTo(true));
+        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        BytesValues hashedBytesValues = fieldData.getBytesValues();
+
+        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
+        assertThat(hashedBytesValues.hasValue(1), equalTo(true));
+        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
+
+        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
+        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(one())));
+        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
+
+        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
+        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+
+        IndexSearcher searcher = new IndexSearcher(readerContext.reader());
+        TopFieldDocs topDocs;
+
+        topDocs = searcher.search(new MatchAllDocsQuery(), 10,
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+        assertThat(topDocs.totalHits, equalTo(3));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
+        assertThat(toString(((FieldDoc) topDocs.scoreDocs[0]).fields[0]), equalTo(one()));
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
+        assertThat(toString(((FieldDoc) topDocs.scoreDocs[1]).fields[0]), equalTo(two()));
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
+        assertThat(toString(((FieldDoc) topDocs.scoreDocs[2]).fields[0]), equalTo(three()));
+
+        topDocs = searcher.search(new MatchAllDocsQuery(), 10,
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+        assertThat(topDocs.totalHits, equalTo(3));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
+    }
+    
+    private HashedBytesRef convert(BytesValues values, int doc) {
+        BytesRef ref = new BytesRef();
+        return new HashedBytesRef(ref, values.getValueHashed(doc, ref));
+    }
+
+    protected abstract void fillSingleValueWithMissing() throws Exception;
+
+    @Test
+    public void testSingleValueWithMissing() throws Exception {
+        fillSingleValueWithMissing();
+        IndexFieldData indexFieldData = getForField("value");
+        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
+        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
+
+        assertThat(fieldData.getNumDocs(), equalTo(3));
+
+        BytesValues bytesValues = fieldData
+                .getBytesValues();
+
+        assertThat(bytesValues.isMultiValued(), equalTo(false));
+
+        assertThat(bytesValues.hasValue(0), equalTo(true));
+        assertThat(bytesValues.hasValue(1), equalTo(false));
+        assertThat(bytesValues.hasValue(2), equalTo(true));
+
+        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValue(1), nullValue());
+        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
+
+        BytesRef bytesRef = new BytesRef();
+        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
+        assertThat(bytesRef, equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef()));
+        assertThat(bytesRef, equalTo(new BytesRef()));
+        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
+        assertThat(bytesRef, equalTo(new BytesRef(three())));
+
+
+        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
+        assertThat(bytesValuesIter.hasNext(), equalTo(true));
+        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        bytesValuesIter = bytesValues.getIter(1);
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        BytesValues hashedBytesValues = fieldData.getBytesValues();
+
+        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
+        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
+        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
+
+        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
+        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(new BytesRef())));
+        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
+
+        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
+        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+
+        hashedBytesValuesIter = hashedBytesValues.getIter(1);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+    }
+
+    protected abstract void fillMultiValueAllSet() throws Exception;
+
+    @Test
+    public void testMultiValueAllSet() throws Exception {
+        fillMultiValueAllSet();
+        IndexFieldData indexFieldData = getForField("value");
+        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
+        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
+
+        assertThat(fieldData.getNumDocs(), equalTo(3));
+
+        BytesValues bytesValues = fieldData.getBytesValues();
+
+        assertThat(bytesValues.isMultiValued(), equalTo(true));
+
+        assertThat(bytesValues.hasValue(0), equalTo(true));
+        assertThat(bytesValues.hasValue(1), equalTo(true));
+        assertThat(bytesValues.hasValue(2), equalTo(true));
+
+        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValue(1), equalTo(new BytesRef(one())));
+        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
+
+        BytesRef bytesRef = new BytesRef();
+        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
+        assertThat(bytesRef, equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef(one())));
+        assertThat(bytesRef, equalTo(new BytesRef(one())));
+        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
+        assertThat(bytesRef, equalTo(new BytesRef(three())));
+
+
+        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
+        assertThat(bytesValuesIter.hasNext(), equalTo(true));
+        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
+        assertThat(bytesValuesIter.hasNext(), equalTo(true));
+        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(four())));
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        BytesValues hashedBytesValues = fieldData.getBytesValues();
+
+        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
+        assertThat(hashedBytesValues.hasValue(1), equalTo(true));
+        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
+
+        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
+        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(one())));
+        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
+
+        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
+        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
+        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(four())));
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+
+        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
+        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+        assertThat(topDocs.totalHits, equalTo(3));
+        assertThat(topDocs.scoreDocs.length, equalTo(3));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
+
+        topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+        assertThat(topDocs.totalHits, equalTo(3));
+        assertThat(topDocs.scoreDocs.length, equalTo(3));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
+    }
+
+    protected abstract void fillMultiValueWithMissing() throws Exception;
+
+    @Test
+    public void testMultiValueWithMissing() throws Exception {
+        fillMultiValueWithMissing();
+        IndexFieldData indexFieldData = getForField("value");
+        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
+        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
+
+        assertThat(fieldData.getNumDocs(), equalTo(3));
+
+        BytesValues bytesValues = fieldData.getBytesValues();
+
+        assertThat(bytesValues.isMultiValued(), equalTo(true));
+
+        assertThat(bytesValues.hasValue(0), equalTo(true));
+        assertThat(bytesValues.hasValue(1), equalTo(false));
+        assertThat(bytesValues.hasValue(2), equalTo(true));
+
+        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValue(1), nullValue());
+        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
+
+        BytesRef bytesRef = new BytesRef();
+        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
+        assertThat(bytesRef, equalTo(new BytesRef(two())));
+        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef()));
+        assertThat(bytesRef, equalTo(new BytesRef()));
+        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
+        assertThat(bytesRef, equalTo(new BytesRef(three())));
+
+
+        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
+        assertThat(bytesValuesIter.hasNext(), equalTo(true));
+        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
+        assertThat(bytesValuesIter.hasNext(), equalTo(true));
+        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(four())));
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        bytesValuesIter = bytesValues.getIter(1);
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        BytesValues hashedBytesValues = fieldData.getBytesValues();
+
+        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
+        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
+        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
+
+        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
+        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(new BytesRef())));
+        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
+
+        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
+        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
+        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(four())));
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+
+        hashedBytesValuesIter = hashedBytesValues.getIter(1);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+    }
+
+    public void testMissingValueForAll() throws Exception {
+        fillAllMissing();
+        IndexFieldData indexFieldData = getForField("value");
+        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
+        // Some impls (FST) return size 0 and some (PagedBytes) do take size in the case no actual data is loaded
+        assertThat(fieldData.getMemorySizeInBytes(), greaterThanOrEqualTo(0l));
+
+        assertThat(fieldData.getNumDocs(), equalTo(3));
+
+        BytesValues bytesValues = fieldData.getBytesValues();
+
+        assertThat(bytesValues.isMultiValued(), equalTo(false));
+
+        assertThat(bytesValues.hasValue(0), equalTo(false));
+        assertThat(bytesValues.hasValue(1), equalTo(false));
+        assertThat(bytesValues.hasValue(2), equalTo(false));
+
+        assertThat(bytesValues.getValue(0), nullValue());
+        assertThat(bytesValues.getValue(1), nullValue());
+        assertThat(bytesValues.getValue(2), nullValue());
+
+        BytesRef bytesRef = new BytesRef();
+        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef()));
+        assertThat(bytesRef, equalTo(new BytesRef()));
+        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef()));
+        assertThat(bytesRef, equalTo(new BytesRef()));
+        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef()));
+        assertThat(bytesRef, equalTo(new BytesRef()));
+
+        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        bytesValuesIter = bytesValues.getIter(1);
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        bytesValuesIter = bytesValues.getIter(2);
+        assertThat(bytesValuesIter.hasNext(), equalTo(false));
+
+        BytesValues hashedBytesValues = fieldData.getBytesValues();
+
+        assertThat(hashedBytesValues.hasValue(0), equalTo(false));
+        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
+        assertThat(hashedBytesValues.hasValue(2), equalTo(false));
+
+        assertThat(hashedBytesValues.getValue(0), nullValue());
+        assertThat(hashedBytesValues.getValue(1), nullValue());
+        assertThat(hashedBytesValues.getValue(2), nullValue());
+
+        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+
+        hashedBytesValuesIter = hashedBytesValues.getIter(1);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+
+        hashedBytesValuesIter = hashedBytesValues.getIter(2);
+        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
+    }
+
+    protected abstract void fillAllMissing() throws Exception;
+
+    @Test
+    public void testSortMultiValuesFields() throws Exception {
+        fillExtendedMvSet();
+        IndexFieldData indexFieldData = getForField("value");
+
+        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
+        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10,
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+        assertThat(topDocs.totalHits, equalTo(8));
+        assertThat(topDocs.scoreDocs.length, equalTo(8));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(7));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[0]).fields[0]).utf8ToString(), equalTo("!08"));
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[1]).fields[0]).utf8ToString(), equalTo("02"));
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[2]).fields[0]).utf8ToString(), equalTo("03"));
+        assertThat(topDocs.scoreDocs[3].doc, equalTo(3));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[3]).fields[0]).utf8ToString(), equalTo("04"));
+        assertThat(topDocs.scoreDocs[4].doc, equalTo(4));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[4]).fields[0]).utf8ToString(), equalTo("06"));
+        assertThat(topDocs.scoreDocs[5].doc, equalTo(6));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[5]).fields[0]).utf8ToString(), equalTo("08"));
+        assertThat(topDocs.scoreDocs[6].doc, equalTo(1));
+        assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[6]).fields[0], equalTo(BytesRefFieldComparatorSource.MAX_TERM));
+        assertThat(topDocs.scoreDocs[7].doc, equalTo(5));
+        assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(BytesRefFieldComparatorSource.MAX_TERM));
+
+        topDocs = searcher.search(new MatchAllDocsQuery(), 10,
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+        assertThat(topDocs.totalHits, equalTo(8));
+        assertThat(topDocs.scoreDocs.length, equalTo(8));
+        assertThat(topDocs.scoreDocs[0].doc, equalTo(6));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[0]).fields[0]).utf8ToString(), equalTo("10"));
+        assertThat(topDocs.scoreDocs[1].doc, equalTo(4));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[1]).fields[0]).utf8ToString(), equalTo("08"));
+        assertThat(topDocs.scoreDocs[2].doc, equalTo(3));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[2]).fields[0]).utf8ToString(), equalTo("06"));
+        assertThat(topDocs.scoreDocs[3].doc, equalTo(0));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[3]).fields[0]).utf8ToString(), equalTo("04"));
+        assertThat(topDocs.scoreDocs[4].doc, equalTo(2));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[4]).fields[0]).utf8ToString(), equalTo("03"));
+        assertThat(topDocs.scoreDocs[5].doc, equalTo(7));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[5]).fields[0]).utf8ToString(), equalTo("!10"));
+        assertThat(topDocs.scoreDocs[6].doc, equalTo(1));
+        assertThat(((FieldDoc) topDocs.scoreDocs[6]).fields[0], equalTo(null));
+        assertThat(topDocs.scoreDocs[7].doc, equalTo(5));
+        assertThat(((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(null));
+    }
+
+    protected abstract void fillExtendedMvSet() throws Exception;
+
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/AbstractNumericFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/AbstractNumericFieldDataTests.java
@@ -33,8 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@Ignore("abstract")
-public abstract class NumericFieldDataTests extends AbstractStringFieldDataTests {
+public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImplTests {
 
     protected abstract FieldDataType getFieldDataType();
 

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/AbstractStringFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/AbstractStringFieldDataTests.java
@@ -19,49 +19,37 @@
 
 package org.elasticsearch.test.unit.index.fielddata;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
-import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.join.ScoreMode;
+import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.lucene.HashedBytesRef;
-import org.elasticsearch.index.fielddata.AtomicFieldData;
-import org.elasticsearch.index.fielddata.BytesValues;
+import org.apache.lucene.util.UnicodeUtil;
+import org.apache.lucene.util._TestUtil;
+import org.elasticsearch.common.lucene.search.NotFilter;
+import org.elasticsearch.common.lucene.search.TermFilter;
+import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
-import org.junit.Test;
+import org.elasticsearch.index.search.nested.NestedFieldComparatorSource;
 
-import static org.hamcrest.Matchers.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
 
 /**
  */
-public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTests {
-
-    protected String one() {
-        return "1";
-    }
-
-    protected String two() {
-        return "2";
-    }
-
-    protected String three() {
-        return "3";
-    }
-
-    protected String four() {
-        return "4";
-    }
-
-    private String toString(Object value) {
-        if (value instanceof BytesRef) {
-            return ((BytesRef) value).utf8ToString();
-        }
-        return value.toString();
-    }
+public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImplTests {
 
     protected void fillSingleValueAllSet() throws Exception {
         Document d = new Document();
@@ -96,100 +84,6 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTest
         writer.deleteDocuments(new Term("_id", "1"));
     }
 
-    @Test
-    public void testDeletedDocs() throws Exception {
-        add2SingleValuedDocumentsAndDeleteOneOfThem();
-        IndexFieldData indexFieldData = getForField("value");
-        AtomicReaderContext readerContext = refreshReader();
-        AtomicFieldData fieldData = indexFieldData.load(readerContext);
-        assertThat(indexFieldData.getHighestNumberOfSeenUniqueValues(), greaterThan(0l));
-        BytesValues values = fieldData.getBytesValues();
-        assertThat(fieldData.getNumDocs(), equalTo(2));
-        assertThat(fieldData.getNumberUniqueValues(), equalTo(2l));
-        for (int i = 0; i < fieldData.getNumDocs(); ++i) {
-            assertThat(values.hasValue(i), equalTo(true));
-        }
-    }
-
-    @Test
-    public void testSingleValueAllSet() throws Exception {
-        fillSingleValueAllSet();
-        IndexFieldData indexFieldData = getForField("value");
-        AtomicReaderContext readerContext = refreshReader();
-        AtomicFieldData fieldData = indexFieldData.load(readerContext);
-        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
-        assertThat(fieldData.getNumberUniqueValues(), equalTo(3l));
-        assertThat(indexFieldData.getHighestNumberOfSeenUniqueValues(), greaterThan(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
-        BytesValues bytesValues = fieldData.getBytesValues();
-
-        assertThat(bytesValues.isMultiValued(), equalTo(false));
-
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(true));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef(one())));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
-        BytesRef bytesRef = new BytesRef();
-        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
-        assertThat(bytesRef, equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef(one())));
-        assertThat(bytesRef, equalTo(new BytesRef(one())));
-        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
-        assertThat(bytesRef, equalTo(new BytesRef(three())));
-
-
-        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
-        assertThat(bytesValuesIter.hasNext(), equalTo(true));
-        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        BytesValues hashedBytesValues = fieldData.getBytesValues();
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
-
-        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
-        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(one())));
-        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
-
-        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
-        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        IndexSearcher searcher = new IndexSearcher(readerContext.reader());
-        TopFieldDocs topDocs;
-
-        topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
-        assertThat(topDocs.totalHits, equalTo(3));
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
-        assertThat(toString(((FieldDoc) topDocs.scoreDocs[0]).fields[0]), equalTo(one()));
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
-        assertThat(toString(((FieldDoc) topDocs.scoreDocs[1]).fields[0]), equalTo(two()));
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
-        assertThat(toString(((FieldDoc) topDocs.scoreDocs[2]).fields[0]), equalTo(three()));
-
-        topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
-        assertThat(topDocs.totalHits, equalTo(3));
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
-    }
-    
-    private HashedBytesRef convert(BytesValues values, int doc) {
-        BytesRef ref = new BytesRef();
-        return new HashedBytesRef(ref, values.getValueHashed(doc, ref));
-    }
-
     protected void fillSingleValueWithMissing() throws Exception {
         Document d = new Document();
         d.add(new StringField("_id", "1", Field.Store.NO));
@@ -205,68 +99,6 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTest
         d.add(new StringField("_id", "3", Field.Store.NO));
         d.add(new StringField("value", "3", Field.Store.NO));
         writer.addDocument(d);
-    }
-
-    @Test
-    public void testSingleValueWithMissing() throws Exception {
-        fillSingleValueWithMissing();
-        IndexFieldData indexFieldData = getForField("value");
-        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
-        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
-
-        assertThat(fieldData.getNumberUniqueValues(), equalTo(2l));
-        assertThat(indexFieldData.getHighestNumberOfSeenUniqueValues(), greaterThan(0l));
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
-        BytesValues bytesValues = fieldData
-                .getBytesValues();
-
-        assertThat(bytesValues.isMultiValued(), equalTo(false));
-
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(false));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), nullValue());
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
-        BytesRef bytesRef = new BytesRef();
-        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
-        assertThat(bytesRef, equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef()));
-        assertThat(bytesRef, equalTo(new BytesRef()));
-        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
-        assertThat(bytesRef, equalTo(new BytesRef(three())));
-
-
-        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
-        assertThat(bytesValuesIter.hasNext(), equalTo(true));
-        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        bytesValuesIter = bytesValues.getIter(1);
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        BytesValues hashedBytesValues = fieldData.getBytesValues();
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
-
-        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
-        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(new BytesRef())));
-        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
-
-        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
-        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        hashedBytesValuesIter = hashedBytesValues.getIter(1);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        // TODO properly support missing....
     }
 
     protected void fillMultiValueAllSet() throws Exception {
@@ -288,78 +120,6 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTest
         writer.addDocument(d);
     }
 
-    @Test
-    public void testMultiValueAllSet() throws Exception {
-        fillMultiValueAllSet();
-        IndexFieldData indexFieldData = getForField("value");
-        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
-        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-        assertThat(fieldData.getNumberUniqueValues(), equalTo(4l));
-        assertThat(indexFieldData.getHighestNumberOfSeenUniqueValues(), greaterThan(0l));
-
-        BytesValues bytesValues = fieldData.getBytesValues();
-
-        assertThat(bytesValues.isMultiValued(), equalTo(true));
-
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(true));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef(one())));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
-        BytesRef bytesRef = new BytesRef();
-        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
-        assertThat(bytesRef, equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef(one())));
-        assertThat(bytesRef, equalTo(new BytesRef(one())));
-        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
-        assertThat(bytesRef, equalTo(new BytesRef(three())));
-
-
-        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
-        assertThat(bytesValuesIter.hasNext(), equalTo(true));
-        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
-        assertThat(bytesValuesIter.hasNext(), equalTo(true));
-        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(four())));
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        BytesValues hashedBytesValues = fieldData.getBytesValues();
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
-
-        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
-        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(one())));
-        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
-
-        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
-        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
-        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(four())));
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
-        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
-        assertThat(topDocs.totalHits, equalTo(3));
-        assertThat(topDocs.scoreDocs.length, equalTo(3));
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
-
-        topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
-        assertThat(topDocs.totalHits, equalTo(3));
-        assertThat(topDocs.scoreDocs.length, equalTo(3));
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
-    }
-
     protected void fillMultiValueWithMissing() throws Exception {
         Document d = new Document();
         d.add(new StringField("_id", "1", Field.Store.NO));
@@ -378,129 +138,6 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTest
         writer.addDocument(d);
     }
 
-    @Test
-    public void testMultiValueWithMissing() throws Exception {
-        fillMultiValueWithMissing();
-        IndexFieldData indexFieldData = getForField("value");
-        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
-        assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-        assertThat(fieldData.getNumberUniqueValues(), equalTo(3l));
-        assertThat(indexFieldData.getHighestNumberOfSeenUniqueValues(), greaterThan(0l));
-
-        BytesValues bytesValues = fieldData.getBytesValues();
-
-        assertThat(bytesValues.isMultiValued(), equalTo(true));
-
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(false));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), nullValue());
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
-        BytesRef bytesRef = new BytesRef();
-        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef(two())));
-        assertThat(bytesRef, equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef()));
-        assertThat(bytesRef, equalTo(new BytesRef()));
-        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef(three())));
-        assertThat(bytesRef, equalTo(new BytesRef(three())));
-
-
-        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
-        assertThat(bytesValuesIter.hasNext(), equalTo(true));
-        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(two())));
-        assertThat(bytesValuesIter.hasNext(), equalTo(true));
-        assertThat(bytesValuesIter.next(), equalTo(new BytesRef(four())));
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        bytesValuesIter = bytesValues.getIter(1);
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        BytesValues hashedBytesValues = fieldData.getBytesValues();
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
-
-        assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
-        assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(new BytesRef())));
-        assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
-
-        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
-        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(two())));
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(true));
-        assertThat(new HashedBytesRef(hashedBytesValuesIter.next(), hashedBytesValuesIter.hash()), equalTo(new HashedBytesRef(four())));
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        hashedBytesValuesIter = hashedBytesValues.getIter(1);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-    }
-
-    public void testMissingValueForAll() throws Exception {
-        fillAllMissing();
-        IndexFieldData indexFieldData = getForField("value");
-        AtomicFieldData fieldData = indexFieldData.load(refreshReader());
-        // Some impls (FST) return size 0 and some (PagedBytes) do take size in the case no actual data is loaded
-        assertThat(fieldData.getMemorySizeInBytes(), greaterThanOrEqualTo(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-        assertThat(fieldData.getNumberUniqueValues(), equalTo(0l));
-        assertThat(indexFieldData.getHighestNumberOfSeenUniqueValues(), equalTo(0l));
-
-        BytesValues bytesValues = fieldData.getBytesValues();
-
-        assertThat(bytesValues.isMultiValued(), equalTo(false));
-
-        assertThat(bytesValues.hasValue(0), equalTo(false));
-        assertThat(bytesValues.hasValue(1), equalTo(false));
-        assertThat(bytesValues.hasValue(2), equalTo(false));
-
-        assertThat(bytesValues.getValue(0), nullValue());
-        assertThat(bytesValues.getValue(1), nullValue());
-        assertThat(bytesValues.getValue(2), nullValue());
-
-        BytesRef bytesRef = new BytesRef();
-        assertThat(bytesValues.getValueScratch(0, bytesRef), equalTo(new BytesRef()));
-        assertThat(bytesRef, equalTo(new BytesRef()));
-        assertThat(bytesValues.getValueScratch(1, bytesRef), equalTo(new BytesRef()));
-        assertThat(bytesRef, equalTo(new BytesRef()));
-        assertThat(bytesValues.getValueScratch(2, bytesRef), equalTo(new BytesRef()));
-        assertThat(bytesRef, equalTo(new BytesRef()));
-
-        BytesValues.Iter bytesValuesIter = bytesValues.getIter(0);
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        bytesValuesIter = bytesValues.getIter(1);
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        bytesValuesIter = bytesValues.getIter(2);
-        assertThat(bytesValuesIter.hasNext(), equalTo(false));
-
-        BytesValues hashedBytesValues = fieldData.getBytesValues();
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(false));
-
-        assertThat(hashedBytesValues.getValue(0), nullValue());
-        assertThat(hashedBytesValues.getValue(1), nullValue());
-        assertThat(hashedBytesValues.getValue(2), nullValue());
-
-        BytesValues.Iter hashedBytesValuesIter = hashedBytesValues.getIter(0);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        hashedBytesValuesIter = hashedBytesValues.getIter(1);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-
-        hashedBytesValuesIter = hashedBytesValues.getIter(2);
-        assertThat(hashedBytesValuesIter.hasNext(), equalTo(false));
-    }
-
     protected void fillAllMissing() throws Exception {
         Document d = new Document();
         d.add(new StringField("_id", "1", Field.Store.NO));
@@ -513,55 +150,6 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTest
         d = new Document();
         d.add(new StringField("_id", "3", Field.Store.NO));
         writer.addDocument(d);
-    }
-
-    @Test
-    public void testSortMultiValuesFields() throws Exception {
-        fillExtendedMvSet();
-        IndexFieldData indexFieldData = getForField("value");
-
-        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
-        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
-        assertThat(topDocs.totalHits, equalTo(8));
-        assertThat(topDocs.scoreDocs.length, equalTo(8));
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
-        assertThat(((FieldDoc) topDocs.scoreDocs[0]).fields[0], equalTo(null));
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(5));
-        assertThat(((FieldDoc) topDocs.scoreDocs[1]).fields[0], equalTo(null));
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(7));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[2]).fields[0]).utf8ToString(), equalTo("!08"));
-        assertThat(topDocs.scoreDocs[3].doc, equalTo(0));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[3]).fields[0]).utf8ToString(), equalTo("02"));
-        assertThat(topDocs.scoreDocs[4].doc, equalTo(2));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[4]).fields[0]).utf8ToString(), equalTo("03"));
-        assertThat(topDocs.scoreDocs[5].doc, equalTo(3));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[5]).fields[0]).utf8ToString(), equalTo("04"));
-        assertThat(topDocs.scoreDocs[6].doc, equalTo(4));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[6]).fields[0]).utf8ToString(), equalTo("06"));
-        assertThat(topDocs.scoreDocs[7].doc, equalTo(6));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0]).utf8ToString(), equalTo("08"));
-
-        topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
-        assertThat(topDocs.totalHits, equalTo(8));
-        assertThat(topDocs.scoreDocs.length, equalTo(8));
-        assertThat(topDocs.scoreDocs[0].doc, equalTo(6));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[0]).fields[0]).utf8ToString(), equalTo("10"));
-        assertThat(topDocs.scoreDocs[1].doc, equalTo(4));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[1]).fields[0]).utf8ToString(), equalTo("08"));
-        assertThat(topDocs.scoreDocs[2].doc, equalTo(3));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[2]).fields[0]).utf8ToString(), equalTo("06"));
-        assertThat(topDocs.scoreDocs[3].doc, equalTo(0));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[3]).fields[0]).utf8ToString(), equalTo("04"));
-        assertThat(topDocs.scoreDocs[4].doc, equalTo(2));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[4]).fields[0]).utf8ToString(), equalTo("03"));
-        assertThat(topDocs.scoreDocs[5].doc, equalTo(7));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[5]).fields[0]).utf8ToString(), equalTo("!10"));
-        assertThat(topDocs.scoreDocs[6].doc, equalTo(1));
-        assertThat(((FieldDoc) topDocs.scoreDocs[6]).fields[0], equalTo(null));
-        assertThat(topDocs.scoreDocs[7].doc, equalTo(5));
-        assertThat(((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(null));
     }
 
     protected void fillExtendedMvSet() throws Exception {
@@ -615,4 +203,224 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataTest
         writer.addDocument(d);
     }
 
+    @Repeat(iterations=10)
+    public void testActualMissingValue() throws IOException {
+        testActualMissingValue(false);
+    }
+
+    @Repeat(iterations=10)
+    public void testActualMissingValueReverse() throws IOException {
+        testActualMissingValue(true);
+    }
+
+    public void testActualMissingValue(boolean reverse) throws IOException {
+        // missing value is set to an actual value
+        Document d = new Document();
+        final StringField s = new StringField("value", "", Field.Store.YES);
+        d.add(s);
+        final String[] values = new String[randomIntBetween(2, 30)];
+        for (int i = 1; i < values.length; ++i) {
+            values[i] = _TestUtil.randomUnicodeString(getRandom());
+        }
+        final int numDocs = atLeast(100);
+        for (int i = 0; i < numDocs; ++i) {
+            final String value = RandomPicks.randomFrom(getRandom(), values);
+            if (value == null) {
+                writer.addDocument(new Document());
+            } else {
+                s.setStringValue(value);
+                writer.addDocument(d);
+            }
+            if (randomInt(10) == 0) {
+                writer.commit();
+            }
+        }
+
+        final IndexFieldData indexFieldData = getForField("value");
+        final String missingValue = values[1];
+        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
+        XFieldComparatorSource comparator = indexFieldData.comparatorSource(missingValue, SortMode.MIN);
+        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), randomBoolean() ? numDocs : randomIntBetween(10, numDocs), new Sort(new SortField("value", comparator, reverse)));
+        assertEquals(numDocs, topDocs.totalHits);
+        BytesRef previousValue = reverse ? UnicodeUtil.BIG_TERM : new BytesRef();
+        for (int i = 0; i < topDocs.scoreDocs.length; ++i) {
+            final String docValue = searcher.doc(topDocs.scoreDocs[i].doc).get("value");
+            final BytesRef value = new BytesRef(docValue == null ? missingValue : docValue);
+            if (reverse) {
+                assertTrue(previousValue.compareTo(value) >= 0);
+            } else {
+                assertTrue(previousValue.compareTo(value) <= 0);
+            }
+            previousValue = value;
+        }
+        searcher.getIndexReader().close();
+    }
+
+    @Repeat(iterations=3)
+    public void testSortMissingFirst() throws IOException {
+        testSortMissing(true, false);
+    }
+
+    @Repeat(iterations=3)
+    public void testSortMissingFirstReverse() throws IOException {
+        testSortMissing(true, true);
+    }
+
+    @Repeat(iterations=3)
+    public void testSortMissingLast() throws IOException {
+        testSortMissing(false, false);
+    }
+
+    @Repeat(iterations=3)
+    public void testSortMissingLastReverse() throws IOException {
+        testSortMissing(false, true);
+    }
+
+    public void testSortMissing(boolean first, boolean reverse) throws IOException {
+        Document d = new Document();
+        final StringField s = new StringField("value", "", Field.Store.YES);
+        d.add(s);
+        final String[] values = new String[randomIntBetween(2, 10)];
+        for (int i = 1; i < values.length; ++i) {
+            values[i] = _TestUtil.randomUnicodeString(getRandom());
+        }
+        final int numDocs = atLeast(100);
+        for (int i = 0; i < numDocs; ++i) {
+            final String value = RandomPicks.randomFrom(getRandom(), values);
+            if (value == null) {
+                writer.addDocument(new Document());
+            } else {
+                s.setStringValue(value);
+                writer.addDocument(d);
+            }
+            if (randomInt(10) == 0) {
+                writer.commit();
+            }
+        }
+        final IndexFieldData indexFieldData = getForField("value");
+        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
+        XFieldComparatorSource comparator = indexFieldData.comparatorSource(first ? "_first" : "_last", SortMode.MIN);
+        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), randomBoolean() ? numDocs : randomIntBetween(10, numDocs), new Sort(new SortField("value", comparator, reverse)));
+        assertEquals(numDocs, topDocs.totalHits);
+        BytesRef previousValue = first ? null : reverse ? UnicodeUtil.BIG_TERM : new BytesRef();
+        for (int i = 0; i < topDocs.scoreDocs.length; ++i) {
+            final String docValue = searcher.doc(topDocs.scoreDocs[i].doc).get("value");
+            if (first && docValue == null) {
+                assertNull(previousValue);
+            } else if (!first && docValue != null) {
+                assertNotNull(previousValue);
+            }
+            final BytesRef value = docValue == null ? null : new BytesRef(docValue);
+            if (previousValue != null && value != null) {
+                if (reverse) {
+                    assertTrue(previousValue.compareTo(value) >= 0);
+                } else {
+                    assertTrue(previousValue.compareTo(value) <= 0);
+                }
+            }
+            previousValue = value;
+        }
+        searcher.getIndexReader().close();
+    }
+
+    @Repeat(iterations=3)
+    public void testNestedSortingMin() throws IOException {
+        testNestedSorting(SortMode.MIN);
+    }
+
+    @Repeat(iterations=3)
+    public void testNestedSortingMax() throws IOException {
+        testNestedSorting(SortMode.MAX);
+    }
+
+    public void testNestedSorting(SortMode sortMode) throws IOException {
+        final String[] values = new String[randomIntBetween(2, 20)];
+        for (int i = 0; i < values.length; ++i) {
+            values[i] = _TestUtil.randomSimpleString(getRandom());
+        }
+        final int numParents = atLeast(100);
+        List<Document> docs = new ArrayList<Document>();
+        final BitSet parents = new BitSet();
+        for (int i = 0; i < numParents; ++i) {
+            docs.clear();
+            final int numChildren = randomInt(4);
+            for (int j = 0; j < numChildren; ++j) {
+                final Document child = new Document();
+                final int numValues = randomInt(3);
+                for (int k = 0; k < numValues; ++k) {
+                    final String value = RandomPicks.randomFrom(getRandom(), values);
+                    child.add(new StringField("text", value, Store.YES));
+                }
+                docs.add(child);
+            }
+            final Document parent = new Document();
+            parent.add(new StringField("type", "parent", Store.YES));
+            final String value = RandomPicks.randomFrom(getRandom(), values);
+            if (value != null) {
+                parent.add(new StringField("text", value, Store.YES));
+            }
+            docs.add(parent);
+            parents.set(parents.length() + docs.size() - 1);
+            writer.addDocuments(docs);
+            if (randomInt(10) == 0) {
+                writer.commit();
+            }
+        }
+        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
+        IndexFieldData<?> fieldData = getForField("text");
+        final BytesRef missingValue;
+        switch (randomInt(4)) {
+        case 0:
+            missingValue = new BytesRef();
+            break;
+        case 1:
+            missingValue = BytesRefFieldComparatorSource.MAX_TERM;
+            break;
+        case 2:
+            missingValue = new BytesRef(RandomPicks.randomFrom(getRandom(), values));
+            break;
+        default:
+            missingValue = new BytesRef(_TestUtil.randomSimpleString(getRandom()));
+            break;
+        }
+        BytesRefFieldComparatorSource innerSource = new BytesRefFieldComparatorSource(fieldData, missingValue, sortMode);
+        Filter parentFilter = new TermFilter(new Term("type", "parent"));
+        Filter childFilter = new NotFilter(parentFilter);
+        NestedFieldComparatorSource nestedComparatorSource = new NestedFieldComparatorSource(sortMode, innerSource, parentFilter, childFilter);
+        ToParentBlockJoinQuery query = new ToParentBlockJoinQuery(new XFilteredQuery(new MatchAllDocsQuery(), childFilter), new CachingWrapperFilter(parentFilter), ScoreMode.None);
+        Sort sort = new Sort(new SortField("text", nestedComparatorSource));
+        TopFieldDocs topDocs = searcher.search(query, randomIntBetween(1, numParents), sort);
+        assertTrue(topDocs.scoreDocs.length > 0);
+        BytesRef previous = null;
+        for (int i = 0; i < topDocs.scoreDocs.length; ++i) {
+            final int docID = topDocs.scoreDocs[i].doc;
+            assert parents.get(docID);
+            BytesRef cmpValue = null;
+            for (int child = parents.previousSetBit(docID - 1) + 1; child < docID; ++child) {
+                String[] vals = searcher.doc(child).getValues("text");
+                if (vals.length == 0) {
+                    vals = new String[] {missingValue.utf8ToString()};
+                }
+                for (String value : vals) {
+                    final BytesRef bytesValue = new BytesRef(value);
+                    if (cmpValue == null) {
+                        cmpValue = bytesValue;
+                    } else if (sortMode == SortMode.MIN && bytesValue.compareTo(cmpValue) < 0) {
+                        cmpValue = bytesValue;
+                    } else if (sortMode == SortMode.MAX && bytesValue.compareTo(cmpValue) > 0) {
+                        cmpValue = bytesValue;
+                    }
+                }
+            }
+            if (cmpValue == null) {
+                cmpValue = missingValue;
+            }
+            if (previous != null) {
+                assertNotNull(cmpValue);
+                assertTrue(previous.utf8ToString() + "   /   " + cmpValue.utf8ToString(), previous.compareTo(cmpValue) <= 0);
+            }
+            previous = cmpValue;
+        }
+        searcher.getIndexReader().close();
+    }
 }

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/DoubleFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/DoubleFieldDataTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 
 /**
  */
-public class DoubleFieldDataTests extends NumericFieldDataTests {
+public class DoubleFieldDataTests extends AbstractNumericFieldDataTests {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/FloatFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/FloatFieldDataTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 
 /**
  */
-public class FloatFieldDataTests extends NumericFieldDataTests {
+public class FloatFieldDataTests extends AbstractNumericFieldDataTests {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/LongFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/LongFieldDataTests.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.instanceOf;
 /**
  * Tests for all integer types (byte, short, int, long).
  */
-public class LongFieldDataTests extends NumericFieldDataTests {
+public class LongFieldDataTests extends AbstractNumericFieldDataTests {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/src/test/java/org/elasticsearch/test/unit/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.unit.index.fielddata;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReader;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.mapper.FieldMapper.Names;
+
+/** Returns an implementation based on paged bytes which doesn't implement WithOrdinals in order to visit different paths in the code,
+ *  eg. BytesRefFieldComparatorSource makes decisions based on whether the field data implements WithOrdinals. */
+public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTests {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public IndexFieldData<AtomicFieldData<ScriptDocValues>> getForField(String fieldName) {
+        final IndexFieldData<?> in = super.getForField(fieldName);
+        return new IndexFieldData<AtomicFieldData<ScriptDocValues>>() {
+
+            @Override
+            public Index index() {
+                return in.index();
+            }
+
+            @Override
+            public Names getFieldNames() {
+                return in.getFieldNames();
+            }
+
+            @Override
+            public boolean valuesOrdered() {
+                return in.valuesOrdered();
+            }
+
+            @Override
+            public AtomicFieldData<ScriptDocValues> load(AtomicReaderContext context) {
+                return in.load(context);
+            }
+
+            @Override
+            public AtomicFieldData<ScriptDocValues> loadDirect(AtomicReaderContext context) throws Exception {
+                return in.loadDirect(context);
+            }
+
+            @Override
+            public XFieldComparatorSource comparatorSource(Object missingValue, SortMode sortMode) {
+                return new BytesRefFieldComparatorSource(this, missingValue, sortMode);
+            }
+
+            @Override
+            public void clear() {
+                in.clear();
+            }
+
+            @Override
+            public void clear(IndexReader reader) {
+                in.clear(reader);
+            }
+
+            @Override
+            public long getHighestNumberOfSeenUniqueValues() {
+                return in.getHighestNumberOfSeenUniqueValues();
+            }
+
+        };
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/unit/index/search/nested/NestedSortingTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/search/nested/NestedSortingTests.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -216,7 +215,7 @@ public class NestedSortingTests extends AbstractFieldDataTests {
         SortMode sortMode = SortMode.MIN;
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, false));
         PagedBytesIndexFieldData indexFieldData = getForField("field2");
-        BytesRefFieldComparatorSource innerSource = new BytesRefFieldComparatorSource(indexFieldData, sortMode);
+        BytesRefFieldComparatorSource innerSource = new BytesRefFieldComparatorSource(indexFieldData, null, sortMode);
         Filter parentFilter = new TermFilter(new Term("__type", "parent"));
         Filter childFilter = new NotFilter(parentFilter);
         NestedFieldComparatorSource nestedComparatorSource = new NestedFieldComparatorSource(sortMode, innerSource, parentFilter, childFilter);


### PR DESCRIPTION
This commit allows for configuring the sort order of missing values in BytesRef
comparators (used for strings) with the following options:
- _first: missing values will appear in the first positions,
- _last: missing values will appear in the last positions (default),
- <any value>: documents with missing sort value will use the given value when
  sorting.

Since the default is _last, sorting by string value will have a different
behavior than in previous versions of elasticsearch which used to insert missing
value in the first positions when sorting in ascending order.

Implementation notes:
- Specialized BytesRefOrdValComparators have been removed now that the ordinals
  rely on packed arrays instead of raw arrays,
- Field data tests hierarchy has been changed so that the numeric tests don't
  inherit from the string tests anymore,
- When _first or _last is used, internally the comparators are told to use
  null or UnicodeUtil.BIG_TERM to replace missing values (depending on the sort
  order),
- BytesRefValComparator just replaces missing values with the provided value
  and uses them for comparisons,
- BytesRefOrdValComparator multiplies ordinals by 4 so that it can find
  ordinals for the missing value and the bottom value which are directly
  comparable with the segment ordinals. For example, if the segment values and
  ordinals are (a,1) and (b,2), they will be stored internally as (a,4) and
  (b,8) and if the missing value is 'ab', it will be assigned 6 as an ordinal,
  since it is between 'a' and 'b'. Then if the bottom value is 'abc', it will
  be assigned 7 as an ordinal since if it between 'ab' and 'b'.

Closes #896
