### PR TITLE
River routing failed for river names containing the river type.

### DIFF
--- a/src/main/java/org/elasticsearch/river/cluster/RiverNodeHelper.java
+++ b/src/main/java/org/elasticsearch/river/cluster/RiverNodeHelper.java
@@ -50,6 +50,11 @@ public class RiverNodeHelper {
         }
         String river = node.attributes().get("river");
         // by default, if not set, its an river node (better OOB exp)
-        return river == null || river.contains(riverName.type()) || river.contains(riverName.name());
+        if (river == null) {
+            return true;
+        } else {
+            List<String> rivers = Arrays.asList(river.split("\\s*,\\s*"));
+            return rivers.contains(riverName.type()) || river.contains(riverName.name());
+        }
     }
 }


### PR DESCRIPTION
Two rivers of type "myRiver" with name "myRiverOnNodeA" and "myRiverOnNodeB" can't be bound to node A or B by setting the configuration node.river to myRiverOnNodeA or myRiverOnNodeB. Both node.river strings contain the river type, and so every node could run the river. this is contrary to the description on http://www.elasticsearch.org/guide/reference/river/
