### PR TITLE
Support date math for `origin` decay function parsing

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -294,44 +294,48 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
 
     @Override
     public Query termQuery(Object value, @Nullable QueryParseContext context) {
-        long now = context == null ? System.currentTimeMillis() : context.nowInMillis();
-        long lValue = dateMathParser.parse(convertToString(value), now);
+        long lValue = parseToMilliseconds(value, context);
         return NumericRangeQuery.newLongRange(names.indexName(), precisionStep,
                 lValue, lValue, true, true);
+    }
+    
+    public long parseToMilliseconds(Object value, @Nullable QueryParseContext context) {
+        return parseToMilliseconds(value, context, false);
+    }
+    
+    public long parseToMilliseconds(Object value, @Nullable QueryParseContext context, boolean includeUpper) {
+        long now = context == null ? System.currentTimeMillis() : context.nowInMillis();
+        return includeUpper ? dateMathParser.parseUpperInclusive(convertToString(value), now) : dateMathParser.parse(convertToString(value), now);
     }
 
     @Override
     public Filter termFilter(Object value, @Nullable QueryParseContext context) {
-        long now = context == null ? System.currentTimeMillis() : context.nowInMillis();
-        long lValue = dateMathParser.parse(convertToString(value), now);
+        final long lValue = parseToMilliseconds(value, context);
         return NumericRangeFilter.newLongRange(names.indexName(), precisionStep,
                 lValue, lValue, true, true);
     }
 
     @Override
     public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
-        long now = context == null ? System.currentTimeMillis() : context.nowInMillis();
         return NumericRangeQuery.newLongRange(names.indexName(), precisionStep,
-                lowerTerm == null ? null : dateMathParser.parse(convertToString(lowerTerm), now),
-                upperTerm == null ? null : (includeUpper && parseUpperInclusive) ? dateMathParser.parseUpperInclusive(convertToString(upperTerm), now) : dateMathParser.parse(convertToString(upperTerm), now),
+                lowerTerm == null ? null : parseToMilliseconds(lowerTerm, context),
+                upperTerm == null ? null : parseToMilliseconds(upperTerm, context, includeUpper && parseUpperInclusive),
                 includeLower, includeUpper);
     }
 
     @Override
     public Filter rangeFilter(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
-        long now = context == null ? System.currentTimeMillis() : context.nowInMillis();
         return NumericRangeFilter.newLongRange(names.indexName(), precisionStep,
-                lowerTerm == null ? null : dateMathParser.parse(convertToString(lowerTerm), now),
-                upperTerm == null ? null : (includeUpper && parseUpperInclusive) ? dateMathParser.parseUpperInclusive(convertToString(upperTerm), now) : dateMathParser.parse(convertToString(upperTerm), now),
+                lowerTerm == null ? null : parseToMilliseconds(lowerTerm, context),
+                upperTerm == null ? null : parseToMilliseconds(upperTerm, context, includeUpper && parseUpperInclusive),
                 includeLower, includeUpper);
     }
 
     @Override
     public Filter rangeFilter(IndexFieldDataService fieldData, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
-        long now = context == null ? System.currentTimeMillis() : context.nowInMillis();
         return NumericRangeFieldDataFilter.newLongRange((IndexNumericFieldData<?>) fieldData.getForField(this),
-                lowerTerm == null ? null : dateMathParser.parse(convertToString(lowerTerm), now),
-                upperTerm == null ? null : (includeUpper && parseUpperInclusive) ? dateMathParser.parseUpperInclusive(convertToString(upperTerm), now) : dateMathParser.parse(convertToString(upperTerm), now),
+                lowerTerm == null ? null : parseToMilliseconds(lowerTerm, context),
+                upperTerm == null ? null : parseToMilliseconds(upperTerm, context, includeUpper && parseUpperInclusive),
                 includeLower, includeUpper);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -250,11 +250,11 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         }
         long origin = SearchContext.current().nowInMillis();
         if (originString != null) {
-            origin = dateFieldMapper.value(originString).longValue();
+            origin = dateFieldMapper.parseToMilliseconds(originString, parseContext);
         }
 
         if (scaleString == null) {
-            throw new ElasticSearchParseException(DecayFunctionBuilder.SCALE + "must be set for date fields.");
+            throw new ElasticSearchParseException(DecayFunctionBuilder.SCALE + " must be set for date fields.");
         }
         TimeValue val = TimeValue.parseTimeValue(scaleString, TimeValue.timeValueHours(24));
         double scale = val.getMillis();


### PR DESCRIPTION
The parser used the method that was supposed to be used for parsing on
the indexing side that never supported date math.

Closes #3892
