### PR TITLE
PR for mget API should support global routing parameter

### DIFF
--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -96,3 +96,31 @@ curl 'localhost:9200/_mget' -d '{
     ]
 }'
 --------------------------------------------------
+
+[float]
+[[mget-routing]]
+=== Routing
+
+You can specify also specify routing value as a parameter:
+
+[source,js]
+--------------------------------------------------
+curl 'localhost:9200/_mget?routing=key1' -d '{
+    "docs" : [
+        {
+            "_index" : "test",
+            "_type" : "type",
+            "_id" : "1",
+            "_routing" : "key2"
+        },
+        {
+            "_index" : "test",
+            "_type" : "type",
+            "_id" : "2"
+        }
+    ]
+}'
+--------------------------------------------------
+
+In this example, document `test/type/2` will be fetch from shard corresponding to routing key `key1` but
+document `test/type/1` will be fetch from shard corresponding to routing key `key2`.

--- a/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -273,6 +273,10 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
     }
 
     public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSource, BytesReference data, boolean allowExplicitIndex) throws Exception {
+        return add(defaultIndex, defaultType, defaultFields, defaultFetchSource, null, data, allowExplicitIndex);
+    }
+
+    public MultiGetRequest add(@Nullable String defaultIndex, @Nullable String defaultType, @Nullable String[] defaultFields, @Nullable FetchSourceContext defaultFetchSource, @Nullable String defaultRouting, BytesReference data, boolean allowExplicitIndex) throws Exception {
         XContentParser parser = XContentFactory.xContent(data).createParser(data);
         try {
             XContentParser.Token token;
@@ -289,7 +293,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
                             String index = defaultIndex;
                             String type = defaultType;
                             String id = null;
-                            String routing = null;
+                            String routing = defaultRouting;
                             String parent = null;
                             List<String> fields = null;
                             long version = Versions.MATCH_ANY;
@@ -389,7 +393,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> {
                             if (!token.isValue()) {
                                 throw new ElasticSearchIllegalArgumentException("ids array element should only contain ids");
                             }
-                            add(new Item(defaultIndex, defaultType, parser.text()).fields(defaultFields).fetchSourceContext(defaultFetchSource));
+                            add(new Item(defaultIndex, defaultType, parser.text()).fields(defaultFields).fetchSourceContext(defaultFetchSource).routing(defaultRouting));
                         }
                     }
                 }

--- a/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
@@ -72,7 +72,7 @@ public class RestMultiGetAction extends BaseRestHandler {
         FetchSourceContext defaultFetchSource = FetchSourceContext.parseFromRestRequest(request);
 
         try {
-            multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource, request.content(), allowExplicitIndex);
+            multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource, request.param("routing"), request.content(), allowExplicitIndex);
         } catch (Exception e) {
             try {
                 XContentBuilder builder = restContentBuilder(request);


### PR DESCRIPTION
mget API support `_routing` field but not `routing` parameter.

Reproduction here:

``` sh
curl -XDELETE "http://localhost:9200/test/"; echo
curl -XPUT "http://localhost:9200/test/" -d'{
   "settings": {
      "number_of_replicas": 0,
      "number_of_shards": 5
   }
}'; echo

curl -XPUT 'http://localhost:9200/test/order/1-1?routing=key1' -d '{
   "productName":"doc 1"
}'; echo
curl -XPUT 'http://localhost:9200/test/order/1-2?routing=key1' -d '{
   "productName":"doc 2"
}'; echo
curl -XPUT 'http://localhost:9200/test/order/1-3?routing=key1&refresh=true' -d '{
   "productName":"doc 3"
}'; echo

# This works and gives 3 documents
curl -XPOST 'http://localhost:9200/test/order/_mget?pretty' -d '{
    "docs" : [
        {
            "_index" : "test",
            "_type" : "order",
            "_id" : "1-1",
            "_routing" : "key1"
        },
        {
            "_index" : "test",
            "_type" : "order",
            "_id" : "1-2",
            "_routing" : "key1"
        },
        {
            "_index" : "test",
            "_type" : "order",
            "_id" : "1-3",
            "_routing" : "key1"
        }
    ]
}'; echo

# This does not work and returns "exists" : false for each doc
curl -XPOST 'http://localhost:9200/test/order/_mget?pretty&routing=key1' -d '{
    "ids": [
        "1-1",
        "1-2",
        "1-3"
    ]
}'; echo
```

Closes #3996.
