### PR TITLE
RegexpQueryBuilder now implements MultiTermQueryBuilder

### DIFF
--- a/docs/reference/query-dsl/queries/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/queries/span-multi-term-query.asciidoc
@@ -2,7 +2,7 @@
 === Span Multi Term Query
 
 The `span_multi` query allows you to wrap a `multi term query` (one of
-fuzzy, prefix, term range or numeric range query) as a `span query`, so
+fuzzy, prefix, term range or regexp query) as a `span query`, so
 it can be nested. Example:
 
 [source,js]

--- a/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  *
  *
  */
-public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<RegexpQueryBuilder> {
+public class RegexpQueryBuilder extends BaseQueryBuilder implements BoostableQueryBuilder<RegexpQueryBuilder>, MultiTermQueryBuilder {
 
     private final String name;
     private final String regexp;


### PR DESCRIPTION
This allows the RegexpQueryBuilder to be used in span queries

Added tests for all span multi term queries.
Also updated the documentation and removed mentioning of numeric range
queries for span queries (they have to be terms).

Closes #3392
