### PR TITLE
Removed ambiguously-worded ES_HEAP_SIZE comment

### DIFF
--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -57,7 +57,7 @@ export JAVA_HOME
 # Directory where the ElasticSearch binary distribution resides
 ES_HOME=/usr/share/$NAME
 
-# Heap Size (defaults to 256m min, 1g max)
+# Heap Size
 #ES_HEAP_SIZE=2g
 
 # Heap new generation


### PR DESCRIPTION
Multiple people have misread the original comment "(defaults to 256m min, 1g max)" as meaning "you must set this to a value between 256m and 1g" - probably partly due to the wording, partly due to it being slightly odd to ["[recommend setting] the min and max memory to the same value"](set the min and max memory to the same value) yet not defaulting to doing so.

In the absence of being able to word it better, I've just stripped it out to minimise confusion (and none of the other settings have their defaults included in the comments)
