### PR TITLE
Fixed concurrency issue in simple id cache.

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdCache.java
@@ -321,6 +321,7 @@ public class SimpleIdCache extends AbstractIndexComponent implements IdCache, Se
          */
         public HashedBytesArray canReuse(HashedBytesArray id) {
             if (idToDoc.containsKey(id)) {
+                // we can use #lkey() since this is called from a synchronized block
                 return idToDoc.lkey();
             } else {
                 return id;

--- a/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdReaderTypeCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdReaderTypeCache.java
@@ -60,7 +60,9 @@ public class SimpleIdReaderTypeCache implements IdReaderTypeCache {
 
     public int docById(HashedBytesArray uid) {
         if (idToDoc.containsKey(uid)) {
-            return idToDoc.lget();
+            // We can't use #lget() here since the idToDoc map shared across threads, so we really need a second lookup...
+            // BTW: This method is only used via TopChildrenQuery
+            return idToDoc.get(uid);
         } else {
             return -1;
         }
@@ -82,6 +84,7 @@ public class SimpleIdReaderTypeCache implements IdReaderTypeCache {
      */
     public HashedBytesArray canReuse(HashedBytesArray id) {
         if (idToDoc.containsKey(id)) {
+            // we can use #lkey() since this is called from a synchronized block
             return idToDoc.lkey();
         } else {
             return id;


### PR DESCRIPTION
The lget() of a map can only be used if the map isn't shared. This issue concurrency issue occurs in none of the released versions and only exists in the master and 0.90 branch. Also only the `top_children` query is affected.
