### PR TITLE
Add 'min_input_len' to completion suggester

### DIFF
--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -65,7 +65,7 @@ Mapping supports the following parameters:
 `payloads`:: 
     Enables the storing of payloads, defaults to `false`
 
-`preserve_separators`: 
+`preserve_separators`::
     Preserves the separators, defaults to `true`.
     If disabled, you could find a field starting with `Foo Fighters`, if you
     suggest for `foof`.
@@ -78,6 +78,14 @@ Mapping supports the following parameters:
     `The Beatles`, no need to change a simple analyzer, if you are able to
     enrich your data.
 
+`max_input_len`::
+    Limits the length of a single input, defaults to `50` UTF-16 code points.
+    This limit is only used at index time to reduce the total number of
+    characters per input string in order to prevent massive inputs from
+    bloating the underlying datastructure. The most usecases won't be influenced
+    by the default value since prefix completions hardly grow beyond prefixes longer
+    than a handful of characters.
+    
 ==== Indexing
 
 [source,js]

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -28,6 +28,8 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequestBuilder;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
@@ -49,6 +51,15 @@ import static org.junit.Assert.fail;
  */
 public class ElasticsearchAssertions {
 
+
+    public static void assertAcked(PutMappingRequestBuilder builder) {
+        assertAcked(builder.get());
+    }
+    
+    private static void assertAcked(PutMappingResponse response) {
+        assertThat("Put Mapping failed - not acked", response.isAcknowledged(), equalTo(true));
+
+    }
 
     public static void assertAcked(DeleteIndexRequestBuilder builder) {
         assertAcked(builder.get());

--- a/src/test/java/org/elasticsearch/test/integration/search/suggest/CompletionPostingsFormatTest.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/suggest/CompletionPostingsFormatTest.java
@@ -91,7 +91,7 @@ public class CompletionPostingsFormatTest extends ElasticsearchTestCase {
         LookupFactory load = provider.load(input);
         PostingsFormatProvider format = new PreBuiltPostingsFormatProvider(new ElasticSearch090PostingsFormat());
         NamedAnalyzer analyzer = new NamedAnalyzer("foo", new StandardAnalyzer(TEST_VERSION_CURRENT));
-        Lookup lookup = load.getLookup(new CompletionFieldMapper(new Names("foo"), analyzer, analyzer, format, null, true, true, true), new CompletionSuggestionContext(null));
+        Lookup lookup = load.getLookup(new CompletionFieldMapper(new Names("foo"), analyzer, analyzer, format, null, true, true, true, Integer.MAX_VALUE), new CompletionSuggestionContext(null));
         List<LookupResult> result = lookup.lookup("ge", false, 10);
         assertThat(result.get(0).key.toString(), equalTo("Generator - Foo Fighters"));
         assertThat(result.get(0).payload.utf8ToString(), equalTo("id:10"));
@@ -176,7 +176,7 @@ public class CompletionPostingsFormatTest extends ElasticsearchTestCase {
 
         NamedAnalyzer namedAnalzyer = new NamedAnalyzer("foo", new StandardAnalyzer(TEST_VERSION_CURRENT));
         final CompletionFieldMapper mapper = new CompletionFieldMapper(new Names("foo"), namedAnalzyer, namedAnalzyer, provider, null, usePayloads,
-                preserveSeparators, preservePositionIncrements);
+                preserveSeparators, preservePositionIncrements, Integer.MAX_VALUE);
         Lookup buildAnalyzingLookup = buildAnalyzingLookup(mapper, titles, titles, weights);
         Field field = buildAnalyzingLookup.getClass().getDeclaredField("maxAnalyzedPathsForOneInput");
         field.setAccessible(true);
@@ -265,7 +265,7 @@ public class CompletionPostingsFormatTest extends ElasticsearchTestCase {
         LookupFactory load = provider.load(input);
         PostingsFormatProvider format = new PreBuiltPostingsFormatProvider(new ElasticSearch090PostingsFormat());
         NamedAnalyzer analyzer = new NamedAnalyzer("foo", new StandardAnalyzer(TEST_VERSION_CURRENT));
-        assertNull(load.getLookup(new CompletionFieldMapper(new Names("foo"), analyzer, analyzer, format, null, true, true, true), new CompletionSuggestionContext(null)));
+        assertNull(load.getLookup(new CompletionFieldMapper(new Names("foo"), analyzer, analyzer, format, null, true, true, true, Integer.MAX_VALUE), new CompletionSuggestionContext(null)));
         dir.close();
     }
 

--- a/src/test/java/org/elasticsearch/test/unit/index/mapper/completion/CompletionFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/test/unit/index/mapper/completion/CompletionFieldMapperTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.test.unit.index.mapper.completion;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -64,6 +63,8 @@ public class CompletionFieldMapperTests {
                 .field("payloads", true)
                 .field("preserve_separators", false)
                 .field("preserve_position_increments", true)
+                .field("max_input_len", 14)
+
                 .endObject().endObject()
                 .endObject().endObject().string();
 
@@ -83,6 +84,7 @@ public class CompletionFieldMapperTests {
         assertThat(Boolean.valueOf(configMap.get("payloads").toString()), is(true));
         assertThat(Boolean.valueOf(configMap.get("preserve_separators").toString()), is(false));
         assertThat(Boolean.valueOf(configMap.get("preserve_position_increments").toString()), is(true));
+        assertThat(Integer.valueOf(configMap.get("max_input_len").toString()), is(14));
     }
 
     @Test


### PR DESCRIPTION
Restrict the size of the input length to a reasonable size otherwise very
long strings can cause StackOverflowExceptions deep down in lucene land.
Yet, this is simply a saftly limit set to `50` UTF-16 codepoints by default.
This limit is only present at index time and not at query time. If prefix
completions > 50 UTF-16 codepoints are expected / desired this limit should be raised.
Critical string sizes are beyone the 1k UTF-16 Codepoints limit.

Closes #3596
