### PR TITLE
Throw exception when content _id is an object

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -307,6 +307,8 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
                 return null;
             }
             return new Field(names.indexName(), context.id(), fieldType);
+        } else if (parser.currentName() != null && parser.currentName().equals(Defaults.NAME) && parser.currentToken().equals(XContentParser.Token.START_OBJECT)) {
+            throw new MapperParsingException("Content id cannot be an object.");
         } else {
             // we are in the pre/post parse phase
             if (!fieldType.indexed() && !fieldType.stored()) {

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/id/IdMappingTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/id/IdMappingTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test.unit.index.mapper.id;
 
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -113,5 +114,23 @@ public class IdMappingTests {
                 .endObject().string();
 
         assertThat(serialized_id_mapping, equalTo(expected_id_mapping));
+    }
+
+    @Test
+    public void testObjectId() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .endObject().endObject().string();
+        DocumentMapper docMapper = MapperTestUtils.newParser().parse(mapping);
+
+        BytesReference source = XContentFactory.jsonBuilder().startObject()
+                .startObject("_id").field("name", "test").endObject()
+                .endObject().bytes();
+        try {
+            ParsedDocument doc = docMapper.parse("type", "1", source);
+            assert false;
+        } catch (MapperParsingException e) {
+            assert true;
+        }
+
     }
 }


### PR DESCRIPTION
An exception is thrown if the provided id does not match the content id, but only if the content id is a string field.  If the content id is a complex object, no exception is thrown and the document is indexed anyway, leading to problems with search later.

This fix adds an additional check for _id fields that are objects and throws an exception if one is encountered.

Fixes #3517
