### PR TITLE
Move systemd files from /etc to /usr/lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -773,7 +773,7 @@
                             </sources>
                         </mapping>
                         <mapping>
-                            <directory>/etc/systemd/system/</directory>
+                            <directory>/usr/lib/systemd/system/</directory>
                             <filemode>755</filemode>
                             <configuration>true</configuration>
                             <sources>
@@ -786,7 +786,7 @@
                             </sources>
                         </mapping>
                         <mapping>
-                            <directory>/etc/tmpfiles.d/</directory>
+                            <directory>/usr/lib/tmpfiles.d/</directory>
                             <configuration>true</configuration>
                             <sources>
                                 <source>


### PR DESCRIPTION
As documented in systemd's manual pages tmpfiles.d(5) and systemd.unit(5),
a package should install its default configuration in /usr/lib, which can
be overridden by system administrators in /etc.

New locations in the rpm:
/usr/lib/systemd/system/elasticsearch.service
/usr/lib/tmpfiles.d/elasticsearch.conf

The man pages are available online:
http://www.freedesktop.org/software/systemd/man/tmpfiles.d.html
http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Unit%20Load%20Path
