### PR TITLE
Call onRemoval of shard IdCache during clear.

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdCache.java
@@ -266,7 +266,7 @@ public class SimpleIdCache extends AbstractIndexComponent implements IdCache, Se
         if (readerCache.shardId != null) {
             IndexShard shard = indexService.shard(readerCache.shardId.id());
             if (shard != null) {
-                shard.idCache().onCached(readerCache.sizeInBytes());
+                shard.idCache().onRemoval(readerCache.sizeInBytes());
             }
         }
     }


### PR DESCRIPTION
This looks like a copy/paste issue where onCached was being called
rather than onRemoval. This should fix the ID cache stats not being
correct after a call to /_cache/clear?id_cache=true
