### PR TITLE
Ignore slow log configuration on shard creation

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchService.java
+++ b/src/main/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.search.slowlog;
 
+import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
@@ -125,15 +126,15 @@ public class ShardSlowLogSearchService extends AbstractIndexShardComponent {
 
         this.reformat = componentSettings.getAsBoolean("reformat", true);
 
-        this.queryWarnThreshold = componentSettings.getAsTime("threshold.query.warn", TimeValue.timeValueNanos(-1)).nanos();
-        this.queryInfoThreshold = componentSettings.getAsTime("threshold.query.info", TimeValue.timeValueNanos(-1)).nanos();
-        this.queryDebugThreshold = componentSettings.getAsTime("threshold.query.debug", TimeValue.timeValueNanos(-1)).nanos();
-        this.queryTraceThreshold = componentSettings.getAsTime("threshold.query.trace", TimeValue.timeValueNanos(-1)).nanos();
+        this.queryWarnThreshold = parseTimeSetting("threshold.query.warn", -1);
+        this.queryInfoThreshold = parseTimeSetting("threshold.query.info", -1);
+        this.queryDebugThreshold = parseTimeSetting("threshold.query.debug", -1);
+        this.queryTraceThreshold = parseTimeSetting("threshold.query.trace", -1);
 
-        this.fetchWarnThreshold = componentSettings.getAsTime("threshold.fetch.warn", TimeValue.timeValueNanos(-1)).nanos();
-        this.fetchInfoThreshold = componentSettings.getAsTime("threshold.fetch.info", TimeValue.timeValueNanos(-1)).nanos();
-        this.fetchDebugThreshold = componentSettings.getAsTime("threshold.fetch.debug", TimeValue.timeValueNanos(-1)).nanos();
-        this.fetchTraceThreshold = componentSettings.getAsTime("threshold.fetch.trace", TimeValue.timeValueNanos(-1)).nanos();
+        this.fetchWarnThreshold = parseTimeSetting("threshold.fetch.warn", -1);
+        this.fetchInfoThreshold = parseTimeSetting("threshold.fetch.info", -1);
+        this.fetchDebugThreshold = parseTimeSetting("threshold.fetch.debug", -1);
+        this.fetchTraceThreshold = parseTimeSetting("threshold.fetch.trace", -1);
 
         this.level = componentSettings.get("level", "TRACE").toUpperCase(Locale.ROOT);
 
@@ -144,6 +145,15 @@ public class ShardSlowLogSearchService extends AbstractIndexShardComponent {
         fetchLogger.setLevel(level);
 
         indexSettingsService.addListener(new ApplySettings());
+    }
+
+    private long parseTimeSetting(String name, long defaultNanos) {
+        try {
+            return componentSettings.getAsTime(name, TimeValue.timeValueNanos(defaultNanos)).nanos();
+        } catch (ElasticSearchParseException e) {
+            logger.error("Could not parse setting for [{}], disabling", name);
+            return -1;
+        }
     }
 
     public void onQueryPhase(SearchContext context, long tookInNanos) {

--- a/src/test/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchServiceTests.java
+++ b/src/test/java/org/elasticsearch/index/search/slowlog/ShardSlowLogSearchServiceTests.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.search.slowlog;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettingsService;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+public class ShardSlowLogSearchServiceTests extends ElasticsearchTestCase {
+
+    private Index index = new Index("test");
+    private ShardId shardId = new ShardId(index, 0);
+
+
+    @Test
+    public void creatingShardSlowLogSearchServiceWithBrokenSettingsShouldWork() throws Exception {
+        Settings brokenIndexSettings = ImmutableSettings.builder()
+                .put("index.search.slowlog.threshold.query.warn", "s")
+                .build();
+
+        IndexSettingsService indexSettingsService = new IndexSettingsService(shardId.index(), brokenIndexSettings);
+        new ShardSlowLogSearchService(shardId, brokenIndexSettings, indexSettingsService);
+    }
+
+    @Test
+    public void updatingViaListenerWithBrokenSettingsLeavesSettingsAsIs() throws Exception {
+        Settings indexSettings = ImmutableSettings.builder()
+                .put("index.search.slowlog.threshold.query.warn", "1s")
+                .build();
+
+        IndexSettingsService indexSettingsService = new IndexSettingsService(shardId.index(), indexSettings);
+        ShardSlowLogSearchService shardSlowLogSearchService = new ShardSlowLogSearchService(shardId, indexSettings, indexSettingsService);
+
+        Settings updatedSettings = ImmutableSettings.builder()
+                .put("index.search.slowlog.threshold.query.warn", "s")
+                .build();
+        indexSettingsService.refreshSettings(updatedSettings);
+
+        // this is still the time from the indexSettings above, but was not overriden from the settings update
+        // this basically ensures that the parsing exception was caught in the refreshSettings() methods
+        String configuredTime = shardSlowLogSearchService.indexSettings().get("index.search.slowlog.threshold.query.warn");
+        assertThat(configuredTime, is("1s"));
+    }
+
+}


### PR DESCRIPTION
In case of a misconfigured slow search/index configuration (unparseable
TimeValue) an exception is thrown.

This is not a problem when creating a shard of an index, as an exception
is returned and all is good. However, this is a huge problem, when
starting up a node, as the shard creation is repeated endlessly.

This patch changes the behaviour to go on as usual and just disable the
slowlog, as an improper configuration of logging should not affect the
allocation behaviour.

Closes #2730
