### PR TITLE
enable GET /_template to show all templates

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -39,7 +39,7 @@ curl -XDELETE localhost:9200/_template/template_1
 --------------------------------------------------
 
 [float]
-=== GETting a Template
+=== GETting templates
 
 Index templates are identified by a name (in the above case
 `template_1`) and can be retrieved using the following:
@@ -55,6 +55,7 @@ by using wildcards like:
 [source,js]
 --------------------------------------------------
 curl -XGET localhost:9200/_template/temp*
+curl -XGET localhost:9200/_template/template_1,template_2
 --------------------------------------------------
 
 To get list of all index templates you can use

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -61,6 +61,14 @@ To get list of all index templates you can use
 <<cluster-state,Cluster State>> API
 and check for the metadata/templates section of the response.
 
+added::[0.90.4] Or run:
+
+[source,js]
+--------------------------------------------------
+curl -XGET localhost:9200/_template/
+--------------------------------------------------
+
+
 [float]
 === Multiple Template Matching
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.action.admin.indices.template.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -88,12 +89,21 @@ public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetInde
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        names = in.readStringArray();
+        if (in.getVersion().onOrAfter(Version.V_0_90_4)) {
+            names = in.readStringArray();
+        } else {
+            names = new String[1];
+            names[0] = in.readString();
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringArray(names);
+        if (out.getVersion().onOrAfter(Version.V_0_90_4)) {
+            out.writeStringArray(names);
+        } else {
+            out.writeString(names[0]);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -21,10 +21,13 @@ package org.elasticsearch.action.admin.indices.template.get;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  *
@@ -47,7 +50,17 @@ public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetInde
 
     @Override
     public ActionRequestValidationException validate() {
-        return null;
+        ActionRequestValidationException validationException = null;
+        if (names == null) {
+            validationException = addValidationError("names is null", validationException);
+        } else {
+            for (String name : names) {
+                if (name == null || !Strings.hasText(name)) {
+                    validationException = addValidationError("name is missing", validationException);
+                }
+            }
+        }
+        return validationException;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -25,54 +25,75 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-import static org.elasticsearch.action.ValidateActions.addValidationError;
-
 /**
  *
  */
 public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetIndexTemplatesRequest> {
 
-    private String name;
+    private String[] names;
 
     public GetIndexTemplatesRequest() {}
 
+    @Deprecated
     public GetIndexTemplatesRequest(String name) {
-        this.name = name;
+        this.names = new String[1];
+        this.names[0] = name;
+    }
+
+    public GetIndexTemplatesRequest(String... names) {
+        this.names = names;
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        ActionRequestValidationException validationException = null;
-        if (name == null) {
-            validationException = addValidationError("name is missing", validationException);
-        }
-        return validationException;
+        return null;
     }
 
     /**
      * Sets the name of the index template.
      */
+    @Deprecated
     public GetIndexTemplatesRequest name(String name) {
-        this.name = name;
+        this.names = new String[1];
+        this.names[0] = name;
         return this;
     }
 
     /**
      * The name of the index template.
      */
+    @Deprecated
     public String name() {
-        return this.name;
+        if (this.names != null && this.names.length > 0) {
+            return this.names[0];
+        }
+        return null;
+    }
+
+    /**
+     * Sets the names of the index templates.
+     */
+    public GetIndexTemplatesRequest names(String... names) {
+        this.names = names;
+        return this;
+    }
+
+    /**
+     * The names of the index templates.
+     */
+    public String[] names() {
+        return this.names;
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        name = in.readString();
+        names = in.readStringArray();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(name);
+        out.writeStringArray(names);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
@@ -32,8 +32,13 @@ public class GetIndexTemplatesRequestBuilder extends MasterNodeOperationRequestB
         super((InternalIndicesAdminClient) indicesClient, new GetIndexTemplatesRequest());
     }
 
+    @Deprecated
     public GetIndexTemplatesRequestBuilder(IndicesAdminClient indicesClient, String name) {
         super((InternalIndicesAdminClient) indicesClient, new GetIndexTemplatesRequest(name));
+    }
+
+    public GetIndexTemplatesRequestBuilder(IndicesAdminClient indicesClient, String... names) {
+        super((InternalIndicesAdminClient) indicesClient, new GetIndexTemplatesRequest(names));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -642,12 +642,13 @@ public interface IndicesAdminClient {
      *
      * @param name The name of the template.
      */
+    @Deprecated
     GetIndexTemplatesRequestBuilder prepareGetTemplates(String name);
 
     /**
-     * Gets all index templates.
+     * Gets an index template (optional).
      */
-    GetIndexTemplatesRequestBuilder prepareGetTemplates();
+    GetIndexTemplatesRequestBuilder prepareGetTemplates(String... name);
 
     /**
      * Validate a query for correctness.

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -645,6 +645,11 @@ public interface IndicesAdminClient {
     GetIndexTemplatesRequestBuilder prepareGetTemplates(String name);
 
     /**
+     * Gets all index templates.
+     */
+    GetIndexTemplatesRequestBuilder prepareGetTemplates();
+
+    /**
      * Validate a query for correctness.
      *
      * @param request The count request

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -486,14 +486,14 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
         execute(GetIndexTemplatesAction.INSTANCE, request, listener);
     }
 
-    @Override
+    @Override @Deprecated
     public GetIndexTemplatesRequestBuilder prepareGetTemplates(String name) {
         return new GetIndexTemplatesRequestBuilder(this, name);
     }
 
     @Override
-    public GetIndexTemplatesRequestBuilder prepareGetTemplates() {
-        return new GetIndexTemplatesRequestBuilder(this, "*");
+    public GetIndexTemplatesRequestBuilder prepareGetTemplates(String... names) {
+        return new GetIndexTemplatesRequestBuilder(this, names);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -492,6 +492,11 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
     }
 
     @Override
+    public GetIndexTemplatesRequestBuilder prepareGetTemplates() {
+        return new GetIndexTemplatesRequestBuilder(this, "*");
+    }
+
+    @Override
     public ActionFuture<DeleteIndexTemplateResponse> deleteTemplate(final DeleteIndexTemplateRequest request) {
         return execute(DeleteIndexTemplateAction.INSTANCE, request);
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
 
 /**
  *
@@ -54,11 +55,9 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String name = request.param("name");
-        if (name == null || name.isEmpty()) {
-            name = "*";
-        }
-        GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(name);
+        final String[] names = splitIndices(request.param("name"));
+
+        GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(names);
         getIndexTemplatesRequest.listenerThreaded(false);
 
         client.admin().indices().getTemplates(getIndexTemplatesRequest, new ActionListener<GetIndexTemplatesResponse>() {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -48,12 +48,17 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
     public RestGetIndexTemplateAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
 
+        controller.registerHandler(GET, "/_template", this);
         controller.registerHandler(GET, "/_template/{name}", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
+        String name = request.param("name");
+        if (name == null || name.isEmpty()) {
+            name = "*";
+        }
+        GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(name);
         getIndexTemplatesRequest.listenerThreaded(false);
 
         client.admin().indices().getTemplates(getIndexTemplatesRequest, new ActionListener<GetIndexTemplatesResponse>() {

--- a/src/test/java/org/elasticsearch/test/integration/indices/template/SimpleIndexTemplateTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/template/SimpleIndexTemplateTests.java
@@ -227,5 +227,14 @@ public class SimpleIndexTemplateTests extends AbstractSharedClusterTest {
         templateNames.add(getTemplate1Response.getIndexTemplates().get(1).name());
         templateNames.add(getTemplate1Response.getIndexTemplates().get(2).name());
         assertThat(templateNames, containsInAnyOrder("template_1", "template_2", "template3"));
+
+        logger.info("--> get templates template_1 and template_2");
+        getTemplate1Response = client().admin().indices().prepareGetTemplates("template_1", "template_2").execute().actionGet();
+        assertThat(getTemplate1Response.getIndexTemplates(), hasSize(2));
+
+        templateNames = Lists.newArrayList();
+        templateNames.add(getTemplate1Response.getIndexTemplates().get(0).name());
+        templateNames.add(getTemplate1Response.getIndexTemplates().get(1).name());
+        assertThat(templateNames, containsInAnyOrder("template_1", "template_2"));
     }
 }

--- a/src/test/java/org/elasticsearch/test/integration/indices/template/SimpleIndexTemplateTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/template/SimpleIndexTemplateTests.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -218,5 +217,15 @@ public class SimpleIndexTemplateTests extends AbstractSharedClusterTest {
         templateNames.add(getTemplate1Response.getIndexTemplates().get(0).name());
         templateNames.add(getTemplate1Response.getIndexTemplates().get(1).name());
         assertThat(templateNames, containsInAnyOrder("template_1", "template_2"));
+
+        logger.info("--> get all templates");
+        getTemplate1Response = client().admin().indices().prepareGetTemplates().execute().actionGet();
+        assertThat(getTemplate1Response.getIndexTemplates(), hasSize(3));
+
+        templateNames = Lists.newArrayList();
+        templateNames.add(getTemplate1Response.getIndexTemplates().get(0).name());
+        templateNames.add(getTemplate1Response.getIndexTemplates().get(1).name());
+        templateNames.add(getTemplate1Response.getIndexTemplates().get(2).name());
+        assertThat(templateNames, containsInAnyOrder("template_1", "template_2", "template3"));
     }
 }

--- a/src/test/java/org/elasticsearch/test/integration/indices/template/SimpleIndexTemplateTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/indices/template/SimpleIndexTemplateTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test.integration.indices.template;
 
 import com.google.common.collect.Lists;
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Priority;
@@ -237,4 +238,29 @@ public class SimpleIndexTemplateTests extends AbstractSharedClusterTest {
         templateNames.add(getTemplate1Response.getIndexTemplates().get(1).name());
         assertThat(templateNames, containsInAnyOrder("template_1", "template_2"));
     }
+
+    @Test
+    public void testThatInvalidGetIndexTemplatesFails() throws Exception {
+        logger.info("--> get template null");
+        testExpectActionRequestValidationException(null);
+
+        logger.info("--> get template empty");
+        testExpectActionRequestValidationException("");
+
+        logger.info("--> get template 'a', '', 'c'");
+        testExpectActionRequestValidationException("a", "", "c");
+
+        logger.info("--> get template 'a', null, 'c'");
+        testExpectActionRequestValidationException("a", null, "c");
+    }
+
+    private void testExpectActionRequestValidationException(String... names) {
+        try {
+            client().admin().indices().prepareGetTemplates(names).execute().actionGet();
+            fail("We should have raised an ActionRequestValidationException for " + names);
+        } catch (ActionRequestValidationException e) {
+            // That's fine!
+        }
+    }
+
 }


### PR DESCRIPTION
PR for #2532

/_template shows:
No handler found for uri [/_template] and method [GET]

It would make sense to list the templates as they are listed in the /_cluster/state call.

See also:
https://groups.google.com/forum/?fromgroups=#!topic/elasticsearch/wnGOnT-JTQo
