### PR TITLE
Document that 50% of system memory is a good default for ES_HEAP_SIZE in production

### DIFF
--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -60,7 +60,10 @@ export JAVA_HOME
 ES_HOME=/usr/share/$NAME
 
 # Heap Size (defaults to 256m min, 1g max)
-#ES_HEAP_SIZE=2g
+# For production environments, a reasonable default is 50% of system memory
+TOTAL_MEM_K=`grep MemTotal /proc/meminfo | awk '{print $2}' `
+HALF_MEM_K=$((TOTAL_MEM_K / 2))
+#ES_HEAP_SIZE="${HALF_MEM_K}k"
 
 # Heap new generation
 #ES_HEAP_NEWSIZE=


### PR DESCRIPTION
I'm new to ElasticSearch. I just installed ElasticSearch, inserted a bunch of documents, and tried to query it. Performance was horrible. I learned on the mailing list that a reasonable default for ES_HEAP_SIZE is 50% of system memory and that a much smaller value is used by default. It would be very nice if operational best practices were documented somewhere on the ElasticSearch site. It's hard to know as a beginner where to look to see what settings have defaults which are not suitable for production use. If I stick millions of records into MongoDB or MySQL with the default settings then they do not fall over even if they are not tuned exactly for my particular use case. It would be great for introducing people to ElasticSearch if it were as similarly easy to get started with.
