### PR TITLE
Recheck cutoffScore during phrase_suggest merge.

### DIFF
--- a/src/main/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellChecker.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellChecker.java
@@ -18,10 +18,6 @@
  */
 package org.elasticsearch.search.suggest.phrase;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.shingle.ShingleFilter;
@@ -35,6 +31,10 @@ import org.elasticsearch.common.io.FastCharArrayReader;
 import org.elasticsearch.search.suggest.SuggestUtils;
 import org.elasticsearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
 import org.elasticsearch.search.suggest.phrase.DirectCandidateGenerator.CandidateSet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 //TODO public for tests
 public final class NoisyChannelSpellChecker {
@@ -59,7 +59,7 @@ public final class NoisyChannelSpellChecker {
                 
     }
 
-    public Correction[] getCorrections(TokenStream stream, final CandidateGenerator generator,
+    public Result getCorrections(TokenStream stream, final CandidateGenerator generator,
             float maxErrors, int numCorrections, IndexReader reader, WordScorer wordScorer, BytesRef separator, float confidence, int gramSize) throws IOException {
         
         final List<CandidateSet> candidateSetsList = new ArrayList<DirectCandidateGenerator.CandidateSet>();
@@ -109,7 +109,7 @@ public final class NoisyChannelSpellChecker {
         });
         
         if (candidateSetsList.isEmpty() || candidateSetsList.size() >= tokenLimit) {
-            return Correction.EMPTY;
+            return Result.EMPTY;
         }
         
         for (CandidateSet candidateSet : candidateSetsList) {
@@ -123,14 +123,15 @@ public final class NoisyChannelSpellChecker {
             for (int i = 0; i < candidates.length; i++) {
                 candidates[i] = candidateSets[i].originalTerm;
             }
-            cutoffScore = scorer.score(candidates, candidateSets);
+            double inputPhraseScore = scorer.score(candidates, candidateSets);
+            cutoffScore = inputPhraseScore * confidence;
         }
-        Correction[] findBestCandiates = scorer.findBestCandiates(candidateSets, maxErrors, cutoffScore * confidence);
+        Correction[] findBestCandiates = scorer.findBestCandiates(candidateSets, maxErrors, cutoffScore);
         
-        return findBestCandiates;
+        return new Result(findBestCandiates, cutoffScore);
     }
 
-    public Correction[] getCorrections(Analyzer analyzer, BytesRef query, CandidateGenerator generator,
+    public Result getCorrections(Analyzer analyzer, BytesRef query, CandidateGenerator generator,
             float maxErrors, int numCorrections, IndexReader reader, String analysisField, WordScorer scorer, float confidence, int gramSize) throws IOException {
        
         return getCorrections(tokenStream(analyzer, query, new CharsRef(), analysisField), generator, maxErrors, numCorrections, reader, scorer, new BytesRef(" "), confidence, gramSize);
@@ -141,6 +142,15 @@ public final class NoisyChannelSpellChecker {
         UnicodeUtil.UTF8toUTF16(query, spare);
         return analyzer.tokenStream(field, new FastCharArrayReader(spare.chars, spare.offset, spare.length));
     }
-      
 
+    public static class Result {
+        public static final Result EMPTY = new Result(Correction.EMPTY, Double.MIN_VALUE);
+        public final Correction[] corrections;
+        public final double cutoffScore;
+
+        public Result(Correction[] corrections, double cutoffScore) {
+            this.corrections = corrections;
+            this.cutoffScore = cutoffScore;
+        }
+    }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.suggest.phrase;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.search.suggest.Suggest.Suggestion;
+
+import java.io.IOException;
+
+/**
+ * Suggestion entry returned from the {@link PhraseSuggester}.
+ */
+public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry> {
+    public static final int TYPE = 3;
+
+    public PhraseSuggestion() {
+    }
+
+    public PhraseSuggestion(String name, int size) {
+        super(name, size);
+    }
+
+    @Override
+    public int getType() {
+        return TYPE;
+    }
+
+    @Override
+    protected Entry newEntry() {
+        return new Entry();
+    }
+
+    public static class Entry extends Suggestion.Entry<Suggestion.Entry.Option> {
+        static class Fields {
+            static final XContentBuilderString CUTOFF_SCORE = new XContentBuilderString("cutoff_score");
+        }
+
+        protected double cutoffScore = Double.MIN_VALUE;
+
+        public Entry(Text text, int offset, int length, double cutoffScore) {
+            super(text, offset, length);
+            this.cutoffScore = cutoffScore;
+        }
+
+        public Entry() {
+        }
+
+        /**
+         * @return cutoff score for suggestions.  input term score * confidence for phrase suggest, 0 otherwise
+         */
+        public double getCutoffScore() {
+            return cutoffScore;
+        }
+
+        @Override
+        protected void merge(Suggestion.Entry<Suggestion.Entry.Option> other) {
+            super.merge(other);
+            // If the cluster contains both pre 0.90.4 and post 0.90.4 nodes then we'll see Suggestion.Entry
+            // objects being merged with PhraseSuggestion.Entry objects.  We merge Suggestion.Entry objects
+            // by assuming they had a low cutoff score rather than a high one as that is the more common scenario
+            // and the simplest one for us to implement.
+            if (!(other instanceof PhraseSuggestion.Entry)) {
+                return;
+            }
+            PhraseSuggestion.Entry otherSuggestionEntry = (PhraseSuggestion.Entry) other;
+            this.cutoffScore = Math.max(this.cutoffScore, otherSuggestionEntry.cutoffScore);
+        }
+
+        @Override
+        public void addOption(Suggestion.Entry.Option option) {
+            if (option.getScore() > this.cutoffScore) {
+                this.options.add(option);
+            }
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            // If the other side is older than 0.90.4 then it shouldn't be sending suggestions of this type but just in case
+            // we're going to assume that they are regular suggestions so we won't read anything.
+            if (in.getVersion().before(Version.V_0_90_4)) {
+                return;
+            }
+            cutoffScore = in.readDouble();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            // If the other side of the message is older than 0.90.4 it'll interpret these suggestions as regular suggestions
+            // so we have to pretend to be one which we can do by just calling the superclass writeTo and doing nothing else
+            if (out.getVersion().before(Version.V_0_90_4)) {
+                return;
+            }
+            out.writeDouble(cutoffScore);
+        }
+    }
+}


### PR DESCRIPTION
The goal is to throw out suggestions that only meet the cutoff in some
shards.  This will happen if your input phrase is only contained in a
few shards.  If your shards are unbanced this rechecking can throw out
good suggestions.

Closes #3547.
