### PR TITLE
Expose size statistics for completion suggest

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -33,6 +34,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
     private String[] types = null;
     private String[] groups = null;
     private String[] fieldDataFields = null;
+    private String[] completionDataFields = null;
 
     /**
      * Sets all flags to return all stats.
@@ -42,6 +44,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         types = null;
         groups = null;
         fieldDataFields = null;
+        completionDataFields = null;
         return this;
     }
 
@@ -53,6 +56,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         types = null;
         groups = null;
         fieldDataFields = null;
+        completionDataFields = null;
         return this;
     }
 
@@ -107,6 +111,14 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         return this.fieldDataFields;
     }
 
+    public CommonStatsFlags completionDataFields(String... completionDataFields) {
+        this.completionDataFields = completionDataFields;
+        return this;
+    }
+
+    public String[] completionDataFields() {
+        return this.completionDataFields;
+    }
 
     public boolean isSet(Flag flag) {
         return flags.contains(flag);
@@ -146,6 +158,9 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         out.writeStringArrayNullable(types);
         out.writeStringArrayNullable(groups);
         out.writeStringArrayNullable(fieldDataFields);
+        if (out.getVersion().onOrAfter(Version.V_0_90_4)) {
+            out.writeStringArrayNullable(completionDataFields);
+        }
     }
 
     @Override
@@ -160,6 +175,9 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         types = in.readStringArray();
         groups = in.readStringArray();
         fieldDataFields = in.readStringArray();
+        if (in.getVersion().onOrAfter(Version.V_0_90_4)) {
+            completionDataFields = in.readStringArray();
+        }
     }
 
     @Override
@@ -188,7 +206,8 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         FieldData("fielddata"),
         Docs("docs"),
         Warmer("warmer"),
-        Percolate("percolate");
+        Percolate("percolate"),
+        Completion("completion");
 
         private final String restName;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -212,6 +212,24 @@ public class IndicesStatsRequest extends BroadcastOperationRequest<IndicesStatsR
         return flags.fieldDataFields();
     }
 
+    public IndicesStatsRequest completion(boolean completion) {
+        flags.set(Flag.Completion, completion);
+        return this;
+    }
+
+    public boolean completion() {
+        return flags.isSet(Flag.Completion);
+    }
+
+    public IndicesStatsRequest completionFields(String ... completionDataFields) {
+        flags.completionDataFields(completionDataFields);
+        return this;
+    }
+
+    public String[] completionFields() {
+        return flags.completionDataFields();
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
@@ -139,6 +139,16 @@ public class IndicesStatsRequestBuilder extends BroadcastOperationRequestBuilder
         return this;
     }
 
+    public IndicesStatsRequestBuilder setCompletion(boolean completion) {
+        request.completion(completion);
+        return this;
+    }
+
+    public IndicesStatsRequestBuilder setCompletionFields(String... fields) {
+        request.completionFields(fields);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<IndicesStatsResponse> listener) {
         ((IndicesAdminClient) client).stats(request, listener);

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -179,6 +179,9 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
         if (request.request.percolate()) {
             stats.stats.percolate = indexShard.shardPercolateService().stats();
         }
+        if (request.request.completion()) {
+            stats.stats.completion = indexShard.completionStats(request.request.completionFields());
+        }
 
         return stats;
     }

--- a/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.warmer.ShardIndexWarmerService;
 import org.elasticsearch.index.warmer.WarmerStats;
+import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 /**
  *
@@ -95,6 +96,8 @@ public interface IndexShard extends IndexShardComponent {
     IdCacheStats idCacheStats();
 
     FieldDataStats fieldDataStats(String... fields);
+
+    CompletionStats completionStats(String ... fields);
 
     PercolatorQueriesRegistry percolateRegistry();
 

--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.shard.service;
 
 import com.google.common.base.Charsets;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
@@ -75,6 +76,8 @@ import org.elasticsearch.index.warmer.WarmerStats;
 import org.elasticsearch.indices.IndicesLifecycle;
 import org.elasticsearch.indices.InternalIndicesLifecycle;
 import org.elasticsearch.indices.recovery.RecoveryStatus;
+import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat;
+import org.elasticsearch.search.suggest.completion.CompletionStats;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -504,6 +507,25 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
     @Override
     public IdCacheStats idCacheStats() {
         return shardIdCache.stats();
+    }
+
+    @Override
+    public CompletionStats completionStats(String... fields) {
+        CompletionStats completionStats = new CompletionStats();
+
+        Engine.Searcher searcher = engine().searcher();
+
+        try {
+            PostingsFormat postingsFormat = this.codecService.postingsFormatService().get(Completion090PostingsFormat.CODEC_NAME).get();
+            if (postingsFormat instanceof Completion090PostingsFormat) {
+                Completion090PostingsFormat completionPostingsFormat = (Completion090PostingsFormat) postingsFormat;
+                completionStats.add(completionPostingsFormat.completionStats(searcher().reader(), fields));
+            }
+        } finally {
+            searcher.release();
+        }
+
+        return completionStats;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
+++ b/src/main/java/org/elasticsearch/indices/InternalIndicesService.java
@@ -76,6 +76,7 @@ import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.plugins.IndexPluginsModule;
 import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -242,6 +243,9 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
                 case Percolate:
                     stats.percolate = new PercolateStats();
                     break;
+                case Completion:
+                    stats.completion = new CompletionStats();
+                    break;
                 default:
                     throw new IllegalStateException("Unknown Flag: " + flag);
             }
@@ -290,6 +294,9 @@ public class InternalIndicesService extends AbstractLifecycleComponent<IndicesSe
                             break;
                         case Percolate:
                             stats.percolate.add(indexShard.shardPercolateService().stats());
+                            break;
+                        case Completion:
+                            stats.completion.add(indexShard.completionStats(flags.completionDataFields()));
                             break;
                         default:
                             throw new IllegalStateException("Unknown Flag: " + flag);

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.suggest.completion;
+
+import gnu.trove.iterator.TObjectLongIterator;
+import gnu.trove.map.hash.TObjectLongHashMap;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class CompletionStats implements Streamable, ToXContent {
+
+    private long sizeInBytes;
+
+    @Nullable
+    private TObjectLongHashMap<String> fields;
+
+    public CompletionStats() {
+    }
+
+    public CompletionStats(long size, @Nullable TObjectLongHashMap<String> fields) {
+        this.sizeInBytes = size;
+        this.fields = fields;
+    }
+
+    public long getSizeInBytes() {
+        return sizeInBytes;
+    }
+
+    public ByteSizeValue getSize() {
+        return new ByteSizeValue(sizeInBytes);
+    }
+
+    public TObjectLongHashMap<String> getFields() {
+        return fields;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        sizeInBytes = in.readVLong();
+        if (in.readBoolean()) {
+            int size = in.readVInt();
+            fields = new TObjectLongHashMap<String>(size);
+            for (int i = 0; i < size; i++) {
+                fields.put(in.readString(), in.readVLong());
+            }
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(sizeInBytes);
+        if (fields == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(fields.size());
+            for (TObjectLongIterator<String> it = fields.iterator(); it.hasNext(); ) {
+                it.advance();
+                out.writeString(it.key());
+                out.writeVLong(it.value());
+            }
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.COMPLETION);
+        builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, sizeInBytes);
+        if (fields != null) {
+            builder.startObject(Fields.FIELDS);
+            for (TObjectLongIterator<String> it = fields.iterator(); it.hasNext(); ) {
+                it.advance();
+                builder.startObject(it.key(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.byteSizeField(Fields.SIZE, Fields.SIZE_IN_BYTES, it.value());
+                builder.endObject();
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static CompletionStats readCompletionStats(StreamInput in) throws IOException {
+        CompletionStats stats = new CompletionStats();
+        stats.readFrom(in);
+        return stats;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString COMPLETION = new XContentBuilderString("completion");
+        static final XContentBuilderString SIZE_IN_BYTES = new XContentBuilderString("size_in_bytes");
+        static final XContentBuilderString SIZE = new XContentBuilderString("size");
+        static final XContentBuilderString FIELDS = new XContentBuilderString("fields");
+    }
+
+    public void add(CompletionStats completion) {
+        if (completion == null) {
+            return;
+        }
+
+        sizeInBytes += completion.getSizeInBytes();
+
+        if (completion.fields != null) {
+            if (fields == null) fields = new TObjectLongHashMap<String>();
+            for (TObjectLongIterator<String> it = completion.fields.iterator(); it.hasNext(); ) {
+                it.advance();
+                fields.adjustOrPutValue(it.key(), it.value(), it.value());
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/indices/stats/SimpleIndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/stats/SimpleIndexStatsTests.java
@@ -309,7 +309,7 @@ public class SimpleIndexStatsTests extends AbstractNodesTests {
     @Test
     public void testFlagOrdinalOrder() {
         Flag[] flags = new Flag[]{Flag.Store, Flag.Indexing, Flag.Get, Flag.Search, Flag.Merge, Flag.Flush, Flag.Refresh,
-                Flag.FilterCache, Flag.IdCache, Flag.FieldData, Flag.Docs, Flag.Warmer, Flag.Percolate};
+                Flag.FilterCache, Flag.IdCache, Flag.FieldData, Flag.Docs, Flag.Warmer, Flag.Percolate, Flag.Completion};
 
         assertThat(flags.length, equalTo(Flag.values().length));
         for (int i = 0; i < flags.length; i++) {
@@ -358,6 +358,9 @@ public class SimpleIndexStatsTests extends AbstractNodesTests {
             case Percolate:
                 builder.setPercolate(set);
                 break;
+            case Completion:
+                builder.setCompletion(set);
+                break;
             default:
                 assert false : "new flag? " + flag;
                 break;
@@ -392,6 +395,8 @@ public class SimpleIndexStatsTests extends AbstractNodesTests {
                 return response.getWarmer() != null;
             case Percolate:
                 return response.getPercolate() != null;
+            case Completion:
+                return response.getCompletion() != null;
             default:
                 assert false : "new flag? " + flag;
                 return false;


### PR DESCRIPTION
In order to determine how many RAM the completion suggest structures will eat up, this data should be exposed.

Closes #3522

Open for discussion: I am not yet sure I moving in the CompletionPostingsFormat class into the InternalIndexShard. Open for better solutions.
