### PR TITLE
Post filter phrase suggestions

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
@@ -73,7 +73,7 @@ public class TransportSearchCountAction extends TransportSearchTypeAction {
         @Override
         protected void moveToSecondPhase() throws Exception {
             // no need to sort, since we know we have no hits back
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults, (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty());
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults, (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty(), request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = buildScrollId(request.searchType(), firstResults, null);

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -180,7 +180,7 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
 
         void innerFinishHim() throws Exception {
             sortedShardList = searchPhaseController.sortDocs(queryFetchResults);
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults, request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -289,7 +289,7 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
         }
 
         void innerFinishHim() throws Exception {
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults, request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
@@ -86,7 +86,7 @@ public class TransportSearchQueryAndFetchAction extends TransportSearchTypeActio
 
         private void innerFinishHim() throws IOException {
             sortedShardList = searchPhaseController.sortDocs(firstResults);
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults, firstResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults, firstResults, request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = buildScrollId(request.searchType(), firstResults, null);

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
@@ -190,7 +190,7 @@ public class TransportSearchQueryThenFetchAction extends TransportSearchTypeActi
         }
 
         void innerFinishHim() throws Exception {
-            InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults, fetchResults);
+            InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults, fetchResults, request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
@@ -70,7 +70,7 @@ public class TransportSearchScanAction extends TransportSearchTypeAction {
 
         @Override
         protected void moveToSecondPhase() throws Exception {
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults, (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty());
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults, (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty(), request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = buildScrollId(request.searchType(), firstResults, ImmutableMap.of("total_hits", Long.toString(internalResponse.hits().totalHits())));

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
@@ -242,7 +242,7 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
 
         private void innerFinishHim() {
             ScoreDoc[] sortedShardList = searchPhaseController.sortDocs(queryFetchResults);
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults, null);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = request.scrollId();

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
@@ -273,7 +273,7 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
         }
 
         private void innerFinishHim() {
-            InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
+            InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults, null);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = request.scrollId();

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
@@ -260,7 +260,7 @@ public class TransportSearchScrollScanAction extends AbstractComponent {
                     docs[counter++] = scoreDoc;
                 }
             }
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(docs, queryFetchResults, queryFetchResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(docs, queryFetchResults, queryFetchResults, null);
             ((InternalSearchHits) internalResponse.hits()).totalHits = Long.parseLong(this.scrollId.getAttributes().get("total_hits"));
 
 

--- a/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
@@ -552,6 +553,10 @@ public abstract class FilterBuilders {
 
     public static WrapperFilterBuilder wrapperFilter(byte[] data, int offset, int length) {
         return new WrapperFilterBuilder(data, offset, length);
+    }
+    
+    public static WrapperFilterBuilder wrapperFilter(BytesReference bytes) {
+        return new WrapperFilterBuilder(bytes);
     }
 
     private FilterBuilders() {

--- a/src/main/java/org/elasticsearch/index/query/WrapperFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/WrapperFilterBuilder.java
@@ -25,7 +25,8 @@ package org.elasticsearch.index.query;
  * Time: 11:30
  */
 
-import com.google.common.base.Charsets;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -36,27 +37,24 @@ import java.io.IOException;
  * query builders.
  */
 public class WrapperFilterBuilder extends BaseFilterBuilder {
-
-    private final byte[] source;
-    private final int offset;
-    private final int length;
+    private final BytesReference bytes;
 
     public WrapperFilterBuilder(String source) {
-        this.source = source.getBytes(Charsets.UTF_8);
-        this.offset = 0;
-        this.length = this.source.length;
+        this(new BytesArray(source));
     }
 
     public WrapperFilterBuilder(byte[] source, int offset, int length) {
-        this.source = source;
-        this.offset = offset;
-        this.length = length;
+        this(new BytesArray(source, offset, length));
+    }
+    
+    public WrapperFilterBuilder(BytesReference bytes) {
+        this.bytes = bytes;
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(WrapperFilterParser.NAME);
-        builder.field("filter", source, offset, length);
+        builder.field("filter", bytes);
         builder.endObject();
     }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -55,6 +55,9 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
             IndexReader indexReader, CharsRef spare) throws IOException {
         double realWordErrorLikelihood = suggestion.realworldErrorLikelyhood();
         final PhraseSuggestion response = new PhraseSuggestion(name, suggestion.getSize());
+        response.setFilterType(suggestion.getFilterType());
+        response.setFilterExtra(suggestion.getFilterExtra());
+        response.setField(new StringText(suggestion.getField()));
 
         List<PhraseSuggestionContext.DirectCandidateGenerator>  generators = suggestion.generators();
         final int numGenerators = generators.size();

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -19,15 +19,32 @@
 
 package org.elasticsearch.search.suggest.phrase;
 
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.search.MultiSearchRequestBuilder;
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.index.query.BoolFilterBuilder;
+import org.elasticsearch.index.query.FilterBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder.Operator;
 import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.search.suggest.Suggest.ReduceContext;
 import org.elasticsearch.search.suggest.Suggest.Suggestion;
+import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 
 import java.io.IOException;
+import java.util.Iterator;
+
+import static org.elasticsearch.index.query.FilterBuilders.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
 
 /**
  * Suggestion entry returned from the {@link PhraseSuggester}.
@@ -35,11 +52,117 @@ import java.io.IOException;
 public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry> {
     public static final int TYPE = 3;
 
+    /**
+     * Field against which suggestion was generated.
+     */
+    private Text field;
+    /**
+     * Type of filter to apply to suggestions. null is invalid.
+     */
+    private FilterType filterType = FilterType.NONE;
+    /**
+     * Extra filter to apply to suggestions. a zero length reference means none.
+     */
+    private BytesReference filterExtra = BytesArray.EMPTY;
+    
     public PhraseSuggestion() {
     }
 
     public PhraseSuggestion(String name, int size) {
         super(name, size);
+    }
+    
+    public void setField(Text field) {
+        this.field = field;
+    }
+    
+    public Text getField() {
+        return this.field;
+    }
+    
+    public void setFilterType(FilterType filterType) {
+        this.filterType = filterType;
+    }
+    
+    public FilterType getFilterType() {
+        return filterType;
+    }
+    
+    public void setFilterExtra(BytesReference filterExtra) {
+        this.filterExtra = filterExtra;
+    }
+    
+    public BytesReference getFilterExtra() {
+        return filterExtra;
+    }
+    
+    @Override
+    protected void filter(ReduceContext context) {
+        // Don't filter if it wasn't asked for or if the search context doesn't support it.
+        if (filterType == FilterType.NONE || context == null) {
+            return;
+        }
+        FilterBuilder filterExtraBuilder = null;
+        if (filterExtra.length() > 0) {
+            filterExtraBuilder = wrapperFilter(filterExtra);
+        }
+        SearchRequestBuilder searchRequest = context.getClient().prepareSearch(context.getIndecies());
+        searchRequest.setTypes(context.getTypes());
+        searchRequest.setRouting(context.getRouting());
+        searchRequest.setPreference(context.getPreference());
+        searchRequest.setNoFields();
+        searchRequest.setFrom(0);
+        searchRequest.setSize(1);
+        searchRequest.setQuery(matchAllQuery());
+        String fieldString = field.string();
+        for (Entry entry: this.getEntries()) {
+            MultiSearchRequestBuilder multi = context.getClient().prepareMultiSearch();
+            for (Option option: entry.getOptions()) {
+                MatchQueryBuilder optionQueryBuilder;
+                switch (filterType) {
+                case MATCH_PHRASE:
+                    optionQueryBuilder = matchPhraseQuery(fieldString, option.getText());
+                    break;
+                case MATCH_AND:
+                    optionQueryBuilder = matchQuery(fieldString, option.getText());
+                    optionQueryBuilder.operator(Operator.AND);
+                    break;
+                case MATCH_OR:
+                    optionQueryBuilder = matchQuery(fieldString, option.getText());
+                    optionQueryBuilder.operator(Operator.OR);
+                    break;
+                default:
+                    throw new ElasticSearchIllegalArgumentException("Unknown filter type:  " + filterType);
+                }
+                FilterBuilder optionFilterBuilder = queryFilter(optionQueryBuilder);
+                if (filterExtraBuilder == null) {
+                    searchRequest.setFilter(optionFilterBuilder);
+                } else {
+                    BoolFilterBuilder searchFilter = boolFilter();
+                    searchFilter.must(filterExtraBuilder);
+                    searchFilter.must(optionFilterBuilder);
+                    searchRequest.setFilter(searchFilter);    
+                }
+                System.err.println(searchRequest);
+                // Force building the searchRequest right now because we reuse the builder for the next option
+                multi.add(searchRequest.request());
+            }
+            MultiSearchResponse multiResponse = multi.get("10s"); // TODO timeout and exception handling
+            int responseIndex = 0;
+            Iterator<? extends Option> itr = entry.getOptions().iterator();
+            while (itr.hasNext()) {
+                Option option = itr.next();
+                SearchResponse response = multiResponse.getResponses()[responseIndex++].getResponse();
+                System.err.println(response);
+                if (response.getHits().getTotalHits() < 1) {
+                    System.err.println("Removing " + option.getText());
+                    itr.remove();
+                }
+                // TODO stop early when we're sure we have enough results
+                // TODO don't just launch all the requests at once?
+                // TODO allow the user to limit the maximum number of of results to try to filter
+            }
+        }
     }
 
     @Override
@@ -50,6 +173,32 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
     @Override
     protected Entry newEntry() {
         return new Entry();
+    }
+    
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        // If the other side is older than 0.90.4 then it shouldn't be sending suggestions of this type but just in case
+        // we're going to assume that they are regular suggestions so we won't read anything.
+        if (in.getVersion().before(Version.V_0_90_4)) {
+            return;
+        }
+        field = in.readText();
+        filterType = FilterType.fromValue(in.readByte());
+        filterExtra = in.readBytesReference();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        // If the other side of the message is older than 0.90.4 it'll interpret these suggestions as regular suggestions
+        // so we have to pretend to be one which we can do by just calling the superclass writeTo and doing nothing else
+        if (out.getVersion().before(Version.V_0_90_4)) {
+            return;
+        }
+        out.writeText(field);
+        out.writeByte(filterType.getValue());
+        out.writeBytesReference(filterExtra);
     }
 
     public static class Entry extends Suggestion.Entry<Suggestion.Entry.Option> {
@@ -115,6 +264,46 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
                 return;
             }
             out.writeDouble(cutoffScore);
+        }
+    }
+    
+    public static enum FilterType {
+        NONE((byte) 0),
+        MATCH_PHRASE((byte) 1),
+        MATCH_OR((byte) 2),
+        MATCH_AND((byte) 3);
+        
+        private byte value;
+        
+        private FilterType(byte value) {
+            this.value = value;
+        }
+        
+        public byte getValue() {
+            return value;
+        }
+        
+        public static FilterType fromValue(byte value) {
+            switch(value) {
+            case 0: return NONE;
+            case 1: return MATCH_PHRASE;
+            case 2: return MATCH_OR;
+            case 3: return MATCH_AND;
+            }
+            throw new ElasticSearchIllegalArgumentException("filter type [" + value + "] not valid, can be one of [0|1|2|3]");
+        }
+        
+        public static FilterType fromString(String filterType) throws ElasticSearchIllegalArgumentException {
+            if ("none".equalsIgnoreCase(filterType)) {
+                return NONE;
+            } else if ("match_phrase".equalsIgnoreCase(filterType) || "matchPhrase".equalsIgnoreCase(filterType)) {
+                return MATCH_PHRASE;
+            } else if ("match_or".equalsIgnoreCase(filterType) || "matchOr".equalsIgnoreCase(filterType)) {
+                return MATCH_OR;
+            } else if ("match_and".equalsIgnoreCase(filterType) || "matchAnd".equalsIgnoreCase(filterType)) {
+                return MATCH_AND;
+            }
+            throw new ElasticSearchIllegalArgumentException("filter type [" + filterType + "] not valid, can be one of [none|match_phrase|matchPhrase|match_or|matchOr|match_and|matchAnd]");
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -21,7 +21,9 @@ package org.elasticsearch.search.suggest.phrase;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.search.suggest.SuggestBuilder.SuggestionBuilder;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestion.FilterType;
 
 import java.io.IOException;
 import java.util.*;
@@ -42,6 +44,8 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     private Integer tokenLimit;
     private String preTag;
     private String postTag;
+    private FilterType filterType;
+    private FilterBuilder filterExtra;
 
     public PhraseSuggestionBuilder(String name) {
         super(name, "phrase");
@@ -148,7 +152,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         return this;
     }
     
-    public PhraseSuggestionBuilder tokenLimit(int tokenLimit) {
+    public PhraseSuggestionBuilder tokenLimit(Integer tokenLimit) {
         this.tokenLimit = tokenLimit;
         return this;
     }
@@ -163,6 +167,16 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         }
         this.preTag = preTag;
         this.postTag = postTag;
+        return this;
+    }
+    
+    public PhraseSuggestionBuilder filterType(FilterType filterType) {
+        this.filterType = filterType;
+        return this;
+    }
+    
+    public PhraseSuggestionBuilder filterExtra(FilterBuilder filterExtra) {
+        this.filterExtra = filterExtra;
         return this;
     }
 
@@ -208,6 +222,17 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
             builder.startObject("highlight");
             builder.field("pre_tag", preTag);
             builder.field("post_tag", postTag);
+            builder.endObject();
+        }
+        if (filterType != null || filterExtra != null) {
+            builder.startObject("filter");
+            if (filterType != null) {
+                builder.field("type", filterType.name().toLowerCase(Locale.US));
+            }
+            if (filterExtra != null) {
+                builder.field("extra");
+                filterExtra.toXContent(builder, params);
+            }
             builder.endObject();
         }
         return builder;

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -18,15 +18,18 @@
  */
 package org.elasticsearch.search.suggest.phrase;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestion.FilterType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 class PhraseSuggestionContext extends SuggestionContext {
     private final BytesRef SEPARATOR = new BytesRef(" ");
@@ -40,6 +43,14 @@ class PhraseSuggestionContext extends SuggestionContext {
     private int tokenLimit = NoisyChannelSpellChecker.DEFAULT_TOKEN_LIMIT;
     private BytesRef preTag;
     private BytesRef postTag;
+    /**
+     * Type of filter to apply to suggestions. null is invalid.
+     */
+    private FilterType filterType = FilterType.NONE;
+    /**
+     * Extra filter to apply to suggestions. a zero length reference means none.
+     */
+    private BytesReference filterExtra = BytesArray.EMPTY;
 
     private WordScorer.WordScorerFactory scorer;
 
@@ -179,5 +190,21 @@ class PhraseSuggestionContext extends SuggestionContext {
 
     public BytesRef getPostTag() {
         return postTag;
+    }
+
+    public PhraseSuggestion.FilterType getFilterType() {
+        return filterType;
+    }
+
+    public void setFilterType(PhraseSuggestion.FilterType filterType) {
+        this.filterType = filterType;
+    }
+
+    public BytesReference getFilterExtra() {
+        return filterExtra;
+    }
+
+    public void setFilterExtra(BytesReference filterExtra) {
+        this.filterExtra = filterExtra;
     }
 }


### PR DESCRIPTION
This implementation has a bunch of problems that'll need to be worked
before it is a valid candidate for merging.  I don't have time to rebase
it right now but would still love the feedback on problem.  The ones I
remember:
1.  It performs the filtering by blocking the suggesting thread.
2.  Because there is no "exists" query type it uses a limit.  I now know
   that isn't ass efficient as just using a count but it might be worth
   implementing an exists query type for it any way.
3.  It feels like there are a lot of plumbing changes required for this
   feature.  My guess is that is because I'm going about it wrong.  This
   correlates with #1 pretty well.
4.  I have to wrap the filter through the map nodes and parse it during
   the reduce step.  That feels silly.

Closes #3482
