### PR TITLE
key is "index.store.type", not "index.storage.type"

### DIFF
--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -44,7 +44,7 @@ script. When set, both override anything set using either `JAVA_OPTS` or
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.storage.type=memory
+$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.store.type=memory
 --------------------------------------------------
 *************************************************************************
 --

--- a/docs/reference/setup/installation.asciidoc
+++ b/docs/reference/setup/installation.asciidoc
@@ -34,6 +34,6 @@ script. When set, both override anything set using either `JAVA_OPTS` or
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.storage.type=memory
+$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.store.type=memory
 --------------------------------------------------
 *************************************************************************


### PR DESCRIPTION
Bumped into this typo with test install.  Copied the documentation to use in-memory store but indices were still saved to disk.
