### PR TITLE
Simplify FieldData API

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/AbstractAtomicNumericFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AbstractAtomicNumericFieldData.java
@@ -46,21 +46,7 @@ public abstract class AbstractAtomicNumericFieldData implements AtomicNumericFie
         if (isFloat) {
             final DoubleValues values = getDoubleValues();
             return new BytesValues(values.isMultiValued()) {
-                @Override
-                public boolean hasValue(int docId) {
-                    return values.hasValue(docId);
-                }
 
-                @Override
-                public BytesRef getValue(int docId) {
-                    if (values.hasValue(docId)) {
-                        scratch.copyChars(Double.toString(values.getValue(docId)));
-                    } else {
-                        scratch.length = 0;
-                    }
-                    return scratch;
-                }
-                
                 @Override
                 public int setDocument(int docId) {
                     this.docId = docId;
@@ -76,21 +62,6 @@ public abstract class AbstractAtomicNumericFieldData implements AtomicNumericFie
         } else {
             final LongValues values = getLongValues();
             return new BytesValues(values.isMultiValued()) {
-
-                @Override
-                public boolean hasValue(int docId) {
-                    return values.hasValue(docId);
-                }
-
-                @Override
-                public BytesRef getValue(int docId) {
-                    if (values.hasValue(docId)) {
-                        scratch.copyChars(Long.toString(values.getValue(docId)));
-                    } else {
-                        scratch.length = 0;
-                    }
-                    return scratch;
-                }
 
                 @Override
                 public int setDocument(int docId) {

--- a/src/main/java/org/elasticsearch/index/fielddata/AtomicGeoPointFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AtomicGeoPointFieldData.java
@@ -35,23 +35,6 @@ public abstract class AtomicGeoPointFieldData<Script extends ScriptDocValues> im
         return new BytesValues(values.isMultiValued()) {
 
             @Override
-            public boolean hasValue(int docId) {
-                return values.hasValue(docId);
-            }
-
-            @Override
-            public BytesRef getValue(int docId) {
-                GeoPoint value = values.getValue(docId);
-                if (value != null) {
-                    scratch.copyChars(GeoHashUtils.encode(value.lat(), value.lon()));
-                } else {
-                    scratch.length = 0;
-                    return scratch;
-                }
-                return scratch;
-            }
-
-            @Override
             public int setDocument(int docId) {
                 this.docId = docId;
                 return values.setDocument(docId);

--- a/src/main/java/org/elasticsearch/index/fielddata/DoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/DoubleValues.java
@@ -63,49 +63,13 @@ public abstract class DoubleValues {
     }
 
     /**
-     * Returns <code>true</code> if the given document ID has a value in this. Otherwise <code>false</code>.
-     */
-    public abstract boolean hasValue(int docId);
-
-    /**
-     * Returns a value for the given document id. If the document
-     * has more than one value the returned value is one of the values
-     * associated with the document.
-     * @param docId the documents id.
-     * @return a value for the given document id.
-     */
-    public abstract double getValue(int docId);
-
-
-    /**
-     * Returns a value for the given document id or the given missing value if
-     * {@link #hasValue(int)} returns <code>false</code> ie. the document has no
-     * value associated with it.
-     *
-     * @param docId        the documents id.
-     * @param missingValue the missing value
-     * @return a value for the given document id or the given missing value if
-     *         {@link #hasValue(int)} returns <code>false</code> ie. the document has no
-     *         value associated with it.
-     */
-    public double getValueMissing(int docId, double missingValue) {
-        if (hasValue(docId)) {
-            return getValue(docId);
-        }
-        return missingValue;
-    }
-
-    /**
      * Sets iteration to the specified docID and returns the number of
      * values for this document ID,
      * @param docId document ID
      *
      * @see #nextValue()
      */
-    public int setDocument(int docId) {
-        this.docId = docId;
-        return hasValue(docId) ?  1 : 0;
-    }
+    public abstract int setDocument(int docId);
 
     /**
      * Returns the next value for the current docID set to {@link #setDocument(int)}.
@@ -115,9 +79,7 @@ public abstract class DoubleValues {
      *
      * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
-    public double nextValue() {
-        return getValue(docId);
-    }
+    public abstract double nextValue();
 
     /**
      * Ordinal based {@link DoubleValues}.
@@ -146,19 +108,6 @@ public abstract class DoubleValues {
          */
         public abstract double getValueByOrd(long ord);
 
-        @Override
-        public final boolean hasValue(int docId) {
-            return ordinals.getOrd(docId) != Ordinals.MISSING_ORDINAL;
-        }
-
-        @Override
-        public final double getValue(int docId) {
-            final long ord = ordinals.getOrd(docId);
-            if (ord == Ordinals.MISSING_ORDINAL) {
-                return 0d;
-            }
-            return getValueByOrd(ord);
-        }
 
         @Override
         public int setDocument(int docId) {
@@ -170,17 +119,6 @@ public abstract class DoubleValues {
         public double nextValue() {
             return getValueByOrd(ordinals.nextOrd());
         }
-
-        @Override
-        public final double getValueMissing(int docId, double missingValue) {
-            final long ord = ordinals.getOrd(docId);
-            if (ord == Ordinals.MISSING_ORDINAL) {
-                return missingValue;
-            } else {
-                return getValueByOrd(ord);
-            }
-        }
-
     }
     /**
      * An empty {@link DoubleValues} implementation
@@ -191,17 +129,6 @@ public abstract class DoubleValues {
             super(false);
         }
 
-        @Override
-        public boolean hasValue(int docId) {
-            return false;
-        }
-
-        @Override
-        public double getValue(int docId) {
-            // conforms with all other impls when there is no value
-            return 0;
-        }
-        
         @Override
         public int setDocument(int docId) {
             return 0;

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterBytesValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterBytesValues.java
@@ -35,11 +35,6 @@ public abstract class FilterBytesValues extends BytesValues {
     }
 
     @Override
-    public boolean hasValue(int docId) {
-        return delegate.hasValue(docId);
-    }
-
-    @Override
     public BytesRef copyShared() {
         return delegate.copyShared();
     }
@@ -57,10 +52,5 @@ public abstract class FilterBytesValues extends BytesValues {
     @Override
     public int currentValueHash() {
         return delegate.currentValueHash();
-    }
-
-    @Override
-    public BytesRef getValue(int docId) {
-        return delegate.getValue(docId);
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterDoubleValues.java
@@ -32,16 +32,6 @@ public abstract class FilterDoubleValues extends DoubleValues {
     }
 
     @Override
-    public boolean hasValue(int docId) {
-        return delegate.hasValue(docId);
-    }
-
-    @Override
-    public double getValue(int docId) {
-        return delegate.getValue(docId);
-    }
-
-    @Override
     public int setDocument(int docId) {
         return delegate.setDocument(docId);
     }
@@ -49,10 +39,5 @@ public abstract class FilterDoubleValues extends DoubleValues {
     @Override
     public double nextValue() {
         return delegate.nextValue();
-    }
-
-    @Override
-    public double getValueMissing(int docId, double missingValue) {
-        return delegate.getValueMissing(docId, missingValue);
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterLongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterLongValues.java
@@ -33,16 +33,6 @@ public class FilterLongValues extends LongValues {
     }
 
     @Override
-    public boolean hasValue(int docId) {
-        return delegate.hasValue(docId);
-    }
-
-    @Override
-    public long getValue(int docId) {
-        return delegate.getValue(docId);
-    }
-
-    @Override
     public int setDocument(int docId) {
         return delegate.setDocument(docId);
     }
@@ -52,8 +42,4 @@ public class FilterLongValues extends LongValues {
         return delegate.nextValue();
     }
 
-    @Override
-    public long getValueMissing(int docId, long missingValue) {
-        return delegate.getValueMissing(docId, missingValue);    //To change body of overridden methods use File | Settings | File Templates.
-    }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/GeoPointValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/GeoPointValues.java
@@ -60,33 +60,13 @@ public abstract class GeoPointValues {
     }
 
     /**
-     * Returns <code>true</code> if the given document ID has a value in this. Otherwise <code>false</code>.
-     */
-    public abstract boolean hasValue(int docId);
-
-    /**
-     * Returns a value for the given document id. If the document
-     * has more than one value the returned value is one of the values
-     * associated with the document.
-     *
-     * Note: the {@link GeoPoint} might be shared across invocations.
-     *
-     * @param docId the documents id.
-     * @return a value for the given document id.
-     */
-    public abstract GeoPoint getValue(int docId);
-
-    /**
      * Sets iteration to the specified docID and returns the number of
      * values for this document ID,
      * @param docId document ID
      *
      * @see #nextValue()
      */
-    public int setDocument(int docId) {
-        this.docId = docId;
-        return hasValue(docId) ? 1 : 0;
-    }
+    public abstract int setDocument(int docId);
     /**
      * Returns the next value for the current docID set to {@link #setDocument(int)}.
      * This method should only be called <tt>N</tt> times where <tt>N</tt> is the number
@@ -97,28 +77,7 @@ public abstract class GeoPointValues {
      *
      * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
-    public GeoPoint nextValue() {
-        assert docId != -1;
-        return getValue(docId);
-    }
-
-    /**
-     * Returns a value for the given document id or the given missing value if
-     * {@link #hasValue(int)} returns <code>false</code> ie. the document has no
-     * value associated with it.
-     *
-     * @param docId        the documents id.
-     * @param missingValue the missing value
-     * @return a value for the given document id or the given missing value if
-     *         {@link #hasValue(int)} returns <code>false</code> ie. the document has no
-     *         value associated with it.
-     */
-    public GeoPoint getValueMissing(int docId, GeoPoint missingValue) {
-        if (hasValue(docId)) {
-            return getValue(docId);
-        } 
-        return missingValue;
-    }
+    public abstract GeoPoint nextValue();
 
     /**
      * An empty {@link GeoPointValues} implementation
@@ -126,16 +85,6 @@ public abstract class GeoPointValues {
     private static final class Empty extends GeoPointValues {
         protected Empty() {
             super(false);
-        }
-
-        @Override
-        public boolean hasValue(int docId) {
-            return false;
-        }
-
-        @Override
-        public GeoPoint getValue(int docId) {
-            return null;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/LongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/LongValues.java
@@ -64,48 +64,13 @@ public abstract class LongValues {
     }
 
     /**
-     * Returns <code>true</code> if the given document ID has a value in this. Otherwise <code>false</code>.
-     */
-    public abstract boolean hasValue(int docId);
-
-    /**
-     * Returns a value for the given document id. If the document
-     * has more than one value the returned value is one of the values
-     * associated with the document.
-     * @param docId the documents id.
-     * @return a value for the given document id.
-     */
-    public abstract long getValue(int docId);
-
-    /**
-     * Returns a value for the given document id or the given missing value if
-     * {@link #hasValue(int)} returns <code>false</code> ie. the document has no
-     * value associated with it.
-     *
-     * @param docId        the documents id.
-     * @param missingValue the missing value
-     * @return a value for the given document id or the given missing value if
-     *         {@link #hasValue(int)} returns <code>false</code> ie. the document has no
-     *         value associated with it.
-     */
-    public long getValueMissing(int docId, long missingValue) {
-        if (hasValue(docId)) {
-            return getValue(docId);
-        }
-        return missingValue;
-    }
-
-    /**
      * Sets iteration to the specified docID and returns the number of
      * values for this document ID,
      * @param docId document ID
      *
      * @see #nextValue()
      */
-    public int setDocument(int docId) {
-        this.docId = docId;
-        return hasValue(docId) ?  1 : 0;
-    }
+    public abstract int setDocument(int docId);
 
     /**
      * Returns the next value for the current docID set to {@link #setDocument(int)}.
@@ -115,9 +80,7 @@ public abstract class LongValues {
      *
      * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
-    public long nextValue() {
-        return getValue(docId);
-    }
+    public abstract long nextValue();
 
     /**
      * Ordinal based {@link LongValues}.
@@ -146,19 +109,6 @@ public abstract class LongValues {
          */
         public abstract long getValueByOrd(long ord);
 
-        @Override
-        public final boolean hasValue(int docId) {
-            return ordinals.getOrd(docId) != Ordinals.MISSING_ORDINAL;
-        }
-
-        @Override
-        public final long getValue(int docId) {
-            long ord = ordinals.getOrd(docId);
-            if (ord == Ordinals.MISSING_ORDINAL) {
-                return 0l;
-            }
-            return getValueByOrd(ord);
-        }
 
         @Override
         public int setDocument(int docId) {
@@ -179,17 +129,6 @@ public abstract class LongValues {
             super(false);
         }
 
-        @Override
-        public boolean hasValue(int docId) {
-            return false;
-        }
-
-        @Override
-        public long getValue(int docId) {
-            // conforms with all other impls when there is no value
-            return 0;
-        }
-        
         @Override
         public int setDocument(int docId) {
             return 0;

--- a/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -94,7 +94,7 @@ public abstract class ScriptDocValues {
 
         @Override
         public boolean isEmpty() {
-            return !values.hasValue(docId);
+            return values.setDocument(docId) == 0;
         }
 
         public BytesValues getInternalValues() {
@@ -102,7 +102,11 @@ public abstract class ScriptDocValues {
         }
 
         public BytesRef getBytesValue() {
-            return values.getValue(docId);
+            int numValues = values.setDocument(docId);
+            if (numValues == 0) {
+                return null;
+            }
+            return values.nextValue();
         }
 
         public String getValue() {
@@ -150,11 +154,15 @@ public abstract class ScriptDocValues {
 
         @Override
         public boolean isEmpty() {
-            return !values.hasValue(docId);
+            return values.setDocument(docId) == 0;
         }
 
         public long getValue() {
-            return values.getValue(docId);
+            int numValues = values.setDocument(docId);
+            if (numValues == 0) {
+                return 0l;
+            }
+            return values.nextValue();
         }
 
         public List<Long> getValues() {
@@ -195,12 +203,16 @@ public abstract class ScriptDocValues {
 
         @Override
         public boolean isEmpty() {
-            return !values.hasValue(docId);
+            return values.setDocument(docId) == 0;
         }
 
 
         public double getValue() {
-            return values.getValue(docId);
+            int numValues = values.setDocument(docId);
+            if (numValues == 0) {
+                return 0d;
+            }
+            return values.nextValue();
         }
 
         public List<Double> getValues() {
@@ -243,11 +255,15 @@ public abstract class ScriptDocValues {
 
         @Override
         public boolean isEmpty() {
-            return !values.hasValue(docId);
+            return values.setDocument(docId) == 0;
         }
 
         public GeoPoint getValue() {
-            return values.getValue(docId);
+            int numValues = values.setDocument(docId);
+            if (numValues == 0) {
+                return null;
+            }
+            return values.nextValue();
         }
 
         public double getLat() {

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefValComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefValComparator.java
@@ -128,17 +128,6 @@ public final class BytesRefValComparator extends NestedWrappableComparator<Bytes
             this.sortMode = sortMode;
         }
 
-        @Override
-        public BytesRef getValue(int docId) {
-            numValues = delegate.setDocument(docId);
-            scratch.length = 0;
-            if (numValues == 0) {
-                scratch.length = 0;
-                return scratch;
-            }
-            return nextValue();
-        }
-
         public int setDocument(int docId) {
             // either 0 or 1
             return Math.min(1, (numValues = delegate.setDocument(docId)));

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparator.java
@@ -49,7 +49,7 @@ public final class DoubleValuesComparator extends DoubleValuesComparatorBase<Dou
 
     @Override
     public void copy(int slot, int doc) throws IOException {
-        values[slot] = readerValues.getValueMissing(doc, missingValue);
+        values[slot] = sortMode.getRelevantValue(readerValues, doc, missingValue);
     }
 
     @Override
@@ -59,7 +59,7 @@ public final class DoubleValuesComparator extends DoubleValuesComparatorBase<Dou
 
     @Override
     public void add(int slot, int doc) {
-        values[slot] += readerValues.getValueMissing(doc, missingValue);
+        values[slot] += sortMode.getRelevantValue(readerValues, doc, missingValue);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorBase.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorBase.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.fielddata.fieldcomparator;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.FieldComparator;
 import org.elasticsearch.index.fielddata.DoubleValues;
-import org.elasticsearch.index.fielddata.FilterDoubleValues;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ abstract class DoubleValuesComparatorBase<T extends Number> extends NumberCompar
     protected final double missingValue;
     protected double bottom;
     protected DoubleValues readerValues;
-    private final SortMode sortMode;
+    protected final SortMode sortMode;
 
     public DoubleValuesComparatorBase(IndexNumericFieldData<?> indexFieldData, double missingValue, SortMode sortMode) {
         this.indexFieldData = indexFieldData;
@@ -42,23 +41,20 @@ abstract class DoubleValuesComparatorBase<T extends Number> extends NumberCompar
 
     @Override
     public final int compareBottom(int doc) throws IOException {
-        final double v2 = readerValues.getValueMissing(doc, missingValue);
+        final double v2 = sortMode.getRelevantValue(readerValues, doc, missingValue);
         return compare(bottom, v2);
     }
 
     @Override
     public final int compareDocToValue(int doc, T valueObj) throws IOException {
         final double value = valueObj.doubleValue();
-        final double docValue = readerValues.getValueMissing(doc, missingValue);
+        final double docValue = sortMode.getRelevantValue(readerValues, doc, missingValue);
         return compare(docValue, value);
     }
 
     @Override
     public final FieldComparator<T> setNextReader(AtomicReaderContext context) throws IOException {
         readerValues = indexFieldData.load(context).getDoubleValues();
-        if (readerValues.isMultiValued()) {
-            readerValues = new MultiValueWrapper(readerValues, sortMode);
-        }
         return this;
     }
 
@@ -70,30 +66,4 @@ abstract class DoubleValuesComparatorBase<T extends Number> extends NumberCompar
     static final int compare(double left, double right) {
         return Double.compare(left, right);
     }
-
-    static final class MultiValueWrapper extends FilterDoubleValues {
-
-        private final SortMode sortMode;
-
-        public MultiValueWrapper(DoubleValues delegate, SortMode sortMode) {
-            super(delegate);
-            this.sortMode = sortMode;
-        }
-
-        @Override
-        public double getValueMissing(int docId, double missing) {
-            int numValues = delegate.setDocument(docId);
-            if (numValues == 0) {
-                return missing;
-            }
-            double relevantVal = sortMode.startDouble();
-            for (int i = 0; i < numValues; i++) {
-                relevantVal = sortMode.apply(relevantVal, delegate.nextValue());
-            }
-            return sortMode.reduce(relevantVal, numValues);
-        }
-
-    }
-
-
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparator.java
@@ -49,7 +49,7 @@ public final class FloatValuesComparator extends DoubleValuesComparatorBase<Floa
 
     @Override
     public void copy(int slot, int doc) throws IOException {
-        values[slot] = (float) readerValues.getValueMissing(doc, missingValue);
+        values[slot] = (float) sortMode.getRelevantValue(readerValues, doc, missingValue);
     }
 
     @Override
@@ -59,7 +59,7 @@ public final class FloatValuesComparator extends DoubleValuesComparatorBase<Floa
 
     @Override
     public void add(int slot, int doc) {
-        values[slot] += (float) readerValues.getValueMissing(doc, missingValue);
+        values[slot] += (float) sortMode.getRelevantValue(readerValues, doc, missingValue);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/GeoDistanceComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/GeoDistanceComparator.java
@@ -148,13 +148,13 @@ public class GeoDistanceComparator extends NumberComparatorBase<Double> {
 
         @Override
         public double computeDistance(int doc) {
-            GeoPoint geoPoint = readerValues.getValue(doc);
-            if (geoPoint == null) {
-                // is this true? push this to the "end"
-                return MISSING_VALUE;
-            } else {
+            int numValues = readerValues.setDocument(doc);
+            double result = MISSING_VALUE;
+            for (int i = 0; i < numValues; i++) {
+                GeoPoint geoPoint = readerValues.nextValue();
                 return fixedSourceDistance.calculate(geoPoint.lat(), geoPoint.lon());
             }
+            return MISSING_VALUE;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparator.java
@@ -48,7 +48,7 @@ public final class LongValuesComparator extends LongValuesComparatorBase<Long> {
     }
 
     public void copy(int slot, int doc) throws IOException {
-        values[slot] = readerValues.getValueMissing(doc, missingValue);
+        values[slot] = sortMode.getRelevantValue(readerValues, doc, missingValue);
     }
 
     @Override
@@ -58,7 +58,7 @@ public final class LongValuesComparator extends LongValuesComparatorBase<Long> {
 
     @Override
     public void add(int slot, int doc) {
-        values[slot] += readerValues.getValueMissing(doc, missingValue);
+        values[slot] += sortMode.getRelevantValue(readerValues, doc, missingValue);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/SortMode.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/SortMode.java
@@ -21,6 +21,8 @@
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.index.fielddata.DoubleValues;
+import org.elasticsearch.index.fielddata.LongValues;
 
 import java.util.Locale;
 
@@ -261,6 +263,27 @@ public enum SortMode {
         } catch (Throwable t) {
             throw new ElasticSearchIllegalArgumentException("Illegal sort_mode " + sortMode);
         }
+    }
+
+
+    public final double getRelevantValue(DoubleValues values, int docId, double defaultValue) {
+        final int numValues = values.setDocument(docId);
+        double relevantVal = startDouble();
+        double result = defaultValue;
+        for (int i = 0; i < numValues; i++) {
+            result = relevantVal = apply(relevantVal, values.nextValue());
+        }
+        return reduce(result, numValues);
+    }
+
+    public final long getRelevantValue(LongValues values, int docId, long defaultValue) {
+        final int numValues = values.setDocument(docId);
+        long relevantVal = startLong();
+        long result = defaultValue;
+        for (int i = 0; i < numValues; i++) {
+            result = relevantVal = apply(relevantVal, values.nextValue());
+        }
+        return reduce(result, numValues);
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
@@ -93,20 +93,16 @@ public class BinaryDVAtomicFieldData implements AtomicFieldData<ScriptDocValues.
         return new BytesValues(false) {
 
             @Override
-            public boolean hasValue(int docId) {
-                return docsWithField.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return docsWithField.get(docId) ? 1 : 0;
             }
 
             @Override
-            public BytesRef getValue(int docId) {
-                if (docsWithField.get(docId)) {
-                    values.get(docId, scratch);
-                    return scratch;
-                }
-                scratch.length = 0;
+            public BytesRef nextValue() {
+                values.get(docId, scratch);
                 return scratch;
             }
-
         };
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DenseDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DenseDoubleValues.java
@@ -16,30 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.elasticsearch.index.fielddata.plain;
 
 import org.elasticsearch.index.fielddata.DoubleValues;
 
 /**
- * Package private base class for dense long values.
+ * Package private base class for dense double values.
  */
 abstract class DenseDoubleValues extends DoubleValues {
-
 
     protected DenseDoubleValues(boolean multiValued) {
         super(multiValued);
     }
 
     @Override
-    public final boolean hasValue(int docId) {
-        return true;
+    public final int setDocument(int docId) {
+        this.docId = docId;
+        return 1;
     }
-
-    public final double getValueMissing(int docId, double missingValue) {
-        assert hasValue(docId);
-        assert !isMultiValued();
-        return getValue(docId);
-    }
-
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DenseLongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DenseLongValues.java
@@ -30,18 +30,7 @@ abstract class DenseLongValues extends LongValues {
     }
 
     @Override
-    public final boolean hasValue(int docId) {
-        return true;
-    }
-
-    public final long getValueMissing(int docId, long missingValue) {
-        assert hasValue(docId);
-        assert !isMultiValued();
-        return getValue(docId);
-    }
-
-    @Override
-    public int setDocument(int docId) {
+    public final int setDocument(int docId) {
         this.docId = docId;
         return 1;
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
@@ -239,15 +239,16 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return set.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return  set.get(docId) ? 1 : 0;
             }
 
             @Override
-            public long getValue(int docId) {
+            public long nextValue() {
                 return (long) values.get(docId);
             }
-        }
+            }
 
         static class DoubleValues extends org.elasticsearch.index.fielddata.DoubleValues {
 
@@ -261,15 +262,15 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return set.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return set.get(docId) ? 1 : 0;
             }
 
             @Override
-            public double getValue(int docId) {
+            public double nextValue() {
                 return values.get(docId);
             }
-
         }
     }
 
@@ -334,17 +335,9 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
             }
 
             @Override
-            public long getValue(int docId) {
-                return (long) values.get(docId);
-            }
-
-            @Override
             public long nextValue() {
                 return (long) values.get(docId);
             }
-            
-            
-
         }
 
         static final class DoubleValues extends DenseDoubleValues {
@@ -356,11 +349,6 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
                 this.values = values;
             }
 
-            @Override
-            public double getValue(int docId) {
-                return values.get(docId);
-            }
-            
             @Override
             public double nextValue() {
                 return values.get(docId);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
@@ -237,12 +237,13 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return set.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return set.get(docId) ? 1 : 0;
             }
 
             @Override
-            public long getValue(int docId) {
+            public long nextValue() {
                 return (long) values.get(docId);
             }
         }
@@ -259,15 +260,15 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return set.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return set.get(docId) ? 1 : 0;
             }
 
             @Override
-            public double getValue(int docId) {
-                return (double) values.get(docId);
+            public double nextValue() {
+                return values.get(docId);
             }
-
         }
 
     }
@@ -334,16 +335,9 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
             }
 
             @Override
-            public long getValue(int docId) {
-                return (long) values.get(docId);
-            }
-            
-            @Override
             public long nextValue() {
                 return (long) values.get(docId);
             }
-            
-
         }
 
         static class DoubleValues extends DenseDoubleValues {
@@ -355,11 +349,6 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
                 this.values = values;
             }
 
-            @Override
-            public double getValue(int docId) {
-                return (double) values.get(docId);
-            }
-            
             @Override
             public double nextValue() {
                 return values.get(docId);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
@@ -156,20 +156,6 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return ordinals.getOrd(docId) != Ordinals.MISSING_ORDINAL;
-            }
-
-            @Override
-            public GeoPoint getValue(int docId) {
-                long ord = ordinals.getOrd(docId);
-                if (ord == Ordinals.MISSING_ORDINAL) {
-                    return null;
-                }
-                return scratch.reset(lat.get(ord), lon.get(ord));
-            }
-
-            @Override
             public GeoPoint nextValue() {
                 final long ord = ordinals.nextOrd();
                 assert ord > 0;
@@ -246,17 +232,14 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return set.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return set.get(docId) ? 1 : 0;
             }
 
             @Override
-            public GeoPoint getValue(int docId) {
-                if (set.get(docId)) {
-                    return scratch.reset(lat.get(docId), lon.get(docId));
-                } else {
-                    return null;
-                }
+            public GeoPoint nextValue() {
+                return scratch.reset(lat.get(docId), lon.get(docId));
             }
         }
     }
@@ -320,12 +303,13 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return true;
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return 1;
             }
 
             @Override
-            public GeoPoint getValue(int docId) {
+            public GeoPoint nextValue() {
                 return scratch.reset(lat.get(docId), lon.get(docId));
             }
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVAtomicFieldData.java
@@ -110,14 +110,14 @@ public class NumericDVAtomicFieldData extends AbstractAtomicNumericFieldData {
         final DocValuesAndBits docValues = getDocValues();
 
         return new LongValues(false) {
-
             @Override
-            public boolean hasValue(int docId) {
-                return docValues.docsWithField.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return docValues.docsWithField.get(docId) ? 1 : 0;
             }
 
             @Override
-            public long getValue(int docId) {
+            public long nextValue() {
                 return docValues.values.get(docId);
             }
         };
@@ -130,12 +130,13 @@ public class NumericDVAtomicFieldData extends AbstractAtomicNumericFieldData {
         return new DoubleValues(false) {
 
             @Override
-            public boolean hasValue(int docId) {
-                return docValues.docsWithField.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return docValues.docsWithField.get(docId) ? 1 : 0;
             }
 
             @Override
-            public double getValue(int docId) {
+            public double nextValue() {
                 return docValues.values.get(docId);
             }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
@@ -244,14 +244,14 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
             }
 
             @Override
-            public boolean hasValue(int docId) {
-                return values.get(docId) != missingValue;
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return values.get(docId) != missingValue ? 1 : 0;
             }
 
             @Override
-            public long getValue(int docId) {
-                final long value = values.get(docId);
-                return value == missingValue ? 0L : minValue + value;
+            public long nextValue() {
+                return  minValue + values.get(docId);
             }
         }
 
@@ -268,16 +268,15 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
                 this.missingValue = missingValue;
             }
 
-
             @Override
-            public boolean hasValue(int docId) {
-                return values.get(docId) != missingValue;
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return values.get(docId) != missingValue ? 1 : 0;
             }
 
             @Override
-            public double getValue(int docId) {
-                final long value = values.get(docId);
-                return value == missingValue ? 0L : minValue + value;
+            public double nextValue() {
+                return  minValue + values.get(docId);
             }
         }
     }
@@ -346,10 +345,6 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
                 this.minValue = minValue;
             }
 
-            @Override
-            public long getValue(int docId) {
-                return minValue + values.get(docId);
-            }
 
             @Override
             public long nextValue() {
@@ -359,7 +354,7 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
 
         }
 
-        static class DoubleValues extends DenseDoubleValues {
+        static class DoubleValues extends org.elasticsearch.index.fielddata.DoubleValues {
 
             private final PackedInts.Mutable values;
             private final long minValue;
@@ -371,10 +366,11 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
             }
 
             @Override
-            public double getValue(int docId) {
-                return minValue + values.get(docId);
+            public int setDocument(int docId) {
+                this.docId = docId;
+                return 1;
             }
-            
+
             @Override
             public double nextValue() {
                 return minValue + values.get(docId);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -153,17 +153,6 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
         }
 
         @Override
-        public final BytesRef getValue(int docId) {
-            final long ord = ordinals.getOrd(docId);
-            if (ord == Ordinals.MISSING_ORDINAL) {
-                scratch.length = 0;
-                return scratch;
-            }
-            bytes.fill(scratch, termOrdToBytesOffset.get(ord));
-            return scratch;
-        }
-
-        @Override
         public final BytesRef nextValue() {
             bytes.fill(scratch, termOrdToBytesOffset.get(ordinals.nextOrd()));
             return scratch;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -284,9 +284,17 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             geoPointValues = fieldData.load(context).getGeoPointValues();
         }
 
+        private final GeoPoint getValue(int doc, GeoPoint missing) {
+            final int num = geoPointValues.setDocument(doc);
+            for (int i = 0; i < num; i++) {
+                return geoPointValues.nextValue();
+            }
+            return missing;
+        }
+
         @Override
         protected double distance(int docId) {
-            GeoPoint other = geoPointValues.getValueMissing(docId, origin);
+            GeoPoint other = getValue(docId, origin);
             double distance = Math.abs(distFunction.calculate(origin.lat(), origin.lon(), other.lat(), other.lon(),
                     DistanceUnit.METERS)) - offset;
             if (distance < 0.0d) {
@@ -297,7 +305,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         @Override
         protected String getDistanceString(int docId) {
-            final GeoPoint other = geoPointValues.getValueMissing(docId, origin);
+            final GeoPoint other = getValue(docId, origin);
             return "arcDistance(" + other + "(=doc value), " + origin + "(=origin)) - " + offset
                     + "(=offset) < 0.0 ? 0.0: arcDistance(" + other + "(=doc value), " + origin + "(=origin)) - " + offset
                     + "(=offset)";
@@ -326,9 +334,17 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             this.doubleValues = this.fieldData.load(context).getDoubleValues();
         }
 
+        private final double getValue(int doc, double missing) {
+            final int num = doubleValues.setDocument(doc);
+            for (int i = 0; i < num; i++) {
+                return doubleValues.nextValue();
+            }
+            return missing;
+        }
+
         @Override
         protected double distance(int docId) {
-            double distance = Math.abs(doubleValues.getValueMissing(docId, origin) - origin) - offset;
+            double distance = Math.abs(getValue(docId, origin) - origin) - offset;
             if (distance < 0.0) {
                 distance = 0.0;
             }
@@ -337,8 +353,8 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         @Override
         protected String getDistanceString(int docId) {
-            return "Math.abs(" + doubleValues.getValueMissing(docId, origin) + "(=doc value) - " + origin + "(=origin)) - "
-                    + offset + "(=offset) < 0.0 ? 0.0: Math.abs(" + doubleValues.getValueMissing(docId, origin) + "(=doc value) - "
+            return "Math.abs(" + getValue(docId, origin) + "(=doc value) - " + origin + "(=origin)) - "
+                    + offset + "(=offset) < 0.0 ? 0.0: Math.abs(" + getValue(docId, origin) + "(=doc value) - "
                     + origin + ") - " + offset + "(=offset)";
         }
 

--- a/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -716,9 +716,9 @@ public class PercolatorService extends AbstractComponent {
                     AtomicReaderContext atomicReaderContext = percolatorSearcher.reader().leaves().get(segmentIdx);
                     BytesValues values = idFieldData.load(atomicReaderContext).getBytesValues(true);
                     final int localDocId = scoreDoc.doc - atomicReaderContext.docBase;
-                    assert values.hasValue(localDocId);
-                    spare.bytes = values.getValue(localDocId);
-
+                    final int numValues = values.setDocument(localDocId);
+                    assert numValues == 1;
+                    spare.bytes = values.nextValue();
                     spare.hash = values.currentValueHash();
                     matches.add(values.copyShared());
                     if (hls != null) {

--- a/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -131,6 +131,19 @@ abstract class QueryCollector extends Collector {
         return new MatchAndSort(logger, context);
     }
 
+
+    protected final Query getQuery(int doc) {
+        final int numValues = values.setDocument(doc);
+        if (numValues == 0) {
+            return null;
+        }
+        assert numValues == 1;
+        spare.reset(values.nextValue(), values.currentValueHash());
+        return queries.get(spare);
+    }
+
+
+
     final static class Match extends QueryCollector {
 
         final PercolateContext context;
@@ -152,8 +165,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.reset(values.getValue(doc), values.currentValueHash());
-            Query query = queries.get(spare);
+            final Query query = getQuery(doc);
             if (query == null) {
                 // log???
                 return;
@@ -210,8 +222,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.reset(values.getValue(doc), values.currentValueHash());
-            Query query = queries.get(spare);
+            final Query query = getQuery(doc);
             if (query == null) {
                 // log???
                 return;
@@ -273,8 +284,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.reset(values.getValue(doc), values.currentValueHash());
-            Query query = queries.get(spare);
+            final Query query = getQuery(doc);
             if (query == null) {
                 // log???
                 return;
@@ -338,8 +348,7 @@ abstract class QueryCollector extends Collector {
 
         @Override
         public void collect(int doc) throws IOException {
-            spare.reset(values.getValue(doc), values.currentValueHash());
-            Query query = queries.get(spare);
+            final Query query = getQuery(doc);
             if (query == null) {
                 // log???
                 return;

--- a/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleFacetExecutor.java
@@ -82,26 +82,11 @@ public class TermsDoubleFacetExecutor extends FacetExecutor {
                         facets.v().putIfAbsent(valuesWithOrds.getValueByOrd(ord), 0);
                     }
                 } else {
-                    // Shouldn't be true, otherwise it is WithOrdinals... just to be sure...
-                    if (values.isMultiValued()) {
-                        for (int docId = 0; docId < maxDoc; docId++) {
-                            if (!values.hasValue(docId)) {
-                                continue;
-                            }
-                            int numValues = values.setDocument(docId);
-                            DoubleIntOpenHashMap map = facets.v();
-                            for (int i = 0; i < numValues; i++) {
-                                map.putIfAbsent(values.nextValue(), 0);
-                            }
-                        }
-                    } else {
-                        for (int docId = 0; docId < maxDoc; docId++) {
-                            if (!values.hasValue(docId)) {
-                                continue;
-                            }
-
-                            double value = values.getValue(docId);
-                            facets.v().putIfAbsent(value, 0);
+                    for (int docId = 0; docId < maxDoc; docId++) {
+                        int numValues = values.setDocument(docId);
+                        DoubleIntOpenHashMap map = facets.v();
+                        for (int i = 0; i < numValues; i++) {
+                            map.putIfAbsent(values.nextValue(), 0);
                         }
                     }
                 }

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetExecutor.java
@@ -81,23 +81,11 @@ public class TermsLongFacetExecutor extends FacetExecutor {
                         facets.v().putIfAbsent(valuesWithOrds.getValueByOrd(ord), 0);
                     }
                 } else {
-                    // Shouldn't be true, otherwise it is WithOrdinals... just to be sure...
-                    if (values.isMultiValued()) {
-                        for (int docId = 0; docId < maxDoc; docId++) {
-                            final int numValues = values.setDocument(docId);
-                            final LongIntOpenHashMap v = facets.v();
-                            for (int i = 0; i < numValues; i++) {
-                                v.putIfAbsent(values.nextValue(), 0);
-                            }
-                        }
-                    } else {
-                        for (int docId = 0; docId < maxDoc; docId++) {
-                            if (!values.hasValue(docId)) {
-                                continue;
-                            }
-
-                            long value = values.getValue(docId);
-                            facets.v().putIfAbsent(value, 0);
+                    for (int docId = 0; docId < maxDoc; docId++) {
+                        final int numValues = values.setDocument(docId);
+                        final LongIntOpenHashMap v = facets.v();
+                        for (int i = 0; i < numValues; i++) {
+                            v.putIfAbsent(values.nextValue(), 0);
                         }
                     }
                 }

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
@@ -68,7 +68,7 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         AtomicFieldData fieldData = indexFieldData.load(readerContext);
         BytesValues values = fieldData.getBytesValues(randomBoolean());
         for (int i = 0; i < fieldData.getNumDocs(); ++i) {
-            assertThat(values.hasValue(i), equalTo(true));
+            assertThat(values.setDocument(i), greaterThanOrEqualTo(1));
         }
     }
 
@@ -86,23 +86,18 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         assertThat(bytesValues.isMultiValued(), equalTo(false));
 
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(true));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef(one())));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
+        assertThat(bytesValues.setDocument(0), equalTo(1));
+        assertThat(bytesValues.nextValue(), equalTo(new BytesRef(two())));
+        assertThat(bytesValues.setDocument(1), equalTo(1));
+        assertThat(bytesValues.nextValue(), equalTo(new BytesRef(one())));
+        assertThat(bytesValues.setDocument(2), equalTo(1));
+        assertThat(bytesValues.nextValue(), equalTo(new BytesRef(three())));
 
         assertValues(bytesValues, 0, two());
         assertValues(bytesValues, 1, one());
         assertValues(bytesValues, 2, three());
 
         BytesValues hashedBytesValues = fieldData.getBytesValues(randomBoolean());
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
 
         assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
         assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(one())));
@@ -133,8 +128,8 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
     }
     
     private HashedBytesRef convert(BytesValues values, int doc) {
-        if (values.hasValue(doc)) {
-            return new HashedBytesRef(BytesRef.deepCopyOf(values.getValue(doc)), values.currentValueHash());
+        if (values.setDocument(doc) > 0) {
+            return new HashedBytesRef(BytesRef.deepCopyOf(values.nextValue()), values.currentValueHash());
         } else {
             return new HashedBytesRef(new BytesRef());
         }
@@ -189,30 +184,19 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         assertThat(bytesValues.isMultiValued(), equalTo(false));
 
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(false));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef()));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
         assertValues(bytesValues, 0, two());
         assertValues(bytesValues, 1, Strings.EMPTY_ARRAY);
-
+        assertValues(bytesValues, 2, three());
 
         BytesValues hashedBytesValues = fieldData.getBytesValues(randomBoolean());
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
-
         assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
         assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(new BytesRef())));
         assertThat(convert(hashedBytesValues, 2), equalTo(new HashedBytesRef(three())));
 
         assertHashedValues(hashedBytesValues, 0, two());
         assertHashedValues(hashedBytesValues, 1, Strings.EMPTY_ARRAY);
+        assertHashedValues(hashedBytesValues,  2, three());
+
 
     }
 
@@ -231,21 +215,12 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         assertThat(bytesValues.isMultiValued(), equalTo(true));
 
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(true));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef(one())));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
         assertValues(bytesValues, 0, two(), four());
+        assertValues(bytesValues, 1, one());
+        assertValues(bytesValues, 2, three());
+
 
         BytesValues hashedBytesValues = fieldData.getBytesValues(randomBoolean());
-
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
 
         assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
         assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(one())));
@@ -284,22 +259,11 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         assertThat(bytesValues.isMultiValued(), equalTo(true));
 
-        assertThat(bytesValues.hasValue(0), equalTo(true));
-        assertThat(bytesValues.hasValue(1), equalTo(false));
-        assertThat(bytesValues.hasValue(2), equalTo(true));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef(two())));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef()));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef(three())));
-
         assertValues(bytesValues, 0, two(), four());
         assertValues(bytesValues, 1, Strings.EMPTY_ARRAY);
 
         BytesValues hashedBytesValues = fieldData.getBytesValues(randomBoolean());
 
-        assertThat(hashedBytesValues.hasValue(0), equalTo(true));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(true));
 
         assertThat(convert(hashedBytesValues, 0), equalTo(new HashedBytesRef(two())));
         assertThat(convert(hashedBytesValues, 1), equalTo(new HashedBytesRef(new BytesRef())));
@@ -307,8 +271,12 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         assertHashedValues(bytesValues, 0, two(), four());
         assertHashedValues(bytesValues, 1, Strings.EMPTY_ARRAY);
+        assertHashedValues(bytesValues, 2, three());
+
         assertHashedValues(hashedBytesValues, 0, two(), four());
         assertHashedValues(hashedBytesValues, 1, Strings.EMPTY_ARRAY);
+        assertHashedValues(hashedBytesValues, 2, three());
+
     }
 
     public void testMissingValueForAll() throws Exception {
@@ -324,26 +292,11 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         assertThat(bytesValues.isMultiValued(), equalTo(false));
 
-        assertThat(bytesValues.hasValue(0), equalTo(false));
-        assertThat(bytesValues.hasValue(1), equalTo(false));
-        assertThat(bytesValues.hasValue(2), equalTo(false));
-
-        assertThat(bytesValues.getValue(0), equalTo(new BytesRef()));
-        assertThat(bytesValues.getValue(1), equalTo(new BytesRef()));
-        assertThat(bytesValues.getValue(2), equalTo(new BytesRef()));
-
         assertValues(bytesValues, 0, Strings.EMPTY_ARRAY);
         assertValues(bytesValues, 1, Strings.EMPTY_ARRAY);
         assertValues(bytesValues, 2, Strings.EMPTY_ARRAY);
         BytesValues hashedBytesValues = fieldData.getBytesValues(randomBoolean());
 
-        assertThat(hashedBytesValues.hasValue(0), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(1), equalTo(false));
-        assertThat(hashedBytesValues.hasValue(2), equalTo(false));
-
-        assertThat(hashedBytesValues.getValue(0), equalTo(new BytesRef()));
-        assertThat(hashedBytesValues.getValue(1), equalTo(new BytesRef()));
-        assertThat(hashedBytesValues.getValue(2), equalTo(new BytesRef()));
         assertValues(hashedBytesValues, 0, Strings.EMPTY_ARRAY);
         assertValues(hashedBytesValues, 1, Strings.EMPTY_ARRAY);
         assertValues(hashedBytesValues, 2, Strings.EMPTY_ARRAY);

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
@@ -47,17 +47,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         assertThat(longValues.isMultiValued(), equalTo(false));
 
-        assertThat(longValues.hasValue(0), equalTo(true));
-        assertThat(longValues.hasValue(1), equalTo(true));
-        assertThat(longValues.hasValue(2), equalTo(true));
-
-        assertThat(longValues.getValue(0), equalTo(2l));
-        assertThat(longValues.getValue(1), equalTo(1l));
-        assertThat(longValues.getValue(2), equalTo(3l));
-
-        assertThat(longValues.getValueMissing(0, -1), equalTo(2l));
-        assertThat(longValues.getValueMissing(1, -1), equalTo(1l));
-        assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
         assertThat(longValues.setDocument(0), equalTo(1));
         assertThat(longValues.nextValue(), equalTo(2l));
 
@@ -70,18 +59,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
         assertThat(doubleValues.isMultiValued(), equalTo(false));
-
-        assertThat(doubleValues.hasValue(0), equalTo(true));
-        assertThat(doubleValues.hasValue(1), equalTo(true));
-        assertThat(doubleValues.hasValue(2), equalTo(true));
-
-        assertThat(doubleValues.getValue(0), equalTo(2d));
-        assertThat(doubleValues.getValue(1), equalTo(1d));
-        assertThat(doubleValues.getValue(2), equalTo(3d));
-
-        assertThat(doubleValues.getValueMissing(0, -1), equalTo(2d));
-        assertThat(doubleValues.getValueMissing(1, -1), equalTo(1d));
-        assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
         assertThat(1, equalTo(doubleValues.setDocument(0)));
         assertThat(doubleValues.nextValue(), equalTo(2d));
@@ -122,39 +99,17 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         assertThat(longValues.isMultiValued(), equalTo(false));
 
-        assertThat(longValues.hasValue(0), equalTo(true));
-        assertThat(longValues.hasValue(1), equalTo(false));
-        assertThat(longValues.hasValue(2), equalTo(true));
-
-        assertThat(longValues.getValue(0), equalTo(2l));
-        assertThat(longValues.getValue(2), equalTo(3l));
-
-        assertThat(longValues.getValueMissing(0, -1), equalTo(2l));
-        assertThat(longValues.getValueMissing(1, -1), equalTo(-1l));
-        assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
-        
         assertThat(longValues.setDocument(0), equalTo(1));
         assertThat(longValues.nextValue(), equalTo(2l));
 
         assertThat(longValues.setDocument(1), equalTo(0));
-        
+
         assertThat(longValues.setDocument(2), equalTo(1));
         assertThat(longValues.nextValue(), equalTo(3l));
 
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
         assertThat(doubleValues.isMultiValued(), equalTo(false));
-
-        assertThat(doubleValues.hasValue(0), equalTo(true));
-        assertThat(doubleValues.hasValue(1), equalTo(false));
-        assertThat(doubleValues.hasValue(2), equalTo(true));
-
-        assertThat(doubleValues.getValue(0), equalTo(2d));
-        assertThat(doubleValues.getValue(2), equalTo(3d));
-
-        assertThat(doubleValues.getValueMissing(0, -1), equalTo(2d));
-        assertThat(doubleValues.getValueMissing(1, -1), equalTo(-1d));
-        assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
         assertThat(1, equalTo(doubleValues.setDocument(0)));
         assertThat(doubleValues.nextValue(), equalTo(2d));
@@ -222,18 +177,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         assertThat(longValues.isMultiValued(), equalTo(true));
 
-        assertThat(longValues.hasValue(0), equalTo(true));
-        assertThat(longValues.hasValue(1), equalTo(true));
-        assertThat(longValues.hasValue(2), equalTo(true));
-
-        assertThat(longValues.getValue(0), equalTo(2l));
-        assertThat(longValues.getValue(1), equalTo(1l));
-        assertThat(longValues.getValue(2), equalTo(3l));
-
-        assertThat(longValues.getValueMissing(0, -1), equalTo(2l));
-        assertThat(longValues.getValueMissing(1, -1), equalTo(1l));
-        assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
-
         assertThat(longValues.setDocument(0), equalTo(2));
         assertThat(longValues.nextValue(), equalTo(2l));
         assertThat(longValues.nextValue(), equalTo(4l));
@@ -247,18 +190,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
         assertThat(doubleValues.isMultiValued(), equalTo(true));
-
-        assertThat(doubleValues.hasValue(0), equalTo(true));
-        assertThat(doubleValues.hasValue(1), equalTo(true));
-        assertThat(doubleValues.hasValue(2), equalTo(true));
-
-        assertThat(doubleValues.getValue(0), equalTo(2d));
-        assertThat(doubleValues.getValue(1), equalTo(1d));
-        assertThat(doubleValues.getValue(2), equalTo(3d));
-
-        assertThat(doubleValues.getValueMissing(0, -1), equalTo(2d));
-        assertThat(doubleValues.getValueMissing(1, -1), equalTo(1d));
-        assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
         assertThat(2, equalTo(doubleValues.setDocument(0)));
         assertThat(doubleValues.nextValue(), equalTo(2d));
@@ -283,17 +214,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         assertThat(longValues.isMultiValued(), equalTo(true));
 
-        assertThat(longValues.hasValue(0), equalTo(true));
-        assertThat(longValues.hasValue(1), equalTo(false));
-        assertThat(longValues.hasValue(2), equalTo(true));
-
-        assertThat(longValues.getValue(0), equalTo(2l));
-        assertThat(longValues.getValue(2), equalTo(3l));
-
-        assertThat(longValues.getValueMissing(0, -1), equalTo(2l));
-        assertThat(longValues.getValueMissing(1, -1), equalTo(-1l));
-        assertThat(longValues.getValueMissing(2, -1), equalTo(3l));
-
         assertThat(longValues.setDocument(0), equalTo(2));
         assertThat(longValues.nextValue(), equalTo(2l));
         assertThat(longValues.nextValue(), equalTo(4l));
@@ -307,16 +227,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         assertThat(doubleValues.isMultiValued(), equalTo(true));
 
-        assertThat(doubleValues.hasValue(0), equalTo(true));
-        assertThat(doubleValues.hasValue(1), equalTo(false));
-        assertThat(doubleValues.hasValue(2), equalTo(true));
-
-        assertThat(doubleValues.getValue(0), equalTo(2d));
-        assertThat(doubleValues.getValue(2), equalTo(3d));
-
-        assertThat(doubleValues.getValueMissing(0, -1), equalTo(2d));
-        assertThat(doubleValues.getValueMissing(1, -1), equalTo(-1d));
-        assertThat(doubleValues.getValueMissing(2, -1), equalTo(3d));
 
         assertThat(2, equalTo(doubleValues.setDocument(0)));
         assertThat(doubleValues.nextValue(), equalTo(2d));
@@ -343,15 +253,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         assertThat(longValues.isMultiValued(), equalTo(false));
 
-        assertThat(longValues.hasValue(0), equalTo(false));
-        assertThat(longValues.hasValue(1), equalTo(false));
-        assertThat(longValues.hasValue(2), equalTo(false));
-
-        assertThat(longValues.getValueMissing(0, -1), equalTo(-1l));
-        assertThat(longValues.getValueMissing(1, -1), equalTo(-1l));
-        assertThat(longValues.getValueMissing(2, -1), equalTo(-1l));
-
-        
         assertThat(longValues.setDocument(0), equalTo(0));
         assertThat(longValues.setDocument(1), equalTo(0));
         assertThat(longValues.setDocument(2), equalTo(0));
@@ -361,14 +262,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         DoubleValues doubleValues = fieldData.getDoubleValues();
 
         assertThat(doubleValues.isMultiValued(), equalTo(false));
-
-        assertThat(doubleValues.hasValue(0), equalTo(false));
-        assertThat(doubleValues.hasValue(1), equalTo(false));
-        assertThat(doubleValues.hasValue(2), equalTo(false));
-
-        assertThat(doubleValues.getValueMissing(0, -1), equalTo(-1d));
-        assertThat(doubleValues.getValueMissing(1, -1), equalTo(-1d));
-        assertThat(doubleValues.getValueMissing(2, -1), equalTo(-1d));
 
         assertThat(0, equalTo(doubleValues.setDocument(0)));
 

--- a/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
@@ -28,7 +28,6 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.*;
@@ -359,26 +358,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
         BytesRef leftSpare = new BytesRef();
         BytesRef rightSpare = new BytesRef();
         for (int i = 0; i < numDocs; i++) {
-            assertThat(leftBytesValues.hasValue(i), equalTo(rightBytesValues.hasValue(i)));
-            if (leftBytesValues.hasValue(i)) {
-                assertThat(pre.toString(leftBytesValues.getValue(i)), equalTo(pre.toString(rightBytesValues.getValue(i))));
-            } else {
-                assertThat(leftBytesValues.getValue(i), equalTo(new BytesRef()));
-                assertThat(rightBytesValues.getValue(i), equalTo(new BytesRef()));
-            }
-            
-            
             int numValues = 0;
-            if (leftBytesValues.hasValue(i)) {
-                assertThat(rightBytesValues.hasValue(i), equalTo(true));
-                assertThat(leftBytesValues.setDocument(i), Matchers.greaterThanOrEqualTo(1));
-                assertThat(rightBytesValues.setDocument(i),  Matchers.greaterThanOrEqualTo(1));
-            } else { 
-                assertThat(rightBytesValues.hasValue(i), equalTo(false));
-                assertThat(leftBytesValues.setDocument(i), equalTo(0));
-                assertThat(rightBytesValues.setDocument(i), equalTo(0));
-            }
-            
             assertThat((numValues = leftBytesValues.setDocument(i)), equalTo(rightBytesValues.setDocument(i)));
             for (int j = 0; j < numValues; j++) {
                 rightSpare.copyBytes(rightBytesValues.nextValue());
@@ -406,14 +386,6 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
         DoubleValues leftDoubleValues = leftData.getDoubleValues();
         DoubleValues rightDoubleValues = rightData.getDoubleValues();
         for (int i = 0; i < numDocs; i++) {
-            assertThat(leftDoubleValues.hasValue(i), equalTo(rightDoubleValues.hasValue(i)));
-            if (leftDoubleValues.hasValue(i)) {
-                assertThat(leftDoubleValues.getValue(i), equalTo(rightDoubleValues.getValue(i)));
-            } else {
-                assertThat(leftDoubleValues.getValue(i), equalTo(0d));
-                assertThat(rightDoubleValues.getValue(i), equalTo(0d));
-            }
-
             int numValues = 0;
             assertThat((numValues = leftDoubleValues.setDocument(i)), equalTo(rightDoubleValues.setDocument(i)));
             for (int j = 0; j < numValues; j++) {
@@ -432,15 +404,6 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
         LongValues leftLongValues = leftData.getLongValues();
         LongValues rightLongValues = rightData.getLongValues();
         for (int i = 0; i < numDocs; i++) {
-            assertThat(leftLongValues.hasValue(i), equalTo(rightLongValues.hasValue(i)));
-            if (leftLongValues.hasValue(i)) {
-                assertThat(leftLongValues.getValue(i), equalTo(rightLongValues.getValue(i)));
-
-            } else {
-                assertThat(leftLongValues.getValue(i), equalTo(0l));
-                assertThat(rightLongValues.getValue(i), equalTo(0l));
-            }
-
             int numValues = 0;
             assertThat((numValues = leftLongValues.setDocument(i)), equalTo(rightLongValues.setDocument(i)));
             for (int j = 0; j < numValues; j++) {

--- a/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
@@ -37,6 +37,7 @@ import java.util.Random;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Tests for all integer types (byte, short, int, long).
@@ -80,8 +81,20 @@ public class LongFieldDataTests extends AbstractNumericFieldDataTests {
         IndexNumericFieldData indexFieldData = getForField("value");
         AtomicNumericFieldData fieldData = indexFieldData.load(refreshReader());
         assertThat(fieldData, instanceOf(PackedArrayAtomicFieldData.class));
-        assertThat(fieldData.getLongValues().getValue(0), equalTo((long) Integer.MAX_VALUE + 1l));
-        assertThat(fieldData.getLongValues().getValue(1), equalTo((long) Integer.MIN_VALUE - 1l));
+        assertThat(getFirst(fieldData.getLongValues(), 0), equalTo((long) Integer.MAX_VALUE + 1l));
+        assertThat(getFirst(fieldData.getLongValues(), 1), equalTo((long) Integer.MIN_VALUE - 1l));
+    }
+
+    private static long getFirst(LongValues values, int docId) {
+        final int numValues = values.setDocument(docId);
+        assertThat(numValues , is(1));
+        return values.nextValue();
+    }
+
+    private static double getFirst(DoubleValues values, int docId) {
+        final int numValues = values.setDocument(docId);
+        assertThat(numValues , is(1));
+        return values.nextValue();
     }
 
     @Test
@@ -325,13 +338,8 @@ public class LongFieldDataTests extends AbstractNumericFieldDataTests {
         for (int i = 0; i < values.size(); ++i) {
             final LongOpenHashSet v = values.get(i);
 
-            assertThat(data.hasValue(i), equalTo(!v.isEmpty()));
-            assertThat(doubleData.hasValue(i), equalTo(!v.isEmpty()));
-
-            if (v.isEmpty()) {
-                assertThat(data.getValue(i), equalTo(0L));
-                assertThat(doubleData.getValue(i), equalTo(0d));
-            }
+            assertThat(data.setDocument(i) > 0, equalTo(!v.isEmpty()));
+            assertThat(doubleData.setDocument(i) > 0, equalTo(!v.isEmpty()));
 
             set.clear();
             int numValues = data.setDocument(i);


### PR DESCRIPTION
Removing #getValue and #hasValue to have a simple and consistent API
for multiple values.
