### PR TITLE
fixes #4045 - allow aliases on morelikethis on nodeclients

### DIFF
--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -236,7 +236,8 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
 
     // Redirects the request to a data node, that has the index meta data locally available.
     private void redirect(MoreLikeThisRequest request, final ActionListener<SearchResponse> listener, ClusterState clusterState) {
-        ShardIterator shardIterator = clusterService.operationRouting().getShards(clusterState, request.index(), request.type(), request.id(), request.routing(), null);
+        final String concreteIndex = clusterState.metaData().concreteIndex(request.index());
+        ShardIterator shardIterator = clusterService.operationRouting().getShards(clusterState, concreteIndex, request.type(), request.id(), request.routing(), null);
         ShardRouting shardRouting = shardIterator.firstOrNull();
         if (shardRouting == null) {
             throw new ElasticSearchException("No shards for index " + request.index());

--- a/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
@@ -119,6 +119,12 @@ public class MoreLikeThisActionTests extends AbstractIntegrationTest {
         mltResponse = client().moreLikeThis(moreLikeThisRequest("test").type("type1").id("1").minTermFreq(1).minDocFreq(1).searchIndices("release")).actionGet();
         assertHitCount(mltResponse, 1l);
         assertThat(mltResponse.getHits().getAt(0).id(), equalTo("2"));
+
+        logger.info("Running moreLikeThis on alias with node client");
+        mltResponse = cluster().clientNodeClient().moreLikeThis(moreLikeThisRequest("beta").type("type1").id("1").minTermFreq(1).minDocFreq(1)).actionGet();
+        assertHitCount(mltResponse, 1l);
+        assertThat(mltResponse.getHits().getAt(0).id(), equalTo("3"));
+
     }
 
     @Test


### PR DESCRIPTION
Even though this was addressed a long time ago, at the time the fix didn't take into account that on redirects, the alias also needed to be resolved. I added a new tests that covers this case(uses a nodeclient to execute the request,so request will be redirected to a node data that can actually resolve the request).
