### PR TITLE
fixes issue #4028; CompletionTokenStream was abusing the TermToBytesRefA...

### DIFF
--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionTokenStream.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionTokenStream.java
@@ -36,7 +36,7 @@ import java.util.Set;
  */
 public final class CompletionTokenStream extends TokenStream {
 
-    private final PayloadAttribute payloadAttr = addAttribute(PayloadAttribute.class);;
+    private final PayloadAttribute payloadAttr = addAttribute(PayloadAttribute.class);
     private final PositionIncrementAttribute posAttr = addAttribute(PositionIncrementAttribute.class);
     private final ByteTermAttribute bytesAtt = addAttribute(ByteTermAttribute.class);
 
@@ -49,6 +49,7 @@ public final class CompletionTokenStream extends TokenStream {
     private final BytesRef scratch = new BytesRef();
 
     public CompletionTokenStream(TokenStream input, BytesRef payload, ToFiniteStrings toFiniteStrings) throws IOException {
+        bytesAtt.setBytesRef(scratch);
         this.input = input;
         this.payload = payload;
         this.toFiniteStrings = toFiniteStrings;
@@ -75,7 +76,6 @@ public final class CompletionTokenStream extends TokenStream {
              */
             posInc = 0;
             Util.toBytesRef(finiteStrings.next(), scratch); // now we have UTF-8
-            bytesAtt.setBytesRef(scratch);
             if (payload != null) {
                 payloadAttr.setPayload(this.payload);
             }


### PR DESCRIPTION
...ttribute interface by reseting the underlying bytesRef on each term.

Didn't add any tests as I didn't know where to start doing so.

Note that issue #4040 attempted to fix this but instead broke the CompletionTokenStream entirely.
