### PR TITLE
DateFieldMapper.merge() can change date format and include_in_all

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -183,7 +183,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
         }
     }
 
-    protected final FormatDateTimeFormatter dateTimeFormatter;
+    protected FormatDateTimeFormatter dateTimeFormatter;
 
     // Triggers rounding up of the upper bound for range queries and filters if
     // set to true.
@@ -444,6 +444,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
         }
         if (!mergeContext.mergeFlags().simulate()) {
             this.nullValue = ((DateFieldMapper) mergeWith).nullValue;
+            this.dateTimeFormatter = ((DateFieldMapper) mergeWith).dateTimeFormatter;
         }
     }
 


### PR DESCRIPTION
In order to be able to add an additional date to a date field mapper,
the merge operation has to support this.

Closes #3727
