### PR TITLE
Correctly apply boosts in query string.

### DIFF
--- a/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -283,7 +283,7 @@ public class MapperQueryParser extends QueryParser {
                     Query q = super.getFieldQuery(mField, queryText, slop);
                     if (q != null) {
                         added = true;
-                        applyBoost(field, q);
+                        applyBoost(mField, q);
                         applySlop(q, slop);
                         disMaxQuery.add(q);
                     }
@@ -297,7 +297,7 @@ public class MapperQueryParser extends QueryParser {
                 for (String mField : fields) {
                     Query q = super.getFieldQuery(mField, queryText, slop);
                     if (q != null) {
-                        applyBoost(field, q);
+                        applyBoost(mField, q);
                         applySlop(q, slop);
                         clauses.add(new BooleanClause(q, BooleanClause.Occur.SHOULD));
                     }


### PR DESCRIPTION
I'm really not sure the extent of this problem I but I found it when
attempting to use boosts for phrase queries generated by query_string.

Closes #3503.
