### PR TITLE
Setting index/bulk thread pools with queue_size can cause replica shard failures

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -40,7 +40,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.XRunnable;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.index.engine.DocumentAlreadyExistsException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.indices.IndicesService;
@@ -696,7 +696,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
                 if (request.operationThreaded()) {
                     request.beforeLocalFork();
                     try {
-                        threadPool.executor(executor).execute(new XRunnable() {
+                        threadPool.executor(executor).execute(new AbstractRunnable() {
                             @Override
                             public void run() {
                                 try {

--- a/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.util.concurrent;
 /**
  * An extension to runnable.
  */
-public abstract class XRunnable implements Runnable {
+public abstract class AbstractRunnable implements Runnable {
 
     /**
      * Should the runnable force its execution in case it gets rejected?

--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -34,8 +34,8 @@ public class EsAbortPolicy implements XRejectedExecutionHandler {
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-        if (r instanceof XRunnable) {
-            if (((XRunnable) r).isForceExecution()) {
+        if (r instanceof AbstractRunnable) {
+            if (((AbstractRunnable) r).isForceExecution()) {
                 BlockingQueue<Runnable> queue = executor.getQueue();
                 if (!(queue instanceof SizeBlockingQueue)) {
                     throw new ElasticSearchIllegalStateException("forced execution, but expected a size queue");

--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -19,8 +19,11 @@
 
 package org.elasticsearch.common.util.concurrent;
 
+import org.elasticsearch.ElasticSearchIllegalStateException;
+import org.elasticsearch.ElasticSearchInterruptedException;
 import org.elasticsearch.common.metrics.CounterMetric;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -31,6 +34,20 @@ public class EsAbortPolicy implements XRejectedExecutionHandler {
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        if (r instanceof XRunnable) {
+            if (((XRunnable) r).isForceExecution()) {
+                BlockingQueue<Runnable> queue = executor.getQueue();
+                if (!(queue instanceof SizeBlockingQueue)) {
+                    throw new ElasticSearchIllegalStateException("forced execution, but expected a size queue");
+                }
+                try {
+                    ((SizeBlockingQueue) queue).forcePut(r);
+                } catch (InterruptedException e) {
+                    throw new ElasticSearchInterruptedException(e.getMessage(), e);
+                }
+                return;
+            }
+        }
         rejected.inc();
         throw new EsRejectedExecutionException("rejected execution of [" + r.getClass().getName() + "]");
     }

--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -57,12 +57,14 @@ public class EsExecutors {
         return new EsThreadPoolExecutor(0, Integer.MAX_VALUE, keepAliveTime, unit, new SynchronousQueue<Runnable>(), threadFactory, new EsAbortPolicy());
     }
 
-    public static EsThreadPoolExecutor newFixed(int size, BlockingQueue<Runnable> queue, ThreadFactory threadFactory) {
+    public static EsThreadPoolExecutor newFixed(int size, int queueCapacity, ThreadFactory threadFactory) {
+        BlockingQueue<Runnable> queue;
+        if (queueCapacity < 0) {
+            queue = ConcurrentCollections.newBlockingQueue();
+        } else {
+            queue = new SizeBlockingQueue<Runnable>(ConcurrentCollections.<Runnable>newBlockingQueue(), queueCapacity);
+        }
         return new EsThreadPoolExecutor(size, size, 0, TimeUnit.MILLISECONDS, queue, threadFactory, new EsAbortPolicy());
-    }
-
-    public static EsThreadPoolExecutor newFixed(int size, BlockingQueue<Runnable> queue, ThreadFactory threadFactory, XRejectedExecutionHandler rejectedExecutionHandler) {
-        return new EsThreadPoolExecutor(size, size, 0, TimeUnit.MILLISECONDS, queue, threadFactory, rejectedExecutionHandler);
     }
 
     public static String threadName(Settings settings, String namePrefix) {
@@ -110,6 +112,7 @@ public class EsExecutors {
      */
     private EsExecutors() {
     }
+
 
     static class ExecutorScalingQueue<E> extends LinkedTransferQueue<E> {
 

--- a/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
@@ -188,7 +188,7 @@ public class SizeBlockingQueue<E> extends AbstractQueue<E> implements BlockingQu
 
     @Override
     public <T> T[] toArray(T[] a) {
-        return (T[]) queue.toArray();
+        return (T[]) queue.toArray(a);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
@@ -41,6 +41,7 @@ public class SizeBlockingQueue<E> extends AbstractQueue<E> implements BlockingQu
     private final AtomicInteger size = new AtomicInteger();
 
     public SizeBlockingQueue(BlockingQueue<E> queue, int capacity) {
+        assert capacity >= 0;
         this.queue = queue;
         this.capacity = capacity;
     }

--- a/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.ElasticSearchIllegalStateException;
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A size based queue wrapping another blocking queue to provide (somewhat relaxed) capacity checks.
+ * Mainly makes sense to use with blocking queues that are unbounded to provide the ability to do
+ * capacity verification.
+ */
+public class SizeBlockingQueue<E> extends AbstractQueue<E> implements BlockingQueue<E> {
+
+    private final BlockingQueue<E> queue;
+    private final int capacity;
+
+    private final AtomicInteger size = new AtomicInteger();
+
+    public SizeBlockingQueue(BlockingQueue<E> queue, int capacity) {
+        this.queue = queue;
+        this.capacity = capacity;
+    }
+
+    @Override
+    public int size() {
+        return size.get();
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        final Iterator<E> it = queue.iterator();
+        return new Iterator<E>() {
+            E current;
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public E next() {
+                current = it.next();
+                return current;
+            }
+
+            @Override
+            public void remove() {
+                // note, we can't call #remove on the iterator because we need to know
+                // if it was removed or not
+                if (queue.remove(current)) {
+                    size.decrementAndGet();
+                }
+            }
+        };
+    }
+
+    @Override
+    public E peek() {
+        return queue.peek();
+    }
+
+    @Override
+    public E poll() {
+        E e = queue.poll();
+        if (e != null) {
+            size.decrementAndGet();
+        }
+        return e;
+    }
+
+    @Override
+    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+        E e = queue.poll(timeout, unit);
+        if (e != null) {
+            size.decrementAndGet();
+        }
+        return e;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        boolean v = queue.remove(o);
+        if (v) {
+            size.decrementAndGet();
+        }
+        return v;
+    }
+
+    /**
+     * Forces adding an element to the queue, without doing size checks.
+     */
+    public void forcePut(E e) throws InterruptedException {
+        size.incrementAndGet();
+        try {
+            queue.put(e);
+        } catch (InterruptedException ie) {
+            size.decrementAndGet();
+            throw ie;
+        }
+    }
+
+
+    @Override
+    public boolean offer(E e) {
+        int count = size.incrementAndGet();
+        if (count > capacity) {
+            size.decrementAndGet();
+            return false;
+        }
+        boolean offered = queue.offer(e);
+        if (!offered) {
+            size.decrementAndGet();
+        }
+        return offered;
+    }
+
+    @Override
+    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
+        // note, not used in ThreadPoolExecutor
+        throw new ElasticSearchIllegalStateException("offer with timeout not allowed on size queue");
+    }
+
+    @Override
+    public void put(E e) throws InterruptedException {
+        // note, not used in ThreadPoolExecutor
+        throw new ElasticSearchIllegalStateException("put not allowed on size queue");
+    }
+
+    @Override
+    public E take() throws InterruptedException {
+        E e;
+        try {
+            e = queue.take();
+            size.decrementAndGet();
+        } catch (InterruptedException ie) {
+            throw ie;
+        }
+        return e;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return capacity - size.get();
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c) {
+        int v = queue.drainTo(c);
+        size.addAndGet(-v);
+        return v;
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c, int maxElements) {
+        int v = queue.drainTo(c, maxElements);
+        size.addAndGet(-v);
+        return v;
+    }
+
+    @Override
+    public Object[] toArray() {
+        return queue.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return (T[]) queue.toArray();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return queue.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return queue.containsAll(c);
+    }
+}

--- a/src/main/java/org/elasticsearch/common/util/concurrent/XRunnable.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/XRunnable.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+/**
+ * An extension to runnable.
+ */
+public abstract class XRunnable implements Runnable {
+
+    /**
+     * Should the runnable force its execution in case it gets rejected?
+     */
+    public boolean isForceExecution() {
+        return false;
+    }
+}

--- a/src/test/java/org/elasticsearch/test/integration/threadpool/SimpleThreadPoolTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/threadpool/SimpleThreadPoolTests.java
@@ -96,7 +96,6 @@ public class SimpleThreadPoolTests extends AbstractNodesTests {
             for (ThreadPool.Info info : nodeInfo.getThreadPool()) {
                 if (info.getName().equals(Names.SEARCH)) {
                     assertThat(info.getType(), equalTo("fixed"));
-                    assertThat(info.getQueueType(), equalTo("linked"));
                     found = true;
                     break;
                 }
@@ -104,7 +103,6 @@ public class SimpleThreadPoolTests extends AbstractNodesTests {
             assertThat(found, equalTo(true));
 
             Map<String, Object> poolMap = getPoolSettingsThroughJson(nodeInfo.getThreadPool(), Names.SEARCH);
-            assertThat(poolMap.get("queue_type").toString(), equalTo("linked"));
         }
     }
 

--- a/src/test/java/org/elasticsearch/test/unit/common/util/concurrent/EsExecutorsTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/util/concurrent/EsExecutorsTests.java
@@ -72,7 +72,7 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
 
         final AtomicBoolean executed3 = new AtomicBoolean();
         final CountDownLatch exec3Wait = new CountDownLatch(1);
-        executor.execute(new XRunnable() {
+        executor.execute(new AbstractRunnable() {
             @Override
             public void run() {
                 executed3.set(true);

--- a/src/test/java/org/elasticsearch/test/unit/common/util/concurrent/EsExecutorsTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/common/util/concurrent/EsExecutorsTests.java
@@ -20,14 +20,14 @@
 package org.elasticsearch.test.unit.common.util.concurrent;
 
 import com.google.common.base.Predicate;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.ThreadBarrier;
+import org.elasticsearch.common.util.concurrent.*;
 import org.elasticsearch.test.integration.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
@@ -38,6 +38,119 @@ public class EsExecutorsTests extends ElasticsearchTestCase {
 
     private TimeUnit randomTimeUnit() {
         return TimeUnit.values()[between(0, TimeUnit.values().length - 1)];
+    }
+
+    @Test
+    public void testFixedForcedExecution() throws Exception {
+        EsThreadPoolExecutor executor = EsExecutors.newFixed(1, 1, EsExecutors.daemonThreadFactory("test"));
+        final CountDownLatch wait = new CountDownLatch(1);
+
+        final CountDownLatch exec1Wait = new CountDownLatch(1);
+        final AtomicBoolean executed1 = new AtomicBoolean();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    wait.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                executed1.set(true);
+                exec1Wait.countDown();
+            }
+        });
+
+        final CountDownLatch exec2Wait = new CountDownLatch(1);
+        final AtomicBoolean executed2 = new AtomicBoolean();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                executed2.set(true);
+                exec2Wait.countDown();
+            }
+        });
+
+        final AtomicBoolean executed3 = new AtomicBoolean();
+        final CountDownLatch exec3Wait = new CountDownLatch(1);
+        executor.execute(new XRunnable() {
+            @Override
+            public void run() {
+                executed3.set(true);
+                exec3Wait.countDown();
+            }
+
+            @Override
+            public boolean isForceExecution() {
+                return true;
+            }
+        });
+
+        wait.countDown();
+
+        exec1Wait.await();
+        exec2Wait.await();
+        exec3Wait.await();
+
+        assertThat(executed1.get(), equalTo(true));
+        assertThat(executed2.get(), equalTo(true));
+        assertThat(executed3.get(), equalTo(true));
+
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testFixedRejected() throws Exception {
+        EsThreadPoolExecutor executor = EsExecutors.newFixed(1, 1, EsExecutors.daemonThreadFactory("test"));
+        final CountDownLatch wait = new CountDownLatch(1);
+
+        final CountDownLatch exec1Wait = new CountDownLatch(1);
+        final AtomicBoolean executed1 = new AtomicBoolean();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    wait.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                executed1.set(true);
+                exec1Wait.countDown();
+            }
+        });
+
+        final CountDownLatch exec2Wait = new CountDownLatch(1);
+        final AtomicBoolean executed2 = new AtomicBoolean();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                executed2.set(true);
+                exec2Wait.countDown();
+            }
+        });
+
+        final AtomicBoolean executed3 = new AtomicBoolean();
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    executed3.set(true);
+                }
+            });
+            assert false : "should be rejected...";
+        } catch (EsRejectedExecutionException e) {
+            // all is well
+        }
+
+        wait.countDown();
+
+        exec1Wait.await();
+        exec2Wait.await();
+
+        assertThat(executed1.get(), equalTo(true));
+        assertThat(executed2.get(), equalTo(true));
+        assertThat(executed3.get(), equalTo(false));
+
+        executor.shutdownNow();
     }
 
     @Test


### PR DESCRIPTION
Setting index/bulk thread pools with queue_size can cause replica shard failures
closes #3526
