### PR TITLE
Don't start up elasticsearch on install as recommended by fedora.

### DIFF
--- a/src/rpm/scripts/postinstall
+++ b/src/rpm/scripts/postinstall
@@ -35,7 +35,6 @@ if [ $1 -eq 1 ] ; then
         /sbin/chkconfig --add elasticsearch
     fi
 
-	startElasticsearch
 elif [ $1 -ge 2 -a "$RESTART_ON_UPGRADE" == "true" ] ; then
 	stopElasticsearch
 	startElasticsearch


### PR DESCRIPTION
This commit fixes #3722

There may be some issues with the systemctl section, let me know if you require more changes
