### PR TITLE
Replace RestActions#splitXXX(String) methods with splitValues(String)

### DIFF
--- a/src/main/java/org/elasticsearch/common/Strings.java
+++ b/src/main/java/org/elasticsearch/common/Strings.java
@@ -1501,7 +1501,14 @@ public class Strings {
         System.arraycopy(spare.bytes, spare.offset, bytes, 0, bytes.length);
         return bytes;
     }
-    
+
+    public static String[] splitValues(String values) {
+        if (values == null) {
+            return EMPTY_ARRAY;
+        }
+        return splitStringByCommaToArray(values);
+    }
+
     private static class SecureRandomHolder {
         // class loading is atomic - this is a lazy & safe singleton
         private static final SecureRandom INSTANCE = new SecureRandom();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -35,6 +34,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.rest.RestStatus.PRECONDITION_FAILED;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -51,7 +51,7 @@ public class RestClusterHealthAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ClusterHealthRequest clusterHealthRequest = clusterHealthRequest(RestActions.splitIndices(request.param("index")));
+        ClusterHealthRequest clusterHealthRequest = clusterHealthRequest(splitValues(request.param("index")));
         clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
         clusterHealthRequest.listenerThreaded(false);
         int level = 0;

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
@@ -29,9 +29,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 
 import java.io.IOException;
+
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -53,7 +54,7 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String[] nodesIds = RestActions.splitNodes(request.param("nodeId"));
+        String[] nodesIds = splitValues(request.param("nodeId"));
         NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(nodesIds);
         nodesHotThreadsRequest.threads(request.paramAsInt("threads", nodesHotThreadsRequest.threads()));
         nodesHotThreadsRequest.type(request.param("type", nodesHotThreadsRequest.type()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -28,10 +28,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
+
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -81,7 +82,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String[] nodesIds = RestActions.splitNodes(request.param("nodeId"));
+        String[] nodesIds = splitValues(request.param("nodeId"));
         final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(nodesIds);
 
         boolean clear = request.paramAsBoolean("clear", false);
@@ -138,7 +139,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestSettingsHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().settings(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -147,7 +148,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestOsHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().os(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -156,7 +157,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestProcessHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().process(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -165,7 +166,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestJvmHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().jvm(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -174,7 +175,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestThreadPoolHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().threadPool(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -183,7 +184,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestNetworkHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().network(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -192,7 +193,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestTransportHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().transport(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -201,7 +202,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestHttpHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().http(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }
@@ -210,7 +211,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     class RestPluginHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(splitValues(request.param("nodeId")));
             nodesInfoRequest.clear().plugin(true);
             executeNodeRequest(request, channel, nodesInfoRequest);
         }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
@@ -27,10 +27,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.Strings.splitValues;
 import static org.elasticsearch.rest.action.support.RestXContentBuilder.restContentBuilder;
 
 /**
@@ -48,7 +48,7 @@ public class RestNodesRestartAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String[] nodesIds = RestActions.splitNodes(request.param("nodeId"));
+        String[] nodesIds = splitValues(request.param("nodeId"));
         NodesRestartRequest nodesRestartRequest = new NodesRestartRequest(nodesIds);
         nodesRestartRequest.listenerThreaded(false);
         nodesRestartRequest.delay(request.paramAsTime("delay", nodesRestartRequest.delay()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
@@ -28,10 +28,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.Strings.splitValues;
 import static org.elasticsearch.rest.action.support.RestXContentBuilder.restContentBuilder;
 
 /**
@@ -50,7 +50,7 @@ public class RestNodesShutdownAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String[] nodesIds = RestActions.splitNodes(request.param("nodeId"));
+        String[] nodesIds = splitValues(request.param("nodeId"));
         NodesShutdownRequest nodesShutdownRequest = new NodesShutdownRequest(nodesIds);
         nodesShutdownRequest.listenerThreaded(false);
         nodesShutdownRequest.delay(request.paramAsTime("delay", nodesShutdownRequest.delay()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -29,10 +29,11 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
+
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -119,7 +120,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String[] nodesIds = RestActions.splitNodes(request.param("nodeId"));
+        String[] nodesIds = splitValues(request.param("nodeId"));
         NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(nodesIds);
         boolean clear = request.paramAsBoolean("clear", false);
         if (clear) {
@@ -180,7 +181,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
 
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             CommonStatsFlags flags = this.flags;
             if (flags.isSet(Flag.FieldData) && request.hasParam("fields")) {
                 flags = flags.clone().fieldDataFields(request.paramAsStringArray("fields", null));
@@ -193,7 +194,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestOsHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().os(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -202,7 +203,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestProcessHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().process(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -211,7 +212,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestJvmHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().jvm(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -220,7 +221,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestThreadPoolHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().threadPool(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -229,7 +230,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestNetworkHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().network(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -238,7 +239,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestFsHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().fs(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -247,7 +248,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestTransportHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().transport(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }
@@ -256,7 +257,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     class RestHttpHandler implements RestHandler {
         @Override
         public void handleRequest(final RestRequest request, final RestChannel channel) {
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(RestActions.splitNodes(request.param("nodeId")));
+            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(splitValues(request.param("nodeId")));
             nodesStatsRequest.clear().http(true);
             executeNodeStats(request, channel, nodesStatsRequest);
         }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
@@ -29,13 +29,13 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -54,12 +54,12 @@ public class RestClusterSearchShardsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String[] indices = RestActions.splitIndices(request.param("index"));
+        String[] indices = splitValues(request.param("index"));
         final ClusterSearchShardsRequest clusterSearchShardsRequest = Requests.clusterSearchShardsRequest(indices);
         clusterSearchShardsRequest.local(request.paramAsBoolean("local", clusterSearchShardsRequest.local()));
         clusterSearchShardsRequest.listenerThreaded(false);
 
-        clusterSearchShardsRequest.types(RestActions.splitTypes(request.param("type")));
+        clusterSearchShardsRequest.types(splitValues(request.param("type")));
         clusterSearchShardsRequest.routing(request.param("routing"));
         clusterSearchShardsRequest.preference(request.param("preference"));
         if (request.hasParam("ignore_indices")) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -31,10 +31,11 @@ import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
+
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -61,7 +62,7 @@ public class RestClusterStateAction extends BaseRestHandler {
         clusterStateRequest.filterRoutingTable(request.paramAsBoolean("filter_routing_table", clusterStateRequest.filterRoutingTable()));
         clusterStateRequest.filterMetaData(request.paramAsBoolean("filter_metadata", clusterStateRequest.filterMetaData()));
         clusterStateRequest.filterBlocks(request.paramAsBoolean("filter_blocks", clusterStateRequest.filterBlocks()));
-        clusterStateRequest.filteredIndices(RestActions.splitIndices(request.param("filter_indices", null)));
+        clusterStateRequest.filteredIndices(splitValues(request.param("filter_indices", null)));
         clusterStateRequest.filteredIndexTemplates(request.paramAsStringArray("filter_index_templates", Strings.EMPTY_ARRAY));
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestGetIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestGetIndicesAliasesAction.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -54,7 +54,7 @@ public class RestGetIndicesAliasesAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        final String[] indices = splitIndices(request.param("index"));
+        final String[] indices = splitValues(request.param("index"));
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
                 .filterRoutingTable(true)

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestIndicesGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestIndicesGetAliasesAction.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -42,6 +41,7 @@ import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -57,7 +57,7 @@ public class RestIndicesGetAliasesAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         String[] aliases = request.paramAsStringArray("name", Strings.EMPTY_ARRAY);
-        final String[] indices = RestActions.splitIndices(request.param("index"));
+        final String[] indices = splitValues(request.param("index"));
         final IndicesGetAliasesRequest getAliasesRequest = new IndicesGetAliasesRequest(aliases);
         getAliasesRequest.indices(indices);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
@@ -29,11 +29,11 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -49,7 +49,7 @@ public class RestAliasesExistAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         String[] aliases = request.paramAsStringArray("name", Strings.EMPTY_ARRAY);
-        final String[] indices = RestActions.splitIndices(request.param("index"));
+        final String[] indices = splitValues(request.param("index"));
         IndicesGetAliasesRequest getAliasesRequest = new IndicesGetAliasesRequest(aliases);
         getAliasesRequest.indices(indices);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -39,6 +38,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -57,7 +57,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(RestActions.splitIndices(request.param("index")));
+        ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(splitValues(request.param("index")));
         clearIndicesCacheRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             clearIndicesCacheRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -50,7 +50,7 @@ public class RestDeleteIndexAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(splitIndices(request.param("index")));
+        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(splitValues(request.param("index")));
         deleteIndexRequest.listenerThreaded(false);
         deleteIndexRequest.timeout(request.paramAsTime("timeout", timeValueSeconds(10)));
         deleteIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteIndexRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.rest.*;
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -52,7 +52,7 @@ public class RestIndicesExistsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(splitIndices(request.param("index")));
+        IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(splitValues(request.param("index")));
         indicesExistsRequest.listenerThreaded(false);
         client.admin().indices().exists(indicesExistsRequest, new ActionListener<IndicesExistsResponse>() {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
@@ -32,8 +32,7 @@ import org.elasticsearch.rest.*;
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  * Rest api for checking if a type exists.
@@ -49,7 +48,7 @@ public class RestTypesExistsAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         TypesExistsRequest typesExistsRequest = new TypesExistsRequest(
-                splitIndices(request.param("index")), splitTypes(request.param("type"))
+                splitValues(request.param("index")), splitValues(request.param("type"))
         );
         typesExistsRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -38,6 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -56,7 +56,7 @@ public class RestFlushAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        FlushRequest flushRequest = new FlushRequest(RestActions.splitIndices(request.param("index")));
+        FlushRequest flushRequest = new FlushRequest(splitValues(request.param("index")));
         flushRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             flushRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/gateway/snapshot/RestGatewaySnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/gateway/snapshot/RestGatewaySnapshotAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -51,7 +51,7 @@ public class RestGatewaySnapshotAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        GatewaySnapshotRequest gatewaySnapshotRequest = new GatewaySnapshotRequest(RestActions.splitIndices(request.param("index")));
+        GatewaySnapshotRequest gatewaySnapshotRequest = new GatewaySnapshotRequest(splitValues(request.param("index")));
         gatewaySnapshotRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             gatewaySnapshotRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import static org.elasticsearch.client.Requests.deleteMappingRequest;
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -50,7 +50,7 @@ public class RestDeleteMappingAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        DeleteMappingRequest deleteMappingRequest = deleteMappingRequest(splitIndices(request.param("index")));
+        DeleteMappingRequest deleteMappingRequest = deleteMappingRequest(splitValues(request.param("index")));
         deleteMappingRequest.listenerThreaded(false);
         deleteMappingRequest.type(request.param("type"));
         deleteMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteMappingRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -43,8 +43,7 @@ import java.util.Set;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -61,8 +60,8 @@ public class RestGetMappingAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        final String[] indices = splitIndices(request.param("index"));
-        final Set<String> types = ImmutableSet.copyOf(splitTypes(request.param("type")));
+        final String[] indices = splitValues(request.param("index"));
+        final Set<String> types = ImmutableSet.copyOf(splitValues(request.param("type")));
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
                 .filterRoutingTable(true)

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -55,7 +55,7 @@ public class RestPutMappingAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        PutMappingRequest putMappingRequest = putMappingRequest(splitIndices(request.param("index")));
+        PutMappingRequest putMappingRequest = putMappingRequest(splitValues(request.param("index")));
         putMappingRequest.listenerThreaded(false);
         putMappingRequest.type(request.param("type"));
         putMappingRequest.source(request.content().toUtf8());

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -39,6 +38,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -57,7 +57,7 @@ public class RestOptimizeAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        OptimizeRequest optimizeRequest = new OptimizeRequest(RestActions.splitIndices(request.param("index")));
+        OptimizeRequest optimizeRequest = new OptimizeRequest(splitValues(request.param("index")));
         optimizeRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             optimizeRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
@@ -38,6 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -56,7 +56,7 @@ public class RestRefreshAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        RefreshRequest refreshRequest = new RefreshRequest(RestActions.splitIndices(request.param("index")));
+        RefreshRequest refreshRequest = new RefreshRequest(splitValues(request.param("index")));
         refreshRequest.listenerThreaded(false);
         refreshRequest.force(request.paramAsBoolean("force", refreshRequest.force()));
         if (request.hasParam("ignore_indices")) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -51,7 +51,7 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(splitIndices(request.param("index")));
+        IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(splitValues(request.param("index")));
         indicesSegmentsRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             indicesSegmentsRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 public class RestGetSettingsAction extends BaseRestHandler {
 
@@ -58,7 +58,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        final String[] indices = splitIndices(request.param("index"));
+        final String[] indices = splitValues(request.param("index"));
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
                 .filterRoutingTable(true)

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import static org.elasticsearch.client.Requests.updateSettingsRequest;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -54,7 +54,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        UpdateSettingsRequest updateSettingsRequest = updateSettingsRequest(splitIndices(request.param("index")));
+        UpdateSettingsRequest updateSettingsRequest = updateSettingsRequest(splitValues(request.param("index")));
         updateSettingsRequest.listenerThreaded(false);
         updateSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", updateSettingsRequest.masterNodeTimeout()));
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -110,8 +110,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
         if (all) {
             indicesStatsRequest.all();
         }
-        indicesStatsRequest.indices(splitIndices(request.param("index")));
-        indicesStatsRequest.types(splitTypes(request.param("types")));
+        indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+        indicesStatsRequest.types(Strings.splitValues(request.param("types")));
         if (request.hasParam("groups")) {
             indicesStatsRequest.groups(Strings.splitStringByCommaToArray(request.param("groups")));
         }
@@ -163,8 +163,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().docs(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -201,8 +201,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().store(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -239,13 +239,13 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().indexing(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
             if (request.hasParam("types")) {
-                indicesStatsRequest.types(splitTypes(request.param("types")));
+                indicesStatsRequest.types(Strings.splitValues(request.param("types")));
             } else if (request.hasParam("indexingTypes1")) {
-                indicesStatsRequest.types(splitTypes(request.param("indexingTypes1")));
+                indicesStatsRequest.types(Strings.splitValues(request.param("indexingTypes1")));
             } else if (request.hasParam("indexingTypes2")) {
-                indicesStatsRequest.types(splitTypes(request.param("indexingTypes2")));
+                indicesStatsRequest.types(Strings.splitValues(request.param("indexingTypes2")));
             }
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
@@ -283,7 +283,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().search(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
             if (request.hasParam("groups")) {
                 indicesStatsRequest.groups(Strings.splitStringByCommaToArray(request.param("groups")));
             } else if (request.hasParam("searchGroupsStats1")) {
@@ -327,7 +327,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().get(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -364,8 +364,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().merge(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -402,8 +402,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().flush(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -440,8 +440,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().warmer(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -478,8 +478,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().filterCache(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -516,8 +516,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().idCache(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
@@ -554,8 +554,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().fieldData(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
             indicesStatsRequest.fieldDataFields(request.paramAsStringArray("fields", null));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
@@ -593,8 +593,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().completion(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
             indicesStatsRequest.completionFields(request.paramAsStringArray("fields", null));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
@@ -632,8 +632,8 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.listenerThreaded(false);
             indicesStatsRequest.clear().refresh(true);
-            indicesStatsRequest.indices(splitIndices(request.param("index")));
-            indicesStatsRequest.types(splitTypes(request.param("types")));
+            indicesStatsRequest.indices(Strings.splitValues(request.param("index")));
+            indicesStatsRequest.types(Strings.splitValues(request.param("types")));
 
             client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/status/RestIndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/status/RestIndicesStatusAction.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -58,7 +58,7 @@ public class RestIndicesStatusAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        IndicesStatusRequest indicesStatusRequest = new IndicesStatusRequest(splitIndices(request.param("index")));
+        IndicesStatusRequest indicesStatusRequest = new IndicesStatusRequest(splitValues(request.param("index")));
         indicesStatusRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             indicesStatusRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -61,7 +61,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest(RestActions.splitIndices(request.param("index")));
+        ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest(splitValues(request.param("index")));
         validateQueryRequest.listenerThreaded(false);
         if (request.hasParam("ignore_indices")) {
             validateQueryRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
@@ -86,7 +86,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
                     }
                 }
             }
-            validateQueryRequest.types(splitTypes(request.param("type")));
+            validateQueryRequest.types(splitValues(request.param("type")));
             if (request.paramAsBoolean("explain", false)) {
                 validateQueryRequest.explain(true);
             } else {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -27,13 +27,13 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -50,7 +50,7 @@ public class RestDeleteWarmerAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         DeleteWarmerRequest deleteWarmerRequest = new DeleteWarmerRequest(request.param("name"))
-                .indices(RestActions.splitIndices(request.param("index")));
+                .indices(splitValues(request.param("index")));
         deleteWarmerRequest.listenerThreaded(false);
         deleteWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteWarmerRequest.masterNodeTimeout()));
         client.admin().indices().deleteWarmer(deleteWarmerRequest, new ActionListener<DeleteWarmerResponse>() {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -59,7 +59,7 @@ public class RestGetWarmerAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        final String[] indices = splitIndices(request.param("index"));
+        final String[] indices = splitValues(request.param("index"));
         final String name = request.param("name");
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -28,13 +28,13 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  */
@@ -51,8 +51,8 @@ public class RestPutWarmerAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         PutWarmerRequest putWarmerRequest = new PutWarmerRequest(request.param("name"));
         putWarmerRequest.listenerThreaded(false);
-        SearchRequest searchRequest = new SearchRequest(RestActions.splitIndices(request.param("index")))
-                .types(RestActions.splitTypes(request.param("type")))
+        SearchRequest searchRequest = new SearchRequest(splitValues(request.param("index")))
+                .types(splitValues(request.param("type")))
                 .source(request.content(), request.contentUnsafe());
         putWarmerRequest.searchRequest(searchRequest);
         putWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putWarmerRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -61,7 +61,7 @@ public class RestCountAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        CountRequest countRequest = new CountRequest(RestActions.splitIndices(request.param("index")));
+        CountRequest countRequest = new CountRequest(splitValues(request.param("index")));
         if (request.hasParam("ignore_indices")) {
             countRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
         }
@@ -88,7 +88,7 @@ public class RestCountAction extends BaseRestHandler {
             }
             countRequest.routing(request.param("routing"));
             countRequest.minScore(request.paramAsFloat("min_score", DEFAULT_MIN_SCORE));
-            countRequest.types(splitTypes(request.param("type")));
+            countRequest.types(splitValues(request.param("type")));
             countRequest.preference(request.param("preference"));
         } catch (Exception e) {
             try {

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -41,8 +41,7 @@ import java.io.IOException;
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.PRECONDITION_FAILED;
-import static org.elasticsearch.rest.action.support.RestActions.splitIndices;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -58,7 +57,7 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(splitIndices(request.param("index")));
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(splitValues(request.param("index")));
         deleteByQueryRequest.listenerThreaded(false);
         try {
             if (request.hasContent()) {
@@ -72,7 +71,7 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
                     deleteByQueryRequest.query(bytes, false);
                 }
             }
-            deleteByQueryRequest.types(splitTypes(request.param("type")));
+            deleteByQueryRequest.types(splitValues(request.param("type")));
             deleteByQueryRequest.timeout(request.paramAsTime("timeout", ShardDeleteByQueryRequest.DEFAULT_TIMEOUT));
 
             deleteByQueryRequest.routing(request.param("routing"));

--- a/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 
 import java.io.IOException;
 
@@ -36,6 +35,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.common.Strings.splitValues;
 import static org.elasticsearch.rest.action.support.RestXContentBuilder.restContentBuilder;
 
 /**
@@ -63,8 +63,8 @@ public class RestMultiSearchAction extends BaseRestHandler {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.listenerThreaded(false);
 
-        String[] indices = RestActions.splitIndices(request.param("index"));
-        String[] types = RestActions.splitTypes(request.param("type"));
+        String[] indices = splitValues(request.param("index"));
+        String[] types = splitValues(request.param("type"));
         IgnoreIndices ignoreIndices = null;
         if (request.hasParam("ignore_indices")) {
             ignoreIndices = IgnoreIndices.fromString(request.param("ignore_indices"));

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -44,6 +43,7 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
+import static org.elasticsearch.common.Strings.splitValues;
 import static org.elasticsearch.rest.action.support.RestXContentBuilder.restContentBuilder;
 import static org.elasticsearch.search.suggest.SuggestBuilder.termSuggestion;
 
@@ -118,7 +118,7 @@ public class RestSearchAction extends BaseRestHandler {
     }
 
     public static SearchRequest parseSearchRequest(RestRequest request) {
-        String[] indices = RestActions.splitIndices(request.param("index"));
+        String[] indices = splitValues(request.param("index"));
         SearchRequest searchRequest = new SearchRequest(indices);
         // get the content, and put it in the body
         if (request.hasContent()) {
@@ -139,7 +139,7 @@ public class RestSearchAction extends BaseRestHandler {
             searchRequest.scroll(new Scroll(parseTimeValue(scroll, null)));
         }
 
-        searchRequest.types(RestActions.splitTypes(request.param("type")));
+        searchRequest.types(splitValues(request.param("type")));
         searchRequest.routing(request.param("routing"));
         searchRequest.preference(request.param("preference"));
         if (request.hasParam("ignore_indices")) {

--- a/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 import org.elasticsearch.search.suggest.Suggest;
 
@@ -41,6 +40,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+import static org.elasticsearch.common.Strings.splitValues;
 
 /**
  *
@@ -58,7 +58,7 @@ public class RestSuggestAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        SuggestRequest suggestRequest = new SuggestRequest(RestActions.splitIndices(request.param("index")));
+        SuggestRequest suggestRequest = new SuggestRequest(splitValues(request.param("index")));
         if (request.hasParam("ignore_indices")) {
             suggestRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
         }

--- a/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -103,24 +103,18 @@ public class RestActions {
         return queryBuilder.buildAsBytes();
     }
 
+    @Deprecated
     public static String[] splitIndices(String indices) {
-        if (indices == null) {
-            return Strings.EMPTY_ARRAY;
-        }
-        return Strings.splitStringByCommaToArray(indices);
+        return Strings.splitValues(indices);
     }
 
+    @Deprecated
     public static String[] splitTypes(String typeNames) {
-        if (typeNames == null) {
-            return Strings.EMPTY_ARRAY;
-        }
-        return Strings.splitStringByCommaToArray(typeNames);
+        return Strings.splitValues(typeNames);
     }
 
+    @Deprecated
     public static String[] splitNodes(String nodes) {
-        if (nodes == null) {
-            return Strings.EMPTY_ARRAY;
-        }
-        return Strings.splitStringByCommaToArray(nodes);
+        return Strings.splitValues(nodes);
     }
 }


### PR DESCRIPTION
We have duplicated code in:
- RestActions#splitIndices(String)
- RestActions#splitTypes(String)
- RestActions#splitNodes(String)

The idea is to have one single RestActions#splitValues(String) method.
