### PR TITLE
Add score_mode to CompletionSuggester

### DIFF
--- a/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -579,7 +579,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                     builder.field(Fields.SCORE, score);
                     return builder;
                 }
-                
+
                 protected void mergeInto(Option otherOption) {
                     score = Math.max(score, otherOption.score);
                 }

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
@@ -51,6 +51,19 @@ public class CompletionSuggestParser implements SuggestContextParser {
                 if (!parseSuggestContext(parser, mapperService, fieldName, suggestion))  {
                     if (token == XContentParser.Token.VALUE_BOOLEAN && "fuzzy".equals(fieldName)) {
                         suggestion.setFuzzy(parser.booleanValue());
+                    } else if (token == XContentParser.Token.VALUE_STRING && "score_mode".equals(fieldName) || "scoreMode".equals(fieldName)) {
+                        String sScoreMode = parser.text();
+                        if ("max".equals(sScoreMode)) {
+                            suggestion.setScoreMode(CompletionSuggestionContext.ScoreMode.Max);
+                        } else if ("min".equals(sScoreMode)) {
+                            suggestion.setScoreMode(CompletionSuggestionContext.ScoreMode.Min);
+                        } else if ("total".equals(sScoreMode) || "sum".equals(sScoreMode)) {
+                            suggestion.setScoreMode(CompletionSuggestionContext.ScoreMode.Total);
+                        } else if ("product".equals(sScoreMode) || "multiply".equals(sScoreMode)) {
+                            suggestion.setScoreMode(CompletionSuggestionContext.ScoreMode.Multiply);
+                        } else {
+                            throw new ElasticSearchIllegalArgumentException("[rescore] illegal score_mode [" + sScoreMode + "]");
+                        }
                     }
                 }
             } else if (token == XContentParser.Token.START_OBJECT && "fuzzy".equals(fieldName)) {

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -74,11 +74,11 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
                     final Option value = results.get(key);
                     if (value == null) {
                         final Option option = new CompletionSuggestion.Entry.Option(new StringText(key), score, res.payload == null ? null
-                                : new BytesArray(res.payload));
+                                : new BytesArray(res.payload), suggestionContext.getScoreMode());
                         results.put(key, option);
-                    } else if (value.getScore() < score) {
-                        value.setScore(score);
-                        value.setPayload(res.payload == null ? null : new BytesArray(res.payload));
+                    } else {
+                            value.setScore(suggestionContext.getScoreMode().combine(score, value.getScore()));
+                            value.setPayload(res.payload == null ? null : new BytesArray(res.payload));
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -28,12 +28,71 @@ import org.elasticsearch.search.suggest.SuggestionSearchContext;
  */
 public class CompletionSuggestionContext extends SuggestionSearchContext.SuggestionContext {
 
+    public static enum ScoreMode {
+        Max {
+            @Override
+            public float combine(float primary, float secondary) {
+                return Math.max(primary, secondary);
+            }
+            @Override
+            public String toString() {
+                return "max";
+            }
+        },
+        Min {
+            @Override
+            public float combine(float primary, float secondary) {
+                return Math.min(primary, secondary);
+            }
+            @Override
+            public String toString() {
+                return "min";
+            }
+        },
+        Total {
+            @Override
+            public float combine(float primary, float secondary) {
+                return primary + secondary;
+            }
+            @Override
+            public String toString() {
+                return "sum";
+            }
+        },
+        Multiply {
+            @Override
+            public float combine(float primary, float secondary) {
+                return primary * secondary;
+            }
+            @Override
+            public String toString() {
+                return "product";
+            }
+        };
+
+        public abstract float combine(float primary, float secondary);
+
+        public static ScoreMode fromOrd(int ord) {
+            switch (ord) {
+                case 1:
+                    return Min;
+                case 2:
+                    return Total;
+                case 3:
+                    return Multiply;
+                default:
+                    return Max;
+            }
+        }
+    }
+
     private FieldMapper<?> mapper;
     private int fuzzyEditDistance = XFuzzySuggester.DEFAULT_MAX_EDITS;
     private boolean fuzzyTranspositions = XFuzzySuggester.DEFAULT_TRANSPOSITIONS;
     private int fuzzyMinLength = XFuzzySuggester.DEFAULT_MIN_FUZZY_LENGTH;
     private int fuzzyPrefixLength = XFuzzySuggester.DEFAULT_NON_FUZZY_PREFIX;
     private boolean fuzzy = false;
+    private ScoreMode scoreMode = ScoreMode.Max;
 
     public CompletionSuggestionContext(Suggester suggester) {
         super(suggester);
@@ -85,5 +144,13 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
 
     public boolean isFuzzy() {
         return fuzzy;
+    }
+
+    public void setScoreMode(ScoreMode scoreMode) {
+        this.scoreMode = scoreMode;
+    }
+
+    public ScoreMode getScoreMode() {
+        return scoreMode;
     }
 }


### PR DESCRIPTION
Support various score_modes in the CompletionSuggester.  Modes supported are max, min, total, and product.  This is useful when you have multiple suggestions with the same output but different inputs and weights.

```
curl -X PUT 'localhost:9200/music/song/1?refresh=true' -d '{
    "name" : "Nevermind",
    "suggest" : { 
        "input": [ "Nevermind" ],
        "output": "Nirvana - Nevermind",
        "payload" : { "artistId" : 2321 }, 
        "weight": 3
    }
}'

curl -X PUT 'localhost:9200/music/song/2?refresh=true' -d '{
    "name" : "Nevermind",
    "suggest" : { 
        "input": [ "Nirvana" ],
        "output": "Nirvana - Nevermind",
        "payload" : { "artistId" : 2321 }, 
        "weight": 2
    }
}'

curl -X POST 'localhost:9200/music/_suggest?pretty' -d '{
    "song-suggest" : {
        "text" : "n",
        "completion" : {
            "field" : "suggest", 
            "score_mode": "total"
        }                                             
    }
}'
{
  "_shards" : {
    "total" : 5,
    "successful" : 5,
    "failed" : 0
  },
  "song-suggest" : [ {
    "text" : "n",
    "offset" : 0,
    "length" : 4,
    "options" : [ {
      "text" : "Nirvana - Nevermind",
      "score" : 5.0, "payload" : {"artistId":2321}
    } ]
  } ]
}

```

Not sure this is the best approach but I wanted to put it out there for comments.
