### PR TITLE
Set nowInMillis to search context created by the count, validate query and explain api

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -36,6 +37,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
     private BytesReference querySource;
     private String[] types = Strings.EMPTY_ARRAY;
     private boolean explain;
+    private long nowInMillis;
 
     @Nullable
     private String[] filteringAliases;
@@ -50,6 +52,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         this.types = request.types();
         this.explain = request.explain();
         this.filteringAliases = filteringAliases;
+        this.nowInMillis = request.nowInMillis;
     }
 
     public BytesReference querySource() {
@@ -66,6 +69,10 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
 
     public String[] filteringAliases() {
         return filteringAliases;
+    }
+
+    public long nowInMillis() {
+        return this.nowInMillis;
     }
 
     @Override
@@ -89,6 +96,12 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         }
 
         explain = in.readBoolean();
+
+        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
+            nowInMillis = in.readVLong();
+        } else {
+            nowInMillis = System.currentTimeMillis();
+        }
     }
 
     @Override
@@ -110,5 +123,9 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         }
 
         out.writeBoolean(explain);
+
+        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
+            out.writeVLong(nowInMillis);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.validate.query;
 
 import jsr166y.ThreadLocalRandom;
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
@@ -71,6 +72,12 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
+    }
+
+    @Override
+    protected void doExecute(ValidateQueryRequest request, ActionListener<ValidateQueryResponse> listener) {
+        request.nowInMillis = System.currentTimeMillis();
+        super.doExecute(request, listener);
     }
 
     @Override
@@ -171,7 +178,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
             valid = true;
         } else {
             SearchContext.setCurrent(new DefaultSearchContext(0,
-                    new ShardSearchRequest().types(request.types()),
+                    new ShardSearchRequest().types(request.types()).nowInMillis(request.nowInMillis()),
                     null, indexShard.acquireSearcher(), indexService, indexShard,
                     scriptService, cacheRecycler));
             try {

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -56,6 +56,8 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
 
     private String[] types = Strings.EMPTY_ARRAY;
 
+    long nowInMillis;
+
     ValidateQueryRequest() {
     }
 
@@ -128,7 +130,6 @@ public class ValidateQueryRequest extends BroadcastOperationRequest<ValidateQuer
     @Required
     public ValidateQueryRequest query(String querySource) {
         this.querySource = new BytesArray(querySource);
-        ;
         this.querySourceUnsafe = false;
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/count/CountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequest.java
@@ -70,6 +70,8 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
 
     private String[] types = Strings.EMPTY_ARRAY;
 
+    long nowInMillis;
+
     CountRequest() {
     }
 

--- a/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.count;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -39,6 +40,8 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
 
     private String[] types = Strings.EMPTY_ARRAY;
 
+    private long nowInMillis;
+
     @Nullable
     private String[] filteringAliases;
 
@@ -52,6 +55,7 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
         this.querySource = request.querySource();
         this.types = request.types();
         this.filteringAliases = filteringAliases;
+        this.nowInMillis = request.nowInMillis;
     }
 
     public float minScore() {
@@ -68,6 +72,10 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
 
     public String[] filteringAliases() {
         return filteringAliases;
+    }
+
+    public long nowInMillis() {
+        return this.nowInMillis;
     }
 
     @Override
@@ -91,6 +99,11 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
                 filteringAliases[i] = in.readString();
             }
         }
+        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
+            nowInMillis = in.readVLong();
+        } else {
+            nowInMillis = System.currentTimeMillis();
+        }
     }
 
     @Override
@@ -111,6 +124,9 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
             }
         } else {
             out.writeVInt(0);
+        }
+        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
+            out.writeVLong(nowInMillis);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.count;
 
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
@@ -73,6 +74,12 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
+    }
+
+    @Override
+    protected void doExecute(CountRequest request, ActionListener<CountResponse> listener) {
+        request.nowInMillis = System.currentTimeMillis();
+        super.doExecute(request, listener);
     }
 
     @Override
@@ -153,7 +160,9 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
 
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
         SearchContext context = new DefaultSearchContext(0,
-                new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
+                new ShardSearchRequest().types(request.types())
+                        .filteringAliases(request.filteringAliases())
+                        .nowInMillis(request.nowInMillis()),
                 shardTarget, indexShard.acquireSearcher(), indexService, indexShard,
                 scriptService, cacheRecycler);
         SearchContext.setCurrent(context);

--- a/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.action.explain;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
 import org.elasticsearch.client.Requests;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,6 +50,8 @@ public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> 
     private FetchSourceContext fetchSourceContext;
 
     private String[] filteringAlias = Strings.EMPTY_ARRAY;
+
+    long nowInMillis;
 
     ExplainRequest() {
     }
@@ -196,6 +198,12 @@ public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> 
         }
 
         fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
+
+        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
+            nowInMillis = in.readVLong();
+        } else {
+            nowInMillis = System.currentTimeMillis();
+        }
     }
 
     @Override
@@ -215,5 +223,9 @@ public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> 
         }
 
         FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
+
+        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
+            out.writeVLong(nowInMillis);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.explain;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
@@ -75,6 +76,12 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
         this.cacheRecycler = cacheRecycler;
     }
 
+    @Override
+    protected void doExecute(ExplainRequest request, ActionListener<ExplainResponse> listener) {
+        request.nowInMillis = System.currentTimeMillis();
+        super.doExecute(request, listener);
+    }
+
     protected String transportAction() {
         return ExplainAction.NAME;
     }
@@ -102,7 +109,8 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
         SearchContext context = new DefaultSearchContext(
                 0,
                 new ShardSearchRequest().types(new String[]{request.type()})
-                        .filteringAliases(request.filteringAlias()),
+                        .filteringAliases(request.filteringAlias())
+                        .nowInMillis(request.nowInMillis),
                 null, result.searcher(), indexService, indexShard,
                 scriptService, cacheRecycler
         );

--- a/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
+++ b/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
@@ -19,18 +19,21 @@
 
 package org.elasticsearch.explain;
 
+import org.elasticsearch.AbstractSharedClusterTest;
 import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndexMissingException;
-import org.elasticsearch.AbstractSharedClusterTest;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.elasticsearch.index.query.QueryBuilders.queryString;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -240,4 +243,19 @@ public class ExplainActionTests extends AbstractSharedClusterTest {
         assertFalse(response.isMatch());
     }
 
+    @Test
+    public void explainDateRangeInQueryString() {
+        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).get();
+
+        String aMonthAgo = ISODateTimeFormat.yearMonthDay().print(new DateTime(DateTimeZone.UTC).minusMonths(1));
+        String aMonthFromNow = ISODateTimeFormat.yearMonthDay().print(new DateTime(DateTimeZone.UTC).plusMonths(1));
+
+        client().prepareIndex("test", "type", "1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
+
+        refresh();
+
+        ExplainResponse explainResponse = client().prepareExplain("test", "type", "1").setQuery(queryString("past:[now-2M/d TO now/d]")).get();
+        assertThat(explainResponse.isExists(), equalTo(true));
+        assertThat(explainResponse.isMatch(), equalTo(true));
+    }
 }


### PR DESCRIPTION
Set nowInMillis to search context created by the count api, validate query api and explain api so that "NOW" can be used within queries

Added nowInMillis to ShardCountRequest, ShardValidateRequest and ExplainRequest in a backwards compatible manner

Fixes #3625, #3626 & #3629 
