### PR TITLE
Remove a comma in doc to make example a valid json.

### DIFF
--- a/docs/reference/mapping/dynamic-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic-mapping.asciidoc
@@ -39,7 +39,7 @@ root and inner object types:
 --------------------------------------------------
 {
     "_default_" : {
-        "date_formats" : ["yyyy-MM-dd", "dd-MM-yyyy", "date_optional_time"],
+        "date_formats" : ["yyyy-MM-dd", "dd-MM-yyyy", "date_optional_time"]
     }
 }
 --------------------------------------------------


### PR DESCRIPTION
This will help reader to do a hurry up copy-paste test.
