### PR TITLE
Unify REST responses for Acknowledged[Request|Response]

### DIFF
--- a/src/main/java/org/elasticsearch/rest/AbstractRestResponseActionListener.java
+++ b/src/main/java/org/elasticsearch/rest/AbstractRestResponseActionListener.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.logging.ESLogger;
+
+import java.io.IOException;
+
+/**
+ */
+public abstract class AbstractRestResponseActionListener<T extends ActionResponse> implements ActionListener<T> {
+
+    protected final RestChannel channel;
+    protected final RestRequest request;
+    protected final ESLogger logger;
+
+    public AbstractRestResponseActionListener(final RestRequest request, final RestChannel channel, final ESLogger logger) {
+        this.request = request;
+        this.channel = channel;
+        this.logger = logger;
+    }
+
+    @Override
+    public abstract void onResponse(T t);
+
+    @Override
+    public void onFailure(Throwable e) {
+        try {
+            channel.sendResponse(new XContentThrowableRestResponse(request, e));
+        } catch (IOException e1) {
+            logger.error("Failed to send failure response", e1);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/rest/AcknowledgedRestResponseActionListener.java
+++ b/src/main/java/org/elasticsearch/rest/AcknowledgedRestResponseActionListener.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.action.support.RestXContentBuilder;
+
+import java.io.IOException;
+
+import static org.elasticsearch.rest.RestStatus.OK;
+
+/**
+ */
+public final class AcknowledgedRestResponseActionListener<T extends AcknowledgedResponse> extends AbstractRestResponseActionListener<T> {
+
+    public AcknowledgedRestResponseActionListener(RestRequest request, RestChannel channel, ESLogger logger) {
+        super(request, channel, logger);
+    }
+
+    @Override
+    public void onResponse(T response) {
+        try {
+            XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
+            builder.startObject()
+                    .field("ok", true)
+                    .field("acknowledged", response.isAcknowledged());
+            builder.endObject();
+            channel.sendResponse(new XContentRestResponse(request, OK, builder));
+        } catch (IOException e) {
+            onFailure(e);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -19,21 +19,14 @@
 
 package org.elasticsearch.rest.action.admin.indices.warmer.delete;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerRequest;
-import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestXContentBuilder;
-
-import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  */
@@ -54,29 +47,6 @@ public class RestDeleteWarmerAction extends BaseRestHandler {
         deleteWarmerRequest.listenerThreaded(false);
         deleteWarmerRequest.timeout(request.paramAsTime("timeout", deleteWarmerRequest.timeout()));
         deleteWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteWarmerRequest.masterNodeTimeout()));
-        client.admin().indices().deleteWarmer(deleteWarmerRequest, new ActionListener<DeleteWarmerResponse>() {
-            @Override
-            public void onResponse(DeleteWarmerResponse response) {
-                try {
-                    XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
-                    builder.startObject()
-                            .field("ok", true)
-                            .field("acknowledged", response.isAcknowledged());
-                    builder.endObject();
-                    channel.sendResponse(new XContentRestResponse(request, OK, builder));
-                } catch (IOException e) {
-                    onFailure(e);
-                }
-            }
-
-            @Override
-            public void onFailure(Throwable e) {
-                try {
-                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
-                } catch (IOException e1) {
-                    logger.error("Failed to send failure response", e1);
-                }
-            }
-        });
+        client.admin().indices().deleteWarmer(deleteWarmerRequest, new AcknowledgedRestResponseActionListener(request, channel, logger));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -19,22 +19,15 @@
 
 package org.elasticsearch.rest.action.admin.indices.warmer.put;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerRequest;
-import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
-import org.elasticsearch.rest.action.support.RestXContentBuilder;
-
-import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  */
@@ -57,29 +50,6 @@ public class RestPutWarmerAction extends BaseRestHandler {
         putWarmerRequest.searchRequest(searchRequest);
         putWarmerRequest.timeout(request.paramAsTime("timeout", putWarmerRequest.timeout()));
         putWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putWarmerRequest.masterNodeTimeout()));
-        client.admin().indices().putWarmer(putWarmerRequest, new ActionListener<PutWarmerResponse>() {
-            @Override
-            public void onResponse(PutWarmerResponse response) {
-                try {
-                    XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
-                    builder.startObject()
-                            .field("ok", true)
-                            .field("acknowledged", response.isAcknowledged());
-                    builder.endObject();
-                    channel.sendResponse(new XContentRestResponse(request, OK, builder));
-                } catch (IOException e) {
-                    onFailure(e);
-                }
-            }
-
-            @Override
-            public void onFailure(Throwable e) {
-                try {
-                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
-                } catch (IOException e1) {
-                    logger.error("Failed to send failure response", e1);
-                }
-            }
-        });
+        client.admin().indices().putWarmer(putWarmerRequest,  new AcknowledgedRestResponseActionListener(request, channel, logger));
     }
 }


### PR DESCRIPTION
All Rest handlers that use AcknowledgedResponse look identical. Since
we gonna have more of them in the future we can abstract the logic away.
