### PR TITLE
Abstract AckedClusterStateUpdateTask to remove boiler plate code

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -30,12 +30,9 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.search.warmer.IndexWarmerMissingException;
@@ -90,37 +87,17 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeOperationAct
 
     @Override
     protected void masterOperation(final DeleteWarmerRequest request, final ClusterState state, final ActionListener<DeleteWarmerResponse> listener) throws ElasticSearchException {
-        clusterService.submitStateUpdateTask("delete_warmer [" + request.name() + "]", new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("delete_warmer [" + request.name() + "]", new AckedClusterStateUpdateTask<DeleteWarmerRequest, DeleteWarmerResponse>(request, true, listener) {
 
             @Override
-            public boolean mustAck(DiscoveryNode discoveryNode) {
-                return true;
-            }
-
-            @Override
-            public void onAllNodesAcked(@Nullable Throwable t) {
-                listener.onResponse(new DeleteWarmerResponse(true));
-            }
-
-            @Override
-            public void onAckTimeout() {
-                listener.onResponse(new DeleteWarmerResponse(false));
-            }
-
-            @Override
-            public TimeValue ackTimeout() {
-                return request.timeout();
-            }
-
-            @Override
-            public TimeValue timeout() {
-                return request.masterNodeTimeout();
+            protected DeleteWarmerResponse newResponse(boolean acked) {
+                return new DeleteWarmerResponse(acked);
             }
 
             @Override
             public void onFailure(String source, Throwable t) {
                 logger.debug("failed to delete warmer [{}] on indices [{}]", t, request.name(), request.indices());
-                listener.onFailure(t);
+                super.onFailure(source, t);
             }
 
             @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -31,12 +31,9 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
@@ -98,37 +95,17 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
                     return;
                 }
 
-                clusterService.submitStateUpdateTask("put_warmer [" + request.name() + "]", new AckedClusterStateUpdateTask() {
-
-                    @Override
-                    public boolean mustAck(DiscoveryNode discoveryNode) {
-                        return true;
-                    }
-
-                    @Override
-                    public void onAllNodesAcked(@Nullable Throwable t) {
-                        listener.onResponse(new PutWarmerResponse(true));
-                    }
-
-                    @Override
-                    public void onAckTimeout() {
-                        listener.onResponse(new PutWarmerResponse(false));
-                    }
-
-                    @Override
-                    public TimeValue ackTimeout() {
-                        return request.timeout();
-                    }
-
-                    @Override
-                    public TimeValue timeout() {
-                        return request.masterNodeTimeout();
-                    }
+                clusterService.submitStateUpdateTask("put_warmer [" + request.name() + "]", new AckedClusterStateUpdateTask<PutWarmerRequest, PutWarmerResponse>(request, true, listener) {
 
                     @Override
                     public void onFailure(String source, Throwable t) {
                         logger.debug("failed to put warmer [{}] on indices [{}]", t, request.name(), request.searchRequest().indices());
-                        listener.onFailure(t);
+                        super.onFailure(source, t);
+                    }
+
+                    @Override
+                    protected PutWarmerResponse newResponse(boolean acked) {
+                        return new PutWarmerResponse(acked);
                     }
 
                     @Override

--- a/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -18,6 +18,9 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
@@ -26,30 +29,63 @@ import org.elasticsearch.common.unit.TimeValue;
  * An extension interface to {@link ClusterStateUpdateTask} that allows to be notified when
  * all the nodes have acknowledged a cluster state update request
  */
-public interface AckedClusterStateUpdateTask extends TimeoutClusterStateUpdateTask {
+public abstract class AckedClusterStateUpdateTask<T extends AcknowledgedRequest, R extends AcknowledgedResponse> implements TimeoutClusterStateUpdateTask {
+
+    protected final T request;
+    private final boolean mustAck;
+    private final ActionListener<R> responseListener;
+
+    protected AckedClusterStateUpdateTask(T request, boolean mustAck, ActionListener<R> responseListener) {
+        this.request = request;
+        this.mustAck = mustAck;
+        this.responseListener = responseListener;
+
+    }
+
 
     /**
      * Called to determine which nodes the acknowledgement is expected from
      * @param discoveryNode a node
      * @return true if the node is expected to send ack back, false otherwise
      */
-    boolean mustAck(DiscoveryNode discoveryNode);
+    public boolean mustAck(DiscoveryNode discoveryNode) {
+        return mustAck;
+    }
+
+    @Override
+    public void onFailure(String source, Throwable t) {
+        responseListener.onFailure(t);
+    }
 
     /**
      * Called once all the nodes have acknowledged the cluster state update request. Must be
      * very lightweight execution, since it gets executed on the cluster service thread.
      * @param t optional error that might have been thrown
      */
-    void onAllNodesAcked(@Nullable Throwable t);
+    public void onAllNodesAcked(@Nullable Throwable t) {
+        responseListener.onResponse(newResponse(true));
+    }
 
     /**
      * Called once the acknowledgement timeout defined by
      * {@link AckedClusterStateUpdateTask#ackTimeout()} has expired
      */
-    void onAckTimeout();
+    public void onAckTimeout() {
+        responseListener.onResponse(newResponse(false));
+    }
 
     /**
      * Acknowledgement timeout, maximum time interval to wait for acknowledgements
      */
-    TimeValue ackTimeout();
+    public TimeValue ackTimeout() {
+        return request.timeout();
+    }
+
+    @Override
+    public TimeValue timeout() {
+        return request.masterNodeTimeout();
+    }
+
+    protected abstract R newResponse(boolean acked);
+
 }


### PR DESCRIPTION
this seems like a common pattern and we should abstract it to remove unnecessary code and improve readability.
