### PR TITLE
Allow packages to disable immediate restart on package upgrade

### DIFF
--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -1,9 +1,20 @@
 #!/bin/sh
 set -e
 
+[ -f /etc/default/elasticsearch ] && . /etc/default/elasticsearch
+
+startElasticsearch() {
+	if [ -x "/etc/init.d/elasticsearch" ]; then
+		if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+			invoke-rc.d elasticsearch start || true
+		else
+			/etc/init.d/elasticsearch start || true
+		fi
+	fi
+}
+
 case "$1" in
-    configure)
-	[ -f /etc/default/elasticsearch ] && . /etc/default/elasticsearch
+	configure)
 	[ -z "$ES_USER" ] && ES_USER="elasticsearch"
 	[ -z "$ES_GROUP" ] && ES_GROUP="elasticsearch"
 	if ! getent group "$ES_GROUP" > /dev/null 2>&1 ; then
@@ -24,16 +35,15 @@ case "$1" in
 	chown -Rh root:root /etc/elasticsearch/*
 	chmod 755 /etc/elasticsearch
 	chmod 644 /etc/elasticsearch/*
-    ;;
-esac
-
-
-if [ -x "/etc/init.d/elasticsearch" ]; then
+	
 	update-rc.d elasticsearch defaults 95 10 >/dev/null
-	if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-		invoke-rc.d elasticsearch start || true
-	else
-		/etc/init.d/elasticsearch start || true
+	# if $2 is set, this is an upgrade
+	if ( [ -n $2 ] && [ "$RESTART_ON_UPGRADE" = "true" ] ) ; then
+		startElasticsearch
+	# this is a fresh installation, start anyway
+	elif [ -z $2 ] ; then
+		startElasticsearch
 	fi
-fi
+	;;
+esac
 

--- a/src/deb/control/prerm
+++ b/src/deb/control/prerm
@@ -1,10 +1,26 @@
 #!/bin/sh
 set -e
 
-if [ -x "/etc/init.d/elasticsearch" ]; then
-	if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-		invoke-rc.d elasticsearch stop || true
-	else
-		/etc/init.d/elasticsearch stop || true
+[ -f /etc/default/elasticsearch ] && . /etc/default/elasticsearch
+
+stopElasticsearch() {
+	if [ -x "/etc/init.d/elasticsearch" ]; then
+		if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+			invoke-rc.d elasticsearch stop || true
+		else
+			/etc/init.d/elasticsearch stop || true
+		fi
 	fi
-fi
+}
+
+case "$1" in
+	upgrade)
+	if [ "$RESTART_ON_UPGRADE" = "true" ] ; then
+		stopElasticsearch
+	fi
+	;;
+	remove)
+	stopElasticsearch
+	;;
+esac
+

--- a/src/deb/default/elasticsearch
+++ b/src/deb/default/elasticsearch
@@ -36,3 +36,6 @@
 
 # Additional Java OPTS
 #ES_JAVA_OPTS=
+
+# Configure restart on package upgrade (true, every other setting will lead to not restarting)
+#RESTART_ON_UPGRADE=true

--- a/src/rpm/scripts/postinstall
+++ b/src/rpm/scripts/postinstall
@@ -1,24 +1,43 @@
-hasBeenEnabledOnStart=false
 
-if [ $1 -eq 1 ] ; then 
-    # Initial installation 
+[ -f /etc/sysconfig/elasticsearch ] && . /etc/sysconfig/elasticsearch
+
+startElasticsearch() {
+	if [ -x /bin/systemctl ] ; then
+		/bin/systemctl start elasticsearch.service
+	elif [ -x /etc/init.d/elasticsearch ] ; then
+		/etc/init.d/elasticsearch start
+	# older suse linux distributions do not ship with systemd
+	# but do not have an /etc/init.d/ directory
+	# this tries to start elasticsearch on these as well without failing this script
+	elif [ -x /etc/rc.d/init.d/elasticsearch ] ; then
+		/etc/rc.d/init.d/elasticsearch start
+	fi
+}
+
+stopElasticsearch() {
+	if [ -x /bin/systemctl ] ; then
+		/bin/systemctl stop elasticsearch.service > /dev/null 2>&1 || :
+	elif [ -x /etc/init.d/elasticsearch ] ; then
+		/etc/init.d/elasticsearch stop
+	elif [ -x /etc/rc.d/init.d/elasticsearch ] ; then
+		/etc/rc.d/init.d/elasticsearch stop
+	fi
+}
+
+# Initial installation: $1 == 1
+# Upgrade: $1 == 2, and configured to restart on upgrade
+if [ $1 -eq 1 ] ; then
+
     if [ -x /bin/systemctl ] ; then
         /bin/systemctl daemon-reload >/dev/null 2>&1 || :
         /bin/systemctl enable elasticsearch.service
-        /bin/systemctl start elasticsearch.service
-        hasBeenEnabledOnStart=true
-    fi
-
-    if [ -x /sbin/chkconfig -a "$hasBeenEnabledOnStart" == "false" ] ; then
+    elif [ -x /sbin/chkconfig ] ; then
         /sbin/chkconfig --add elasticsearch
-        # older suse linux distributions do not ship with systemd
-        # but do not have an /etc/init.d/ directory
-        # this tries to start elasticsearch on these as well without failing this script
-        if [ -x /etc/init.d/elasticsearch ] ; then
-            /etc/init.d/elasticsearch start
-        elif [ -x /etc/rc.d/init.d/elasticsearch ] ; then
-            /etc/rc.d/init.d/elasticsearch start
-        fi
     fi
 
+	startElasticsearch
+elif [ $1 -ge 2 -a "$RESTART_ON_UPGRADE" == "true" ] ; then
+	stopElasticsearch
+	startElasticsearch
 fi
+

--- a/src/rpm/scripts/preremove
+++ b/src/rpm/scripts/preremove
@@ -1,16 +1,29 @@
+
+[ -f /etc/sysconfig/elasticsearch ] && . /etc/sysconfig/elasticsearch
+
+stopElasticsearch() {
+	if [ -x /bin/systemctl ] ; then
+		/bin/systemctl stop elasticsearch.service > /dev/null 2>&1 || :
+	elif [ -x /etc/init.d/elasticsearch ] ; then
+		/etc/init.d/elasticsearch stop
+	elif [ -x /etc/rc.d/init.d/elasticsearch ] ; then
+		/etc/rc.d/init.d/elasticsearch stop
+	fi
+}
+
+# Removal: $1 == 0
+# Dont do anything on upgrade, because the preun script in redhat gets executed after the postinst (madness!)
 if [ $1 -eq 0 ] ; then
-    # Package removal, not upgrade
+
     if [ -x /bin/systemctl ] ; then
         /bin/systemctl --no-reload disable elasticsearch.service > /dev/null 2>&1 || :
-		/bin/systemctl stop elasticsearch.service > /dev/null 2>&1 || :
     fi
 
     if [ -x /sbin/chkconfig ] ; then
-        if [ -x /etc/init.d/elasticsearch ] ; then
-            /etc/init.d/elasticsearch stop
-        fi
         /sbin/chkconfig --del elasticsearch 2> /dev/null
     fi
+
+	stopElasticsearch
 fi
 
 exit 0

--- a/src/rpm/sysconfig/elasticsearch
+++ b/src/rpm/sysconfig/elasticsearch
@@ -38,3 +38,6 @@ CONF_FILE=/etc/elasticsearch/elasticsearch.yml
 # Also make sure, this user can write into the log directories in case you change them
 # This setting only works for the init script, but has to be configured separately for systemd startup
 ES_USER=elasticsearch
+
+# Configure restart on package upgrade (true, every other setting will lead to not restarting)
+#RESTART_ON_UPGRADE=true


### PR DESCRIPTION
Both package types, RPM and deb now contain an option to not restart on upgrade.

This option can be configure in /etc/default/elasticsearch for dpkg based systems
and /etc/sysconfig/elasticsearch for rpm based systems. If the RESTART_ON_UPGRADE option is set to false, the node will not be restarted after the package has been installed.

By default the setting is as before, where a restart is executed on upgrade.
