### PR TITLE
Enable a configurable delay for shutdown when calling killproc.

### DIFF
--- a/src/rpm/init.d/elasticsearch
+++ b/src/rpm/init.d/elasticsearch
@@ -92,7 +92,7 @@ start() {
 stop() {
     echo -n $"Stopping $prog: "
     # stop it here, often "killproc $prog"
-    killproc -p $pidfile $prog
+    killproc -p $pidfile -d $SHUTDOWN_DELAY $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile

--- a/src/rpm/sysconfig/elasticsearch
+++ b/src/rpm/sysconfig/elasticsearch
@@ -41,3 +41,6 @@ ES_USER=elasticsearch
 
 # Configure restart on package upgrade (true, every other setting will lead to not restarting)
 #RESTART_ON_UPGRADE=true
+
+# Shutdown delay
+SHUTDOWN_DELAY=5


### PR DESCRIPTION
Useful as soem nodes may take longer than others.
