### PR TITLE
Add century interval in Date Histogram facet

### DIFF
--- a/docs/reference/search/facets/date-histogram-facet.asciidoc
+++ b/docs/reference/search/facets/date-histogram-facet.asciidoc
@@ -26,7 +26,7 @@ facet>>. Here is a quick example:
 ==== Interval
 
 The `interval` allows to set the interval at which buckets will be
-created for each hit. It allows for the constant values of `year`,
+created for each hit. It allows for the constant values of `century`, `year`,
 `quarter`, `month`, `week`, `day`, `hour`, `minute`.
 
 It also support time setting like `1.5h` (up to `w` for weeks).

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/DateHistogramFacetParser.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/DateHistogramFacetParser.java
@@ -56,6 +56,7 @@ public class DateHistogramFacetParser extends AbstractComponent implements Facet
         InternalDateHistogramFacet.registerStreams();
 
         dateFieldParsers = MapBuilder.<String, DateFieldParser>newMapBuilder()
+                .put("century", new DateFieldParser.Century())
                 .put("year", new DateFieldParser.YearOfCentury())
                 .put("1y", new DateFieldParser.YearOfCentury())
                 .put("quarter", new DateFieldParser.Quarter())
@@ -235,6 +236,13 @@ public class DateHistogramFacetParser extends AbstractComponent implements Facet
             @Override
             public DateTimeField parse(Chronology chronology) {
                 return chronology.yearOfCentury();
+            }
+        }
+
+        static class Century implements DateFieldParser {
+            @Override
+            public DateTimeField parse(Chronology chronology) {
+                return chronology.centuryOfEra();
             }
         }
 

--- a/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
@@ -1851,6 +1851,7 @@ public class SimpleFacetsTests extends AbstractIntegrationTest {
                     .addFacet(dateHistogramFacet("stats6").field("date").valueField("num").interval("day").preZone("-02:00").postZone("-02:00").mode(mode))
                     .addFacet(dateHistogramFacet("stats7").field("date").interval("quarter").mode(mode))
                     .addFacet(dateHistogramFacet("stats8").field("date_in_seconds").interval("day").factor(1000f).mode(mode))
+                    .addFacet(dateHistogramFacet("stats9").field("date").interval("century").mode(mode))
                     .execute().actionGet();
 
             if (searchResponse.getFailedShards() > 0) {
@@ -1931,6 +1932,11 @@ public class SimpleFacetsTests extends AbstractIntegrationTest {
             assertThat(facet.getEntries().get(0).getCount(), equalTo(2l));
             assertThat(facet.getEntries().get(1).getTime(), equalTo(utcTimeInMillis("2009-03-06")));
             assertThat(facet.getEntries().get(1).getCount(), equalTo(1l));
+
+            facet = searchResponse.getFacets().facet("stats9");
+            assertThat(facet.getName(), equalTo("stats9"));
+            assertThat(facet.getEntries().size(), equalTo(1));
+            assertThat(facet.getEntries().get(0).getTime(), equalTo(utcTimeInMillis("2000-01-01")));
         }
     }
 


### PR DESCRIPTION
Heya

I would like to have a century interval option in the Date Histogram Facet.

``` javascript
{
    "query" : {
        "match_all" : {}
    },
    "facets" : {
        "histo" : {
            "date_histogram" : {
                "field" : "field_name",
                "interval" : "century"
            }
        }
    }
}
```

Closes #2473.

Cc @uboness: what do you think? Can we add it in 0.90 and master as well? If so, could you add this option as well for the aggregation feature?

BTW JODA does not seem to support decades. That's why I removed this option from the original feature request.
