### PR TITLE
Closes #3843, fixes river routing for river names containing the river type

### DIFF
--- a/src/main/java/org/elasticsearch/river/cluster/RiverNodeHelper.java
+++ b/src/main/java/org/elasticsearch/river/cluster/RiverNodeHelper.java
@@ -22,6 +22,9 @@ package org.elasticsearch.river.cluster;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.river.RiverName;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  *
  */
@@ -50,6 +53,11 @@ public class RiverNodeHelper {
         }
         String river = node.attributes().get("river");
         // by default, if not set, its an river node (better OOB exp)
-        return river == null || river.contains(riverName.type()) || river.contains(riverName.name());
+        if (river == null) {
+            return true;
+        } else {
+            List<String> rivers = Arrays.asList(river.split("\\s*,\\s*"));
+            return rivers.contains(riverName.type()) || river.contains(riverName.name());
+        }
     }
 }


### PR DESCRIPTION
this closes #3843
the fix splits the the node.river configuration at the comma separator (and leading and following spaces) and checks every part for equality with the current riverName.type() or riverName.name().

so a node with an attribute node.river: dummyRiverOnNodeA will not match a river with name dummyRiverOnNodeB which is of type "dummy".
