### PR TITLE
Generalising the RangeFacet (and associated parser/generator/test) to be optionally inclusive on each bound

### DIFF
--- a/src/main/java/org/elasticsearch/search/facet/range/RangeFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/range/RangeFacet.java
@@ -42,6 +42,8 @@ public interface RangeFacet extends Facet, Iterable<RangeFacet.Entry> {
 
         double from = Double.NEGATIVE_INFINITY;
         double to = Double.POSITIVE_INFINITY;
+        boolean fromIsInclusive = true;
+        boolean toIsInclusive = false;
         String fromAsString;
         String toAsString;
         long count;
@@ -60,6 +62,14 @@ public interface RangeFacet extends Facet, Iterable<RangeFacet.Entry> {
 
         public double getFrom() {
             return this.from;
+        }
+
+        public boolean getFromIsInclusive() {
+            return fromIsInclusive;
+        }
+
+        public boolean getToIsInclusive() {
+            return toIsInclusive;
         }
 
         public String getFromAsString() {

--- a/src/main/java/org/elasticsearch/search/facet/range/RangeFacetBuilder.java
+++ b/src/main/java/org/elasticsearch/search/facet/range/RangeFacetBuilder.java
@@ -77,7 +77,7 @@ public class RangeFacetBuilder extends FacetBuilder {
     }
 
     /**
-     * Adds a range entry with explicit from and to.
+     * Adds a range entry with explicit from and to. The from bound is inclusive and the to bound is exclusive
      *
      * @param from The from range limit
      * @param to   The to range limit
@@ -87,8 +87,26 @@ public class RangeFacetBuilder extends FacetBuilder {
         return this;
     }
 
+    /**
+     * Adds a range entry with explicit from and to with the inclusivity being explicitly specified.
+     *
+     * @param from The from range limit
+     * @param isFromInclusive Is the from bound inclusive
+     * @param to   The to range limit
+     * @param isToInclusive Is the to bound inclusive
+     */
+    public RangeFacetBuilder addRange(double from, boolean isFromInclusive, double to, boolean isToInclusive) {
+        entries.add(new Entry(from, isFromInclusive, to, isToInclusive));
+        return this;
+    }
+
     public RangeFacetBuilder addRange(String from, String to) {
         entries.add(new Entry(from, to));
+        return this;
+    }
+
+    public RangeFacetBuilder addRange(String from, boolean isFromInclusive, String to, boolean isToInclusive) {
+        entries.add(new Entry(from, isFromInclusive, to, isToInclusive));
         return this;
     }
 
@@ -102,8 +120,24 @@ public class RangeFacetBuilder extends FacetBuilder {
         return this;
     }
 
+    /**
+     * Adds a range entry with explicit from and unbounded to.
+     *
+     * @param from the from range limit, to is unbounded.
+     * @param isFromInclusive whether or not the from limit is inclusive
+     */
+    public RangeFacetBuilder addUnboundedTo(double from, boolean isFromInclusive) {
+        entries.add(new Entry(from, isFromInclusive, Double.POSITIVE_INFINITY, false));
+        return this;
+    }
+
     public RangeFacetBuilder addUnboundedTo(String from) {
         entries.add(new Entry(from, null));
+        return this;
+    }
+
+    public RangeFacetBuilder addUnboundedTo(String from, boolean isFromInclusive) {
+        entries.add(new Entry(from, isFromInclusive, null, false));
         return this;
     }
 
@@ -117,8 +151,24 @@ public class RangeFacetBuilder extends FacetBuilder {
         return this;
     }
 
+    /**
+     * Adds a range entry with explicit to and unbounded from.
+     *
+     * @param to the to range limit, from is unbounded.
+     * @param isToInclusive whether or not the to limit is inclusive
+     */
+    public RangeFacetBuilder addUnboundedFrom(double to, boolean isToInclusive) {
+        entries.add(new Entry(Double.NEGATIVE_INFINITY, true, to, isToInclusive));
+        return this;
+    }
+
     public RangeFacetBuilder addUnboundedFrom(String to) {
         entries.add(new Entry(null, to));
+        return this;
+    }
+
+    public RangeFacetBuilder addUnboundedFrom(String to, boolean isToInclusive) {
+        entries.add(new Entry(null, true, to, isToInclusive));
         return this;
     }
 
@@ -176,10 +226,17 @@ public class RangeFacetBuilder extends FacetBuilder {
             } else if (!Double.isInfinite(entry.from)) {
                 builder.field("from", entry.from);
             }
+            if(!entry.fromIsInclusive) {
+                builder.field("fromIsInclusive", entry.fromIsInclusive);
+            }
+
             if (entry.toAsString != null) {
                 builder.field("to", entry.toAsString);
             } else if (!Double.isInfinite(entry.to)) {
                 builder.field("to", entry.to);
+            }
+            if(entry.toIsInclusive) {
+                builder.field("toIsInclusive", entry.toIsInclusive);
             }
             builder.endObject();
         }
@@ -197,6 +254,9 @@ public class RangeFacetBuilder extends FacetBuilder {
         double from = Double.NEGATIVE_INFINITY;
         double to = Double.POSITIVE_INFINITY;
 
+        boolean fromIsInclusive = true;
+        boolean toIsInclusive = false;
+
         String fromAsString;
         String toAsString;
 
@@ -205,9 +265,21 @@ public class RangeFacetBuilder extends FacetBuilder {
             this.toAsString = toAsString;
         }
 
+        Entry(String from, boolean fromIsInclusive, String to, boolean toIsInclusive) {
+            this(from, to);
+            this.fromIsInclusive = fromIsInclusive;
+            this.toIsInclusive = toIsInclusive;
+        }
+
         Entry(double from, double to) {
             this.from = from;
             this.to = to;
+        }
+
+        Entry(double from, boolean fromIsInclusive, double to, boolean toIsInclusive) {
+            this(from, to);
+            this.fromIsInclusive = fromIsInclusive;
+            this.toIsInclusive = toIsInclusive;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/facet/range/RangeFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/range/RangeFacetExecutor.java
@@ -94,7 +94,8 @@ public class RangeFacetExecutor extends FacetExecutor {
                 if (entry.foundInDoc) {
                     continue;
                 }
-                if (value >= entry.getFrom() && value < entry.getTo()) {
+                if ((entry.getFromIsInclusive() ? value >= entry.getFrom() : value > entry.getFrom())
+                 && (entry.getToIsInclusive() ? value <= entry.getTo() : value < entry.getTo())) {
                     entry.foundInDoc = true;
                     entry.count++;
                     entry.totalCount++;

--- a/src/main/java/org/elasticsearch/search/facet/range/RangeFacetParser.java
+++ b/src/main/java/org/elasticsearch/search/facet/range/RangeFacetParser.java
@@ -97,6 +97,10 @@ public class RangeFacetParser extends AbstractComponent implements FacetParser {
                                 entry.from = parser.doubleValue();
                             } else if ("to".equals(fieldName)) {
                                 entry.to = parser.doubleValue();
+                            } else if ("toIsInclusive".equals(fieldName)) {
+                                entry.toIsInclusive = parser.booleanValue();
+                            } else if ("fromIsInclusive".equals(fieldName)) {
+                                entry.fromIsInclusive = parser.booleanValue();
                             }
                         }
                     }

--- a/src/test/java/org/elasticsearch/test/integration/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/test/integration/search/facet/SimpleFacetsTests.java
@@ -1632,6 +1632,7 @@ public class SimpleFacetsTests extends AbstractSharedClusterTest {
                     .addFacet(rangeFacet("range4").keyField("multi_num").valueField("value").addUnboundedFrom(16).addRange(10, 26).addUnboundedTo(20))
                     .addFacet(rangeScriptFacet("range5").keyScript("doc['num'].value").valueScript("doc['value'].value").addUnboundedFrom(1056).addRange(1000, 1170).addUnboundedTo(1170))
                     .addFacet(rangeFacet("range6").field("date").addUnboundedFrom("1970-01-01T00:00:26").addRange("1970-01-01T00:00:15", "1970-01-01T00:00:53").addUnboundedTo("1970-01-01T00:00:26"))
+                    .addFacet(rangeFacet("range7").field("num").addUnboundedTo(1055).addUnboundedTo(1055, false).addRange(1055, 1175).addRange(1055, true, 1175, true).addUnboundedFrom(1175).addUnboundedFrom(1175, true))
                     .execute().actionGet();
 
             if (searchResponse.getFailedShards() > 0) {
@@ -1743,6 +1744,38 @@ public class SimpleFacetsTests extends AbstractSharedClusterTest {
             assertThat(facet.getEntries().get(1).getToAsString(), equalTo("1970-01-01T00:00:53"));
             assertThat(facet.getEntries().get(2).getCount(), equalTo(1l));
             assertThat(facet.getEntries().get(2).getFromAsString(), equalTo("1970-01-01T00:00:26"));
+
+            facet = searchResponse.getFacets().facet("range7");
+            assertThat(facet.getName(), equalTo("range7"));
+            assertThat(facet.getEntries().size(), equalTo(6));
+            assertThat(facet.getEntries().get(0).getFrom(), closeTo(1055, 0.000001));
+            assertThat(facet.getEntries().get(0).getFromIsInclusive(), equalTo(true));
+            assertThat(facet.getEntries().get(0).getCount(), equalTo(3l));
+            assertThat(facet.getEntries().get(0).getTotal(), closeTo(3295, 0.000001));
+            assertThat(facet.getEntries().get(1).getFrom(), closeTo(1055, 0.000001));
+            assertThat(facet.getEntries().get(1).getFromIsInclusive(), equalTo(false));
+            assertThat(facet.getEntries().get(1).getCount(), equalTo(2l));
+            assertThat(facet.getEntries().get(1).getTotal(), closeTo(2240, 0.000001));
+            assertThat(facet.getEntries().get(2).getFrom(), closeTo(1055, 0.000001));
+            assertThat(facet.getEntries().get(2).getTo(), closeTo(1175, 0.000001));
+            assertThat(facet.getEntries().get(2).getFromIsInclusive(), equalTo(true));
+            assertThat(facet.getEntries().get(2).getToIsInclusive(), equalTo(false));
+            assertThat(facet.getEntries().get(2).getCount(), equalTo(2l));
+            assertThat(facet.getEntries().get(2).getTotal(), closeTo(2120, 0.000001));
+            assertThat(facet.getEntries().get(3).getFrom(), closeTo(1055, 0.000001));
+            assertThat(facet.getEntries().get(3).getTo(), closeTo(1175, 0.000001));
+            assertThat(facet.getEntries().get(3).getFromIsInclusive(), equalTo(true));
+            assertThat(facet.getEntries().get(3).getToIsInclusive(), equalTo(true));
+            assertThat(facet.getEntries().get(3).getCount(), equalTo(3l));
+            assertThat(facet.getEntries().get(3).getTotal(), closeTo(3295, 0.000001));
+            assertThat(facet.getEntries().get(4).getTo(), closeTo(1175, 0.000001));
+            assertThat(facet.getEntries().get(4).getToIsInclusive(), equalTo(false));
+            assertThat(facet.getEntries().get(4).getCount(), equalTo(2l));
+            assertThat(facet.getEntries().get(4).getTotal(), closeTo(2120, 0.000001));
+            assertThat(facet.getEntries().get(5).getTo(), closeTo(1175, 0.000001));
+            assertThat(facet.getEntries().get(5).getToIsInclusive(), equalTo(true));
+            assertThat(facet.getEntries().get(5).getCount(), equalTo(3l));
+            assertThat(facet.getEntries().get(5).getTotal(), closeTo(3295, 0.000001));
         }
     }
 


### PR DESCRIPTION
Generalising the RangeFacet (and associated parser/generator/test) to be able to specify whether or not each bound is inclusive. The default behaviour remains the same (from is inclusive, to is exclusive). Issue #3660.

Have also requested a merge into master -- pull request #3665
