### PR TITLE
Improve new field mapping introduction performance

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
@@ -19,27 +19,25 @@
 
 package org.elasticsearch.index.analysis;
 
-import com.google.common.collect.ImmutableMap;
+import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.AnalyzerWrapper;
-
-import java.util.Map;
 
 /**
  *
  */
 public final class FieldNameAnalyzer extends AnalyzerWrapper {
 
-    private final ImmutableMap<String, Analyzer> analyzers;
+    private final ObjectObjectOpenHashMap<String, Analyzer> analyzers;
 
     private final Analyzer defaultAnalyzer;
 
-    public FieldNameAnalyzer(Map<String, Analyzer> analyzers, Analyzer defaultAnalyzer) {
-        this.analyzers = ImmutableMap.copyOf(analyzers);
+    public FieldNameAnalyzer(ObjectObjectOpenHashMap<String, Analyzer> analyzers, Analyzer defaultAnalyzer) {
+        this.analyzers = analyzers;
         this.defaultAnalyzer = defaultAnalyzer;
     }
 
-    public ImmutableMap<String, Analyzer> analyzers() {
+    public ObjectObjectOpenHashMap<String, Analyzer> analyzers() {
         return analyzers;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -21,16 +21,12 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.common.hppc.HppcMaps;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.analysis.FieldNameAnalyzer;
 
 import java.util.Set;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 /**
  *
@@ -38,63 +34,28 @@ import static com.google.common.collect.Lists.newArrayList;
 public class DocumentFieldMappers implements Iterable<FieldMapper> {
 
     private final DocumentMapper docMapper;
+    private final FieldMappersLookup fieldMappers;
 
-    private final ImmutableList<FieldMapper> fieldMappers;
-    private final ObjectObjectOpenHashMap<String, FieldMappers> fullNameFieldMappers;
-    private final ObjectObjectOpenHashMap<String, FieldMappers> nameFieldMappers;
-    private final ObjectObjectOpenHashMap<String, FieldMappers> indexNameFieldMappers;
-
-    private final FieldNameAnalyzer indexAnalyzer;
-    private final FieldNameAnalyzer searchAnalyzer;
-    private final FieldNameAnalyzer searchQuoteAnalyzer;
+    private volatile FieldNameAnalyzer indexAnalyzer;
+    private volatile FieldNameAnalyzer searchAnalyzer;
+    private volatile FieldNameAnalyzer searchQuoteAnalyzer;
 
     public DocumentFieldMappers(DocumentMapper docMapper) {
         this.docMapper = docMapper;
-        this.fieldMappers = ImmutableList.of();
-        this.fullNameFieldMappers = HppcMaps.newMap();
-        this.nameFieldMappers = HppcMaps.newMap();
-        this.indexNameFieldMappers = HppcMaps.newMap();
-
+        this.fieldMappers = new FieldMappersLookup();
         this.indexAnalyzer = new FieldNameAnalyzer(HppcMaps.<String, Analyzer>newMap(), docMapper.indexAnalyzer());
         this.searchAnalyzer = new FieldNameAnalyzer(HppcMaps.<String, Analyzer>newMap(), docMapper.searchAnalyzer());
         this.searchQuoteAnalyzer = new FieldNameAnalyzer(HppcMaps.<String, Analyzer>newMap(), docMapper.searchQuotedAnalyzer());
     }
 
-    public DocumentFieldMappers(DocumentMapper docMapper, DocumentFieldMappers copyFrom, Iterable<FieldMapper> newMappers) {
-        this.docMapper = docMapper;
-        final ObjectObjectOpenHashMap<String, FieldMappers> tempNameFieldMappers = copyFrom.nameFieldMappers.clone();
-        final ObjectObjectOpenHashMap<String, FieldMappers> tempIndexNameFieldMappers = copyFrom.indexNameFieldMappers.clone();
-        final ObjectObjectOpenHashMap<String, FieldMappers> tempFullNameFieldMappers = copyFrom.fullNameFieldMappers.clone();
+    public void addNewMappers(Iterable<FieldMapper> newMappers) {
+        fieldMappers.addNewMappers(newMappers);
 
-        final ObjectObjectOpenHashMap<String, Analyzer> indexAnalyzers = copyFrom.indexAnalyzer.analyzers().clone();
-        final ObjectObjectOpenHashMap<String, Analyzer> searchAnalyzers = copyFrom.searchAnalyzer.analyzers().clone();
-        final ObjectObjectOpenHashMap<String, Analyzer> searchQuoteAnalyzers = copyFrom.searchQuoteAnalyzer.analyzers().clone();
+        final ObjectObjectOpenHashMap<String, Analyzer> indexAnalyzers = this.indexAnalyzer.analyzers().clone();
+        final ObjectObjectOpenHashMap<String, Analyzer> searchAnalyzers = this.searchAnalyzer.analyzers().clone();
+        final ObjectObjectOpenHashMap<String, Analyzer> searchQuoteAnalyzers = this.searchQuoteAnalyzer.analyzers().clone();
 
         for (FieldMapper fieldMapper : newMappers) {
-            FieldMappers mappers = tempNameFieldMappers.get(fieldMapper.names().name());
-            if (mappers == null) {
-                mappers = new FieldMappers(fieldMapper);
-            } else {
-                mappers = mappers.concat(fieldMapper);
-            }
-            tempNameFieldMappers.put(fieldMapper.names().name(), mappers);
-
-            mappers = tempIndexNameFieldMappers.get(fieldMapper.names().indexName());
-            if (mappers == null) {
-                mappers = new FieldMappers(fieldMapper);
-            } else {
-                mappers = mappers.concat(fieldMapper);
-            }
-            tempIndexNameFieldMappers.put(fieldMapper.names().indexName(), mappers);
-
-            mappers = tempFullNameFieldMappers.get(fieldMapper.names().fullName());
-            if (mappers == null) {
-                mappers = new FieldMappers(fieldMapper);
-            } else {
-                mappers = mappers.concat(fieldMapper);
-            }
-            tempFullNameFieldMappers.put(fieldMapper.names().fullName(), mappers);
-
             if (fieldMapper.indexAnalyzer() != null) {
                 indexAnalyzers.put(fieldMapper.names().indexName(), fieldMapper.indexAnalyzer());
             }
@@ -105,10 +66,6 @@ public class DocumentFieldMappers implements Iterable<FieldMapper> {
                 searchQuoteAnalyzers.put(fieldMapper.names().indexName(), fieldMapper.searchQuoteAnalyzer());
             }
         }
-        this.fieldMappers = ImmutableList.<FieldMapper>builder().addAll(copyFrom.fieldMappers).addAll(newMappers).build();
-        this.nameFieldMappers = tempNameFieldMappers;
-        this.indexNameFieldMappers = tempIndexNameFieldMappers;
-        this.fullNameFieldMappers = tempFullNameFieldMappers;
 
         this.indexAnalyzer = new FieldNameAnalyzer(indexAnalyzers, docMapper.indexAnalyzer());
         this.searchAnalyzer = new FieldNameAnalyzer(searchAnalyzers, docMapper.searchAnalyzer());
@@ -121,51 +78,31 @@ public class DocumentFieldMappers implements Iterable<FieldMapper> {
     }
 
     public ImmutableList<FieldMapper> mappers() {
-        return this.fieldMappers;
+        return this.fieldMappers.mappers();
     }
 
     public boolean hasMapper(FieldMapper fieldMapper) {
-        return fieldMappers.contains(fieldMapper);
+        return fieldMappers.mappers().contains(fieldMapper);
     }
 
     public FieldMappers name(String name) {
-        return nameFieldMappers.get(name);
+        return fieldMappers.name(name);
     }
 
     public FieldMappers indexName(String indexName) {
-        return indexNameFieldMappers.get(indexName);
+        return fieldMappers.indexName(indexName);
     }
 
     public FieldMappers fullName(String fullName) {
-        return fullNameFieldMappers.get(fullName);
+        return fieldMappers.fullName(fullName);
     }
 
     public Set<String> simpleMatchToIndexNames(String pattern) {
-        Set<String> fields = Sets.newHashSet();
-        for (FieldMapper fieldMapper : fieldMappers) {
-            if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
-                fields.add(fieldMapper.names().indexName());
-            } else if (Regex.simpleMatch(pattern, fieldMapper.names().indexName())) {
-                fields.add(fieldMapper.names().indexName());
-            } else if (Regex.simpleMatch(pattern, fieldMapper.names().name())) {
-                fields.add(fieldMapper.names().indexName());
-            }
-        }
-        return fields;
+        return fieldMappers.simpleMatchToIndexNames(pattern);
     }
 
     public Set<String> simpleMatchToFullName(String pattern) {
-        Set<String> fields = Sets.newHashSet();
-        for (FieldMapper fieldMapper : fieldMappers) {
-            if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
-                fields.add(fieldMapper.names().fullName());
-            } else if (Regex.simpleMatch(pattern, fieldMapper.names().indexName())) {
-                fields.add(fieldMapper.names().fullName());
-            } else if (Regex.simpleMatch(pattern, fieldMapper.names().name())) {
-                fields.add(fieldMapper.names().fullName());
-            }
-        }
-        return fields;
+        return fieldMappers.simpleMatchToFullName(pattern);
     }
 
     /**
@@ -173,23 +110,11 @@ public class DocumentFieldMappers implements Iterable<FieldMapper> {
      * by {@link #name(String)}.
      */
     public FieldMappers smartName(String name) {
-        FieldMappers fieldMappers = fullName(name);
-        if (fieldMappers != null) {
-            return fieldMappers;
-        }
-        fieldMappers = indexName(name);
-        if (fieldMappers != null) {
-            return fieldMappers;
-        }
-        return name(name);
+        return fieldMappers.smartName(name);
     }
 
     public FieldMapper smartNameFieldMapper(String name) {
-        FieldMappers fieldMappers = smartName(name);
-        if (fieldMappers == null) {
-            return null;
-        }
-        return fieldMappers.mapper();
+        return fieldMappers.smartNameFieldMapper(name);
     }
 
     /**
@@ -218,13 +143,5 @@ public class DocumentFieldMappers implements Iterable<FieldMapper> {
 
     public Analyzer searchQuoteAnalyzer() {
         return this.searchQuoteAnalyzer;
-    }
-
-    public DocumentFieldMappers concat(FieldMapper... fieldMappers) {
-        return concat(newArrayList(fieldMappers));
-    }
-
-    public DocumentFieldMappers concat(Iterable<FieldMapper> fieldMappers) {
-        return new DocumentFieldMappers(docMapper, this, fieldMappers);
     }
 }

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -325,7 +325,7 @@ public class DocumentMapper implements ToXContent {
         // now traverse and get all the statically defined ones
         rootObjectMapper.traverse(fieldMappersAgg);
 
-        this.fieldMappers = new DocumentFieldMappers(this, fieldMappersAgg.mappers);
+        this.fieldMappers = new DocumentFieldMappers(this).concat(fieldMappersAgg.mappers);
 
         final Map<String, ObjectMapper> objectMappers = Maps.newHashMap();
         rootObjectMapper.traverse(new ObjectMapperListener() {
@@ -575,7 +575,7 @@ public class DocumentMapper implements ToXContent {
 
     public void addFieldMappers(FieldMapper... fieldMappers) {
         synchronized (mappersMutex) {
-            this.fieldMappers = this.fieldMappers.concat(this, fieldMappers);
+            this.fieldMappers = this.fieldMappers.concat(fieldMappers);
         }
         for (FieldMapperListener listener : fieldMapperListeners) {
             listener.fieldMappers(fieldMappers);

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -261,7 +261,7 @@ public class DocumentMapper implements ToXContent {
     private final NamedAnalyzer searchAnalyzer;
     private final NamedAnalyzer searchQuoteAnalyzer;
 
-    private volatile DocumentFieldMappers fieldMappers;
+    private final DocumentFieldMappers fieldMappers;
 
     private volatile ImmutableMap<String, ObjectMapper> objectMappers = ImmutableMap.of();
 
@@ -325,7 +325,8 @@ public class DocumentMapper implements ToXContent {
         // now traverse and get all the statically defined ones
         rootObjectMapper.traverse(fieldMappersAgg);
 
-        this.fieldMappers = new DocumentFieldMappers(this).concat(fieldMappersAgg.mappers);
+        this.fieldMappers = new DocumentFieldMappers(this);
+        this.fieldMappers.addNewMappers(fieldMappersAgg.mappers);
 
         final Map<String, ObjectMapper> objectMappers = Maps.newHashMap();
         rootObjectMapper.traverse(new ObjectMapperListener() {
@@ -575,7 +576,7 @@ public class DocumentMapper implements ToXContent {
 
     public void addFieldMappers(FieldMapper... fieldMappers) {
         synchronized (mappersMutex) {
-            this.fieldMappers = this.fieldMappers.concat(fieldMappers);
+            this.fieldMappers.addNewMappers(Arrays.asList(fieldMappers));
         }
         for (FieldMapperListener listener : fieldMapperListeners) {
             listener.fieldMappers(fieldMappers);

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMappersLookup.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.google.common.collect.UnmodifiableIterator;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.hppc.HppcMaps;
+import org.elasticsearch.common.regex.Regex;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A class that holds a map of field mappers from name, index name, and full name.
+ */
+public class FieldMappersLookup implements Iterable<FieldMapper> {
+
+    private volatile ImmutableList<FieldMapper> mappers;
+    private volatile ObjectObjectOpenHashMap<String, FieldMappers> name;
+    private volatile ObjectObjectOpenHashMap<String, FieldMappers> indexName;
+    private volatile ObjectObjectOpenHashMap<String, FieldMappers> fullName;
+
+    public FieldMappersLookup() {
+        this.mappers = ImmutableList.of();
+        this.fullName = HppcMaps.newMap();
+        this.name = HppcMaps.newMap();
+        this.indexName = HppcMaps.newMap();
+    }
+
+    /**
+     * Adds a new set of mappers.
+     */
+    public void addNewMappers(Iterable<FieldMapper> newMappers) {
+        final ObjectObjectOpenHashMap<String, FieldMappers> tempName = this.name.clone();
+        final ObjectObjectOpenHashMap<String, FieldMappers> tempIndexName = this.indexName.clone();
+        final ObjectObjectOpenHashMap<String, FieldMappers> tempFullName = this.fullName.clone();
+
+        for (FieldMapper fieldMapper : newMappers) {
+            FieldMappers mappers = tempName.get(fieldMapper.names().name());
+            if (mappers == null) {
+                mappers = new FieldMappers(fieldMapper);
+            } else {
+                mappers = mappers.concat(fieldMapper);
+            }
+            tempName.put(fieldMapper.names().name(), mappers);
+
+            mappers = tempIndexName.get(fieldMapper.names().indexName());
+            if (mappers == null) {
+                mappers = new FieldMappers(fieldMapper);
+            } else {
+                mappers = mappers.concat(fieldMapper);
+            }
+            tempIndexName.put(fieldMapper.names().indexName(), mappers);
+
+            mappers = tempFullName.get(fieldMapper.names().fullName());
+            if (mappers == null) {
+                mappers = new FieldMappers(fieldMapper);
+            } else {
+                mappers = mappers.concat(fieldMapper);
+            }
+            tempFullName.put(fieldMapper.names().fullName(), mappers);
+        }
+        this.mappers = ImmutableList.<FieldMapper>builder().addAll(this.mappers).addAll(newMappers).build();
+        this.name = tempName;
+        this.indexName = tempIndexName;
+        this.fullName = tempFullName;
+    }
+
+    /**
+     * Removes the set of mappers.
+     */
+    public void removeMappers(Iterable<FieldMapper> mappersToRemove) {
+        List<FieldMapper> tempMappers = new ArrayList<FieldMapper>(this.mappers);
+        ObjectObjectOpenHashMap<String, FieldMappers> tempName = this.name.clone();
+        ObjectObjectOpenHashMap<String, FieldMappers> tempIndexName = this.indexName.clone();
+        ObjectObjectOpenHashMap<String, FieldMappers> tempFullName = this.fullName.clone();
+
+        for (FieldMapper mapper : mappersToRemove) {
+            FieldMappers mappers = tempName.get(mapper.names().name());
+            if (mappers != null) {
+                mappers = mappers.remove(mapper);
+                if (mappers.isEmpty()) {
+                    tempName.remove(mapper.names().name());
+                } else {
+                    tempName.put(mapper.names().name(), mappers);
+                }
+            }
+
+            mappers = tempIndexName.get(mapper.names().indexName());
+            if (mappers != null) {
+                mappers = mappers.remove(mapper);
+                if (mappers.isEmpty()) {
+                    tempIndexName.remove(mapper.names().indexName());
+                } else {
+                    tempIndexName.put(mapper.names().indexName(), mappers);
+                }
+            }
+
+            mappers = tempFullName.get(mapper.names().fullName());
+            if (mappers != null) {
+                mappers = mappers.remove(mapper);
+                if (mappers.isEmpty()) {
+                    tempFullName.remove(mapper.names().fullName());
+                } else {
+                    tempFullName.put(mapper.names().fullName(), mappers);
+                }
+            }
+
+            tempMappers.remove(mapper);
+        }
+
+
+        this.mappers = ImmutableList.copyOf(tempMappers);
+        this.name = tempName;
+        this.indexName = tempIndexName;
+        this.fullName = tempFullName;
+    }
+
+    @Override
+    public UnmodifiableIterator<FieldMapper> iterator() {
+        return mappers.iterator();
+    }
+
+    /**
+     * The list of all mappers.
+     */
+    public ImmutableList<FieldMapper> mappers() {
+        return this.mappers;
+    }
+
+    /**
+     * Is there a mapper (based on unique {@link FieldMapper} identity)?
+     */
+    public boolean hasMapper(FieldMapper fieldMapper) {
+        return mappers.contains(fieldMapper);
+    }
+
+    /**
+     * Returns the field mappers based on the mapper name.
+     */
+    public FieldMappers name(String name) {
+        return this.name.get(name);
+    }
+
+    /**
+     * Returns the field mappers based on the mapper index name.
+     */
+    public FieldMappers indexName(String indexName) {
+        return this.indexName.get(indexName);
+    }
+
+    /**
+     * Returns the field mappers based on the mapper full name.
+     */
+    public FieldMappers fullName(String fullName) {
+        return this.fullName.get(fullName);
+    }
+
+    /**
+     * Returns a set of the index names of a simple match regex like pattern against full name, name and index name.
+     */
+    public Set<String> simpleMatchToIndexNames(String pattern) {
+        Set<String> fields = Sets.newHashSet();
+        for (FieldMapper fieldMapper : mappers) {
+            if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
+                fields.add(fieldMapper.names().indexName());
+            } else if (Regex.simpleMatch(pattern, fieldMapper.names().indexName())) {
+                fields.add(fieldMapper.names().indexName());
+            } else if (Regex.simpleMatch(pattern, fieldMapper.names().name())) {
+                fields.add(fieldMapper.names().indexName());
+            }
+        }
+        return fields;
+    }
+
+    /**
+     * Returns a set of the full names of a simple match regex like pattern against full name, name and index name.
+     */
+    public Set<String> simpleMatchToFullName(String pattern) {
+        Set<String> fields = Sets.newHashSet();
+        for (FieldMapper fieldMapper : mappers) {
+            if (Regex.simpleMatch(pattern, fieldMapper.names().fullName())) {
+                fields.add(fieldMapper.names().fullName());
+            } else if (Regex.simpleMatch(pattern, fieldMapper.names().indexName())) {
+                fields.add(fieldMapper.names().fullName());
+            } else if (Regex.simpleMatch(pattern, fieldMapper.names().name())) {
+                fields.add(fieldMapper.names().fullName());
+            }
+        }
+        return fields;
+    }
+
+    /**
+     * Tries to find first based on {@link #fullName(String)}, then by {@link #indexName(String)}, and last
+     * by {@link #name(String)}.
+     */
+    @Nullable
+    public FieldMappers smartName(String name) {
+        FieldMappers fieldMappers = fullName(name);
+        if (fieldMappers != null) {
+            return fieldMappers;
+        }
+        fieldMappers = indexName(name);
+        if (fieldMappers != null) {
+            return fieldMappers;
+        }
+        return name(name);
+    }
+
+    /**
+     * Tries to find first based on {@link #fullName(String)}, then by {@link #indexName(String)}, and last
+     * by {@link #name(String)} and return the first mapper for it (see {@link org.elasticsearch.index.mapper.FieldMappers#mapper()}).
+     */
+    @Nullable
+    public FieldMapper smartNameFieldMapper(String name) {
+        FieldMappers fieldMappers = smartName(name);
+        if (fieldMappers == null) {
+            return null;
+        }
+        return fieldMappers.mapper();
+    }
+}


### PR DESCRIPTION
Improve the introduction of new fields into the concrete parsed mappings by not relying on immutable maps and copying over entries, but instead using open maps (which will also use less memory), and using clone to perform the copy on write logic
