### PR TITLE
Added generic cluster state update ack mechanism

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -31,10 +31,9 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.MetaDataDeleteIndexService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Delete index action.
@@ -102,9 +101,10 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
     protected void masterOperation(final DeleteIndexRequest request, final ClusterState state, final ActionListener<DeleteIndexResponse> listener) throws ElasticSearchException {
         if (request.indices().length == 0) {
             listener.onResponse(new DeleteIndexResponse(true));
+            return;
         }
         // TODO: this API should be improved, currently, if one delete index failed, we send a failure, we should send a response array that includes all the indices that were deleted
-        final AtomicInteger count = new AtomicInteger(request.indices().length);
+        final CountDown count = new CountDown(request.indices().length);
         for (final String index : request.indices()) {
             deleteIndexService.deleteIndex(new MetaDataDeleteIndexService.Request(index).timeout(request.timeout()).masterTimeout(request.masterNodeTimeout()), new MetaDataDeleteIndexService.Listener() {
 
@@ -116,7 +116,7 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
                     if (!response.acknowledged()) {
                         ack = false;
                     }
-                    if (count.decrementAndGet() == 0) {
+                    if (count.countDown()) {
                         if (lastFailure != null) {
                             listener.onFailure(lastFailure);
                         } else {
@@ -129,7 +129,7 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
                 public void onFailure(Throwable t) {
                     logger.debug("[{}] failed to delete index", t, index);
                     lastFailure = t;
-                    if (count.decrementAndGet() == 0) {
+                    if (count.countDown()) {
                         listener.onFailure(t);
                     }
                 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
@@ -19,23 +19,32 @@
 
 package org.elasticsearch.action.admin.indices.warmer.delete;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
+
+import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
+import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 
 /**
  * A request to delete an index warmer.
  */
-public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmerRequest> {
+public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmerRequest>
+        implements AcknowledgedRequest<DeleteWarmerRequest> {
 
     private String name;
 
     private String[] indices = Strings.EMPTY_ARRAY;
+
+    private TimeValue timeout = timeValueSeconds(10);
 
     DeleteWarmerRequest() {
     }
@@ -88,10 +97,30 @@ public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmer
     }
 
     @Override
+    public DeleteWarmerRequest timeout(String timeout) {
+        this.timeout = TimeValue.parseTimeValue(timeout, this.timeout);
+        return this;
+    }
+
+    @Override
+    public DeleteWarmerRequest timeout(TimeValue timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    @Override
+    public TimeValue timeout() {
+        return timeout;
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         name = in.readOptionalString();
         indices = in.readStringArray();
+        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
+            timeout = readTimeValue(in);
+        }
     }
 
     @Override
@@ -99,5 +128,8 @@ public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmer
         super.writeTo(out);
         out.writeOptionalString(name);
         out.writeStringArrayNullable(indices);
+        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
+            timeout.writeTo(out);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestBuilder.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
+import org.elasticsearch.common.unit.TimeValue;
 
 /**
  *
@@ -44,6 +45,23 @@ public class DeleteWarmerRequestBuilder extends MasterNodeOperationRequestBuilde
      */
     public DeleteWarmerRequestBuilder setName(String name) {
         request.name(name);
+        return this;
+    }
+
+    /**
+     * Sets the maximum wait for acknowledgement from other nodes
+     */
+    public DeleteWarmerRequestBuilder setTimeout(TimeValue timeout) {
+        request.timeout(timeout);
+        return this;
+    }
+
+    /**
+     * Timeout to wait for the operation to be acknowledged by current cluster nodes. Defaults
+     * to <tt>10s</tt>.
+     */
+    public DeleteWarmerRequestBuilder setTimeout(String timeout) {
+        request.timeout(timeout);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerResponse.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.warmer.delete;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -28,7 +29,7 @@ import java.io.IOException;
 /**
  * A response for a delete warmer.
  */
-public class DeleteWarmerResponse extends ActionResponse {
+public class DeleteWarmerResponse extends ActionResponse implements AcknowledgedResponse {
 
     private boolean acknowledged;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
+import org.elasticsearch.common.unit.TimeValue;
 
 /**
  *
@@ -60,6 +61,23 @@ public class PutWarmerRequestBuilder extends MasterNodeOperationRequestBuilder<P
      */
     public PutWarmerRequestBuilder setSearchRequest(SearchRequestBuilder searchRequest) {
         request.searchRequest(searchRequest);
+        return this;
+    }
+
+    /**
+     * Sets the maximum wait for acknowledgement from other nodes
+     */
+    public PutWarmerRequestBuilder setTimeout(TimeValue timeout) {
+        request.timeout(timeout);
+        return this;
+    }
+
+    /**
+     * Timeout to wait for the operation to be acknowledged by current cluster nodes. Defaults
+     * to <tt>10s</tt>.
+     */
+    public PutWarmerRequestBuilder setTimeout(String timeout) {
+        request.timeout(timeout);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerResponse.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.warmer.put;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -28,7 +29,7 @@ import java.io.IOException;
 /**
  * The response of put warmer operation.
  */
-public class PutWarmerResponse extends ActionResponse {
+public class PutWarmerResponse extends ActionResponse implements AcknowledgedResponse {
 
     private boolean acknowledged;
 

--- a/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.action.support.master;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * Interface that allows to mark action requests that support acknowledgements.
+ * Facilitates consistency across different api.
+ */
+public interface AcknowledgedRequest<T extends ActionRequest<T>> {
+
+    /**
+     * Allows to set the timeout
+     * @param timeout timeout as a string (e.g. 1s)
+     * @return the request itself
+     */
+    T timeout(String timeout);
+
+    /**
+     * Allows to set the timeout
+     * @param timeout timeout as a {@link TimeValue}
+     * @return the request itself
+     */
+    T timeout(TimeValue timeout);
+
+    /**
+     * Returns the current timeout
+     * @return the current timeout as a {@link TimeValue}
+     */
+    TimeValue timeout();
+}

--- a/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.action.support.master;
+
+/**
+ * Interface that allows to mark action responses that support acknowledgements.
+ * Facilitates consistency across different api.
+ */
+public interface AcknowledgedResponse {
+
+    /**
+     * Returns whether the response is acknowledged or not
+     * @return true if the response is acknowledged, false otherwise
+     */
+    boolean isAcknowledged();
+}

--- a/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * An extension interface to {@link ClusterStateUpdateTask} that allows to be notified when
+ * all the nodes have acknowledged a cluster state update request
+ */
+public interface AckedClusterStateUpdateTask extends TimeoutClusterStateUpdateTask {
+
+    /**
+     * Called to determine which nodes the acknowledgement is expected from
+     * @param discoveryNode a node
+     * @return true if the node is expected to send ack back, false otherwise
+     */
+    boolean mustAck(DiscoveryNode discoveryNode);
+
+    /**
+     * Called once all the nodes have acknowledged the cluster state update request. Must be
+     * very lightweight execution, since it gets executed on the cluster service thread.
+     * @param t optional error that might have been thrown
+     */
+    void onAllNodesAcked(@Nullable Throwable t);
+
+    /**
+     * Called once the acknowledgement timeout defined by
+     * {@link AckedClusterStateUpdateTask#ackTimeout()} has expired
+     */
+    void onAckTimeout();
+
+    /**
+     * Acknowledgement timeout, maximum time interval to wait for acknowledgements
+     */
+    TimeValue ackTimeout();
+}

--- a/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple thread safe count-down class that in contrast to a {@link CountDownLatch}
+ * never blocks. This class is useful if a certain action has to wait for N concurrent 
+ * tasks to return or a timeout to occur in order to proceed.
+ */
+public final class CountDown {
+
+    private final AtomicInteger countDown;
+    private final int originalCount;
+
+    public CountDown(int count) {
+        if (count < 0) {
+            throw new ElasticSearchIllegalArgumentException("count must be greater or equal to 0 but was: " + count);
+        }
+        this.originalCount = count;
+        this.countDown = new AtomicInteger(count);
+    }
+
+    /**
+     * Decrements the count-down and returns <code>true</code> iff this call
+     * reached zero otherwise <code>false</code>
+     */
+    public boolean countDown() {
+        assert originalCount > 0;
+        for (;;) {
+            final int current = countDown.get();
+            assert current >= 0;
+            if (current == 0) {
+                return false;
+            }
+            if (countDown.compareAndSet(current, current - 1)) {
+                return current == 1;
+            }
+        }
+    }
+
+    /**
+     * Fast forwards the count-down to zero and returns <code>true</code> iff
+     * the count down reached zero with this fast forward call otherwise
+     * <code>false</code>
+     */
+    public boolean fastForward() {
+        assert originalCount > 0;
+        assert countDown.get() >= 0;
+        return countDown.getAndSet(0) > 0;
+    }
+    
+    /**
+     * Returns <code>true</code> iff the count-down has reached zero. Otherwise <code>false</code>
+     */
+    public boolean isCountedDown() {
+        assert countDown.get() >= 0;
+        return countDown.get() == 0;
+    }
+}

--- a/src/main/java/org/elasticsearch/discovery/AckClusterStatePublishResponseHandler.java
+++ b/src/main/java/org/elasticsearch/discovery/AckClusterStatePublishResponseHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.discovery;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+
+/**
+ * Allows to wait for all nodes to reply to the publish of a new cluster state
+ * and notifies the {@link org.elasticsearch.discovery.Discovery.AckListener}
+ * so that the cluster state update can be acknowledged
+ */
+public class AckClusterStatePublishResponseHandler extends BlockingClusterStatePublishResponseHandler {
+
+    private static final ESLogger logger = ESLoggerFactory.getLogger(AckClusterStatePublishResponseHandler.class.getName());
+
+    private final Discovery.AckListener ackListener;
+
+    /**
+     * Creates a new AckClusterStatePublishResponseHandler
+     * @param nonMasterNodes number of nodes that are supposed to reply to a cluster state publish from master
+     * @param ackListener the {@link org.elasticsearch.discovery.Discovery.AckListener} to notify for each response
+     *                    gotten from non master nodes
+     */
+    public AckClusterStatePublishResponseHandler(int nonMasterNodes, Discovery.AckListener ackListener) {
+        //Don't count the master as acknowledged, because it's not done yet
+        //otherwise we might end up with all the nodes but the master holding the latest cluster state
+        super(nonMasterNodes);
+        this.ackListener = ackListener;
+    }
+
+    @Override
+    public void onResponse(DiscoveryNode node) {
+        super.onResponse(node);
+        onNodeAck(ackListener, node, null);
+    }
+
+    @Override
+    public void onFailure(DiscoveryNode node, Throwable t) {
+        try {
+            super.onFailure(node, t);
+        } finally {
+            onNodeAck(ackListener, node, t);
+        }
+    }
+
+    private void onNodeAck(final Discovery.AckListener ackListener, DiscoveryNode node, Throwable t) {
+        try {
+            ackListener.onNodeAck(node, t);
+        } catch (Throwable t1) {
+            logger.debug("error while processing ack for node [{}]", t1, node);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandler.java
+++ b/src/main/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.discovery;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Default implementation of {@link ClusterStatePublishResponseHandler}, allows to  await a reply
+ * to a cluster state publish from all non master nodes, up to a timeout
+ */
+public class BlockingClusterStatePublishResponseHandler implements ClusterStatePublishResponseHandler {
+
+    private final CountDownLatch latch;
+
+    /**
+     * Creates a new BlockingClusterStatePublishResponseHandler
+     * @param nonMasterNodes number of nodes that are supposed to reply to a cluster state publish from master
+     */
+    public BlockingClusterStatePublishResponseHandler(int nonMasterNodes) {
+        //Don't count the master, as it's the one that does the publish
+        //the master won't call onResponse either
+        this.latch = new CountDownLatch(nonMasterNodes);
+    }
+
+    @Override
+    public void onResponse(DiscoveryNode node) {
+        latch.countDown();
+    }
+
+    @Override
+    public void onFailure(DiscoveryNode node, Throwable t) {
+        latch.countDown();
+    }
+
+    @Override
+    public boolean awaitAllNodes(TimeValue timeout) throws InterruptedException {
+        return latch.await(timeout.millis(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/org/elasticsearch/discovery/ClusterStatePublishResponseHandler.java
+++ b/src/main/java/org/elasticsearch/discovery/ClusterStatePublishResponseHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.discovery;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * Handles responses obtained when publishing a new cluster state from master to all non master nodes.
+ * Allows to await a reply from all non master nodes, up to a timeout
+ */
+public interface ClusterStatePublishResponseHandler {
+
+    /**
+     * Called for each response obtained from non master nodes
+     * @param node the node that replied to the publish event
+     */
+    void onResponse(DiscoveryNode node);
+
+    /**
+     * Called for each failure obtained from non master nodes
+     * @param node the node that replied to the publish event
+     */
+    void onFailure(DiscoveryNode node, Throwable t);
+
+    /**
+     * Allows to wait for all non master nodes to reply to the publish event up to a timeout
+     * @param timeout the timeout
+     * @return true if the timeout expired or not, false otherwise
+     * @throws InterruptedException
+     */
+    boolean awaitAllNodes(TimeValue timeout) throws InterruptedException;
+}

--- a/src/main/java/org/elasticsearch/discovery/Discovery.java
+++ b/src/main/java/org/elasticsearch/discovery/Discovery.java
@@ -24,8 +24,8 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.LifecycleComponent;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.rest.RestStatus;
 
@@ -60,6 +60,14 @@ public interface Discovery extends LifecycleComponent<Discovery> {
     /**
      * Publish all the changes to the cluster from the master (can be called just by the master). The publish
      * process should not publish this state to the master as well! (the master is sending it...).
+     *
+     * The {@link AckListener} allows to keep track of the ack received from nodes, and verify whether
+     * they updated their own cluster state or not.
      */
-    void publish(ClusterState clusterState);
+    void publish(ClusterState clusterState, AckListener ackListener);
+
+    public static interface AckListener {
+        void onNodeAck(DiscoveryNode node, @Nullable Throwable t);
+        void onTimeout();
+    }
 }

--- a/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
@@ -107,11 +107,13 @@ public class DiscoveryService extends AbstractLifecycleComponent<DiscoveryServic
     /**
      * Publish all the changes to the cluster from the master (can be called just by the master). The publish
      * process should not publish this state to the master as well! (the master is sending it...).
+     *
+     * The {@link org.elasticsearch.discovery.Discovery.AckListener} allows to acknowledge the publish
+     * event based on the response gotten from all nodes
      */
-    public void publish(ClusterState clusterState) {
-        if (!lifecycle.started()) {
-            return;
+    public void publish(ClusterState clusterState, Discovery.AckListener ackListener) {
+        if (lifecycle.started()) {
+            discovery.publish(clusterState, ackListener);
         }
-        discovery.publish(clusterState);
     }
 }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -262,13 +262,13 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     }
 
     @Override
-    public void publish(ClusterState clusterState) {
+    public void publish(ClusterState clusterState, AckListener ackListener) {
         if (!master) {
             throw new ElasticSearchIllegalStateException("Shouldn't publish state when not master");
         }
         latestDiscoNodes = clusterState.nodes();
         nodesFD.updateNodes(clusterState.nodes());
-        publishClusterState.publish(clusterState);
+        publishClusterState.publish(clusterState, ackListener);
     }
 
     private void asyncJoinCluster() {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -52,6 +52,7 @@ public class RestDeleteWarmerAction extends BaseRestHandler {
         DeleteWarmerRequest deleteWarmerRequest = new DeleteWarmerRequest(request.param("name"))
                 .indices(Strings.splitStringByCommaToArray(request.param("index")));
         deleteWarmerRequest.listenerThreaded(false);
+        deleteWarmerRequest.timeout(request.paramAsTime("timeout", deleteWarmerRequest.timeout()));
         deleteWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteWarmerRequest.masterNodeTimeout()));
         client.admin().indices().deleteWarmer(deleteWarmerRequest, new ActionListener<DeleteWarmerResponse>() {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -55,6 +55,7 @@ public class RestPutWarmerAction extends BaseRestHandler {
                 .types(Strings.splitStringByCommaToArray(request.param("type")))
                 .source(request.content(), request.contentUnsafe());
         putWarmerRequest.searchRequest(searchRequest);
+        putWarmerRequest.timeout(request.paramAsTime("timeout", putWarmerRequest.timeout()));
         putWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putWarmerRequest.masterNodeTimeout()));
         client.admin().indices().putWarmer(putWarmerRequest, new ActionListener<PutWarmerResponse>() {
             @Override

--- a/src/test/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestTests.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.action.admin.indices.warmer.delete;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ElasticSearchTestCase;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class DeleteWarmerRequestTests extends ElasticSearchTestCase {
+
+    @Test
+    public void testDeleteWarmerTimeoutBwComp_Pre0906Format() throws Exception {
+        DeleteWarmerRequest outRequest = new DeleteWarmerRequest("warmer1");
+        outRequest.timeout(TimeValue.timeValueMillis(1000));
+
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setVersion(Version.V_0_90_0);
+        outRequest.writeTo(out);
+
+        ByteArrayInputStream esInBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        InputStreamStreamInput esBuffer = new InputStreamStreamInput(esInBuffer);
+        esBuffer.setVersion(Version.V_0_90_0);
+        DeleteWarmerRequest inRequest = new DeleteWarmerRequest();
+        inRequest.readFrom(esBuffer);
+
+        assertThat(inRequest.name(), equalTo("warmer1"));
+        //timeout is default as we don't read it from the received buffer
+        assertThat(inRequest.timeout().millis(), equalTo(new DeleteWarmerRequest().timeout().millis()));
+
+    }
+
+    @Test
+    public void testDeleteWarmerTimeoutBwComp_Post0906Format() throws Exception {
+        DeleteWarmerRequest outRequest = new DeleteWarmerRequest("warmer1");
+        outRequest.timeout(TimeValue.timeValueMillis(1000));
+
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setVersion(Version.V_0_90_6);
+        outRequest.writeTo(out);
+
+        ByteArrayInputStream esInBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        InputStreamStreamInput esBuffer = new InputStreamStreamInput(esInBuffer);
+        esBuffer.setVersion(Version.V_0_90_6);
+        DeleteWarmerRequest inRequest = new DeleteWarmerRequest();
+        inRequest.readFrom(esBuffer);
+
+        assertThat(inRequest.name(), equalTo("warmer1"));
+        //timeout is default as we don't read it from the received buffer
+        assertThat(inRequest.timeout().millis(), equalTo(outRequest.timeout().millis()));
+
+    }
+}

--- a/src/test/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestTests.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.action.admin.indices.warmer.put;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ElasticSearchTestCase;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class PutWarmerRequestTests extends ElasticSearchTestCase {
+
+    @Test
+    public void testPutWarmerTimeoutBwComp_Pre0906Format() throws Exception {
+        PutWarmerRequest outRequest = new PutWarmerRequest("warmer1");
+        outRequest.timeout(TimeValue.timeValueMillis(1000));
+
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setVersion(Version.V_0_90_0);
+        outRequest.writeTo(out);
+
+        ByteArrayInputStream esInBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        InputStreamStreamInput esBuffer = new InputStreamStreamInput(esInBuffer);
+        esBuffer.setVersion(Version.V_0_90_0);
+        PutWarmerRequest inRequest = new PutWarmerRequest();
+        inRequest.readFrom(esBuffer);
+
+        assertThat(inRequest.name(), equalTo("warmer1"));
+        //timeout is default as we don't read it from the received buffer
+        assertThat(inRequest.timeout().millis(), equalTo(new PutWarmerRequest().timeout().millis()));
+    }
+
+    @Test
+    public void testPutWarmerTimeoutBwComp_Post0906Format() throws Exception {
+        PutWarmerRequest outRequest = new PutWarmerRequest("warmer1");
+        outRequest.timeout(TimeValue.timeValueMillis(1000));
+
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setVersion(Version.V_0_90_6);
+        outRequest.writeTo(out);
+
+        ByteArrayInputStream esInBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        InputStreamStreamInput esBuffer = new InputStreamStreamInput(esInBuffer);
+        esBuffer.setVersion(Version.V_0_90_6);
+        PutWarmerRequest inRequest = new PutWarmerRequest();
+        inRequest.readFrom(esBuffer);
+
+        assertThat(inRequest.name(), equalTo("warmer1"));
+        //timeout is default as we don't read it from the received buffer
+        assertThat(inRequest.timeout().millis(), equalTo(outRequest.timeout().millis()));
+    }
+}

--- a/src/test/java/org/elasticsearch/common/util/concurrent/CountDownTest.java
+++ b/src/test/java/org/elasticsearch/common/util/concurrent/CountDownTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.test.ElasticSearchTestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+
+public class CountDownTest extends ElasticSearchTestCase {
+
+    @Test
+    public void testConcurrent() throws InterruptedException {
+        final AtomicInteger count = new AtomicInteger(0);
+        final CountDown countDown = new CountDown(atLeast(10000));
+        Thread[] threads = new Thread[atLeast(3)];
+        final CountDownLatch latch = new CountDownLatch(1);
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread() {
+                
+                public void run() {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException();
+                    }
+                    while (!countDown.isCountedDown()) {
+                        if (countDown.countDown()) {
+                            count.incrementAndGet();
+                            break;
+                        }
+                    }
+                }
+            };
+            threads[i].start();
+        }
+        latch.countDown();
+        Thread.yield();
+        if (rarely()) {
+            countDown.fastForward();
+        }
+        for (int i = 0; i < threads.length; i++) {
+            threads[i].join();
+        }
+        assertThat(count.get(), Matchers.equalTo(1));
+    }
+    
+    @Test
+    public void testSingleThreaded() {
+        int atLeast = atLeast(10);
+        final CountDown countDown = new CountDown(atLeast);
+        while(!countDown.isCountedDown()) {
+            atLeast--;
+            if (countDown.countDown()) {
+                assertThat(atLeast, equalTo(0));
+                assertThat(countDown.isCountedDown(), equalTo(true));
+                assertThat(countDown.fastForward(), equalTo(false));
+                break;
+            }
+            if (rarely()) {
+                assertThat(countDown.fastForward(), equalTo(true));
+                assertThat(countDown.isCountedDown(), equalTo(true));
+            }
+            assertThat(atLeast, greaterThan(0));
+        }
+
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices.warmer;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse;
 import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Priority;
@@ -126,7 +127,8 @@ public class LocalGatewayIndicesWarmerTests extends AbstractIntegrationTest {
 
 
         logger.info("--> delete warmer warmer_1");
-        client().admin().indices().prepareDeleteWarmer().setIndices("test").setName("warmer_1").execute().actionGet();
+        DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer().setIndices("test").setName("warmer_1").execute().actionGet();
+        assertThat(deleteWarmerResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> verify warmers (delete) are registered in cluster state");
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();

--- a/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices.warmer;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.logging.ESLogger;
@@ -58,12 +59,14 @@ public class LocalGatewayIndicesWarmerTests extends AbstractIntegrationTest {
 
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
-        client().admin().indices().preparePutWarmer("warmer_1")
+        PutWarmerResponse putWarmerResponse = client().admin().indices().preparePutWarmer("warmer_1")
                 .setSearchRequest(client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field", "value1")))
                 .execute().actionGet();
-        client().admin().indices().preparePutWarmer("warmer_2")
+        assertThat(putWarmerResponse.isAcknowledged(), equalTo(true));
+        putWarmerResponse = client().admin().indices().preparePutWarmer("warmer_2")
                 .setSearchRequest(client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field", "value2")))
                 .execute().actionGet();
+        assertThat(putWarmerResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> put template with warmer");
         client().admin().indices().preparePutTemplate("template_1")

--- a/src/test/java/org/elasticsearch/search/scan/SearchScanScrollingTests.java
+++ b/src/test/java/org/elasticsearch/search/scan/SearchScanScrollingTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.scan;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
@@ -31,6 +30,7 @@ import org.elasticsearch.test.AbstractIntegrationTest;
 import java.util.Set;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.hamcrest.ElasticSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SearchScanScrollingTests extends AbstractIntegrationTest {
@@ -40,9 +40,8 @@ public class SearchScanScrollingTests extends AbstractIntegrationTest {
     }
 
     private void testScroll(int numberOfShards, long numberOfDocs, int size, boolean unbalanced) throws Exception {
-        wipeIndex("test");
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", numberOfShards)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", numberOfShards)).get();
+        ensureGreen();
 
         Set<String> ids = Sets.newHashSet();
         Set<String> expectedIds = Sets.newHashSet();
@@ -66,7 +65,7 @@ public class SearchScanScrollingTests extends AbstractIntegrationTest {
             }
         }
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setSearchType(SearchType.SCAN)
@@ -75,15 +74,15 @@ public class SearchScanScrollingTests extends AbstractIntegrationTest {
                 .setScroll(TimeValue.timeValueMinutes(2))
                 .execute().actionGet();
         try {
-            assertThat(searchResponse.getHits().totalHits(), equalTo(numberOfDocs));
+            assertHitCount(searchResponse, numberOfDocs);
     
             // start scrolling, until we get not results
             while (true) {
                 searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(2)).execute().actionGet();
-                assertThat(searchResponse.getHits().totalHits(), equalTo(numberOfDocs));
-                assertThat(searchResponse.getFailedShards(), equalTo(0));
+                assertHitCount(searchResponse, numberOfDocs);
+
                 for (SearchHit hit : searchResponse.getHits()) {
-                    assertThat(hit.id() + "should not exists in the result set", ids.contains(hit.id()), equalTo(false));
+                    assertThat(hit.id() + "should not exist in the result set", ids.contains(hit.id()), equalTo(false));
                     ids.add(hit.id());
                 }
                 if (searchResponse.getHits().hits().length == 0) {


### PR DESCRIPTION
Added new AckedClusterStateUpdateTask interface that can be used to submit cluster state update tasks and allows actions to be notified back when a set of (configurable) nodes have acknowledged the cluster state update. Supports a configurable timeout, so that we wait for acknowledgement for a limited amount of time (will be provided in the request as it curently happens, default 10s).

Internally, a low level AckListener is created (InternalClusterService) and passed to the publish method, so that it can be notified whenever each node responds to the publish request. Once all the expected nodes have responded or the timeoeout has expired, the AckListener notifies the action which will return adding the proper acknowledged flag to the response.

Ideally, this new mechanism will gradually replace the existing ones based on custom endpoints and notifications (per api).

Once we get this in I'll start adding this new mechanism to the apis that don't currently support acknowledgements when changing the cluster state (e.g. put and delete warmer etc.).

Closes #3786
