### PR TITLE
term lookup query with no results should evaluate to no match

### DIFF
--- a/src/main/java/org/elasticsearch/indices/cache/filter/terms/IndicesTermsFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/terms/IndicesTermsFilterCache.java
@@ -31,6 +31,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.MatchNoDocsFilter;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -47,7 +48,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class IndicesTermsFilterCache extends AbstractComponent {
 
-    private static TermsFilterValue NO_TERMS = new TermsFilterValue(0, null);
+    private static TermsFilterValue NO_TERMS = new TermsFilterValue(0, new MatchNoDocsFilter());
 
     private final Client client;
 


### PR DESCRIPTION
When a term lookup query returns no results it is considered a no filter rather than a no match which causes other filters to ignore the results.

For example:

``` js
 {
   "query": {
       "filtered": {
           "filter": {
               "and": [
                   {
                       "term": {
                           "name": "value1"
                       }
                   },
                   {
                       "terms": {
                           "_id": {
                               "index": "users",
                               "type": "user",
                               "id": "2",
                               "path": "followers"
                           }
                       }
                   }
               ]
           }
       }
   } 
}
```

In this case if the terms lookup returned no results it would ignore the terms lookup filter altogether when it should return no results because of the overall evaluation of the and should be false.
