### PR TITLE
Fixed inability to set keep_words_path in KeepWordFilter

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/KeepWordFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/KeepWordFilterFactory.java
@@ -75,7 +75,7 @@ public class KeepWordFilterFactory extends AbstractTokenFilterFactory {
                                      @Assisted String name, @Assisted Settings settings) {
         super(index, indexSettings, name, settings);
         
-        final String[] arrayKeepWords = settings.getAsArray(KEEP_WORDS_KEY);
+        final String[] arrayKeepWords = settings.getAsArray(KEEP_WORDS_KEY, null);
         final String keepWordsPath = settings.get(KEEP_WORDS_PATH_KEY, null);
         if (!(arrayKeepWords == null ^ keepWordsPath == null)) {
             // we don't allow both or non

--- a/src/test/java/org/elasticsearch/index/analysis/KeepFilterFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/KeepFilterFactoryTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.analysis;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.env.FailedToResolveConfigException;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ElasticSearchTokenStreamTestCase;
@@ -57,6 +58,19 @@ public class KeepFilterFactoryTests extends ElasticSearchTokenStreamTestCase {
             Assert.fail("path and array are configured");
         } catch (Exception e) {
             assertThat(e.getCause(), instanceOf(ElasticSearchIllegalArgumentException.class));
+        }
+    }
+
+    @Test
+    public void testKeepWordsPathSettings() {
+        Settings settings = ImmutableSettings.settingsBuilder()
+        .put("index.analysis.filter.non_broken_keep_filter.type", "keep")
+        .put("index.analysis.filter.non_broken_keep_filter.keep_words_path", "does/not/exists.txt")
+        .build();
+        try {
+            AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(settings);
+        } catch (Exception e) {
+            assertThat(e.getCause(), instanceOf(FailedToResolveConfigException.class));
         }
     }
 


### PR DESCRIPTION
It seems `keep_words_path` can't be set, because `keep_words` (`arrayKeepWords`) is not `null` when not defined in config. So `ElasticSearchIllegalArgumentException` is thrown.
