### PR TITLE
Add asserting searcher to track searcher references

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/IndexEngineModule.java
+++ b/src/main/java/org/elasticsearch/index/engine/IndexEngineModule.java
@@ -36,6 +36,7 @@ public class IndexEngineModule extends AbstractModule implements SpawnModules {
 
     public static final class EngineSettings {
         public static final String ENGINE_TYPE = "index.engine.type";
+        public static final String INDEX_ENGINE_TYPE = "index.index_engine.type";
         public static final Class<? extends Module> DEFAULT_INDEX_ENGINE = RobinIndexEngineModule.class;
         public static final Class<? extends Module> DEFAULT_ENGINE = RobinEngineModule.class;
     }
@@ -48,7 +49,7 @@ public class IndexEngineModule extends AbstractModule implements SpawnModules {
 
     @Override
     public Iterable<? extends Module> spawnModules() {
-        return ImmutableList.of(createModule(settings.getAsClass(EngineSettings.ENGINE_TYPE, EngineSettings.DEFAULT_INDEX_ENGINE, "org.elasticsearch.index.engine.", "IndexEngineModule"), settings));
+        return ImmutableList.of(createModule(settings.getAsClass(EngineSettings.INDEX_ENGINE_TYPE, EngineSettings.DEFAULT_INDEX_ENGINE, "org.elasticsearch.index.engine.", "IndexEngineModule"), settings));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
@@ -676,15 +676,19 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
     }
 
     @Override
-    public Searcher searcher() throws EngineException {
+    public final Searcher searcher() throws EngineException {
         SearcherManager manager = this.searcherManager;
         try {
             IndexSearcher searcher = manager.acquire();
-            return new RobinSearcher(searcher, manager);
+            return newSearcher(searcher, manager);
         } catch (IOException ex) {
             logger.error("failed to accquire searcher for shard [{}]", ex, shardId);
             throw new EngineException(shardId, ex.getMessage());
         }
+    }
+    
+    protected Searcher newSearcher(IndexSearcher searcher, SearcherManager manager) {
+        return new RobinSearcher(searcher, manager);
     }
 
     @Override

--- a/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
+++ b/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
@@ -19,7 +19,10 @@
 
 package org.apache.lucene.util;
 
-import com.carrotsearch.randomizedtesting.*;
+import com.carrotsearch.randomizedtesting.JUnit4MethodProvider;
+import com.carrotsearch.randomizedtesting.LifecycleScope;
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
 import com.carrotsearch.randomizedtesting.annotations.TestGroup;
 import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
@@ -59,7 +62,6 @@ import java.util.logging.Logger;
 // NOTE: this class is in o.a.lucene.util since it uses some classes that are related
 // to the test framework that didn't make sense to copy but are package private access
 public abstract class AbstractRandomizedTest extends RandomizedTest {
-
     /**
      * Annotation for integration tests
      */
@@ -305,7 +307,6 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
     @Before
     public void setUp() throws Exception {
         parentChainCallRule.setupCalled = true;
-        currentSeed = SeedUtils.parseSeed(getContext().getRunnerSeedAsString());
     }
 
     /**
@@ -314,7 +315,6 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
     @After
     public void tearDown() throws Exception {
         parentChainCallRule.teardownCalled = true;
-        currentSeed = null;
     }
 
 
@@ -354,11 +354,5 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
      */
     public String getTestName() {
         return threadAndTestNameRule.testMethodName;
-    }
-
-    private static volatile Long currentSeed;
-
-    public static Long getCurrentSeed() {
-        return currentSeed;
     }
 }

--- a/src/test/java/org/elasticsearch/AbstractSharedClusterTest.java
+++ b/src/test/java/org/elasticsearch/AbstractSharedClusterTest.java
@@ -103,6 +103,7 @@ public abstract class AbstractSharedClusterTest extends ElasticsearchTestCase {
         cluster.beforeTest(getRandom());
         wipeIndices();
         wipeTemplates();
+        randomIndexTemplate();
         logger.info("[{}#{}]: before test", getTestClass().getSimpleName(), getTestName());
     }
 
@@ -116,6 +117,7 @@ public abstract class AbstractSharedClusterTest extends ElasticsearchTestCase {
                 .persistentSettings().getAsMap().size(), equalTo(0));
         wipeIndices(); // wipe after to make sure we fail in the test that didn't ack the delete
         wipeTemplates();
+        ensureAllSearchersClosed();
         ensureAllFilesClosed();
         logger.info("[{}#{}]: cleaned up after test", getTestClass().getSimpleName(), getTestName());
     }
@@ -134,6 +136,15 @@ public abstract class AbstractSharedClusterTest extends ElasticsearchTestCase {
 
     public static Client client() {
         return cluster().client();
+    }
+    
+    private static void randomIndexTemplate() {
+        client().admin().indices().preparePutTemplate("random_index_template")
+        .setTemplate("*")
+        .setOrder(0)
+        .setSettings(ImmutableSettings.builder()
+                .put(INDEX_SEED_SETTING, getRandom().nextLong()))
+                .execute().actionGet();
     }
 
     public static Iterable<Client> clients() {

--- a/src/test/java/org/elasticsearch/TestCluster.java
+++ b/src/test/java/org/elasticsearch/TestCluster.java
@@ -40,9 +40,11 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.engine.IndexEngineModule;
 import org.elasticsearch.index.store.mock.MockFSIndexStoreModule;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.test.engine.MockEngineModule;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.Closeable;
@@ -114,6 +116,7 @@ public class TestCluster {
                 /* use RAM directories in 10% of the runs */
 //                .put("index.store.type", random.nextInt(10) == 0 ? MockRamIndexStoreModule.class.getName() : MockFSIndexStoreModule.class.getName())
                 .put("index.store.type", MockFSIndexStoreModule.class.getName()) // no RAM dir for now!
+                .put(IndexEngineModule.EngineSettings.ENGINE_TYPE, MockEngineModule.class.getName())
                 .put(defaultSettings)
                 .put("cluster.name", clusterName).build();
     }

--- a/src/test/java/org/elasticsearch/deleteByQuery/DeleteByQueryTests.java
+++ b/src/test/java/org/elasticsearch/deleteByQuery/DeleteByQueryTests.java
@@ -39,7 +39,7 @@ public class DeleteByQueryTests extends AbstractSharedClusterTest {
     public void testDeleteAllNoIndices() {
         client().admin().indices().prepareDelete().execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
-        DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = new DeleteByQueryRequestBuilder(client());
+        DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = client().prepareDeleteByQuery();
         deleteByQueryRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
         DeleteByQueryResponse actionGet = deleteByQueryRequestBuilder.execute().actionGet();
         assertThat(actionGet.getIndices().size(), equalTo(0));
@@ -55,7 +55,7 @@ public class DeleteByQueryTests extends AbstractSharedClusterTest {
         
         SearchResponse search = client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
         assertThat(search.getHits().totalHits(), equalTo(1l));
-        DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = new DeleteByQueryRequestBuilder(client());
+        DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = client().prepareDeleteByQuery();
         deleteByQueryRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
         
         DeleteByQueryResponse actionGet = deleteByQueryRequestBuilder.execute().actionGet();
@@ -78,7 +78,7 @@ public class DeleteByQueryTests extends AbstractSharedClusterTest {
 
         SearchResponse search = client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
         assertThat(search.getHits().totalHits(), equalTo(1l));
-        DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = new DeleteByQueryRequestBuilder(client());
+        DeleteByQueryRequestBuilder deleteByQueryRequestBuilder = client().prepareDeleteByQuery();
         deleteByQueryRequestBuilder.setIndices("twitter", "missing");
         deleteByQueryRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
 

--- a/src/test/java/org/elasticsearch/index/engine/robin/RobinEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/robin/RobinEngineTests.java
@@ -27,6 +27,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexDeletionPolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.ElasticsearchTestCase;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
@@ -39,6 +40,7 @@ import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.deletionpolicy.KeepOnlyLastDeletionPolicy;
 import org.elasticsearch.index.deletionpolicy.SnapshotDeletionPolicy;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
+import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommitExistsMatcher;
 import org.elasticsearch.index.engine.*;
 import org.elasticsearch.index.indexing.ShardIndexingService;
 import org.elasticsearch.index.indexing.slowlog.ShardSlowLogIndexingService;
@@ -57,11 +59,8 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.distributor.LeastUsedDistributor;
 import org.elasticsearch.index.store.ram.RamDirectoryService;
 import org.elasticsearch.index.translog.Translog;
-import org.elasticsearch.index.translog.fs.FsTranslog;
-import org.elasticsearch.ElasticsearchTestCase;
-import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommitExistsMatcher;
-import org.elasticsearch.index.engine.EngineSearcherTotalHitsMatcher;
 import org.elasticsearch.index.translog.TranslogSizeMatcher;
+import org.elasticsearch.index.translog.fs.FsTranslog;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -321,11 +320,12 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         assertThat(getResult.exists(), equalTo(true));
         assertThat(getResult.source().source.toBytesArray(), equalTo(B_1.toBytesArray()));
         assertThat(getResult.docIdAndVersion(), nullValue());
-
+        getResult.release();
+        
         // but, not there non realtime
         getResult = engine.get(new Engine.Get(false, newUid("1")));
         assertThat(getResult.exists(), equalTo(false));
-
+        getResult.release();
         // refresh and it should be there
         engine.refresh(new Engine.Refresh().force(false));
 
@@ -339,7 +339,8 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         getResult = engine.get(new Engine.Get(false, newUid("1")));
         assertThat(getResult.exists(), equalTo(true));
         assertThat(getResult.docIdAndVersion(), notNullValue());
-
+        getResult.release();
+        
         // now do an update
         document = testDocument();
         document.add(new TextField("value", "test1", Field.Store.YES));
@@ -359,7 +360,8 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         assertThat(getResult.exists(), equalTo(true));
         assertThat(getResult.source().source.toBytesArray(), equalTo(B_2.toBytesArray()));
         assertThat(getResult.docIdAndVersion(), nullValue());
-
+        getResult.release();
+        
         // refresh and it should be updated
         engine.refresh(new Engine.Refresh().force(false));
 
@@ -382,7 +384,8 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         // but, get should not see it (in realtime)
         getResult = engine.get(new Engine.Get(true, newUid("1")));
         assertThat(getResult.exists(), equalTo(false));
-
+        getResult.release();
+        
         // refresh and it should be deleted
         engine.refresh(new Engine.Refresh().force(false));
 
@@ -423,7 +426,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         assertThat(getResult.exists(), equalTo(true));
         assertThat(getResult.source(), nullValue());
         assertThat(getResult.docIdAndVersion(), notNullValue());
-
+        getResult.release();
 
         // make sure we can still work with the engine
         // now do an update

--- a/src/test/java/org/elasticsearch/index/store/mock/MockDirectoryHelper.java
+++ b/src/test/java/org/elasticsearch/index/store/mock/MockDirectoryHelper.java
@@ -22,8 +22,8 @@ package org.elasticsearch.index.store.mock;
 import com.carrotsearch.randomizedtesting.SeedUtils;
 import org.apache.lucene.store.*;
 import org.apache.lucene.store.MockDirectoryWrapper.Throttling;
-import org.apache.lucene.util.AbstractRandomizedTest;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.ElasticsearchTestCase;
 import org.elasticsearch.cache.memory.ByteBufferCache;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
@@ -44,7 +44,6 @@ import java.util.Set;
 public class MockDirectoryHelper {
     public static final String RANDOM_IO_EXCEPTION_RATE = "index.store.mock.random.io_exception_rate";
     public static final String RANDOM_IO_EXCEPTION_RATE_ON_OPEN = "index.store.mock.random.io_exception_rate_on_open";
-    public static final String RANDOM_SEED = "index.store.mock.random.seed";
     public static final String RANDOM_THROTTLE = "index.store.mock.random.throttle";
     public static final String CHECK_INDEX_ON_CLOSE = "index.store.mock.check_index_on_close";
     public static final Set<MockDirectoryWrapper> wrappers = ConcurrentCollections.newConcurrentSet();
@@ -59,9 +58,7 @@ public class MockDirectoryHelper {
     public MockDirectoryHelper(ShardId shardId, Settings indexSettings, ESLogger logger) {
         randomIOExceptionRate = indexSettings.getAsDouble(RANDOM_IO_EXCEPTION_RATE, 0.0d);
         randomIOExceptionRateOnOpen = indexSettings.getAsDouble(RANDOM_IO_EXCEPTION_RATE_ON_OPEN, 0.0d);
-        final Long currentSeed = AbstractRandomizedTest.getCurrentSeed();
-        assert currentSeed != null;
-        final long seed = indexSettings.getAsLong(RANDOM_SEED, currentSeed);
+        final long seed = indexSettings.getAsLong(ElasticsearchTestCase.INDEX_SEED_SETTING, 0l);
         random = new Random(seed);
         random.nextInt(shardId.getId() + 1); // some randomness per shard
         throttle = Throttling.valueOf(indexSettings.get(RANDOM_THROTTLE, random.nextDouble() < 0.1 ? "SOMETIMES" : "NEVER"));

--- a/src/test/java/org/elasticsearch/search/basic/SearchWhileRelocatingTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWhileRelocatingTests.java
@@ -66,10 +66,7 @@ public class SearchWhileRelocatingTests extends AbstractSharedClusterTest {
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
         final int numDocs = between(10, 20);
         for (int i = 0; i < numDocs; i++) {
-            indexBuilders.add(new IndexRequestBuilder(client())
-                    .setType("type")
-                    .setId(Integer.toString(i))
-                    .setIndex("test")
+            indexBuilders.add(client().prepareIndex("test", "type", Integer.toString(i))
                     .setSource(
                             jsonBuilder().startObject().field("test", "value").startObject("loc").field("lat", 11).field("lon", 21)
                                     .endObject().endObject()));

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.child;
 
+import org.elasticsearch.AbstractSharedClusterTest;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.count.CountResponse;
@@ -33,7 +34,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.facet.terms.TermsFacet;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.AbstractSharedClusterTest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -1107,54 +1107,54 @@ public class SimpleChildQuerySearchTests extends AbstractSharedClusterTest {
     List<IndexRequestBuilder> createDocBuilders() {
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
         // Parent 1 and its children
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("parent").setId("1").setIndex("test").setSource("p_field", "p_value1"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("1").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("parent").setId("1").setIndex("test").setSource("p_field", "p_value1"));
+        indexBuilders.add(client().prepareIndex().setType("child").setId("1").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 0).setParent("1"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("2").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("2").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 0).setParent("1"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("3").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("3").setIndex("test")
                 .setSource("c_field1", 2, "c_field2", 0).setParent("1"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("4").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("4").setIndex("test")
                 .setSource("c_field1", 2, "c_field2", 0).setParent("1"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("5").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("5").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 1).setParent("1"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("6").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("6").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2).setParent("1"));
 
         // Parent 2 and its children
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("parent").setId("2").setIndex("test").setSource("p_field", "p_value2"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("7").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("parent").setId("2").setIndex("test").setSource("p_field", "p_value2"));
+        indexBuilders.add(client().prepareIndex().setType("child").setId("7").setIndex("test")
                 .setSource("c_field1", 3, "c_field2", 0).setParent("2"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("8").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("8").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 1).setParent("2"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("9").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("9").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 1).setParent("p")); // why
                                                                           // "p"????
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("10").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("10").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 1).setParent("2"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("11").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("11").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 1).setParent("2"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("12").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("12").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2).setParent("2"));
 
         // Parent 3 and its children
 
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("parent").setId("3").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("parent").setId("3").setIndex("test")
                 .setSource("p_field1", "p_value3", "p_field2", 5));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("13").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("13").setIndex("test")
                 .setSource("c_field1", 4, "c_field2", 0, "c_field3", 0).setParent("3"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("14").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("14").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 1, "c_field3", 1).setParent("3"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("15").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("15").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2, "c_field3", 2).setParent("3")); // why
                                                                                          // "p"????
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("16").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("16").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2, "c_field3", 3).setParent("3"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("17").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("17").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2, "c_field3", 4).setParent("3"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child").setId("18").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child").setId("18").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2, "c_field3", 5).setParent("3"));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("child1").setId("1").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("child1").setId("1").setIndex("test")
                 .setSource("c_field1", 1, "c_field2", 2, "c_field3", 6).setParent("3"));
 
         return indexBuilders;

--- a/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
@@ -61,14 +61,14 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
         ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
-        indexBuilders.add(new IndexRequestBuilder(client())
+        indexBuilders.add(client().prepareIndex()
                 .setType("type1")
                 .setId("1")
                 .setIndex("test")
                 .setSource(
                         jsonBuilder().startObject().field("test", "value").startObject("loc").field("lat", 10).field("lon", 20).endObject()
                                 .endObject()));
-        indexBuilders.add(new IndexRequestBuilder(client())
+        indexBuilders.add(client().prepareIndex()
                 .setType("type1")
                 .setId("2")
                 .setIndex("test")
@@ -78,7 +78,7 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
 
         int numDummyDocs = 20;
         for (int i = 1; i <= numDummyDocs; i++) {
-            indexBuilders.add(new IndexRequestBuilder(client())
+            indexBuilders.add(client().prepareIndex()
                     .setType("type1")
                     .setId(Integer.toString(i + 3))
                     .setIndex("test")
@@ -163,15 +163,15 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
 
         // add tw docs within offset
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("type1").setId("1").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("type1").setId("1").setIndex("test")
                 .setSource(jsonBuilder().startObject().field("test", "value").field("num", 0.5).endObject()));
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("type1").setId("2").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("type1").setId("2").setIndex("test")
                 .setSource(jsonBuilder().startObject().field("test", "value").field("num", 1.7).endObject()));
 
         // add docs outside offset
         int numDummyDocs = 20;
         for (int i = 0; i < numDummyDocs; i++) {
-            indexBuilders.add(new IndexRequestBuilder(client()).setType("type1").setId(Integer.toString(i + 3)).setIndex("test")
+            indexBuilders.add(client().prepareIndex().setType("type1").setId(Integer.toString(i + 3)).setIndex("test")
                     .setSource(jsonBuilder().startObject().field("test", "value").field("num", 3.0 + i).endObject()));
         }
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
@@ -242,14 +242,14 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
         ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
-        indexBuilders.add(new IndexRequestBuilder(client())
+        indexBuilders.add(client().prepareIndex()
                 .setType("type1")
                 .setId("1")
                 .setIndex("test")
                 .setSource(
                         jsonBuilder().startObject().field("test", "value").startObject("loc").field("lat", 11).field("lon", 21).endObject()
                                 .endObject()));
-        indexBuilders.add(new IndexRequestBuilder(client())
+        indexBuilders.add(client().prepareIndex()
                 .setType("type1")
                 .setId("2")
                 .setIndex("test")
@@ -300,7 +300,7 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
         ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
-        indexBuilders.add(new IndexRequestBuilder(client())
+        indexBuilders.add(client().prepareIndex()
                 .setType("type1")
                 .setId("1")
                 .setIndex("test")
@@ -346,7 +346,7 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
         ensureYellow();
 
         List<IndexRequestBuilder> indexBuilders = new ArrayList<IndexRequestBuilder>();
-        indexBuilders.add(new IndexRequestBuilder(client()).setType("type1").setId("1").setIndex("test")
+        indexBuilders.add(client().prepareIndex().setType("type1").setId("1").setIndex("test")
                 .setSource(jsonBuilder().startObject().field("test", "value").field("num", 1.0).endObject()));
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
 
@@ -579,7 +579,7 @@ public class DecayFunctionScoreTests extends AbstractSharedClusterTest {
             String dayString = day < 10 ? "0" + Integer.toString(day) : Integer.toString(day);
             String date = "2013-05-" + dayString;
 
-            indexBuilders.add(new IndexRequestBuilder(client())
+            indexBuilders.add(client().prepareIndex()
                     .setType("type")
                     .setId(Integer.toString(i))
                     .setIndex("test")

--- a/src/test/java/org/elasticsearch/search/scroll/SearchScrollTests.java
+++ b/src/test/java/org/elasticsearch/search/scroll/SearchScrollTests.java
@@ -214,11 +214,6 @@ public class SearchScrollTests extends AbstractSharedClusterTest {
 
     @Test
     public void testSimpleScrollQueryThenFetch_clearScrollIds() throws Exception {
-        try {
-            client().admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (Exception e) {
-            // ignore
-        }
         client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 3)).execute().actionGet();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
 
@@ -234,6 +229,7 @@ public class SearchScrollTests extends AbstractSharedClusterTest {
                 .setQuery(matchAllQuery())
                 .setSize(35)
                 .setScroll(TimeValue.timeValueMinutes(2))
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .addSort("field", SortOrder.ASC)
                 .execute().actionGet();
 
@@ -241,6 +237,7 @@ public class SearchScrollTests extends AbstractSharedClusterTest {
                 .setQuery(matchAllQuery())
                 .setSize(35)
                 .setScroll(TimeValue.timeValueMinutes(2))
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .addSort("field", SortOrder.ASC)
                 .execute().actionGet();
 
@@ -302,11 +299,6 @@ public class SearchScrollTests extends AbstractSharedClusterTest {
 
     @Test
     public void testSimpleScrollQueryThenFetch_clearAllScrollIds() throws Exception {
-        try {
-            client().admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (Exception e) {
-            // ignore
-        }
         client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 3)).execute().actionGet();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
 
@@ -322,6 +314,7 @@ public class SearchScrollTests extends AbstractSharedClusterTest {
                 .setQuery(matchAllQuery())
                 .setSize(35)
                 .setScroll(TimeValue.timeValueMinutes(2))
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .addSort("field", SortOrder.ASC)
                 .execute().actionGet();
 
@@ -329,6 +322,7 @@ public class SearchScrollTests extends AbstractSharedClusterTest {
                 .setQuery(matchAllQuery())
                 .setSize(35)
                 .setScroll(TimeValue.timeValueMinutes(2))
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .addSort("field", SortOrder.ASC)
                 .execute().actionGet();
 

--- a/src/test/java/org/elasticsearch/test/engine/MockEngineModule.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockEngineModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.engine;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.index.engine.Engine;
+
+public class MockEngineModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(Engine.class).to(MockRobinEngine.class).asEagerSingleton();
+    }
+}

--- a/src/test/java/org/elasticsearch/test/engine/MockRobinEngine.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockRobinEngine.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.engine;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.AssertingIndexSearcher;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.SearcherManager;
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticsearchTestCase;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.analysis.AnalysisService;
+import org.elasticsearch.index.codec.CodecService;
+import org.elasticsearch.index.deletionpolicy.SnapshotDeletionPolicy;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.engine.robin.RobinEngine;
+import org.elasticsearch.index.indexing.ShardIndexingService;
+import org.elasticsearch.index.merge.policy.MergePolicyProvider;
+import org.elasticsearch.index.merge.scheduler.MergeSchedulerProvider;
+import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.settings.IndexSettingsService;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.similarity.SimilarityService;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.warmer.IndicesWarmer;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public final class MockRobinEngine extends RobinEngine implements Engine {
+    public static final ConcurrentMap<AssertingSearcher, RuntimeException> INFLIGHT_ENGINE_SEARCHERS = new ConcurrentHashMap<AssertingSearcher, RuntimeException>();
+    private final Random random;
+    @Inject
+    public MockRobinEngine(ShardId shardId, @IndexSettings Settings indexSettings, ThreadPool threadPool,
+            IndexSettingsService indexSettingsService, ShardIndexingService indexingService, @Nullable IndicesWarmer warmer, Store store,
+            SnapshotDeletionPolicy deletionPolicy, Translog translog, MergePolicyProvider mergePolicyProvider,
+            MergeSchedulerProvider mergeScheduler, AnalysisService analysisService, SimilarityService similarityService,
+            CodecService codecService) throws EngineException {
+       super(shardId, indexSettings, threadPool, indexSettingsService, indexingService, warmer, store,
+                deletionPolicy, translog, mergePolicyProvider, mergeScheduler, analysisService, similarityService, codecService);
+        final long seed = indexSettings.getAsLong(ElasticsearchTestCase.INDEX_SEED_SETTING, 0l);
+        if (logger.isTraceEnabled()){
+            logger.trace("Using [{}] for shard [{}] seed: [{}]", this.getClass().getName(), shardId, seed);
+        }
+        random = new Random(seed);
+    }
+
+
+    public void close() throws ElasticSearchException {
+        try {
+            super.close();
+        } finally {
+            if (logger.isDebugEnabled()) {
+                // log debug if we have pending searchers
+                for (Entry<MockRobinEngine.AssertingSearcher, RuntimeException> entry : MockRobinEngine.INFLIGHT_ENGINE_SEARCHERS.entrySet()) {
+                    logger.debug("Unreleased Searchers instance for shard [{}]", entry.getValue(), entry.getKey().shardId);
+                }
+            }
+        }
+    }
+    
+    @Override
+    protected Searcher newSearcher(IndexSearcher searcher, SearcherManager manager) throws EngineException {
+        // this executes basic query checks and asserts that weights are normalized only once etc.
+        final AssertingIndexSearcher assertingIndexSearcher = new AssertingIndexSearcher(random, searcher.getTopReaderContext());
+        assertingIndexSearcher.setSimilarity(searcher.getSimilarity());
+        return new AssertingSearcher(super.newSearcher(assertingIndexSearcher, manager), shardId);
+    }
+
+    public static final class AssertingSearcher implements Searcher {
+        private final Searcher searcher;
+        private final ShardId shardId;
+        
+        public AssertingSearcher(Searcher searcher, ShardId shardId) {
+            this.searcher = searcher;
+            this.shardId = shardId;
+            INFLIGHT_ENGINE_SEARCHERS.put(this, new RuntimeException("Unreleased Searcher"));
+        }
+
+        @Override
+        public boolean release() throws ElasticSearchException {
+            RuntimeException remove = INFLIGHT_ENGINE_SEARCHERS.remove(this);
+            assert remove != null : "Released Searcher more than once";
+            return searcher.release();  
+        }
+
+        @Override
+        public IndexReader reader() {
+            return searcher.reader();
+        }
+
+        @Override
+        public IndexSearcher searcher() {
+            return searcher.searcher();
+        }
+        
+        public ShardId shardId() {
+            return shardId;
+        }
+    }
+}


### PR DESCRIPTION
This assertion module also injects an AssertingIndexSearcher that
checks if our queries are all compliant with the lucene specification
which is improtant for future updates and changes in the upstream project.
