### PR TITLE
Fix toXContent of GeoShapeQueryBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -160,6 +160,8 @@ public class GeoShapeQueryBuilder extends BaseQueryBuilder implements BoostableQ
         }
 
         builder.endObject();
+
+        builder.endObject();
     }
 
 }

--- a/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Test;
+
+public class GeoShapeQueryBuilderTests {
+
+    @Test // see #3878
+    public void testThatXContentSerializationInsideOfArrayWorks() throws Exception {
+        EnvelopeBuilder envelopeBuilder = ShapeBuilder.newEnvelope().topLeft(0, 0).bottomRight(10, 10);
+        GeoShapeQueryBuilder geoQuery = QueryBuilders.geoShapeQuery("searchGeometry", envelopeBuilder);
+        JsonXContent.contentBuilder().startArray().value(geoQuery).endArray();
+    }
+}


### PR DESCRIPTION
A missing endObject() resulted in serialization errors.

Closes #3878
