### PR TITLE
Added missing builder.endObject calls

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
@@ -52,6 +52,7 @@ public class RestPendingClusterTasksAction extends BaseRestHandler {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
                     response.toXContent(builder, request);
+                    builder.endObject();
                     channel.sendResponse(new XContentRestResponse(request, RestStatus.OK, builder));
                 } catch (Throwable e) {
                     onFailure(e);

--- a/src/main/java/org/elasticsearch/river/RiversService.java
+++ b/src/main/java/org/elasticsearch/river/RiversService.java
@@ -172,6 +172,7 @@ public class RiversService extends AbstractLifecycleComponent<RiversService> {
                 builder.field("name", clusterService.localNode().name());
                 builder.field("transport_address", clusterService.localNode().address().toString());
                 builder.endObject();
+                builder.endObject();
 
                 client.prepareIndex(riverIndexName, riverName.name(), "_status")
                         .setConsistencyLevel(WriteConsistencyLevel.ONE)


### PR DESCRIPTION
After closing #3878 it came to me, that we might have other code snippets of missing or too much `builder.endObject()` / `builder.startObject()` methods (same for arrays), so I wrote this kind of hacky shell script

``` sh
#/bin/bash
for x in Object Array ; do

    start="\.start$x"
    end="\.end$x"

    for i in $(ag -l "$start") ; do
        startingCount=$(grep -c "$start" $i)
        endingCount=$(grep -c "$end" $i)

        if [ $startingCount -ne $endingCount ] ; then
            echo "$i $x: start $startingCount end $endingCount"
        fi
    done

done
```

only found two other pieces of code and a couple of false positives.

I am thinking if we could automate this by doing something similar as the `forbidden-api` maven module does and parse the source itself (to prevent false positives).

Anyone having experience with that?
