### PR TITLE
Add FieldMappers before adding Mappers (used for parsing) and while holding the relevant's ObjectMapper mutex

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -572,7 +572,7 @@ public class DocumentMapper implements ToXContent {
         addFieldMappers(fieldMappers.toArray(new FieldMapper[fieldMappers.size()]));
     }
 
-    private void addFieldMappers(FieldMapper... fieldMappers) {
+    public void addFieldMappers(FieldMapper... fieldMappers) {
         synchronized (mappersMutex) {
             this.fieldMappers = this.fieldMappers.concat(this, fieldMappers);
         }
@@ -644,12 +644,6 @@ public class DocumentMapper implements ToXContent {
         }
 
         if (!mergeFlags.simulate()) {
-            if (!mergeContext.newFieldMappers().mappers.isEmpty()) {
-                addFieldMappers(mergeContext.newFieldMappers().mappers);
-            }
-            if (!mergeContext.newObjectMappers().mappers.isEmpty()) {
-                addObjectMappers(mergeContext.newObjectMappers().mappers);
-            }
             // let the merge with attributes to override the attributes
             meta = mergeWith.meta();
             // update the source of the merged one

--- a/src/main/java/org/elasticsearch/index/mapper/MergeContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MergeContext.java
@@ -21,8 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.Lists;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,11 +31,6 @@ public class MergeContext {
     private final DocumentMapper documentMapper;
     private final DocumentMapper.MergeFlags mergeFlags;
     private final List<String> mergeConflicts = Lists.newArrayList();
-
-    private final FieldMapperListener.Aggregator newFieldMappers = new FieldMapperListener.Aggregator();
-    private final ObjectMapperListener.Aggregator newObjectMappers = new ObjectMapperListener.Aggregator();
-
-    private List<FieldMapper> fieldDataChanges = null;
 
     public MergeContext(DocumentMapper documentMapper, DocumentMapper.MergeFlags mergeFlags) {
         this.documentMapper = documentMapper;
@@ -52,14 +45,6 @@ public class MergeContext {
         return mergeFlags;
     }
 
-    public FieldMapperListener.Aggregator newFieldMappers() {
-        return newFieldMappers;
-    }
-
-    public ObjectMapperListener.Aggregator newObjectMappers() {
-        return newObjectMappers;
-    }
-
     public void addConflict(String mergeFailure) {
         mergeConflicts.add(mergeFailure);
     }
@@ -70,19 +55,5 @@ public class MergeContext {
 
     public String[] buildConflicts() {
         return mergeConflicts.toArray(new String[mergeConflicts.size()]);
-    }
-
-    public void addFieldDataChange(FieldMapper mapper) {
-        if (fieldDataChanges == null) {
-            fieldDataChanges = new ArrayList<FieldMapper>();
-        }
-        fieldDataChanges.add(mapper);
-    }
-
-    public List<FieldMapper> fieldMapperChanges() {
-        if (fieldDataChanges == null) {
-            return Collections.emptyList();
-        }
-        return fieldDataChanges;
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -578,7 +578,6 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T>, Mapper {
                     this.fieldDataType = new FieldDataType(defaultFieldDataType().getType(),
                             ImmutableSettings.builder().put(defaultFieldDataType().getSettings()).put(this.customFieldDataSettings)
                     );
-                    mergeContext.addFieldDataChange(this);
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/mapper/multifield/MultiFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/multifield/MultiFieldMapper.java
@@ -21,17 +21,14 @@ package org.elasticsearch.index.mapper.multifield;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
@@ -227,18 +224,25 @@ public class MultiFieldMapper implements Mapper, AllFieldMapper.IncludeInAll {
                 // its a single field mapper, upgraded into a multi field mapper, just update the default mapper
                 if (defaultMapper == null) {
                     if (!mergeContext.mergeFlags().simulate()) {
-                        defaultMapper = mergeWith;
-                        mergeContext.newFieldMappers().mappers.add((FieldMapper) defaultMapper);
+                        mergeContext.docMapper().addFieldMappers((FieldMapper) defaultMapper);
+                        defaultMapper = mergeWith; // only set & expose it after adding fieldmapper
                     }
                 }
             } else {
                 MultiFieldMapper mergeWithMultiField = (MultiFieldMapper) mergeWith;
+
+                List<FieldMapper> newFieldMappers = null;
+                MapBuilder<String, Mapper> newMappersBuilder = null;
+                Mapper newDefaultMapper = null;
                 // merge the default mapper
                 if (defaultMapper == null) {
                     if (mergeWithMultiField.defaultMapper != null) {
                         if (!mergeContext.mergeFlags().simulate()) {
-                            defaultMapper = mergeWithMultiField.defaultMapper;
-                            mergeContext.newFieldMappers().mappers.add((FieldMapper) defaultMapper);
+                            if (newFieldMappers == null) {
+                                newFieldMappers = new ArrayList<FieldMapper>();
+                            }
+                            newFieldMappers.add((FieldMapper) defaultMapper);
+                            newDefaultMapper = mergeWithMultiField.defaultMapper;
                         }
                     }
                 } else {
@@ -257,14 +261,32 @@ public class MultiFieldMapper implements Mapper, AllFieldMapper.IncludeInAll {
                             if (mergeWithMapper instanceof AllFieldMapper.IncludeInAll) {
                                 ((AllFieldMapper.IncludeInAll) mergeWithMapper).includeInAll(false);
                             }
-                            mappers = newMapBuilder(mappers).put(mergeWithMapper.name(), mergeWithMapper).immutableMap();
+                            if (newMappersBuilder == null) {
+                                newMappersBuilder = newMapBuilder(mappers);
+                            }
+                            newMappersBuilder.put(mergeWithMapper.name(), mergeWithMapper);
                             if (mergeWithMapper instanceof AbstractFieldMapper) {
-                                mergeContext.newFieldMappers().mappers.add((FieldMapper) mergeWithMapper);
+                                if (newFieldMappers == null) {
+                                    newFieldMappers = new ArrayList<FieldMapper>();
+                                }
+                                newFieldMappers.add((FieldMapper) mergeWithMapper);
                             }
                         }
                     } else {
                         mergeIntoMapper.merge(mergeWithMapper, mergeContext);
                     }
+                }
+
+                // first add all field mappers
+                if (newFieldMappers != null && !newFieldMappers.isEmpty()) {
+                    mergeContext.docMapper().addFieldMappers(newFieldMappers);
+                }
+                // now publish mappers
+                if (newDefaultMapper != null) {
+                    defaultMapper = newDefaultMapper;
+                }
+                if (newMappersBuilder != null) {
+                    mappers = newMappersBuilder.immutableMap();
                 }
             }
         }


### PR DESCRIPTION
Adding the mappers first could cause the wrong FieldMappers to be used during object parsing

Also:
Removed MergeContext.newFieldMappers, MergeContext.newObjectMappers and relatives as they are not used anymore.
Similarly removed MergeContext.addFieldDataChange & fieldMapperChanges as they were not used.

Closes #3844
