### PR TITLE
Add match query support for stacked tokens

### DIFF
--- a/docs/reference/query-dsl/queries/match-query.asciidoc
+++ b/docs/reference/query-dsl/queries/match-query.asciidoc
@@ -97,6 +97,13 @@ The `cutoff_frequency` can either be relative to the number of documents
 in the index if in the range `[0..1)` or absolute if greater or equal to
 `1.0`.
 
+Note: If the `cutoff_frequency` is used and the operator is `and`
+_stacked tokens_ (tokens that are on the same position like `synonym` filter emits)
+are not handled gracefully as they are in a pure `and` query. For instance the query
+`fast fox` is analyzed into 3 terms `[fast, quick, fox]` where `quick` is a synonym
+for `fast` on the same token positions the query might require `fast` and `quick` to 
+match if the operator is `and`. 
+
 Here is an example showing a query composed of stopwords exclusivly:
 
 [source,js]

--- a/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -27,6 +27,7 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.ExtendedCommonTermsQuery;
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
@@ -240,6 +241,28 @@ public class MatchQuery {
                     assert hasNext == true;
                     q.add(new Term(field, termToByteRef(termAtt)));
                 }
+                return wrapSmartNameQuery(q, smartNameFieldMappers, parseContext);
+            } if (severalTokensAtSamePosition && occur == Occur.MUST) {
+                BooleanQuery q = new BooleanQuery(positionCount == 1);
+                Query currentQuery = null;
+                for (int i = 0; i < numTokens; i++) {
+                    boolean hasNext = buffer.incrementToken();
+                    assert hasNext == true;
+                  if (posIncrAtt != null && posIncrAtt.getPositionIncrement() == 0) {
+                    if (!(currentQuery instanceof BooleanQuery)) {
+                      Query t = currentQuery;
+                      currentQuery = new BooleanQuery(true);
+                      ((BooleanQuery)currentQuery).add(t, BooleanClause.Occur.SHOULD);
+                    }
+                    ((BooleanQuery)currentQuery).add(newTermQuery(mapper, new Term(field, termToByteRef(termAtt))), BooleanClause.Occur.SHOULD);
+                  } else {
+                    if (currentQuery != null) {
+                      q.add(currentQuery, occur);
+                    }
+                    currentQuery = newTermQuery(mapper, new Term(field, termToByteRef(termAtt)));
+                  }
+                }
+                q.add(currentQuery, occur);
                 return wrapSmartNameQuery(q, smartNameFieldMappers, parseContext);
             } else {
                 BooleanQuery q = new BooleanQuery(positionCount == 1);

--- a/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
@@ -40,9 +40,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 /**
  *


### PR DESCRIPTION
SynonymFilters produces token streams with stacked tokens such that
conjunction queries need to be parsed in a special way such that the
stacked tokens are added as an innner disjuncition.

Closes #3881
