### PR TITLE
Highlighting can return excerpt with no highlights

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -164,6 +164,28 @@ is required. Note that `fragment_size` is ignored in this case.
 When using `fast-vector-highlighter` one can use `fragment_offset`
 parameter to control the margin to start highlighting from.
 
+coming[0.90.6]
+It is also possible to ask Elasticsearch to return a fragment from the
+beginning of the field in the case where there are no matches by setting
+`no_match_size` to something greater than 0.  The default is 0.
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {...},
+    "highlight" : {
+        "fields" : {
+            "content" : {
+                "fragment_size" : 150,
+                "number_of_fragments" : 3,
+                "no_match_size": 150
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+
 ==== Highlight query
 
 It is also possible to highlight against a query other than the search

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -692,6 +692,17 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
+    /**
+     * Sets the size of the fragment to return from the beginning of the field if there are no matches to
+     * highlight and the field doesn't also define noMatchSize.
+     * @param noMatchSize integer to set or null to leave out of request.  default is null.
+     * @return this builder for chaining
+     */
+    public SearchRequestBuilder setHighlighterNoMatchSize(Integer noMatchSize) {
+        highlightBuilder().noMatchSize(noMatchSize);
+        return this;
+    }
+
     public SearchRequestBuilder setHighlighterOptions(Map<String, Object> options) {
         highlightBuilder().options(options);
         return this;

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
@@ -56,6 +56,8 @@ public class HighlightBuilder implements ToXContent {
 
     private QueryBuilder highlightQuery;
 
+    private Integer noMatchSize;
+
     private Map<String, Object> options;
 
     /**
@@ -213,6 +215,17 @@ public class HighlightBuilder implements ToXContent {
     }
 
     /**
+     * Sets the size of the fragment to return from the beginning of the field if there are no matches to
+     * highlight and the field doesn't also define noMatchSize.
+     * @param noMatchSize integer to set or null to leave out of request.  default is null.
+     * @return this for chaining
+     */
+    public HighlightBuilder noMatchSize(Integer noMatchSize) {
+        this.noMatchSize = noMatchSize;
+        return this;
+    }
+
+    /**
      * Allows to set custom options for custom highlighters.
      */
     public HighlightBuilder options(Map<String, Object> options) {
@@ -249,6 +262,9 @@ public class HighlightBuilder implements ToXContent {
         }
         if (highlightQuery != null) {
             builder.field("highlight_query", highlightQuery);
+        }
+        if (noMatchSize != null) {
+            builder.field("no_match_size", noMatchSize);
         }
         if (options != null && options.size() > 0) {
             builder.field("options", options);
@@ -296,6 +312,9 @@ public class HighlightBuilder implements ToXContent {
                 if (field.highlightQuery != null) {
                     builder.field("highlight_query", field.highlightQuery);
                 }
+                if (field.noMatchSize != null) {
+                    builder.field("no_match_size", field.noMatchSize);
+                }
                 if (field.options != null && field.options.size() > 0) {
                     builder.field("options", field.options);
                 }
@@ -324,6 +343,7 @@ public class HighlightBuilder implements ToXContent {
         String highlighterType;
         String fragmenter;
         QueryBuilder highlightQuery;
+        Integer noMatchSize;
         Map<String, Object> options;
 
         public Field(String name) {
@@ -423,6 +443,17 @@ public class HighlightBuilder implements ToXContent {
          */
         public Field highlightQuery(QueryBuilder highlightQuery) {
             this.highlightQuery = highlightQuery;
+            return this;
+        }
+
+        /**
+         * Sets the size of the fragment to return from the beginning of the field if there are no matches to
+         * highlight.
+         * @param noMatchSize integer to set or null to leave out of request.  default is null.
+         * @return this for chaining
+         */
+        public Field noMatchSize(Integer noMatchSize) {
+            this.noMatchSize = noMatchSize;
             return this;
         }
 

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -82,6 +82,7 @@ public class HighlighterParseElement implements SearchParseElement {
         String globalFragmenter = null;
         Map<String, Object> globalOptions = null;
         Query globalHighlightQuery = null;
+        int globalNoMatchSize = 0;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -131,6 +132,8 @@ public class HighlighterParseElement implements SearchParseElement {
                     globalHighlighterType = parser.text();
                 } else if ("fragmenter".equals(topLevelFieldName)) {
                     globalFragmenter = parser.text();
+                } else if ("no_match_size".equals(topLevelFieldName) || "noMatchSize".equals(topLevelFieldName)) {
+                    globalNoMatchSize = parser.intValue();
                 }
             } else if (token == XContentParser.Token.START_OBJECT && "options".equals(topLevelFieldName)) {
                 globalOptions = parser.map();
@@ -186,6 +189,8 @@ public class HighlighterParseElement implements SearchParseElement {
                                         field.highlighterType(parser.text());
                                     } else if ("fragmenter".equals(fieldName)) {
                                         field.fragmenter(parser.text());
+                                    } else if ("no_match_size".equals(fieldName) || "noMatchSize".equals(fieldName)) {
+                                        field.noMatchSize(parser.intValue());
                                     }
                                 } else if (token == XContentParser.Token.START_OBJECT) {
                                     if ("highlight_query".equals(fieldName) || "highlightQuery".equals(fieldName)) {
@@ -250,6 +255,9 @@ public class HighlighterParseElement implements SearchParseElement {
             }
             if (field.highlightQuery() == null && globalHighlightQuery != null) {
                 field.highlightQuery(globalHighlightQuery);
+            }
+            if (field.noMatchSize() == -1) {
+                field.noMatchSize(globalNoMatchSize);
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -40,7 +40,7 @@ public class SearchContextHighlight {
     }
 
     public static class Field {
-
+        // Fields that default to null or -1 are often set to their real default in HighlighterParseElement#parse
         private final String field;
 
         private int fragmentCharSize = -1;
@@ -66,9 +66,12 @@ public class SearchContextHighlight {
         private String fragmenter;
 
         private int boundaryMaxScan = -1;
+
         private Character[] boundaryChars = null;
 
         private Query highlightQuery;
+
+        private int noMatchSize = -1;
 
         private Map<String, Object> options;
 
@@ -190,6 +193,14 @@ public class SearchContextHighlight {
 
         public void highlightQuery(Query highlightQuery) {
             this.highlightQuery = highlightQuery;
+        }
+
+        public int noMatchSize() {
+            return noMatchSize;
+        }
+
+        public void noMatchSize(int noMatchSize) {
+            this.noMatchSize = noMatchSize;
         }
 
         public Map<String, Object> options() {

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -189,10 +189,16 @@ public class ElasticsearchAssertions {
     public static void assertHighlight(SearchResponse resp, int hit, String field, int fragment, Matcher<String> matcher) {
         assertNoFailures(resp);
         assertThat("not enough hits", resp.getHits().hits().length, greaterThan(hit));
-        assertThat(resp.getHits().hits()[hit].getHighlightFields().get(field), notNullValue());
+        assertThat(resp.getHits().hits()[hit].getHighlightFields(), hasKey(field));
         assertThat(resp.getHits().hits()[hit].getHighlightFields().get(field).fragments().length, greaterThan(fragment));
         assertThat(resp.getHits().hits()[hit].highlightFields().get(field).fragments()[fragment].string(), matcher);
         assertVersionSerializable(resp);
+    }
+
+    public static void assertNotHighlighted(SearchResponse resp, int hit, String field) {
+        assertNoFailures(resp);
+        assertThat("not enough hits", resp.getHits().hits().length, greaterThan(hit));
+        assertThat(resp.getHits().hits()[hit].getHighlightFields(), not(hasKey(field)));
     }
 
     public static void assertSuggestionSize(Suggest searchSuggest, int entry, int size, String key) {


### PR DESCRIPTION
You can configure the highlighting api to return an excerpt of a field
even if there wasn't a match on the field.

The FVH makes excerpts from the beginning of the string to the first
boundary character after the requested length or the boundary_max_scan,
whichever comes first.  The Plain highlighter makes excerpts from the
beginning of the string to the end of the last token before the requested
length.

Closes #1171
