### PR TITLE
Added support for random sort

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/RandomComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/RandomComparator.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata.fieldcomparator;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.search.SearchShardTarget;
+
+import java.io.IOException;
+
+/**
+*
+*/
+public class RandomComparator extends FieldComparator<Long> {
+
+    private final long[] values;
+    private final long salt;
+
+    private int docBase;
+    private double bottom;
+
+    public static IndexFieldData.XFieldComparatorSource comparatorSource(long seed, SearchShardTarget shardTarget) {
+        return new InnerSource(seed, shardTarget);
+    }
+
+    static class InnerSource extends IndexFieldData.XFieldComparatorSource {
+
+        private final long seed;
+        private final SearchShardTarget shardTarget;
+
+        public InnerSource(long seed, SearchShardTarget shardTarget) {
+            this.seed = seed;
+            this.shardTarget = shardTarget;
+        }
+
+        @Override
+        public SortField.Type reducedType() {
+            return SortField.Type.LONG;
+        }
+
+        @Override
+        public FieldComparator<?> newComparator(String fieldname, int numHits, int sortPos, boolean reversed) throws IOException {
+            return new RandomComparator(numHits, seed, shardTarget);
+        }
+
+    }
+
+    RandomComparator(int numHits, long seed, SearchShardTarget shardTarget) {
+        values = new long[numHits];
+        this.salt = salt(seed, shardTarget.index(), shardTarget.shardId());
+    }
+
+    @Override
+    public int compare(int slot1, int slot2) {
+        if (values[slot1] > values[slot2]) {
+            return 1;
+        }
+        return values[slot1] < values[slot2] ? -1 : 0;
+    }
+
+    @Override
+    public int compareBottom(int doc) {
+        long value = random(salt, docBase + doc);
+        if (bottom > value) {
+            return 1;
+        }
+        return bottom < value ? -1 : 0;
+    }
+
+    @Override
+    public void copy(int slot, int doc) {
+        values[slot] = random(salt, docBase + doc);
+    }
+
+    @Override
+    public FieldComparator<Long> setNextReader(AtomicReaderContext context) {
+        this.docBase = context.docBase;
+        return this;
+    }
+
+    @Override
+    public void setBottom(int slot) {
+        this.bottom = values[slot];
+    }
+
+    @Override
+    public Long value(int slot) {
+        return Long.valueOf(values[slot]);
+    }
+
+    @Override
+    public int compareDocToValue(int doc, Long valueObj) {
+        final long value = valueObj.longValue();
+        long docValue = random(salt, docBase + doc);
+        if (docValue < value) {
+            return -1;
+        }
+        return docValue > value ? 1 : 0;
+    }
+
+    public static long random(long salt, int doc) {
+        long x = doc + salt * 2057;
+        x ^= x << 32 ^ x >> 32;
+        x ^= (x << 21);
+        x ^= (x >>> 35);
+        x ^= (x << 4);
+        return (x < 0) ? -x : x;
+    }
+
+    public static long salt(long seed, String index, int shardId) {
+        long salt = index.hashCode();
+        salt += 31 * shardId;
+        salt ^= salt << 32;
+        salt += 31 * salt + seed;
+        salt ^= salt << 13;
+        salt ^= salt >> 25;
+        return salt;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.LongFieldMapper;
@@ -144,6 +145,11 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
                 parseUpperInclusive, ignoreMalformed, provider, null, fieldDataSettings);
         this.enabledState = enabledState;
         this.path = path;
+    }
+
+    @Override
+    public FieldDataType defaultFieldDataType() {
+        return new FieldDataType("long");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -150,4 +150,9 @@ public class GeoDistanceSortParser implements SortParser {
 
         return new SortField(fieldName, geoDistanceComparatorSource, reverse);
     }
+
+    @Override
+    public SortField createDefault(SearchContext context) {
+        return null;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/sort/RandomSortBuilder.java
+++ b/src/main/java/org/elasticsearch/search/sort/RandomSortBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * A builder for random sort
+ */
+public class RandomSortBuilder extends SortBuilder {
+
+    private SortOrder order;
+    private long seed;
+
+    /**
+     * Creates this builder with the current timestamp as the default seed for the RNG.
+     */
+    public RandomSortBuilder() {
+        this(System.currentTimeMillis());
+    }
+
+    /**
+     * Creates this builder with a seed to base the random number generation on
+     *
+     * @param seed The seed
+     */
+    public RandomSortBuilder(long seed) {
+        this.seed = seed;
+    }
+
+    /**
+     * Sets the sort order
+     *
+     * @param order The sort order
+     */
+    @Override
+    public RandomSortBuilder order(SortOrder order) {
+        this.order = order;
+        return this;
+    }
+
+    /**
+     * @return The seed that the RNG will be based on
+     */
+    public long seed() {
+        return seed;
+    }
+
+    /**
+     * Sets the seed that the RNG will be based on
+     *
+     * @param seed The seed that the RNG will be based on
+     */
+    public RandomSortBuilder seed(long seed) {
+        this.seed = seed;
+        return this;
+    }
+
+    @Override
+    public SortBuilder missing(Object missing) {
+        return this;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("_random");
+        if (order == SortOrder.ASC) {
+            builder.field("reverse", true);
+        }
+        builder.field("seed", seed);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/sort/RandomSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/RandomSortParser.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.fieldcomparator.RandomComparator;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ *
+ */
+public class RandomSortParser implements SortParser {
+
+    @Override
+    public String[] names() {
+        return new String[]{ "_random" };
+    }
+
+    @Override
+    public SortField parse(XContentParser parser, SearchContext context) throws Exception {
+        long seed = System.currentTimeMillis();
+        boolean reverse = false;
+
+        XContentParser.Token token;
+        String currentName = parser.currentName();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentName = parser.currentName();
+            } else if (token.isValue()) {
+                if ("reverse".equals(currentName)) {
+                    reverse = parser.booleanValue();
+                } else if ("order".equals(currentName)) {
+                    reverse = "desc".equals(parser.text());
+                } else if ("seed".equals(currentName)) {
+                    seed = parser.longValue();
+                }
+            }
+        }
+
+        return new SortField("_random", RandomComparator.comparatorSource(seed, context.shardTarget()), reverse);
+    }
+
+    @Override
+    public SortField createDefault(SearchContext context) {
+        return new SortField("_random", RandomComparator.comparatorSource(System.currentTimeMillis(), context.shardTarget()));
+    }
+}

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -136,4 +136,9 @@ public class ScriptSortParser implements SortParser {
 
         return new SortField("_script", fieldComparatorSource, reverse);
     }
+
+    @Override
+    public SortField createDefault(SearchContext context) {
+        return null;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/sort/SortBuilders.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortBuilders.java
@@ -60,4 +60,15 @@ public class SortBuilders {
     public static GeoDistanceSortBuilder geoDistanceSort(String fieldName) {
         return new GeoDistanceSortBuilder(fieldName);
     }
+
+    /**
+     * A pseudo random sort.
+     *
+     * @param seed The seed to initialize the PRNG for the query
+     * @return
+     */
+    public static RandomSortBuilder randomSort(long seed) {
+        return new RandomSortBuilder(seed);
+    }
+
 }

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -60,6 +60,7 @@ public class SortParseElement implements SearchParseElement {
         ImmutableMap.Builder<String, SortParser> builder = ImmutableMap.builder();
         addParser(builder, new ScriptSortParser());
         addParser(builder, new GeoDistanceSortParser());
+        addParser(builder, new RandomSortParser());
         this.parsers = builder.build();
     }
 
@@ -188,6 +189,16 @@ public class SortParseElement implements SearchParseElement {
                 sortFields.add(SORT_DOC);
             }
         } else {
+
+            if (parsers.containsKey(fieldName)) {
+                SortField sortField = parsers.get(fieldName).createDefault(context);
+                if (sortField == null) {
+                    throw new SearchParseException(context, "[" + fieldName + "] sort does not support default values and must be configured with the appropriate settings");
+                }
+                sortFields.add(sortField);
+                return;
+            }
+
             FieldMapper fieldMapper = context.smartNameFieldMapper(fieldName);
             if (fieldMapper == null) {
                 if (ignoreUnmapped) {

--- a/src/main/java/org/elasticsearch/search/sort/SortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParser.java
@@ -31,4 +31,6 @@ public interface SortParser {
     String[] names();
 
     SortField parse(XContentParser parser, SearchContext context) throws Exception;
+
+    SortField createDefault(SearchContext context);
 }

--- a/src/test/java/org/elasticsearch/test/integration/search/sort/RandomSortTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/sort/RandomSortTests.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.integration.search.sort;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.test.integration.AbstractSharedClusterTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ *
+ */
+public class RandomSortTests extends AbstractSharedClusterTest {
+
+    @Override
+    public Settings getSettings() {
+        return randomSettingsBuilder()
+                .put("index.number_of_shards", 3)
+                .put("index.number_of_replicas", 0)
+                .build();
+    }
+
+    @Override
+    protected int numberOfNodes() {
+        return 2;
+    }
+
+    @Test
+    public void testConsistentSeed() throws Exception {
+        Client client = client();
+        try {
+            client.admin().indices().prepareDelete("test").execute().actionGet();
+        } catch (Exception e) {
+            // ignore
+        }
+        client.admin().indices().prepareCreate("test").execute().actionGet();
+        client.admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+
+        client.prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
+                .endObject()).execute().actionGet();
+
+        client.prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject()
+                .endObject()).execute().actionGet();
+
+        client.prepareIndex("test", "type1", "3").setSource(jsonBuilder().startObject()
+                .endObject()).execute().actionGet();
+
+
+        client.admin().indices().prepareFlush().setRefresh(true).execute().actionGet();
+
+        long seed = System.currentTimeMillis();
+
+        String[] ids = null;
+
+        for (int i = 0; i < 2; i++) {
+
+            SearchResponse searchResponse = client.prepareSearch()
+                    .setQuery(matchAllQuery())
+                    .addSort(SortBuilders.randomSort(seed))
+                    .execute().actionGet();
+
+            assertThat("Failures " + Arrays.toString(searchResponse.getShardFailures()), searchResponse.getShardFailures().length, equalTo(0));
+
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+
+            if (ids == null) {
+                ids = new String[3];
+                ids[0] = searchResponse.getHits().getAt(0).id();
+                ids[1] = searchResponse.getHits().getAt(1).id();
+                ids[2] = searchResponse.getHits().getAt(2).id();
+            } else {
+                assertThat(searchResponse.getHits().getAt(0).id(), equalTo(ids[0]));
+                assertThat(searchResponse.getHits().getAt(1).id(), equalTo(ids[1]));
+                assertThat(searchResponse.getHits().getAt(2).id(), equalTo(ids[2]));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- Support seeds for consistent pagination. If no seed is provided, the current timestamp is used (at the "cost" of consistent pagination)
- Note, just like normal search, the pagination will be consistent up to segment merges, for absolute consistency scroll should be used
- order is supported for (reverse) consistent pagination
- Enhanced the SortParser abstraction to enable sort parser with default configurations (enables the user to specify the sort as a simple string w

Closes #1170
