### PR TITLE
Fix for has_child can cause an infinite loop (100% CPU) when used in bool query

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -276,6 +276,7 @@ public class ChildrenQuery extends Query {
             @Override
             public int nextDoc() throws IOException {
                 if (remaining == 0) {
+                    currentDocId = NO_MORE_DOCS;
                     return NO_MORE_DOCS;
                 }
 
@@ -297,6 +298,7 @@ public class ChildrenQuery extends Query {
             @Override
             public int advance(int target) throws IOException {
                 if (remaining == 0) {
+                    currentDocId = NO_MORE_DOCS;
                     return NO_MORE_DOCS;
                 }
 


### PR DESCRIPTION
https://github.com/elasticsearch/elasticsearch/issues/3955
