### PR TITLE
Rename Engine#seacher() into Engine#acquireSearcher()

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -81,7 +81,14 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
 
     GetResult get(Get get) throws EngineException;
 
-    Searcher searcher() throws EngineException;
+    /**
+     * Retruns a new searcher instance. The consumer of this
+     * API is responsible for releasing the returned seacher in a
+     * safe manner, preferrablly in a try/finally block.
+     * 
+     * @see Searcher#release()
+     */
+    Searcher acquireSearcher() throws EngineException;
 
     List<Segment> segments();
 

--- a/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/robin/RobinEngine.java
@@ -337,7 +337,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
             }
 
             // no version, get the version from the index, we know that we refresh on flush
-            Searcher searcher = searcher();
+            Searcher searcher = acquireSearcher();
             final Versions.DocIdAndVersion docIdAndVersion;
             try {
                 docIdAndVersion = Versions.loadDocIdAndVersion(searcher.reader(), get.uid());
@@ -676,7 +676,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
     }
 
     @Override
-    public final Searcher searcher() throws EngineException {
+    public final Searcher acquireSearcher() throws EngineException {
         SearcherManager manager = this.searcherManager;
         try {
             IndexSearcher searcher = manager.acquire();
@@ -1128,7 +1128,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
             Map<String, Segment> segments = new HashMap<String, Segment>();
 
             // first, go over and compute the search ones...
-            Searcher searcher = searcher();
+            Searcher searcher = acquireSearcher();
             try {
                 for (AtomicReaderContext reader : searcher.reader().leaves()) {
                     assert reader.reader() instanceof SegmentReader;
@@ -1279,7 +1279,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
     }
 
     private long loadCurrentVersionFromIndex(Term uid) throws IOException {
-        Searcher searcher = searcher();
+        Searcher searcher = acquireSearcher();
         try {
             return Versions.loadVersion(searcher.reader(), uid);
         } finally {
@@ -1478,7 +1478,7 @@ public class RobinEngine extends AbstractIndexShardComponent implements Engine {
                         // fresh index writer, just do on all of it
                         newSearcher = searcher;
                     } else {
-                        currentSearcher = searcher();
+                        currentSearcher = acquireSearcher();
                         // figure out the newSearcher, with only the new readers that are relevant for us
                         List<IndexReader> readers = Lists.newArrayList();
                         for (AtomicReaderContext newReaderContext : searcher.getIndexReader().leaves()) {

--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -593,7 +593,7 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
     @Override
     public Engine.Searcher acquireSearcher() {
         readAllowed();
-        return engine.searcher();
+        return engine.acquireSearcher();
     }
 
     public void close(String reason) {

--- a/src/test/java/org/elasticsearch/index/engine/robin/RobinEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/robin/RobinEngineTests.java
@@ -299,7 +299,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
 
     @Test
     public void testSimpleOperations() throws Exception {
-        Engine.Searcher searchResult = engine.searcher();
+        Engine.Searcher searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         searchResult.release();
 
@@ -310,7 +310,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.create(new Engine.Create(null, newUid("1"), doc));
 
         // its not there...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         searchResult.release();
@@ -330,7 +330,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.refresh(new Engine.Refresh().force(false));
 
         // now its there...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         searchResult.release();
@@ -349,7 +349,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.index(new Engine.Index(null, newUid("1"), doc));
 
         // its not updated yet...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
@@ -365,7 +365,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         // refresh and it should be updated
         engine.refresh(new Engine.Refresh().force(false));
 
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 1));
@@ -375,7 +375,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.delete(new Engine.Delete("test", "1", newUid("1")));
 
         // its not deleted yet
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 1));
@@ -389,7 +389,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         // refresh and it should be deleted
         engine.refresh(new Engine.Refresh().force(false));
 
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
@@ -402,7 +402,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.create(new Engine.Create(null, newUid("1"), doc));
 
         // its not there...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
@@ -412,7 +412,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.refresh(new Engine.Refresh().force(false));
 
         // now its there...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
@@ -436,7 +436,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.index(new Engine.Index(null, newUid("1"), doc));
 
         // its not updated yet...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
@@ -445,7 +445,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         // refresh and it should be updated
         engine.refresh(new Engine.Refresh().force(false));
 
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 1));
@@ -456,7 +456,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
 
     @Test
     public void testSearchResultRelease() throws Exception {
-        Engine.Searcher searchResult = engine.searcher();
+        Engine.Searcher searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         searchResult.release();
 
@@ -465,7 +465,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.create(new Engine.Create(null, newUid("1"), doc));
 
         // its not there...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         searchResult.release();
@@ -474,7 +474,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         engine.refresh(new Engine.Refresh().force(false));
 
         // now its there...
-        searchResult = engine.searcher();
+        searchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         // don't release the search result yet...
@@ -482,7 +482,7 @@ public class RobinEngineTests extends ElasticsearchTestCase {
         // delete, refresh and do a new search, it should not be there
         engine.delete(new Engine.Delete("test", "1", newUid("1")));
         engine.refresh(new Engine.Refresh().force(false));
-        Engine.Searcher updateSearchResult = engine.searcher();
+        Engine.Searcher updateSearchResult = engine.acquireSearcher();
         MatcherAssert.assertThat(updateSearchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         updateSearchResult.release();
 


### PR DESCRIPTION
The name should reflect that the caller is responsible for
releaseing the searcher again.
