### PR TITLE
Guarantee sorted order for [Double|Long|Bytes]Values

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/AbstractAtomicNumericFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AbstractAtomicNumericFieldData.java
@@ -58,6 +58,12 @@ public abstract class AbstractAtomicNumericFieldData implements AtomicNumericFie
                     scratch.copyChars(Double.toString(values.nextValue()));
                     return scratch;
                 }
+
+                @Override
+                public Order getOrder() {
+                    return values.getOrder();
+                }
+
             };
         } else {
             final LongValues values = getLongValues();
@@ -73,6 +79,11 @@ public abstract class AbstractAtomicNumericFieldData implements AtomicNumericFie
                 public BytesRef nextValue() {
                     scratch.copyChars(Long.toString(values.nextValue()));
                     return scratch;
+                }
+
+                @Override
+                public Order getOrder() {
+                    return values.getOrder();
                 }
             };
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/AtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AtomicFieldData.java
@@ -79,4 +79,36 @@ public interface AtomicFieldData<Script extends ScriptDocValues> {
          */
         BytesValues.WithOrdinals getBytesValues(boolean needsHashes);
     }
+
+    /**
+     * This enum provides information about the order of the values for
+     * a given document. For instance {@link BytesValues} by default
+     * return values in {@link #BYTES} order but if the interface
+     * wraps a numeric variant the sort order might change to {@link #NUMERIC}.
+     * In that case the values might not be returned in byte sort order but in numeric
+     * order instead while maintaining the property of <tt>N < N+1</tt> during the
+     * value iterations.
+     *
+     * @see org.elasticsearch.index.fielddata.BytesValues#getOrder()
+     * @see org.elasticsearch.index.fielddata.DoubleValues#getOrder()
+     * @see org.elasticsearch.index.fielddata.LongValues#getOrder()
+     */
+    public enum Order {
+        /**
+         * Donates Byte sort order
+         */
+        BYTES,
+        /**
+         * Donates Numeric sort order
+         */
+        NUMERIC,
+        /**
+         * Donates custom sort order
+         */
+        CUSTOM,
+        /**
+         * Donates no sort order
+         */
+        NONE
+    }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/BytesValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/BytesValues.java
@@ -87,7 +87,13 @@ public abstract class BytesValues {
      * Returns the next value for the current docID set to {@link #setDocument(int)}.
      * This method should only be called <tt>N</tt> times where <tt>N</tt> is the number
      * returned from {@link #setDocument(int)}. If called more than <tt>N</tt> times the behavior
-     * is undefined.
+     * is undefined. This interface guarantees that the values are returned in order.
+     * <p>
+     * If this instance returns ordered values the <tt>Nth</tt> value is strictly less than the <tt>N+1</tt> value with
+     * respect to the {@link AtomicFieldData.Order} returned from {@link #getOrder()}. If this instance returns
+     * <i>unordered</i> values {@link #getOrder()} must return {@link AtomicFieldData.Order#NONE}
+     * Note: the values returned are de-duplicated, only unique values are returned.
+     * </p>
      *
      * Note: the returned {@link BytesRef} might be shared across invocations.
      *
@@ -102,6 +108,14 @@ public abstract class BytesValues {
      */
     public int currentValueHash() {
         return scratch.hashCode();
+    }
+
+    /**
+     * Returns the order the values are returned from {@link #nextValue()}.
+     * <p> Note: {@link BytesValues} have {@link AtomicFieldData.Order#BYTES} by default.</p>
+     */
+    public AtomicFieldData.Order getOrder() {
+        return AtomicFieldData.Order.BYTES;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/fielddata/DoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/DoubleValues.java
@@ -76,10 +76,24 @@ public abstract class DoubleValues {
      * This method should only be called <tt>N</tt> times where <tt>N</tt> is the number
      * returned from {@link #setDocument(int)}. If called more than <tt>N</tt> times the behavior
      * is undefined.
+     * <p>
+     * If this instance returns ordered values the <tt>Nth</tt> value is strictly less than the <tt>N+1</tt> value with
+     * respect to the {@link AtomicFieldData.Order} returned from {@link #getOrder()}. If this instance returns
+     * <i>unordered</i> values {@link #getOrder()} must return {@link AtomicFieldData.Order#NONE}
+     * Note: the values returned are de-duplicated, only unique values are returned.
+     * </p>
      *
      * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
     public abstract double nextValue();
+
+    /**
+     * Returns the order the values are returned from {@link #nextValue()}.
+     * <p> Note: {@link DoubleValues} have {@link AtomicFieldData.Order#NUMERIC} by default.</p>
+     */
+    public AtomicFieldData.Order getOrder() {
+        return AtomicFieldData.Order.NUMERIC;
+    }
 
     /**
      * Ordinal based {@link DoubleValues}.

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterBytesValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterBytesValues.java
@@ -53,4 +53,9 @@ public abstract class FilterBytesValues extends BytesValues {
     public int currentValueHash() {
         return delegate.currentValueHash();
     }
+
+    @Override
+    public AtomicFieldData.Order getOrder() {
+        return delegate.getOrder();
+    }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterDoubleValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterDoubleValues.java
@@ -40,4 +40,11 @@ public abstract class FilterDoubleValues extends DoubleValues {
     public double nextValue() {
         return delegate.nextValue();
     }
+
+    @Override
+    public AtomicFieldData.Order getOrder() {
+        return delegate.getOrder();
+    }
+
+
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FilterLongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FilterLongValues.java
@@ -42,4 +42,9 @@ public class FilterLongValues extends LongValues {
         return delegate.nextValue();
     }
 
+    @Override
+    public AtomicFieldData.Order getOrder() {
+        return delegate.getOrder();
+    }
+
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/GeoPointValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/GeoPointValues.java
@@ -72,12 +72,26 @@ public abstract class GeoPointValues {
      * This method should only be called <tt>N</tt> times where <tt>N</tt> is the number
      * returned from {@link #setDocument(int)}. If called more than <tt>N</tt> times the behavior
      * is undefined.
+     * <p>
+     * If this instance returns ordered values the <tt>Nth</tt> value is strictly less than the <tt>N+1</tt> value with
+     * respect to the {@link AtomicFieldData.Order} returned from {@link #getOrder()}. If this instance returns
+     * <i>unordered</i> values {@link #getOrder()} must return {@link AtomicFieldData.Order#NONE}
+     * Note: the values returned are de-duplicated, only unique values are returned.
+     * </p>
      *
      * Note: the returned {@link GeoPoint} might be shared across invocations.
      *
      * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
     public abstract GeoPoint nextValue();
+
+    /**
+     * Returns the order the values are returned from {@link #nextValue()}.
+     * <p> Note: {@link GeoPointValues} have {@link AtomicFieldData.Order#NONE} by default.</p>
+     */
+    public AtomicFieldData.Order getOrder() {
+        return AtomicFieldData.Order.NONE;
+    }
 
     /**
      * An empty {@link GeoPointValues} implementation

--- a/src/main/java/org/elasticsearch/index/fielddata/LongValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/LongValues.java
@@ -77,10 +77,24 @@ public abstract class LongValues {
      * This method should only be called <tt>N</tt> times where <tt>N</tt> is the number
      * returned from {@link #setDocument(int)}. If called more than <tt>N</tt> times the behavior
      * is undefined.
+     * <p>
+     * If this instance returns ordered values the <tt>Nth</tt> value is strictly less than the <tt>N+1</tt> value with
+     * respect to the {@link AtomicFieldData.Order} returned from {@link #getOrder()}. If this instance returns
+     * <i>unordered</i> values {@link #getOrder()} must return {@link AtomicFieldData.Order#NONE}
+     * Note: the values returned are de-duplicated, only unique values are returned.
+     * </p>
      *
      * @return the next value for the current docID set to {@link #setDocument(int)}.
      */
     public abstract long nextValue();
+
+    /**
+     * Returns the order the values are returned from {@link #nextValue()}.
+     * <p> Note: {@link LongValues} have {@link AtomicFieldData.Order#NUMERIC} by default.</p>
+     */
+    public AtomicFieldData.Order getOrder() {
+        return AtomicFieldData.Order.NUMERIC;
+    }
 
     /**
      * Ordinal based {@link LongValues}.

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVNumericAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVNumericAtomicFieldData.java
@@ -93,6 +93,11 @@ public class SortedSetDVNumericAtomicFieldData extends SortedSetDVAtomicFieldDat
             public BytesRef getValueByOrd(long ord) {
                 return convert(values.getValueByOrd(ord), scratch);
             }
+
+            @Override
+            public Order getOrder() {
+                return Order.NUMERIC;
+            }
         };
     }
 }

--- a/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
@@ -35,9 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Tests for all integer types (byte, short, int, long).
@@ -358,8 +356,14 @@ public class LongFieldDataTests extends AbstractNumericFieldDataTests {
             }
             doubleSet.clear();
             numValues = doubleData.setDocument(i);
+            double prev = 0;
             for (int j = 0; j < numValues; j++) {
-                doubleSet.add(doubleData.nextValue());
+                double current;
+                doubleSet.add(current = doubleData.nextValue());
+                if (j > 0) {
+                    assertThat(prev, lessThan(current));
+                }
+                prev = current;
             }
             assertThat(doubleSet, equalTo(doubleV));
         }


### PR DESCRIPTION
Values returned by [Double|Long|Bytes]Values are sorted today which
is guaranteed by the underlying Lucene index. Several implementations can
make use of this property but the interfaces don't guarantee this behavior.
This commit adds the guarantees and makes use of them in several places.

Note: This change might require sorting for 3rd party implemenations of these
interaces.
