### PR TITLE
Refactor FieldData iterations

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/BytesValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/BytesValues.java
@@ -25,13 +25,35 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
 
 /**
+ * A state-full lightweight per document set of <code>byte[]</code> values.
+ *
+ * To iterate over values in a document use the following pattern:
+ * <pre>
+ *   BytesValues values = ..;
+ *   final int numValues = values.setDocId(docId);
+ *   for (int i = 0; i < numValues; i++) {
+ *       BytesRef value = values.nextValue();
+ *       // process value
+ *   }
+ * </pre>
  */
 public abstract class BytesValues {
 
+    /**
+     * An empty {@link BytesValues instance}
+     */
     public static final BytesValues EMPTY = new Empty();
+
     private boolean multiValued;
+
     protected final BytesRef scratch = new BytesRef();
 
+    protected int docId = -1;
+
+    /**
+     * Creates a new {@link BytesValues} instance
+     * @param multiValued <code>true</code> iff this instance is multivalued. Otherwise <code>false</code>.
+     */
     protected BytesValues(boolean multiValued) {
         this.multiValued = multiValued;
     }
@@ -44,191 +66,70 @@ public abstract class BytesValues {
     }
 
     /**
-     * Is there a value for this doc?
+     * Returns <code>true</code> if the given document ID has a value in this. Otherwise <code>false</code>.
      */
     public abstract boolean hasValue(int docId);
 
     /**
-     * Converts the provided bytes to "safe" ones from a "non" safe call made (if needed). Note,
+     * Converts the current shared {@link BytesRef} to a stable instance. Note,
      * this calls makes the bytes safe for *reads*, not writes (into the same BytesRef). For example,
      * it makes it safe to be placed in a map.
      */
-    public BytesRef makeSafe(BytesRef bytes) {
-        return BytesRef.deepCopyOf(bytes);
+    public BytesRef copyShared() {
+        return BytesRef.deepCopyOf(scratch);
     }
 
     /**
-     * Returns a bytes value for a docId. Note, the content of it might be shared across invocation.
+     * Returns a value for the given document id. If the document
+     * has more than one value the returned value is one of the values
+     * associated with the document.
+     *
+     * Note: the {@link BytesRef} might be shared across invocations.
+     *
+     * @param docId the documents id.
+     * @return a value for the given document id or a {@link BytesRef} with a length of <tt>0</tt>if the document
+     *         has no value.
      */
-    public BytesRef getValue(int docId) {
-        if (hasValue(docId)) {
-            return getValueScratch(docId, scratch);
-        }
-        return null;
-    }
+    public abstract BytesRef getValue(int docId);
 
     /**
-     * Returns the bytes value for the docId, with the provided "ret" which will be filled with the
-     * result which will also be returned. If there is no value for this docId, the length will be 0.
-     * Implementations can either change the {@link BytesRef#bytes bytes reference} of the {@link BytesRef}
-     * to point to an internal structure or modify the content of the {@link BytesRef} but should
-     * always do it in a consistent way. For example, it is illegal to change the bytes content in
-     * some call and to change the reference to point to an internal structure in another call, this
-     * will lead to bugs. It is also illegal for callers to write into the {@link BytesRef#bytes bytes}
-     * after this method has returned.
+     * Sets iteration to the specified docID and returns the number of
+     * values for this document ID,
+     * @param docId document ID
+     *
+     * @see #nextValue()
      */
-    public abstract BytesRef getValueScratch(int docId, BytesRef ret);
-
+    public int setDocument(int docId) {
+        this.docId = docId;
+        return hasValue(docId) ? 1 : 0;
+    }
 
     /**
-     * Fills the given spare for the given doc ID and returns the hashcode of the reference as defined by
-     * {@link BytesRef#hashCode()}
+     * Returns the next value for the current docID set to {@link #setDocument(int)}.
+     * This method should only be called <tt>N</tt> times where <tt>N</tt> is the number
+     * returned from {@link #setDocument(int)}. If called more than <tt>N</tt> times the behavior
+     * is undefined.
+     *
+     * Note: the returned {@link BytesRef} might be shared across invocations.
+     *
+     * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
-    public int getValueHashed(int docId, BytesRef spare) {
-        return getValueScratch(docId, spare).hashCode();
+    public BytesRef nextValue() {
+        assert docId != -1;
+        return getValue(docId);
     }
 
     /**
-     * Returns a bytes value iterator for a docId. Note, the content of it might be shared across invocation.
+     * Returns the hash value of the previously returned shared {@link BytesRef} instances.
+     *
+     * @return the hash value of the previously returned shared {@link BytesRef} instances.
      */
-    public abstract Iter getIter(int docId); // TODO: maybe this should return null for no values so we can safe one call?
-
-
-    public static interface Iter {
-
-        /**
-         * Returns whether this iterator still contains elements.
-         */
-        boolean hasNext();
-
-        /**
-         * Returns the next element of this iterator. Please note that the returned bytes may be
-         * reused across invocations so they should be copied for later reference. The behavior of
-         * this method is undefined if the iterator is exhausted.
-         */
-        BytesRef next();
-
-        /**
-         * Returns the hash value of the last {@link BytesRef} returned by {@link #next()}. The
-         * behavior is undefined if this iterator is not positioned or exhausted.
-         */
-        int hash();
-
-        public static class Empty implements Iter {
-
-            public static final Empty INSTANCE = new Empty();
-
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
-
-            @Override
-            public BytesRef next() {
-                throw new ElasticSearchIllegalStateException();
-            }
-
-            @Override
-            public int hash() {
-                return 0;
-            }
-        }
-
-        public static class Single implements Iter {
-
-            protected BytesRef value;
-            protected long ord;
-            protected boolean done;
-
-            public Single reset(BytesRef value, long ord) {
-                this.value = value;
-                this.ord = ord;
-                this.done = false;
-                return this;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return !done;
-            }
-
-            @Override
-            public BytesRef next() {
-                assert !done;
-                done = true;
-                return value;
-            }
-
-            public int hash() {
-                return value.hashCode();
-            }
-        }
-
-        static class Multi implements Iter {
-
-            protected long innerOrd;
-            protected long ord;
-            protected BytesValues.WithOrdinals withOrds;
-            protected Ordinals.Docs.Iter ordsIter;
-            protected final BytesRef scratch = new BytesRef();
-
-            public Multi(WithOrdinals withOrds) {
-                this.withOrds = withOrds;
-                assert withOrds.isMultiValued();
-
-            }
-
-            public Multi reset(Ordinals.Docs.Iter ordsIter) {
-                this.ordsIter = ordsIter;
-                innerOrd = ord = ordsIter.next();
-                return this;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return innerOrd != 0;
-            }
-
-            @Override
-            public BytesRef next() {
-                withOrds.getValueScratchByOrd(innerOrd, scratch);
-                ord = innerOrd;
-                innerOrd = ordsIter.next();
-                return scratch;
-            }
-
-            public int hash() {
-                return scratch.hashCode();
-            }
-        }
+    public int currentValueHash() {
+        return scratch.hashCode();
     }
-
-    public static class Empty extends BytesValues {
-
-        public Empty() {
-            super(false);
-        }
-
-        @Override
-        public boolean hasValue(int docId) {
-            return false;
-        }
-
-        @Override
-        public Iter getIter(int docId) {
-            return Iter.Empty.INSTANCE;
-        }
-
-        @Override
-        public BytesRef getValueScratch(int docId, BytesRef ret) {
-            ret.length = 0;
-            return ret;
-        }
-    }
-
 
     /**
-     * Bytes values that are based on ordinals.
+     * Ordinal based {@link BytesValues}.
      */
     public static abstract class WithOrdinals extends BytesValues {
 
@@ -239,76 +140,86 @@ public abstract class BytesValues {
             this.ordinals = ordinals;
         }
 
+        /**
+         * Returns the associated ordinals instance.
+         * @return the associated ordinals instance.
+         */
         public Ordinals.Docs ordinals() {
             return ordinals;
         }
 
-        public BytesRef getValueByOrd(long ord) {
-            return getValueScratchByOrd(ord, scratch);
-        }
-
-        protected Iter.Multi newMultiIter() {
-            assert this.isMultiValued();
-            return new Iter.Multi(this);
-        }
-
-        protected Iter.Single newSingleIter() {
-            assert !this.isMultiValued();
-            return new Iter.Single();
-        }
+        /**
+         * Returns the value for the given ordinal.
+         * @param ord the ordinal to lookup.
+         * @return a shared {@link BytesRef} instance holding the value associated
+         *         with the given ordinal or <code>null</code> if ordinal is <tt>0</tt>
+         */
+        public abstract BytesRef getValueByOrd(long ord);
 
         @Override
         public boolean hasValue(int docId) {
-            return ordinals.getOrd(docId) != 0;
+            return ordinals.getOrd(docId) != Ordinals.MISSING_ORDINAL;
         }
 
         @Override
         public BytesRef getValue(int docId) {
             final long ord = ordinals.getOrd(docId);
-            if (ord == 0) {
-                return null;
+            if (ord == Ordinals.MISSING_ORDINAL) {
+                scratch.length = 0;
+                return scratch;
             }
-            return getValueScratchByOrd(ord, scratch);
+            return getValueByOrd(ord);
         }
 
         @Override
-        public BytesRef getValueScratch(int docId, BytesRef ret) {
-            return getValueScratchByOrd(ordinals.getOrd(docId), ret);
+        public int setDocument(int docId) {
+            this.docId = docId;
+            int length = ordinals.setDocument(docId);
+            assert hasValue(docId) == length > 0 : "Doc: [" + docId + "] hasValue: [" + hasValue(docId) + "] but length is [" + length + "]";
+            return length;
         }
 
-        public BytesRef getSafeValueByOrd(int ord) {
-            return getValueScratchByOrd(ord, new BytesRef());
+        @Override
+        public BytesRef nextValue() {
+            assert docId != -1;
+            return getValueByOrd(ordinals.nextOrd());
+        }
+    }
+
+    /**
+     * An empty {@link BytesValues} implementation
+     */
+    private final static class Empty extends BytesValues {
+
+        Empty() {
+            super(false);
         }
 
-        /**
-         * Returns the bytes value for the docId, with the provided "ret" which will be filled with the
-         * result which will also be returned. If there is no value for this docId, the length will be 0.
-         * Implementations can either change the {@link BytesRef#bytes bytes reference} of the {@link BytesRef}
-         * to point to an internal structure or modify the content of the {@link BytesRef} but should
-         * always do it in a consistent way. For example, it is illegal to change the bytes content in
-         * some call and to change the reference to point to an internal structure in another call, this
-         * will lead to bugs. It is also illegal for callers to write into the {@link BytesRef#bytes bytes}
-         * after this method has returned.
-         */
-        public abstract BytesRef getValueScratchByOrd(long ord, BytesRef ret);
-
-        public static class Empty extends WithOrdinals {
-
-            public Empty(Ordinals.Docs ordinals) {
-                super(ordinals);
-            }
-
-            @Override
-            public BytesRef getValueScratchByOrd(long ord, BytesRef ret) {
-                ret.length = 0;
-                return ret;
-            }
-
-            @Override
-            public Iter getIter(int docId) {
-                return Iter.Empty.INSTANCE;
-            }
-
+        @Override
+        public boolean hasValue(int docId) {
+            return false;
         }
+
+        @Override
+        public BytesRef getValue(int docId) {
+            scratch.length = 0;
+            return scratch;
+        }
+
+        @Override
+        public int setDocument(int docId) {
+            return 0;
+        }
+
+        @Override
+        public BytesRef nextValue() {
+            throw new ElasticSearchIllegalStateException("Empty BytesValues has no next value");
+        }
+
+        @Override
+        public int currentValueHash() {
+            throw new ElasticSearchIllegalStateException("Empty BytesValues has no hash for the current Value");
+        }
+
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterBytesValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterBytesValues.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * <code>FilterBytesValues</code> contains another {@link BytesValues}, which it
+ * uses as its basic source of data, possibly transforming the data along the
+ * way or providing additional functionality.
+ */
+public abstract class FilterBytesValues extends BytesValues {
+
+    protected final BytesValues delegate;
+
+    protected FilterBytesValues(BytesValues delegate) {
+        super(delegate.isMultiValued());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasValue(int docId) {
+        return delegate.hasValue(docId);
+    }
+
+    @Override
+    public BytesRef copyShared() {
+        return delegate.copyShared();
+    }
+
+    @Override
+    public int setDocument(int docId) {
+        return delegate.setDocument(docId);
+    }
+
+    @Override
+    public BytesRef nextValue() {
+        return delegate.nextValue();
+    }
+
+    @Override
+    public int currentValueHash() {
+        return delegate.currentValueHash();
+    }
+
+    @Override
+    public BytesRef getValue(int docId) {
+        return delegate.getValue(docId);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterDoubleValues.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata;
+/**
+ * <code>FilterDoubleValues</code> contains another {@link DoubleValues}, which it
+ * uses as its basic source of data, possibly transforming the data along the
+ * way or providing additional functionality.
+ */
+public abstract class FilterDoubleValues extends DoubleValues {
+
+    protected final DoubleValues delegate;
+
+    protected FilterDoubleValues(DoubleValues delegate) {
+        super(delegate.isMultiValued());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasValue(int docId) {
+        return delegate.hasValue(docId);
+    }
+
+    @Override
+    public double getValue(int docId) {
+        return delegate.getValue(docId);
+    }
+
+    @Override
+    public int setDocument(int docId) {
+        return delegate.setDocument(docId);
+    }
+
+    @Override
+    public double nextValue() {
+        return delegate.nextValue();
+    }
+
+    @Override
+    public double getValueMissing(int docId, double missingValue) {
+        return delegate.getValueMissing(docId, missingValue);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterLongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterLongValues.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata;
+
+/**
+ * <code>FilterLongValues</code> contains another {@link LongValues}, which it
+ * uses as its basic source of data, possibly transforming the data along the
+ * way or providing additional functionality.
+ */
+public class FilterLongValues extends LongValues {
+
+    protected final LongValues delegate;
+
+    protected FilterLongValues(LongValues delegate) {
+        super(delegate.isMultiValued());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasValue(int docId) {
+        return delegate.hasValue(docId);
+    }
+
+    @Override
+    public long getValue(int docId) {
+        return delegate.getValue(docId);
+    }
+
+    @Override
+    public int setDocument(int docId) {
+        return delegate.setDocument(docId);
+    }
+
+    @Override
+    public long nextValue() {
+        return delegate.nextValue();
+    }
+
+    @Override
+    public long getValueMissing(int docId, long missingValue) {
+        return delegate.getValueMissing(docId, missingValue);    //To change body of overridden methods use File | Settings | File Templates.
+    }
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/SortMode.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/SortMode.java
@@ -22,6 +22,8 @@ package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
 
+import java.util.Locale;
+
 /**
  * Defines what values to pick in the case a document contains multiple values for a particular field.
  */
@@ -30,33 +32,233 @@ public enum SortMode {
     /**
      * Sum of all the values.
      */
-    SUM,
+    SUM {
+        /**
+         * Returns the sum of the two values
+         */
+        @Override
+        public double apply(double a, double b) {
+            return a + b;
+        }
+
+        /**
+         * Returns the sum of the two values
+         */
+        @Override
+        public long apply(long a, long b) {
+            return a + b;
+        }
+    },
 
     /**
      * Average of all the values.
      */
-    AVG,
+    AVG {
+
+        /**
+         * Returns the sum of the two values
+         */
+        @Override
+        public double apply(double a, double b) {
+            return a + b;
+        }
+
+        /**
+         * Returns the sum of the two values
+         */
+        @Override
+        public long apply(long a, long b) {
+            return a + b;
+        }
+
+        /**
+         * Returns <code>a / Math.max(1.0d, numValues)</code>
+         */
+        @Override
+        public double reduce(double a, int numValues) {
+            return a / Math.max(1.0d, (double) numValues);
+        }
+
+        /**
+         * Returns <code>Math.round(a / Math.max(1.0, numValues))</code>
+         */
+        @Override
+        public long reduce(long a, int numValues) {
+            return Math.round(a / Math.max(1.0, numValues));
+        }
+    },
 
     /**
      * Pick the lowest value.
      */
-    MIN,
+    MIN {
+        /**
+         * Equivalent to {@link Math#min(double, double)}
+         */
+        @Override
+        public double apply(double a, double b) {
+            return Math.min(a, b);
+        }
+
+        /**
+         * Equivalent to {@link Math#min(long, long)}
+         */
+        @Override
+        public long apply(long a, long b) {
+            return Math.min(a, b);
+        }
+
+        /**
+         * Returns {@link Double#POSITIVE_INFINITY}
+         */
+        @Override
+        public double startDouble() {
+            return Double.POSITIVE_INFINITY;
+        }
+
+        /**
+         * Returns {@link Long#MAX_VALUE}
+         */
+        @Override
+        public long startLong() {
+            return Long.MAX_VALUE;
+        }
+    },
 
     /**
      * Pick the highest value.
      */
-    MAX;
+    MAX {
+        /**
+         * Equivalent to {@link Math#max(double, double)}
+         */
+        @Override
+        public double apply(double a, double b) {
+            return Math.max(a, b);
+        }
 
+        /**
+         * Equivalent to {@link Math#max(long, long)}
+         */
+        @Override
+        public long apply(long a, long b) {
+            return Math.max(a, b);
+        }
+
+        /**
+         * Returns {@link Double#NEGATIVE_INFINITY}
+         */
+        @Override
+        public double startDouble() {
+            return Double.NEGATIVE_INFINITY;
+        }
+
+
+        /**
+         * Returns {@link Long#MIN_VALUE}
+         */
+        @Override
+        public long startLong() {
+            return Long.MIN_VALUE;
+        }
+    };
+
+    /**
+     * Applies the sort mode and returns the result. This method is meant to be
+     * a binary function that is commonly used in a loop to find the relevant
+     * value for the sort mode in a list of values. For instance if the sort mode
+     * is {@link SortMode#MAX} this method is equivalent to {@link Math#max(double, double)}.
+     *
+     * Note: all implementations are idempotent.
+     *
+     * @param a an argument
+     * @param b another argument
+     * @return the result of the function.
+     */
+    public abstract double apply(double a, double b);
+
+    /**
+     * Applies the sort mode and returns the result. This method is meant to be
+     * a binary function that is commonly used in a loop to find the relevant
+     * value for the sort mode in a list of values. For instance if the sort mode
+     * is {@link SortMode#MAX} this method is equivalent to {@link Math#max(long, long)}.
+     *
+     * Note: all implementations are idempotent.
+     *
+     * @param a an argument
+     * @param b another argument
+     * @return the result of the function.
+     */
+    public abstract long apply(long a, long b);
+
+    /**
+     * Returns an initial value for the sort mode that is guaranteed to have no impact if passed
+     * to {@link #apply(double, double)}. This value should be used as the initial value if the
+     * sort mode is applied to a non-empty list of values. For instance:
+     * <pre>
+     *     double relevantValue = sortMode.startDouble();
+     *     for (int i = 0; i < array.length; i++) {
+     *         relevantValue = sortMode.apply(array[i], relevantValue);
+     *     }
+     * </pre>
+     *
+     * Note: This method return <code>0</code> by default.
+     *
+     * @return an initial value for the sort mode.
+     */
+    public double startDouble() {
+        return 0;
+    }
+
+    /**
+     * Returns an initial value for the sort mode that is guaranteed to have no impact if passed
+     * to {@link #apply(long, long)}. This value should be used as the initial value if the
+     * sort mode is applied to a non-empty list of values. For instance:
+     * <pre>
+     *     long relevantValue = sortMode.startLong();
+     *     for (int i = 0; i < array.length; i++) {
+     *         relevantValue = sortMode.apply(array[i], relevantValue);
+     *     }
+     * </pre>
+     *
+     * Note: This method return <code>0</code> by default.
+     * @return an initial value for the sort mode.
+     */
+    public long startLong() {
+        return 0;
+    }
+
+    /**
+     * Returns the aggregated value based on the sort mode. For instance if {@link SortMode#AVG} is used
+     * this method divides the given value by the number of values. The default implementation returns
+     * the first argument.
+     *
+     * Note: all implementations are idempotent.
+     */
+    public double reduce(double a, int numValues) {
+        return a;
+    }
+
+    /**
+     * Returns the aggregated value based on the sort mode. For instance if {@link SortMode#AVG} is used
+     * this method divides the given value by the number of values. The default implementation returns
+     * the first argument.
+     *
+     * Note: all implementations are idempotent.
+     */
+    public long reduce(long a, int numValues) {
+        return a;
+    }
+
+    /**
+     * A case insensitive version of {@link #valueOf(String)}
+     *
+     * @throws ElasticSearchIllegalArgumentException if the given string doesn't match a sort mode or is <code>null</code>.
+     */
     public static SortMode fromString(String sortMode) {
-        if ("min".equals(sortMode)) {
-            return MIN;
-        } else if ("max".equals(sortMode)) {
-            return MAX;
-        } else if ("sum".equals(sortMode)) {
-            return SUM;
-        } else if ("avg".equals(sortMode)) {
-            return AVG;
-        } else {
+        try {
+            return valueOf(sortMode.toUpperCase(Locale.ROOT));
+        } catch (Throwable t) {
             throw new ElasticSearchIllegalArgumentException("Illegal sort_mode " + sortMode);
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/DocIdOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/DocIdOrdinals.java
@@ -39,16 +39,6 @@ public class DocIdOrdinals implements Ordinals {
     }
 
     @Override
-    public boolean hasSingleArrayBackingStorage() {
-        return false;
-    }
-
-    @Override
-    public Object getBackingStorage() {
-        return null;
-    }
-
-    @Override
     public long getMemorySizeInBytes() {
         return RamUsageEstimator.NUM_BYTES_OBJECT_REF;
     }
@@ -82,7 +72,8 @@ public class DocIdOrdinals implements Ordinals {
 
         private final DocIdOrdinals parent;
         private final LongsRef longsScratch = new LongsRef(new long[1], 0, 1);
-        private final SingleValueIter iter = new SingleValueIter();
+        private int docId = -1;
+        private long currentOrdinal = -1;
 
         public Docs(DocIdOrdinals parent) {
             this.parent = parent;
@@ -115,18 +106,32 @@ public class DocIdOrdinals implements Ordinals {
 
         @Override
         public long getOrd(int docId) {
-            return docId + 1;
+            return currentOrdinal = docId + 1;
         }
 
         @Override
         public LongsRef getOrds(int docId) {
-            longsScratch.longs[0] = docId + 1;
+            longsScratch.longs[0] = currentOrdinal = docId + 1;
             return longsScratch;
         }
 
         @Override
-        public Iter getIter(int docId) {
-            return iter.reset(docId + 1);
+        public long nextOrd() {
+            assert docId >= 0;
+            currentOrdinal = docId + 1;
+            docId = -1;
+            return currentOrdinal;
+        }
+
+        @Override
+        public int setDocument(int docId) {
+            this.docId = docId;
+            return 1;
+        }
+
+        @Override
+        public long currentOrd() {
+            return currentOrdinal;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/EmptyOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/EmptyOrdinals.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata.ordinals;
 
 import org.apache.lucene.util.LongsRef;
+import org.elasticsearch.ElasticSearchIllegalStateException;
 
 /**
  */
@@ -34,16 +35,6 @@ public class EmptyOrdinals implements Ordinals {
     @Override
     public long getMemorySizeInBytes() {
         return 0;
-    }
-
-    @Override
-    public boolean hasSingleArrayBackingStorage() {
-        return false;
-    }
-
-    @Override
-    public Object getBackingStorage() {
-        return null;
     }
 
     @Override
@@ -72,7 +63,6 @@ public class EmptyOrdinals implements Ordinals {
     }
 
     public static class Docs implements Ordinals.Docs {
-
         private final EmptyOrdinals parent;
         public static final LongsRef EMPTY_LONGS_REF = new LongsRef();
 
@@ -116,9 +106,18 @@ public class EmptyOrdinals implements Ordinals {
         }
 
         @Override
-        public Iter getIter(int docId) {
-            return EmptyIter.INSTANCE;
+        public long nextOrd() {
+            throw new ElasticSearchIllegalStateException("Empty ordinals has no nextOrd");
         }
 
+        @Override
+        public int setDocument(int docId) {
+            return 0;
+        }
+
+        @Override
+        public long currentOrd() {
+            return 0;
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
@@ -90,27 +90,19 @@ public class BinaryDVAtomicFieldData implements AtomicFieldData<ScriptDocValues.
 
         return new BytesValues(false) {
 
-            final BytesValues.Iter.Single iter = new BytesValues.Iter.Single();
-            final BytesRef spare = new BytesRef();
-
             @Override
             public boolean hasValue(int docId) {
                 return docsWithField.get(docId);
             }
 
             @Override
-            public BytesRef getValueScratch(int docId, BytesRef ret) {
-                values.get(docId, ret);
-                return ret;
-            }
-
-            @Override
-            public Iter getIter(int docId) {
-                if (!docsWithField.get(docId)) {
-                    return BytesValues.Iter.Empty.INSTANCE;
+            public BytesRef getValue(int docId) {
+                if (docsWithField.get(docId)) {
+                    values.get(docId, scratch);
+                    return scratch;
                 }
-                values.get(docId, spare);
-                return iter.reset(spare, -1L);
+                scratch.length = 0;
+                return scratch;
             }
 
         };

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DenseDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DenseDoubleValues.java
@@ -16,35 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.facet;
+
+package org.elasticsearch.index.fielddata.plain;
 
 import org.elasticsearch.index.fielddata.DoubleValues;
 
 /**
- * Simple Facet aggregator base class for {@link DoubleValues}
+ * Package private base class for dense long values.
  */
-public abstract class DoubleFacetAggregatorBase {
-    private int total;
-    private int missing;
+abstract class DenseDoubleValues extends DoubleValues {
 
-    public void onDoc(int docId, DoubleValues values) {
-        int numValues = values.setDocument(docId);
-        int tempMissing = 1;
-        for (int i = 0; i < numValues; i++) {
-            tempMissing = 0;
-            onValue(docId, values.nextValue());
-            total++;
-        }
-        missing += tempMissing;
+
+    protected DenseDoubleValues(boolean multiValued) {
+        super(multiValued);
     }
 
-    protected abstract void onValue(int docId, double next);
-
-    public final int total() {
-        return total;
+    @Override
+    public final boolean hasValue(int docId) {
+        return true;
     }
 
-    public final int missing() {
-        return missing;
+    public final double getValueMissing(int docId, double missingValue) {
+        assert hasValue(docId);
+        assert !isMultiValued();
+        return getValue(docId);
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DenseLongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DenseLongValues.java
@@ -16,35 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.facet;
+package org.elasticsearch.index.fielddata.plain;
 
-import org.elasticsearch.index.fielddata.DoubleValues;
+import org.elasticsearch.index.fielddata.LongValues;
 
 /**
- * Simple Facet aggregator base class for {@link DoubleValues}
+ * Package private base class for dense long values.
  */
-public abstract class DoubleFacetAggregatorBase {
-    private int total;
-    private int missing;
+abstract class DenseLongValues extends LongValues {
 
-    public void onDoc(int docId, DoubleValues values) {
-        int numValues = values.setDocument(docId);
-        int tempMissing = 1;
-        for (int i = 0; i < numValues; i++) {
-            tempMissing = 0;
-            onValue(docId, values.nextValue());
-            total++;
-        }
-        missing += tempMissing;
+    protected DenseLongValues(boolean multiValued) {
+        super(multiValued);
     }
 
-    protected abstract void onValue(int docId, double next);
-
-    public final int total() {
-        return total;
+    @Override
+    public final boolean hasValue(int docId) {
+        return true;
     }
 
-    public final int missing() {
-        return missing;
+    public final long getValueMissing(int docId, long missingValue) {
+        assert hasValue(docId);
+        assert !isMultiValued();
+        return getValue(docId);
+    }
+
+    @Override
+    public int setDocument(int docId) {
+        this.docId = docId;
+        return 1;
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
@@ -155,6 +155,7 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
 
             @Override
             public final long getValueByOrd(long ord) {
+                assert ord != Ordinals.MISSING_ORDINAL;
                 return (long) values.get(ord);
             }
         }
@@ -170,6 +171,7 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
 
             @Override
             public double getValueByOrd(long ord) {
+                assert ord != Ordinals.MISSING_ORDINAL;
                 return values.get(ord);
             }
         }
@@ -322,7 +324,7 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
             return new DoubleValues(values);
         }
 
-        static class LongValues extends org.elasticsearch.index.fielddata.LongValues.Dense {
+        static final class LongValues extends DenseLongValues {
 
             private final BigDoubleArrayList values;
 
@@ -336,9 +338,16 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
                 return (long) values.get(docId);
             }
 
+            @Override
+            public long nextValue() {
+                return (long) values.get(docId);
+            }
+            
+            
+
         }
 
-        static class DoubleValues extends org.elasticsearch.index.fielddata.DoubleValues.Dense {
+        static final class DoubleValues extends DenseDoubleValues {
 
             private final BigDoubleArrayList values;
 
@@ -351,7 +360,12 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
             public double getValue(int docId) {
                 return values.get(docId);
             }
-
+            
+            @Override
+            public double nextValue() {
+                return values.get(docId);
+            }
+            
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/EmptyByteValuesWithOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/EmptyByteValuesWithOrdinals.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata.plain;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticSearchIllegalStateException;
+import org.elasticsearch.index.fielddata.BytesValues;
+import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+
+/**
+ * An empty {@link org.elasticsearch.index.fielddata.BytesValues.WithOrdinals} implementation
+ */
+final class EmptyByteValuesWithOrdinals extends BytesValues.WithOrdinals {
+
+    EmptyByteValuesWithOrdinals(Ordinals.Docs ordinals) {
+        super(ordinals);
+    }
+
+    @Override
+    public BytesRef getValueByOrd(long ord) {
+        scratch.length = 0;
+        return scratch;
+    }
+
+    @Override
+    public int setDocument(int docId) {
+        return 0;
+    }
+
+    @Override
+    public BytesRef nextValue() {
+        throw new ElasticSearchIllegalStateException("Empty BytesValues has no next value");
+    }
+
+    @Override
+    public int currentValueHash() {
+        throw new ElasticSearchIllegalStateException("Empty BytesValues has no hash for the current value");
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
@@ -153,6 +153,7 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
 
             @Override
             public long getValueByOrd(long ord) {
+                assert ord != Ordinals.MISSING_ORDINAL;
                 return (long) values.get(ord);
             }
         }
@@ -323,7 +324,7 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
         }
 
 
-        static class LongValues extends org.elasticsearch.index.fielddata.LongValues.Dense {
+        static class LongValues extends DenseLongValues {
 
             private final BigFloatArrayList values;
 
@@ -336,10 +337,16 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
             public long getValue(int docId) {
                 return (long) values.get(docId);
             }
+            
+            @Override
+            public long nextValue() {
+                return (long) values.get(docId);
+            }
+            
 
         }
 
-        static class DoubleValues extends org.elasticsearch.index.fielddata.DoubleValues.Dense {
+        static class DoubleValues extends DenseDoubleValues {
 
             private final BigFloatArrayList values;
 
@@ -352,6 +359,12 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
             public double getValue(int docId) {
                 return (double) values.get(docId);
             }
+            
+            @Override
+            public double nextValue() {
+                return values.get(docId);
+            }
+            
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
@@ -154,7 +154,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
 
             @Override
             public long getValueByOrd(long ord) {
-                return ord == 0 ? 0L : values.get(ord - 1);
+                assert ord != Ordinals.MISSING_ORDINAL;
+                return values.get(ord - 1);
             }
         }
 
@@ -169,7 +170,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
 
             @Override
             public double getValueByOrd(long ord) {
-                return ord == 0 ? 0L : values.get(ord - 1);
+                assert ord != Ordinals.MISSING_ORDINAL;
+                return values.get(ord - 1);
             }
 
 
@@ -333,7 +335,7 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
             return new DoubleValues(values, minValue);
         }
 
-        static class LongValues extends org.elasticsearch.index.fielddata.LongValues.Dense {
+        static class LongValues extends DenseLongValues {
 
             private final PackedInts.Mutable values;
             private final long minValue;
@@ -349,9 +351,15 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
                 return minValue + values.get(docId);
             }
 
+            @Override
+            public long nextValue() {
+                return minValue + values.get(docId);
+            }
+            
+
         }
 
-        static class DoubleValues extends org.elasticsearch.index.fielddata.DoubleValues.Dense {
+        static class DoubleValues extends DenseDoubleValues {
 
             private final PackedInts.Mutable values;
             private final long minValue;
@@ -364,6 +372,11 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
 
             @Override
             public double getValue(int docId) {
+                return minValue + values.get(docId);
+            }
+            
+            @Override
+            public double nextValue() {
                 return minValue + values.get(docId);
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -165,7 +165,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                 }
                 for (int i = 0; i < reader.maxDoc(); i++) {
                     final long ord = ordinals.getOrd(i);
-                    if (ord > 0) {
+                    if (ord != Ordinals.MISSING_ORDINAL) {
                         sValues.set(i, values.get(ord - 1) - minValue);
                     }
                 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -24,7 +24,14 @@ import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues.Strings;
 
-public class SortedSetDVBytesAtomicFieldData extends SortedSetDVAtomicFieldData implements AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> {
+/**
+ * An {@link AtomicFieldData} implementation that uses Lucene {@link org.apache.lucene.index.SortedSetDocValues}.
+ */
+public final class SortedSetDVBytesAtomicFieldData extends SortedSetDVAtomicFieldData implements AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> {
+
+    /* NOTE: This class inherits the methods getBytesValues() and getHashedBytesValues()
+     * from SortedSetDVAtomicFieldData. This can cause confusion since the are
+     * part of the interface this class implements.*/
 
     SortedSetDVBytesAtomicFieldData(AtomicReader reader, String field) {
         super(reader, field);
@@ -39,5 +46,4 @@ public class SortedSetDVBytesAtomicFieldData extends SortedSetDVAtomicFieldData 
     public Strings getScriptValues() {
         return new ScriptDocValues.Strings(getBytesValues());
     }
-
 }

--- a/src/main/java/org/elasticsearch/index/search/NumericRangeFieldDataFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/NumericRangeFieldDataFilter.java
@@ -25,7 +25,9 @@ import org.apache.lucene.search.Filter;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.lucene.docset.MatchDocIdSet;
-import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.DoubleValues;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.LongValues;
 
 import java.io.IOException;
 
@@ -132,25 +134,7 @@ public abstract class NumericRangeFieldDataFilter<T> extends Filter {
                     return null;
 
                 final LongValues values = indexFieldData.load(ctx).getLongValues();
-                return new MatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs) {
-
-                    @Override
-                    public boolean isCacheable() {
-                        return true;
-                    }
-
-                    @Override
-                    protected boolean matchDoc(int doc) {
-                        LongValues.Iter iter = values.getIter(doc);
-                        while (iter.hasNext()) {
-                            long value = iter.next();
-                            if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }
-                };
+                return new LongRangeMatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs, values, inclusiveLowerPoint, inclusiveUpperPoint);
             }
         };
     }
@@ -182,25 +166,7 @@ public abstract class NumericRangeFieldDataFilter<T> extends Filter {
                     return null;
 
                 final LongValues values = indexFieldData.load(ctx).getLongValues();
-                return new MatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs) {
-
-                    @Override
-                    public boolean isCacheable() {
-                        return true;
-                    }
-
-                    @Override
-                    protected boolean matchDoc(int doc) {
-                        LongValues.Iter iter = values.getIter(doc);
-                        while (iter.hasNext()) {
-                            long value = iter.next();
-                            if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }
-                };
+                return new LongRangeMatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs, values, inclusiveLowerPoint, inclusiveUpperPoint);
             }
         };
     }
@@ -231,25 +197,7 @@ public abstract class NumericRangeFieldDataFilter<T> extends Filter {
                     return null;
 
                 final LongValues values = indexFieldData.load(ctx).getLongValues();
-                return new MatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs) {
-
-                    @Override
-                    public boolean isCacheable() {
-                        return true;
-                    }
-
-                    @Override
-                    protected boolean matchDoc(int doc) {
-                        LongValues.Iter iter = values.getIter(doc);
-                        while (iter.hasNext()) {
-                            long value = iter.next();
-                            if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }
-                };
+                return new LongRangeMatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs, values, inclusiveLowerPoint, inclusiveUpperPoint);
             }
         };
     }
@@ -280,25 +228,8 @@ public abstract class NumericRangeFieldDataFilter<T> extends Filter {
                     return null;
 
                 final LongValues values = indexFieldData.load(ctx).getLongValues();
-                return new MatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs) {
+                return new LongRangeMatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs, values, inclusiveLowerPoint, inclusiveUpperPoint);
 
-                    @Override
-                    public boolean isCacheable() {
-                        return true;
-                    }
-
-                    @Override
-                    protected boolean matchDoc(int doc) {
-                        LongValues.Iter iter = values.getIter(doc);
-                        while (iter.hasNext()) {
-                            long value = iter.next();
-                            if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }
-                };
             }
         };
     }
@@ -333,25 +264,7 @@ public abstract class NumericRangeFieldDataFilter<T> extends Filter {
                     return null;
 
                 final DoubleValues values = indexFieldData.load(ctx).getDoubleValues();
-                return new MatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs) {
-
-                    @Override
-                    public boolean isCacheable() {
-                        return true;
-                    }
-
-                    @Override
-                    protected boolean matchDoc(int doc) {
-                        DoubleValues.Iter iter = values.getIter(doc);
-                        while (iter.hasNext()) {
-                            double value = iter.next();
-                            if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }
-                };
+                return new DoubleRangeMatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs, values, inclusiveLowerPoint, inclusiveUpperPoint);
             }
         };
     }
@@ -386,26 +299,71 @@ public abstract class NumericRangeFieldDataFilter<T> extends Filter {
                     return null;
 
                 final DoubleValues values = indexFieldData.load(ctx).getDoubleValues();
-                return new MatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs) {
-
-                    @Override
-                    public boolean isCacheable() {
-                        return true;
-                    }
-
-                    @Override
-                    protected boolean matchDoc(int doc) {
-                        DoubleValues.Iter iter = values.getIter(doc);
-                        while (iter.hasNext()) {
-                            double value = iter.next();
-                            if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }
-                };
+                return new DoubleRangeMatchDocIdSet(ctx.reader().maxDoc(), acceptedDocs, values, inclusiveLowerPoint, inclusiveUpperPoint);
             }
         };
     }
+    
+    private static final class DoubleRangeMatchDocIdSet extends MatchDocIdSet {
+        private final DoubleValues values;
+        private final double inclusiveLowerPoint;
+        private final double inclusiveUpperPoint;
+
+        protected DoubleRangeMatchDocIdSet(int maxDoc, Bits acceptDocs, final DoubleValues values,final double inclusiveLowerPoint, final double inclusiveUpperPoint ) {
+            super(maxDoc, acceptDocs);
+            this.inclusiveLowerPoint = inclusiveLowerPoint;
+            this.inclusiveUpperPoint = inclusiveUpperPoint; 
+            this.values = values;
+        }
+        
+        @Override
+        public boolean isCacheable() {
+            return true;
+        }
+
+        @Override
+        protected boolean matchDoc(int doc) {
+            int numValues = values.setDocument(doc);
+            for (int i = 0; i < numValues; i++) {
+                double value = values.nextValue();
+                if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        
+    }
+    
+    private static final class LongRangeMatchDocIdSet extends MatchDocIdSet {
+        private final LongValues values;
+        private final long inclusiveLowerPoint;
+        private final long inclusiveUpperPoint;
+
+        protected LongRangeMatchDocIdSet(int maxDoc, Bits acceptDocs, final LongValues values,final long inclusiveLowerPoint, final long inclusiveUpperPoint ) {
+            super(maxDoc, acceptDocs);
+            this.inclusiveLowerPoint = inclusiveLowerPoint;
+            this.inclusiveUpperPoint = inclusiveUpperPoint; 
+            this.values = values;
+        }
+        
+        @Override
+        public boolean isCacheable() {
+            return true;
+        }
+
+        @Override
+        protected boolean matchDoc(int doc) {
+            int numValues = values.setDocument(doc);
+            for (int i = 0; i < numValues; i++) {
+                long value = values.nextValue();
+                if (value >= inclusiveLowerPoint && value <= inclusiveUpperPoint) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        
+    }
+
 }

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceFilter.java
@@ -177,27 +177,15 @@ public class GeoDistanceFilter extends Filter {
 
         @Override
         protected boolean matchDoc(int doc) {
-            if (!values.hasValue(doc)) {
-                return false;
-            }
 
-            if (values.isMultiValued()) {
-                GeoPointValues.Iter iter = values.getIter(doc);
-                while (iter.hasNext()) {
-                    GeoPoint point = iter.next();
-                    if (distanceBoundingCheck.isWithin(point.lat(), point.lon())) {
-                        double d = fixedSourceDistance.calculate(point.lat(), point.lon());
-                        if (d < distance) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            } else {
-                GeoPoint point = values.getValue(doc);
+            final int length = values.setDocument(doc);
+            for (int i = 0; i < length; i++) {
+                GeoPoint point = values.nextValue();
                 if (distanceBoundingCheck.isWithin(point.lat(), point.lon())) {
                     double d = fixedSourceDistance.calculate(point.lat(), point.lon());
-                    return d < distance;
+                    if (d < distance) {
+                        return true;
+                    }
                 }
             }
             return false;

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeFilter.java
@@ -195,32 +195,17 @@ public class GeoDistanceRangeFilter extends Filter {
 
         @Override
         protected boolean matchDoc(int doc) {
-            if (!values.hasValue(doc)) {
-                return false;
-            }
-
-            if (values.isMultiValued()) {
-                GeoPointValues.Iter iter = values.getIter(doc);
-                while (iter.hasNext()) {
-                    GeoPoint point = iter.next();
-                    if (distanceBoundingCheck.isWithin(point.lat(), point.lon())) {
-                        double d = fixedSourceDistance.calculate(point.lat(), point.lon());
-                        if (d >= inclusiveLowerPoint && d <= inclusiveUpperPoint) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            } else {
-                GeoPoint point = values.getValue(doc);
+            final int length = values.setDocument(doc);
+            for (int i = 0; i < length; i++) {
+                GeoPoint point = values.nextValue();
                 if (distanceBoundingCheck.isWithin(point.lat(), point.lon())) {
                     double d = fixedSourceDistance.calculate(point.lat(), point.lon());
                     if (d >= inclusiveLowerPoint && d <= inclusiveUpperPoint) {
                         return true;
                     }
                 }
-                return false;
             }
+            return false;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonFilter.java
@@ -82,21 +82,12 @@ public class GeoPolygonFilter extends Filter {
 
         @Override
         protected boolean matchDoc(int doc) {
-            if (!values.hasValue(doc)) {
-                return false;
-            }
-
-            if (values.isMultiValued()) {
-                GeoPointValues.Iter iter = values.getIter(doc);
-                while (iter.hasNext()) {
-                    GeoPoint point = iter.next();
-                    if (pointInPolygon(points, point.lat(), point.lon())) {
-                        return true;
-                    }
+            final int length = values.setDocument(doc);
+            for (int i = 0; i < length; i++) {
+                GeoPoint point = values.nextValue();
+                if (pointInPolygon(points, point.lat(), point.lon())) {
+                    return true;
                 }
-            } else {
-                GeoPoint point = values.getValue(doc);
-                return pointInPolygon(points, point.lat(), point.lon());
             }
             return false;
         }

--- a/src/main/java/org/elasticsearch/index/search/geo/InMemoryGeoBoundingBoxFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/InMemoryGeoBoundingBoxFilter.java
@@ -95,22 +95,9 @@ public class InMemoryGeoBoundingBoxFilter extends Filter {
 
         @Override
         protected boolean matchDoc(int doc) {
-            if (!values.hasValue(doc)) {
-                return false;
-            }
-
-            if (values.isMultiValued()) {
-                GeoPointValues.Iter iter = values.getIter(doc);
-                while (iter.hasNext()) {
-                    GeoPoint point = iter.next();
-                    if (((topLeft.lon() <= point.lon() || bottomRight.lon() >= point.lon())) &&
-                            (topLeft.lat() >= point.lat() && bottomRight.lat() <= point.lat())) {
-                        return true;
-                    }
-                }
-            } else {
-                GeoPoint point = values.getValue(doc);
-
+            final int length = values.setDocument(doc);
+            for (int i = 0; i < length; i++) {
+                GeoPoint point = values.nextValue();
                 if (((topLeft.lon() <= point.lon() || bottomRight.lon() >= point.lon())) &&
                         (topLeft.lat() >= point.lat() && bottomRight.lat() <= point.lat())) {
                     return true;
@@ -139,21 +126,9 @@ public class InMemoryGeoBoundingBoxFilter extends Filter {
 
         @Override
         protected boolean matchDoc(int doc) {
-            if (!values.hasValue(doc)) {
-                return false;
-            }
-
-            if (values.isMultiValued()) {
-                GeoPointValues.Iter iter = values.getIter(doc);
-                while (iter.hasNext()) {
-                    GeoPoint point = iter.next();
-                    if (topLeft.lon() <= point.lon() && bottomRight.lon() >= point.lon()
-                            && topLeft.lat() >= point.lat() && bottomRight.lat() <= point.lat()) {
-                        return true;
-                    }
-                }
-            } else {
-                GeoPoint point = values.getValue(doc);
+            final int length = values.setDocument(doc);
+            for (int i = 0; i < length; i++) {
+                GeoPoint point = values.nextValue();
                 if (topLeft.lon() <= point.lon() && bottomRight.lon() >= point.lon()
                         && topLeft.lat() >= point.lat() && bottomRight.lat() <= point.lat()) {
                     return true;

--- a/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -152,7 +152,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.hash = values.getValueHashed(doc, spare.bytes);
+            spare.reset(values.getValue(doc), values.currentValueHash());
             Query query = queries.get(spare);
             if (query == null) {
                 // log???
@@ -169,7 +169,7 @@ abstract class QueryCollector extends Collector {
                 searcher.search(query, collector);
                 if (collector.exists()) {
                     if (!limit || counter < size) {
-                        matches.add(values.makeSafe(spare.bytes));
+                        matches.add(values.copyShared());
                         if (context.highlight() != null) {
                             highlightPhase.hitExecute(context, context.hitContext());
                             hls.add(context.hitContext().hit().getHighlightFields());
@@ -210,7 +210,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.hash = values.getValueHashed(doc, spare.bytes);
+            spare.reset(values.getValue(doc), values.currentValueHash());
             Query query = queries.get(spare);
             if (query == null) {
                 // log???
@@ -273,7 +273,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.hash = values.getValueHashed(doc, spare.bytes);
+            spare.reset(values.getValue(doc), values.currentValueHash());
             Query query = queries.get(spare);
             if (query == null) {
                 // log???
@@ -289,7 +289,7 @@ abstract class QueryCollector extends Collector {
                 searcher.search(query, collector);
                 if (collector.exists()) {
                     if (!limit || counter < size) {
-                        matches.add(values.makeSafe(spare.bytes));
+                        matches.add(values.copyShared());
                         scores.add(scorer.score());
                         if (context.highlight() != null) {
                             highlightPhase.hitExecute(context, context.hitContext());
@@ -338,7 +338,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.hash = values.getValueHashed(doc, spare.bytes);
+            spare.reset(values.getValue(doc), values.currentValueHash());
             Query query = queries.get(spare);
             if (query == null) {
                 // log???

--- a/src/main/java/org/elasticsearch/search/facet/LongFacetAggregatorBase.java
+++ b/src/main/java/org/elasticsearch/search/facet/LongFacetAggregatorBase.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.facet;
 
 import org.elasticsearch.index.fielddata.LongValues;
-import org.elasticsearch.index.fielddata.LongValues.Iter;
 
 /**
  * Simple Facet aggregator base class for {@link LongValues}
@@ -29,15 +28,14 @@ public abstract class LongFacetAggregatorBase {
     private int missing;
 
     public void onDoc(int docId, LongValues values) {
-        if (values.hasValue(docId)) {
-            final Iter iter = values.getIter(docId);
-            while(iter.hasNext()) {
-                onValue(docId, iter.next());
-                total++;
-            }
-        } else {
-            missing++;
+        final int numValues = values.setDocument(docId);
+        int tempMissing = 1;
+        for (int i = 0; i < numValues; i++) {
+            tempMissing = 0;
+            onValue(docId, values.nextValue());
+            total++;
         }
+        missing += tempMissing;
     }
 
     protected abstract void onValue(int docId, long next);

--- a/src/main/java/org/elasticsearch/search/facet/geodistance/GeoDistanceFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/geodistance/GeoDistanceFacetExecutor.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.fielddata.GeoPointValues;
-import org.elasticsearch.index.fielddata.GeoPointValues.Iter;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.search.facet.FacetExecutor;
 import org.elasticsearch.search.facet.InternalFacet;
@@ -106,9 +105,9 @@ public class GeoDistanceFacetExecutor extends FacetExecutor {
         }
         
         public void onDoc(int docId, GeoPointValues values) {
-            final Iter iter = values.getIter(docId);
-            while(iter.hasNext()) {
-                final GeoPoint next = iter.next();
+            final int length = values.setDocument(docId);
+            for (int i = 0; i < length; i++) {
+                final GeoPoint next = values.nextValue();
                 double distance = fixedSourceDistance.calculate(next.getLat(), next.getLon());
                 for (GeoDistanceFacet.Entry entry : entries) {
                     if (entry.foundInDoc) {

--- a/src/main/java/org/elasticsearch/search/facet/geodistance/ValueGeoDistanceFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/geodistance/ValueGeoDistanceFacetExecutor.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.search.facet.geodistance;
 
-import java.io.IOException;
-
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -28,6 +26,8 @@ import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
 
 /**
  *
@@ -73,9 +73,9 @@ public class ValueGeoDistanceFacetExecutor extends GeoDistanceFacetExecutor {
         protected void collectGeoPoint(GeoDistanceFacet.Entry entry, int docId, double distance) {
             entry.foundInDoc = true;
             entry.count++;
-            DoubleValues.Iter iter = valueValues.getIter(docId);
-            while(iter.hasNext()) {
-                double value = iter.next();
+            int seek = valueValues.setDocument(docId);
+            for (int i = 0; i < seek; i++) {
+                double value = valueValues.nextValue();
                 entry.totalCount++;
                 entry.total += value;
                 if (value < entry.min) {

--- a/src/main/java/org/elasticsearch/search/facet/range/KeyValueRangeFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/range/KeyValueRangeFacetExecutor.java
@@ -102,29 +102,14 @@ public class KeyValueRangeFacetExecutor extends FacetExecutor {
                 if (value >= entry.getFrom() && value < entry.getTo()) {
                     entry.foundInDoc = true;
                     entry.count++;
-                    if (valueValues.isMultiValued()) {
-                        for (DoubleValues.Iter iter = valueValues.getIter(docId); iter.hasNext(); ) {
-                            double valueValue = iter.next();
-                            entry.total += valueValue;
-                            if (valueValue < entry.min) {
-                                entry.min = valueValue;
-                            }
-                            if (valueValue > entry.max) {
-                                entry.max = valueValue;
-                            }
-                            entry.totalCount++;
-                        }
-                    } else if (valueValues.hasValue(docId)) {
-                        double valueValue = valueValues.getValue(docId);
-                        entry.totalCount++;
+                    int seek = valueValues.setDocument(docId);
+                    for (int i = 0; i < seek; i++) {
+                        double valueValue = valueValues.nextValue();
                         entry.total += valueValue;
-                        if (valueValue < entry.min) {
-                            entry.min = valueValue;
-                        }
-                        if (valueValue > entry.max) {
-                            entry.max = valueValue;
-                        }
+                        entry.min = Math.min(entry.min, valueValue);
+                        entry.max = Math.max(entry.max, valueValue);
                     }
+                    entry.totalCount+=seek;
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleFacetExecutor.java
@@ -78,7 +78,7 @@ public class TermsDoubleFacetExecutor extends FacetExecutor {
                 if (values instanceof DoubleValues.WithOrdinals) {
                     DoubleValues.WithOrdinals valuesWithOrds = (DoubleValues.WithOrdinals) values;
                     Ordinals.Docs ordinals = valuesWithOrds.ordinals();
-                    for (int ord = 1; ord < ordinals.getMaxOrd(); ord++) {
+                    for (long ord = Ordinals.MIN_ORDINAL; ord < ordinals.getMaxOrd(); ord++) {
                         facets.v().putIfAbsent(valuesWithOrds.getValueByOrd(ord), 0);
                     }
                 } else {
@@ -88,10 +88,10 @@ public class TermsDoubleFacetExecutor extends FacetExecutor {
                             if (!values.hasValue(docId)) {
                                 continue;
                             }
-
-                            DoubleValues.Iter iter = values.getIter(docId);
-                            while (iter.hasNext()) {
-                                facets.v().putIfAbsent(iter.next(), 0);
+                            int numValues = values.setDocument(docId);
+                            DoubleIntOpenHashMap map = facets.v();
+                            for (int i = 0; i < numValues; i++) {
+                                map.putIfAbsent(values.nextValue(), 0);
                             }
                         }
                     } else {

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetExecutor.java
@@ -77,20 +77,17 @@ public class TermsLongFacetExecutor extends FacetExecutor {
                 if (values instanceof LongValues.WithOrdinals) {
                     LongValues.WithOrdinals valuesWithOrds = (LongValues.WithOrdinals) values;
                     Ordinals.Docs ordinals = valuesWithOrds.ordinals();
-                    for (int ord = 1; ord < ordinals.getMaxOrd(); ord++) {
+                    for (long ord = Ordinals.MIN_ORDINAL; ord < ordinals.getMaxOrd(); ord++) {
                         facets.v().putIfAbsent(valuesWithOrds.getValueByOrd(ord), 0);
                     }
                 } else {
                     // Shouldn't be true, otherwise it is WithOrdinals... just to be sure...
                     if (values.isMultiValued()) {
                         for (int docId = 0; docId < maxDoc; docId++) {
-                            if (!values.hasValue(docId)) {
-                                continue;
-                            }
-
-                            LongValues.Iter iter = values.getIter(docId);
-                            while (iter.hasNext()) {
-                                facets.v().putIfAbsent(iter.next(), 0);
+                            final int numValues = values.setDocument(docId);
+                            final LongIntOpenHashMap v = facets.v();
+                            for (int i = 0; i < numValues; i++) {
+                                v.putIfAbsent(values.nextValue(), 0);
                             }
                         }
                     } else {

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/HashedScriptAggregator.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/HashedScriptAggregator.java
@@ -76,7 +76,7 @@ public final class HashedScriptAggregator extends HashedAggregator {
                 script.setNextDocId(docId);
                 // LUCENE 4 UPGRADE: needs optimization -- maybe a CharSequence
                 // does the job here?
-                // we only creat that string if we really need
+                // we only create that string if we really need
                 script.setNextVar("term", spare.toString());
                 Object scriptValue = script.run();
                 if (scriptValue == null) {
@@ -87,8 +87,6 @@ public final class HashedScriptAggregator extends HashedAggregator {
                         return;
                     }
                 } else {
-                    // LUCENE 4 UPGRADE: should be possible to convert directly
-                    // to BR
                     scriptSpare.copyChars(scriptValue.toString());
                     hashCode = scriptSpare.hashCode();
                     super.onValue(docId, scriptSpare, hashCode, values);

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/strings/TermsStatsStringFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/strings/TermsStatsStringFacetExecutor.java
@@ -170,7 +170,7 @@ public class TermsStatsStringFacetExecutor extends FacetExecutor {
             spare.reset(value, hashCode);
             InternalTermsStatsStringFacet.StringEntry stringEntry = entries.get(spare);
             if (stringEntry == null) {
-                HashedBytesRef theValue = new HashedBytesRef(values.makeSafe(value), hashCode);
+                HashedBytesRef theValue = new HashedBytesRef(values.copyShared(), hashCode);
                 stringEntry = new InternalTermsStatsStringFacet.StringEntry(theValue, 0, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
                 entries.put(theValue, stringEntry);
             }
@@ -210,7 +210,7 @@ public class TermsStatsStringFacetExecutor extends FacetExecutor {
             spare.reset(value, hashCode);
             InternalTermsStatsStringFacet.StringEntry stringEntry = entries.get(spare);
             if (stringEntry == null) {
-                HashedBytesRef theValue = new HashedBytesRef(values.makeSafe(value), hashCode);
+                HashedBytesRef theValue = new HashedBytesRef(values.copyShared(), hashCode);
                 stringEntry = new InternalTermsStatsStringFacet.StringEntry(theValue, 1, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
                 entries.put(theValue, stringEntry);
             } else {

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
@@ -58,21 +58,14 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(longValues.getValueMissing(0, -1), equalTo(2l));
         assertThat(longValues.getValueMissing(1, -1), equalTo(1l));
         assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
+        assertThat(longValues.setDocument(0), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(2l));
 
-        LongValues.Iter longValuesIter = longValues.getIter(0);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(2l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(1), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(1l));
 
-        longValuesIter = longValues.getIter(1);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(1l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
-
-        longValuesIter = longValues.getIter(2);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(3l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(2), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(3l));
 
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
@@ -90,20 +83,14 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(doubleValues.getValueMissing(1, -1), equalTo(1d));
         assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
-        DoubleValues.Iter doubleValuesIter = doubleValues.getIter(0);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(2d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(0)));
+        assertThat(doubleValues.nextValue(), equalTo(2d));
 
-        doubleValuesIter = doubleValues.getIter(1);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(1d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(1)));
+        assertThat(doubleValues.nextValue(), equalTo(1d));
 
-        doubleValuesIter = doubleValues.getIter(2);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(3d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(2)));
+        assertThat(doubleValues.nextValue(), equalTo(3d));
 
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopFieldDocs topDocs;
@@ -145,19 +132,14 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(longValues.getValueMissing(0, -1), equalTo(2l));
         assertThat(longValues.getValueMissing(1, -1), equalTo(-1l));
         assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
+        
+        assertThat(longValues.setDocument(0), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(2l));
 
-        LongValues.Iter longValuesIter = longValues.getIter(0);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(2l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
-
-        longValuesIter = longValues.getIter(1);
-        assertThat(longValuesIter.hasNext(), equalTo(false));
-
-        longValuesIter = longValues.getIter(2);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(3l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(1), equalTo(0));
+        
+        assertThat(longValues.setDocument(2), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(3l));
 
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
@@ -174,19 +156,14 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(doubleValues.getValueMissing(1, -1), equalTo(-1d));
         assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
-        DoubleValues.Iter doubleValuesIter = doubleValues.getIter(0);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(2d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(0)));
+        assertThat(doubleValues.nextValue(), equalTo(2d));
 
-        doubleValuesIter = doubleValues.getIter(1);
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(0, equalTo(doubleValues.setDocument(1)));
 
-        doubleValuesIter = doubleValues.getIter(2);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(3d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
-
+        assertThat(1, equalTo(doubleValues.setDocument(2)));
+        assertThat(doubleValues.nextValue(), equalTo(3d));
+        
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());
         TopFieldDocs topDocs;
 
@@ -257,22 +234,15 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(longValues.getValueMissing(1, -1), equalTo(1l));
         assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
 
-        LongValues.Iter longValuesIter = longValues.getIter(0);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(2l));
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(4l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(0), equalTo(2));
+        assertThat(longValues.nextValue(), equalTo(2l));
+        assertThat(longValues.nextValue(), equalTo(4l));
 
-        longValuesIter = longValues.getIter(1);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(1l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(1), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(1l));
 
-        longValuesIter = longValues.getIter(2);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(3l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(2), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(3l));
 
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
@@ -290,22 +260,15 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(doubleValues.getValueMissing(1, -1), equalTo(1d));
         assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
-        DoubleValues.Iter doubleValuesIter = doubleValues.getIter(0);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(2d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(4d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(2, equalTo(doubleValues.setDocument(0)));
+        assertThat(doubleValues.nextValue(), equalTo(2d));
+        assertThat(doubleValues.nextValue(), equalTo(4d));
 
-        doubleValuesIter = doubleValues.getIter(1);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(1d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(1)));
+        assertThat(doubleValues.nextValue(), equalTo(1d));
 
-        doubleValuesIter = doubleValues.getIter(2);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(3d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(2)));
+        assertThat(doubleValues.nextValue(), equalTo(3d));
     }
 
     @Test
@@ -331,20 +294,14 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(longValues.getValueMissing(1, -1), equalTo(-1l));
         assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
 
-        LongValues.Iter longValuesIter = longValues.getIter(0);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(2l));
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(4l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(0), equalTo(2));
+        assertThat(longValues.nextValue(), equalTo(2l));
+        assertThat(longValues.nextValue(), equalTo(4l));
 
-        longValuesIter = longValues.getIter(1);
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(1), equalTo(0));
 
-        longValuesIter = longValues.getIter(2);
-        assertThat(longValuesIter.hasNext(), equalTo(true));
-        assertThat(longValuesIter.next(), equalTo(3l));
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        assertThat(longValues.setDocument(2), equalTo(1));
+        assertThat(longValues.nextValue(), equalTo(3l));
 
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
@@ -361,20 +318,15 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(doubleValues.getValueMissing(1, -1), equalTo(-1d));
         assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
-        DoubleValues.Iter doubleValuesIter = doubleValues.getIter(0);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(2d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(4d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(2, equalTo(doubleValues.setDocument(0)));
+        assertThat(doubleValues.nextValue(), equalTo(2d));
+        assertThat(doubleValues.nextValue(), equalTo(4d));
 
-        doubleValuesIter = doubleValues.getIter(1);
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(0, equalTo(doubleValues.setDocument(1)));
 
-        doubleValuesIter = doubleValues.getIter(2);
-        assertThat(doubleValuesIter.hasNext(), equalTo(true));
-        assertThat(doubleValuesIter.next(), equalTo(3d));
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(1, equalTo(doubleValues.setDocument(2)));
+        assertThat(doubleValues.nextValue(), equalTo(3d));
+        
     }
 
     @Test
@@ -399,14 +351,10 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(longValues.getValueMissing(1, -1), equalTo(-1l));
         assertThat(longValues.getValueMissing(2, -1), equalTo(-1l));
 
-        LongValues.Iter longValuesIter = longValues.getIter(0);
-        assertThat(longValuesIter.hasNext(), equalTo(false));
-
-        longValuesIter = longValues.getIter(1);
-        assertThat(longValuesIter.hasNext(), equalTo(false));
-
-        longValuesIter = longValues.getIter(2);
-        assertThat(longValuesIter.hasNext(), equalTo(false));
+        
+        assertThat(longValues.setDocument(0), equalTo(0));
+        assertThat(longValues.setDocument(1), equalTo(0));
+        assertThat(longValues.setDocument(2), equalTo(0));
 
         // double values
 
@@ -422,15 +370,13 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(doubleValues.getValueMissing(1, -1), equalTo(-1d));
         assertThat(doubleValues.getValueMissing(2, -1), equalTo(-1d));
 
-        DoubleValues.Iter doubleValuesIter = doubleValues.getIter(0);
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(0, equalTo(doubleValues.setDocument(0)));
 
-        doubleValuesIter = doubleValues.getIter(1);
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
+        assertThat(0, equalTo(doubleValues.setDocument(1)));
 
-        doubleValuesIter = doubleValues.getIter(2);
-        assertThat(doubleValuesIter.hasNext(), equalTo(false));
-    }
+        assertThat(0, equalTo(doubleValues.setDocument(2)));
+    }        
+
 
     protected void fillAllMissing() throws Exception {
         Document d = new Document();

--- a/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
@@ -334,8 +334,9 @@ public class LongFieldDataTests extends AbstractNumericFieldDataTests {
             }
 
             set.clear();
-            for (LongValues.Iter iter = data.getIter(i); iter.hasNext(); ) {
-                set.add(iter.next());
+            int numValues = data.setDocument(i);
+            for (int j = 0; j < numValues; j++) {
+                set.add(data.nextValue());
             }
             assertThat(set, equalTo(v));
 
@@ -348,8 +349,9 @@ public class LongFieldDataTests extends AbstractNumericFieldDataTests {
                 }
             }
             doubleSet.clear();
-            for (DoubleValues.Iter iter = doubleData.getIter(i); iter.hasNext(); ) {
-                doubleSet.add(iter.next());
+            numValues = doubleData.setDocument(i);
+            for (int j = 0; j < numValues; j++) {
+                doubleSet.add(doubleData.nextValue());
             }
             assertThat(doubleSet, equalTo(doubleV));
         }

--- a/src/test/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinalsTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinalsTests.java
@@ -124,7 +124,7 @@ public class MultiOrdinalsTests extends ElasticsearchTestCase {
                     for (int i = 0; i < array.length; i++) {
                         array[i] = docOrds.get(i);
                     }
-                    assertIter(docs.getIter(docId), array);
+                    assertIter(docs, docId, array);
                 }
                 for (int i = docId + 1; i < ordAndId.id; i++) {
                     assertThat(docs.getOrd(i), equalTo(0L));
@@ -215,12 +215,11 @@ public class MultiOrdinalsTests extends ElasticsearchTestCase {
         assertEquals(docs, ordinalPlan);
     }
 
-    protected static void assertIter(Ordinals.Docs.Iter iter, long... expectedOrdinals) {
+    protected static void assertIter(Ordinals.Docs docs, int docId, long... expectedOrdinals) {
+        assertThat(docs.setDocument(docId), equalTo(expectedOrdinals.length));
         for (long expectedOrdinal : expectedOrdinals) {
-            assertThat(iter.next(), equalTo(expectedOrdinal));
+            assertThat(docs.nextOrd(), equalTo(expectedOrdinal));
         }
-        assertThat(iter.next(), equalTo(0L)); // Last one should always be 0
-        assertThat(iter.next(), equalTo(0L)); // Just checking it stays 0
     }
 
     @Test
@@ -284,7 +283,7 @@ public class MultiOrdinalsTests extends ElasticsearchTestCase {
             assertThat(ref.offset, equalTo(0));
             long[] ords = ordinalPlan[doc];
             assertThat(ref, equalTo(new LongsRef(ords, 0, ords.length)));
-            assertIter(docs.getIter(doc), ords);
+            assertIter(docs, doc, ords);
         }
     }
 


### PR DESCRIPTION
This commit primarily folds [Double|Bytes|Long|GeoPoint]Values.Iter
into [Double|Bytes|Long|GeoPoint]Values. Iterations now don't require
a auxillary class (Iter) but instead driven by native for loops. All
[Double|Bytes|Long|GeoPoint]Values are stateful and provide `setDocId`
and `nextValue` methods to iterate over all values in a document.
This has several advantage:
- The amout of specialized classes is reduced
- Iteration is clearly stateful ie. Iters can't be confused to be local.
- All iterations are size bounded which prevents runtime checks and
  allows JIT optimizations / loop un-rolling and most iterations are
  branch free.
- Due to the bounded iteration the need for a `hasNext` method call
  is removed.
- Value iterations feels more native.

This commit also adds consistent documentation and unifies the calcualtion
if SortMode is involved.

This commit also changes the runtime behavior of BytesValues#getValue() such that it
will never return `null` anymore. If a document has no value in a field
this method still returns a `BytesRef` with a `length` of 0. To identify
documents with no values #hasValue() or #setDocument(int) should be used.
The latter should be preferred if the value will be consumed in the case
the document has a value.
