### PR TITLE
Use abstract classes as super typs for Acknowledge operations

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.indices.warmer.delete;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,14 +30,12 @@ import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 
 /**
  * A request to delete an index warmer.
  */
-public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmerRequest>
-        implements AcknowledgedRequest<DeleteWarmerRequest> {
+public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest> {
 
     private String name;
 
@@ -97,30 +94,11 @@ public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmer
     }
 
     @Override
-    public DeleteWarmerRequest timeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, this.timeout);
-        return this;
-    }
-
-    @Override
-    public DeleteWarmerRequest timeout(TimeValue timeout) {
-        this.timeout = timeout;
-        return this;
-    }
-
-    @Override
-    public TimeValue timeout() {
-        return timeout;
-    }
-
-    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         name = in.readOptionalString();
         indices = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            timeout = readTimeValue(in);
-        }
+        readTimeout(in, Version.V_0_90_6);
     }
 
     @Override
@@ -128,8 +106,6 @@ public class DeleteWarmerRequest extends MasterNodeOperationRequest<DeleteWarmer
         super.writeTo(out);
         out.writeOptionalString(name);
         out.writeStringArrayNullable(indices);
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            timeout.writeTo(out);
-        }
+        writeTimeout(out, Version.V_0_90_6);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerResponse.java
@@ -19,40 +19,18 @@
 
 package org.elasticsearch.action.admin.indices.warmer.delete;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
 
 /**
  * A response for a delete warmer.
  */
-public class DeleteWarmerResponse extends ActionResponse implements AcknowledgedResponse {
-
-    private boolean acknowledged;
+public class DeleteWarmerResponse  extends AcknowledgedResponse {
 
     DeleteWarmerResponse() {
+        super();
     }
 
     DeleteWarmerResponse(boolean acknowledged) {
-        this.acknowledged = acknowledged;
-    }
-
-    public boolean isAcknowledged() {
-        return acknowledged;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        acknowledged = in.readBoolean();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeBoolean(acknowledged);
+        super(acknowledged);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -24,29 +24,23 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
-import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 
 /**
  * A request to put a search warmer.
  */
-public class PutWarmerRequest extends MasterNodeOperationRequest<PutWarmerRequest>
-        implements AcknowledgedRequest<PutWarmerRequest> {
+public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> {
 
     private String name;
 
     private SearchRequest searchRequest;
 
-    private TimeValue timeout = timeValueSeconds(10);
 
     PutWarmerRequest() {
 
@@ -95,22 +89,6 @@ public class PutWarmerRequest extends MasterNodeOperationRequest<PutWarmerReques
     }
 
     @Override
-    public PutWarmerRequest timeout(String timeout) {
-        return this;
-    }
-
-    @Override
-    public PutWarmerRequest timeout(TimeValue timeout) {
-        this.timeout = timeout;
-        return this;
-    }
-
-    @Override
-    public TimeValue timeout() {
-        return timeout;
-    }
-
-    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = searchRequest.validate();
         if (name == null) {
@@ -127,9 +105,7 @@ public class PutWarmerRequest extends MasterNodeOperationRequest<PutWarmerReques
             searchRequest = new SearchRequest();
             searchRequest.readFrom(in);
         }
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            timeout = readTimeValue(in);
-        }
+        readTimeout(in, Version.V_0_90_6);
     }
 
     @Override
@@ -142,8 +118,6 @@ public class PutWarmerRequest extends MasterNodeOperationRequest<PutWarmerReques
             out.writeBoolean(true);
             searchRequest.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            timeout.writeTo(out);
-        }
+        writeTimeout(out, Version.V_0_90_6);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerResponse.java
@@ -19,44 +19,19 @@
 
 package org.elasticsearch.action.admin.indices.warmer.put;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
 
 /**
  * The response of put warmer operation.
  */
-public class PutWarmerResponse extends ActionResponse implements AcknowledgedResponse {
-
-    private boolean acknowledged;
+public class PutWarmerResponse extends AcknowledgedResponse {
 
     PutWarmerResponse() {
-
+        super();
     }
 
     PutWarmerResponse(boolean acknowledged) {
-        this.acknowledged = acknowledged;
+        super(acknowledged);
     }
 
-    /**
-     * Has the put warmer been ack'ed.
-     */
-    public boolean isAcknowledged() {
-        return acknowledged;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        acknowledged = in.readBoolean();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeBoolean(acknowledged);
-    }
 }

--- a/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
+++ b/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
@@ -18,15 +18,45 @@
 
 package org.elasticsearch.action.support.master;
 
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
 /**
- * Interface that allows to mark action responses that support acknowledgements.
+ * Abstract class that allows to mark action responses that support acknowledgements.
  * Facilitates consistency across different api.
  */
-public interface AcknowledgedResponse {
+public abstract class AcknowledgedResponse extends ActionResponse {
+
+    private boolean acknowledged;
+
+    protected AcknowledgedResponse() {
+
+    }
+
+    protected AcknowledgedResponse(boolean acknowledged) {
+        this.acknowledged = acknowledged;
+    }
 
     /**
      * Returns whether the response is acknowledged or not
      * @return true if the response is acknowledged, false otherwise
      */
-    boolean isAcknowledged();
+    public final boolean isAcknowledged() {
+        return acknowledged;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        acknowledged = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(acknowledged);
+    }
 }


### PR DESCRIPTION
Currently we have a marker interface for Acknowledged[Request|Response],
this makes not much sense since we duplicate the code in each subclass
or class that implements the interface. We can simply use abstract
classes and have it implemented only once.
