### PR TITLE
Changed the minScore comparator from > to >=

### DIFF
--- a/docs/reference/search/request/min-score.asciidoc
+++ b/docs/reference/search/request/min-score.asciidoc
@@ -1,7 +1,8 @@
 [[search-request-min-score]]
 === min_score
 
-Allows to filter out documents based on a minimum score:
+Exclude documents which have a `_score` less than the minimum specified
+in `min_score`:
 
 [source,js]
 --------------------------------------------------
@@ -14,4 +15,4 @@ Allows to filter out documents based on a minimum score:
 --------------------------------------------------
 
 Note, most times, this does not make much sense, but is provided for
-advance use cases.
+advanced use cases.

--- a/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
+++ b/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.lucene;
 
 import org.apache.lucene.index.AtomicReaderContext;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.ScoreCachingWrappingScorer;
 import org.apache.lucene.search.Scorer;
@@ -54,7 +53,7 @@ public class MinimumScoreCollector extends Collector {
 
     @Override
     public void collect(int doc) throws IOException {
-        if (scorer.score() > minimumScore) {
+        if (scorer.score() >= minimumScore) {
             collector.collect(doc);
         }
     }

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -1486,7 +1486,7 @@ public class SimpleChildQuerySearchTests extends AbstractIntegrationTest {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", matchAllQuery()).scoreType("sum"))
-                .setMinScore(2) // Score needs to be above 2.0!
+                .setMinScore(3) // Score needs to be 3 or above!
                 .execute().actionGet();
         assertNoFailures(searchResponse);
         assertThat(searchResponse.getFailedShards(), equalTo(0));


### PR DESCRIPTION
The parameter `min_score` implies that any document that has at least that score is included, but the current logic requires that a document has a higher score than the minimum specified.

This doesn't make sense to me, so I've changed the comparator from > to >=
