### PR TITLE
Dont write pidfile twice on startup

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -126,16 +126,14 @@ launch_service()
         es_parms="$es_parms -Des.foreground=yes"
         exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                 org.elasticsearch.bootstrap.ElasticSearch
-        execval=$?
+        # exec without running it in the background, makes it replace this shell, we'll never get here...
+        # no need to return something
     else
         # Startup ElasticSearch, background it, and write the pid.
         exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                     org.elasticsearch.bootstrap.ElasticSearch <&- &
-        execval=$?
-        [ ! -z "$pidpath" ] && printf '%d' $! > "$pidpath"
+        return $?
     fi
-
-    return $execval
 }
 
 # Parse any command line options.


### PR DESCRIPTION
There is no need to write the pidfile in the bin/elasticsearchshell script
as this happens already in the java code.

Also cleaning up the bin/elasticsearch shell script a bit (no need to return
an error code when exec is called, as this forks and exits the shell script
immediately).

Closes #3529
Closes #1745
