### PR TITLE
Fix for "has_child ignores type" - #3818

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/child/HasChildFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/HasChildFilter.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.lucene.search.TermFilter;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.index.cache.id.IdReaderTypeCache;
 import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -130,7 +131,8 @@ public class HasChildFilter extends Filter implements SearchContext.Rewrite {
         searchContext.idCache().refresh(searchContext.searcher().getTopReaderContext().leaves());
         collectedUids = searchContext.cacheRecycler().hashSet(-1);
         UidCollector collector = new UidCollector(parentType, searchContext, collectedUids.v());
-        searchContext.searcher().search(childQuery, collector);
+        TermFilter childTypeFilter = new TermFilter(new Term(TypeFieldMapper.NAME, childType));
+        searchContext.searcher().search(childQuery, childTypeFilter, collector);
         remaining = collectedUids.v().size();
         if (remaining == 0) {
             shortCircuitFilter = Queries.MATCH_NO_FILTER;


### PR DESCRIPTION
`HasChildFilter` ignores the `childType` provided. The fix is to include this in a filter while searching for the children to fix the context.

Test cases verify that we do not qualify children whose types conflict with the provided type in `has_child`.

The test scenario is simpler than the description in #3818. Simply, create a parent with two children of different types and issue a `has_child` query with fields from one child and the type of another. This returns the parent, whereas with the fix, it won't
