### PR TITLE
Introduce internal post recovery state

### DIFF
--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -179,8 +179,8 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                     lastTotalTranslogOperations = recoveryStatus.translog().currentTranslogOperations();
 
                     // start the shard if the gateway has not started it already
-                    if (indexShard.state() != IndexShardState.STARTED) {
-                        indexShard.start("post recovery from gateway");
+                    if (indexShard.state() != IndexShardState.POST_RECOVERY) {
+                        indexShard.postRecovery("post recovery from gateway");
                     }
                     // refresh the shard
                     indexShard.refresh(new Engine.Refresh("post_gateway").force(true));

--- a/src/main/java/org/elasticsearch/index/gateway/blobstore/BlobStoreIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/blobstore/BlobStoreIndexShardGateway.java
@@ -429,7 +429,7 @@ public abstract class BlobStoreIndexShardGateway extends AbstractIndexShardCompo
             // no translog files, bail
             recoveryStatus.start().startTime(System.currentTimeMillis());
             recoveryStatus.updateStage(RecoveryStatus.Stage.START);
-            indexShard.start("post recovery from gateway, no translog");
+            indexShard.postRecovery("post recovery from gateway, no translog");
             recoveryStatus.start().time(System.currentTimeMillis() - recoveryStatus.start().startTime());
             recoveryStatus.start().checkIndexTime(indexShard.checkIndexTook());
             return;

--- a/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/local/LocalIndexShardGateway.java
@@ -154,7 +154,7 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
         recoveryStatus.updateStage(RecoveryStatus.Stage.START);
         if (translogId == -1) {
             // no translog files, bail
-            indexShard.start("post recovery from gateway, no translog");
+            indexShard.postRecovery("post recovery from gateway, no translog");
             // no index, just start the shard and bail
             recoveryStatus.start().time(System.currentTimeMillis() - recoveryStatus.start().startTime());
             recoveryStatus.start().checkIndexTime(indexShard.checkIndexTook());
@@ -189,7 +189,7 @@ public class LocalIndexShardGateway extends AbstractIndexShardComponent implemen
         if (recoveringTranslogFile == null || !recoveringTranslogFile.exists()) {
             // no translog to recovery from, start and bail
             // no translog files, bail
-            indexShard.start("post recovery from gateway, no translog");
+            indexShard.postRecovery("post recovery from gateway, no translog");
             // no index, just start the shard and bail
             recoveryStatus.start().time(System.currentTimeMillis() - recoveryStatus.start().startTime());
             recoveryStatus.start().checkIndexTime(indexShard.checkIndexTook());

--- a/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
@@ -70,7 +70,7 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
         } catch (IOException e) {
             logger.warn("failed to clean store before starting shard", e);
         }
-        indexShard.start("post recovery from gateway");
+        indexShard.postRecovery("post recovery from gateway");
         recoveryStatus.index().time(System.currentTimeMillis() - recoveryStatus.index().startTime());
         recoveryStatus.translog().startTime(System.currentTimeMillis());
         recoveryStatus.translog().time(System.currentTimeMillis() - recoveryStatus.index().startTime());

--- a/src/main/java/org/elasticsearch/index/shard/IndexShardState.java
+++ b/src/main/java/org/elasticsearch/index/shard/IndexShardState.java
@@ -27,9 +27,10 @@ import org.elasticsearch.ElasticSearchIllegalArgumentException;
 public enum IndexShardState {
     CREATED((byte) 0),
     RECOVERING((byte) 1),
-    STARTED((byte) 2),
-    RELOCATED((byte) 3),
-    CLOSED((byte) 4);
+    POST_RECOVERY((byte) 2),
+    STARTED((byte) 3),
+    RELOCATED((byte) 4),
+    CLOSED((byte) 5);
 
     private final byte id;
 

--- a/src/test/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.basic;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -44,28 +43,24 @@ public class SearchWhileCreatingIndexTests extends AbstractIntegrationTest {
 
     @Test
     @Slow
-    @AwaitsFix(bugUrl = "fix is coming")
     public void testIndexCausesIndexCreation() throws Exception {
         searchWhileCreatingIndex(-1, 1); // 1 replica in our default...
     }
 
     @Test
     @Slow
-    @AwaitsFix(bugUrl = "fix is coming")
     public void testNoReplicas() throws Exception {
         searchWhileCreatingIndex(10, 0);
     }
 
     @Test
     @Slow
-    @AwaitsFix(bugUrl = "fix is coming")
     public void testOneReplica() throws Exception {
         searchWhileCreatingIndex(10, 1);
     }
 
     @Test
     @Slow
-    @AwaitsFix(bugUrl = "fix is coming")
     public void testTwoReplicas() throws Exception {
         searchWhileCreatingIndex(10, 2);
     }


### PR DESCRIPTION
Introduce a new internal, index shard level, post recovery state, where the shard moves to when its done with recovery. The shard will now move to started only once the cluster state with its respective cluster state level state is started.

This change allow to have more fine grained control over when to allow reads on a shard, resolving potential refresh temporal visibility aspects while indexing and issuign a refresh. By only allowing reads on started shards, and making sure we refresh right before we move to started
