### PR TITLE
Use Locale.ROOT by default to parse dates instead of the system locale.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -70,7 +70,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
     public static final String CONTENT_TYPE = "date";
 
     public static class Defaults extends NumberFieldMapper.Defaults {
-        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("dateOptionalTime");
+        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("dateOptionalTime", Locale.ROOT);
 
         public static final FieldType FIELD_TYPE = new FieldType(NumberFieldMapper.Defaults.FIELD_TYPE);
 
@@ -97,6 +97,8 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
         public Builder(String name) {
             super(name, new FieldType(Defaults.FIELD_TYPE));
             builder = this;
+            // do *NOT* rely on the default locale
+            locale = Locale.ROOT;
         }
 
         public Builder timeUnit(TimeUnit timeUnit) {
@@ -121,8 +123,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                 parseUpperInclusive = context.indexSettings().getAsBoolean("index.mapping.date.parse_upper_inclusive", Defaults.PARSE_UPPER_INCLUSIVE);
             }
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
-            if (locale != null && !locale.equals(dateTimeFormatter.locale())) {
-                // this sucks we should use the root local by default and not be dependent on the node if it is null?
+            if (!locale.equals(dateTimeFormatter.locale())) {
                 dateTimeFormatter = new FormatDateTimeFormatter(dateTimeFormatter.format(), dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale);
             }
             DateFieldMapper fieldMapper = new DateFieldMapper(buildNames(context), dateTimeFormatter,


### PR DESCRIPTION
SimpleDateMappingTests fails on my computer because the default locale is french and DateFieldMapper uses the system locale by default for date parsing.

This commit makes DateFieldMapper use Locale.ROOT instead by default.
