### PR TITLE
Fixed bug that document with a suggest field can't be percolated.

### DIFF
--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionTokenStream.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionTokenStream.java
@@ -36,7 +36,7 @@ import java.util.Set;
  */
 public final class CompletionTokenStream extends TokenStream {
 
-    private final PayloadAttribute payloadAttr = addAttribute(PayloadAttribute.class);;
+    private final PayloadAttribute payloadAttr = addAttribute(PayloadAttribute.class);
     private final PositionIncrementAttribute posAttr = addAttribute(PositionIncrementAttribute.class);
     private final ByteTermAttribute bytesAtt = addAttribute(ByteTermAttribute.class);
 
@@ -49,6 +49,7 @@ public final class CompletionTokenStream extends TokenStream {
     private final BytesRef scratch = new BytesRef();
 
     public CompletionTokenStream(TokenStream input, BytesRef payload, ToFiniteStrings toFiniteStrings) throws IOException {
+        super(input);
         this.input = input;
         this.payload = payload;
         this.toFiniteStrings = toFiniteStrings;
@@ -95,6 +96,7 @@ public final class CompletionTokenStream extends TokenStream {
 
     @Override
     public void close() throws IOException {
+        super.close();
         if (posInc == -1) {
             input.close();
         }
@@ -115,6 +117,7 @@ public final class CompletionTokenStream extends TokenStream {
         public void setBytesRef(BytesRef bytes);
     }
 
+    // Unused class, should this be removed?
     public static final class ByteTermAttributeImpl extends AttributeImpl implements ByteTermAttribute, TermToBytesRefAttribute {
         private BytesRef bytes;
 

--- a/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
@@ -28,14 +28,17 @@ import org.elasticsearch.action.admin.indices.segments.IndexShardSegments;
 import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.suggest.SuggestResponse;
+import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
+import org.elasticsearch.percolator.PercolatorService;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
@@ -56,6 +59,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
@@ -87,6 +91,36 @@ public class CompletionSuggestSearchTests extends AbstractIntegrationTest {
 
         assertSuggestionsNotInOrder("f", "Foo Fighters", "Firestarter", "Foo Fighters Generator", "Foo Fighters Learn to Fly");
         assertSuggestionsNotInOrder("t", "The Prodigy", "Turbonegro", "Turbonegro Get it on", "The Prodigy Firestarter");
+    }
+
+    @Test
+    public void testSuggestFieldWithPercolateApi() throws Exception {
+        createIndexAndMapping();
+        String[][] input = {{"Foo Fighters"}, {"Foo Fighters"}, {"Foo Fighters"}, {"Foo Fighters"},
+                {"Generator", "Foo Fighters Generator"}, {"Learn to Fly", "Foo Fighters Learn to Fly"},
+                {"The Prodigy"}, {"The Prodigy"}, {"The Prodigy"}, {"Firestarter", "The Prodigy Firestarter"},
+                {"Turbonegro"}, {"Turbonegro"}, {"Get it on", "Turbonegro Get it on"}}; // work with frequencies
+        for (int i = 0; i < input.length; i++) {
+            client().prepareIndex(INDEX, TYPE, "" + i)
+                    .setSource(jsonBuilder()
+                            .startObject().startObject(FIELD)
+                            .startArray("input").value(input[i]).endArray()
+                            .endObject()
+                            .endObject()
+                    )
+                    .execute().actionGet();
+        }
+
+        client().prepareIndex(INDEX, PercolatorService.TYPE_NAME, "4")
+                .setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject())
+                .execute().actionGet();
+
+        refresh();
+
+        PercolateResponse response = client().preparePercolate().setIndices(INDEX).setDocumentType(TYPE)
+                .setGetRequest(Requests.getRequest(INDEX).type(TYPE).id("1"))
+                .execute().actionGet();
+        assertThat(response.getCount(), equalTo(1l));
     }
 
     @Test


### PR DESCRIPTION
The CompletionTokenStream doesn't properly forward the call to its attributes, so when the percolator needs to access terms of this stream, null was returned and this isn't expected in the MemoryIndex.

Relates to #4028
