### PR TITLE
Adding methods to HttpRequest for retrieving informations about the http client (remoteaddr ...)

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/HttpRequestHandler.java
+++ b/src/main/java/org/elasticsearch/http/netty/HttpRequestHandler.java
@@ -39,8 +39,8 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
     public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
         HttpRequest request = (HttpRequest) e.getMessage();
         // the netty HTTP handling always copy over the buffer to its own buffer, either in NioWorker internally
-        // when reading, or using a cumalation buffer
-        serverTransport.dispatchRequest(new NettyHttpRequest(request), new NettyHttpChannel(serverTransport, e.getChannel(), request));
+        // when reading, or using a cumulation buffer
+        serverTransport.dispatchRequest(new NettyHttpRequest(request, e.getChannel()), new NettyHttpChannel(serverTransport, e.getChannel(), request));
         super.messageReceived(ctx, e);
     }
 

--- a/src/test/java/org/elasticsearch/plugin/HttpRequestPluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/HttpRequestPluginTests.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elastic Search and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.plugin.httprequest.TestHttpRequestPlugin;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.helper.HttpClient;
+import org.elasticsearch.rest.helper.HttpClientResponse;
+import org.elasticsearch.test.AbstractIntegrationTest;
+import org.elasticsearch.test.AbstractIntegrationTest.ClusterScope;
+import org.elasticsearch.test.AbstractIntegrationTest.Scope;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Test a rest action that casts RestRequest to HttpRequest and call some new methods (mainly for client identification)
+ */
+@ClusterScope(scope=Scope.SUITE, numNodes=1)
+public class HttpRequestPluginTests extends AbstractIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder().put("plugin.types", TestHttpRequestPlugin.class.getName()).put(super.nodeSettings(nodeOrdinal)).build();
+    }
+    
+    @Test
+    public void testHttpRequestMethods() throws Exception {
+        ensureGreen();
+        Map<String,String> headers = new HashMap<String,String>();
+        headers.put("X-Opaque-Id","veryOpaque");        
+        
+        HttpClientResponse response = httpClient().request("GET","/_httprequestinfo",headers);
+        logger.info(response.getHeaders().toString());
+        assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
+        assertThat(response.getHeader("opaqueId"), equalTo("veryOpaque"));
+        assertThat(response.getHeader("localAddr"), not(""));
+        assertThat(response.getHeader("remoteAddr"), not(""));
+        assertThat(response.getHeader("localPort"), not(""));
+        assertThat(response.getHeader("remotePort"), not(""));
+    }
+
+    private HttpClient httpClient() {
+        HttpServerTransport httpServerTransport = cluster().getInstance(HttpServerTransport.class);
+        return new HttpClient(httpServerTransport.boundAddress().publishAddress());
+    }
+}

--- a/src/test/java/org/elasticsearch/plugin/httprequest/TestHttpRequestPlugin.java
+++ b/src/test/java/org/elasticsearch/plugin/httprequest/TestHttpRequestPlugin.java
@@ -17,19 +17,24 @@
  * under the License.
  */
 
-package org.elasticsearch.http;
+package org.elasticsearch.plugin.httprequest;
 
-import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.rest.RestModule;
 
-/**
- *
- */
-public interface HttpRequest extends RestRequest {
-    
-    public String localAddr();
-    public long localPort();
-    public String remoteAddr();
-    public long remotePort();
-    public String opaqueId() ;
+public class TestHttpRequestPlugin extends AbstractPlugin {
 
+    @Override
+    public String name() {
+        return "test-plugin-httprequest";
+    }
+
+    @Override
+    public String description() {
+        return "test-plugin-httprequest-desc";
+    }
+
+    public void onModule(RestModule restModule) {
+        restModule.addRestAction(TestHttpRequestRestAction.class);
+    }
 }

--- a/src/test/java/org/elasticsearch/plugin/httprequest/TestHttpRequestRestAction.java
+++ b/src/test/java/org/elasticsearch/plugin/httprequest/TestHttpRequestRestAction.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugin.httprequest;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpRequest;
+import org.elasticsearch.rest.*;
+
+public class TestHttpRequestRestAction extends BaseRestHandler {
+
+    @Inject
+    public TestHttpRequestRestAction(Settings settings, Client client, RestController controller) {
+        super(settings, client);
+        controller.registerHandler(RestRequest.Method.GET, "/_httprequestinfo", this);
+    }
+
+    @Override
+    public void handleRequest(RestRequest request, RestChannel channel) {
+                     
+        HttpRequest httpRequest = (HttpRequest) request; 
+                       
+        RestResponse response = new StringRestResponse(RestStatus.OK, "httprequestinfo");
+        response.addHeader("localAddr", httpRequest.localAddr()+"");
+        response.addHeader("remoteAddr", httpRequest.remoteAddr()+"");
+        response.addHeader("opaqueId", httpRequest.opaqueId()+"");
+        response.addHeader("localPort", httpRequest.localPort()+"");
+        response.addHeader("remotePort", httpRequest.remotePort()+"");
+        channel.sendResponse(response);
+        
+    }
+}


### PR DESCRIPTION
Added methods to `org.elasticsearch.http.HttpRequest` which can be used  within `RestFilters` for retrieving informations about the http client (like remote address and remote port). The local address, local port and the X-Opaque-Id header can also be retrieved. remote address and remote port are mainly for security purposes like implementing a `RestFilter` which grant different privileges to different client hosts. If you know that your `RestRequest` is a `HttpRequest` (or check this via `instanceof`) a cast to `HttpRequest` gives you access to the following new methods:

```
public String localAddr();
public long localPort();
public String remoteAddr();
public long remotePort();
public String opaqueId();
```

The modified `org.elasticsearch.http.HttpRequest` interface should not
break the https://github.com/sonian/elasticsearch-jetty plugin (and hopefully not any other code).
