### PR TITLE
Fixed fetch subphase to not recreate the HitContext for each hit

### DIFF
--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -142,6 +142,7 @@ public class FetchPhase implements SearchPhase {
         }
 
         InternalSearchHit[] hits = new InternalSearchHit[context.docIdsToLoadSize()];
+        FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext();
         for (int index = 0; index < context.docIdsToLoadSize(); index++) {
             int docId = context.docIdsToLoad()[context.docIdsToLoadFrom() + index];
 
@@ -195,10 +196,9 @@ public class FetchPhase implements SearchPhase {
                 }
             }
 
+            hitContext.reset(searchHit, subReaderContext, subDoc, context.searcher().getIndexReader(), docId, fieldsVisitor);
             for (FetchSubPhase fetchSubPhase : fetchSubPhases) {
-                FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext();
                 if (fetchSubPhase.hitExecutionNeeded(context)) {
-                    hitContext.reset(searchHit, subReaderContext, subDoc, context.searcher().getIndexReader(), docId, fieldsVisitor);
                     fetchSubPhase.hitExecute(context, hitContext);
                 }
             }

--- a/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -22,15 +22,9 @@ package org.elasticsearch.search.highlight;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.common.Priority;
+import org.elasticsearch.action.search.*;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.ImmutableSettings.Builder;
-import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.FilterBuilders;
@@ -47,7 +41,6 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,96 +61,74 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
     @Test
     // see #3486
     public void testHighTermFrequencyDoc() throws ElasticSearchException, IOException {
-        wipeIndex("test");
-        client().admin().indices().prepareCreate("test")
-        .addMapping("test", jsonBuilder()
-                .startObject()
-                    .startObject("test")
-                        .startObject("properties")
-                            .startObject("name")
-                                .field("type", "string")
-                                .field("term_vector", "with_positions_offsets")
-                                .field("store", randomBoolean() ? "yes" : "no")
-                            .endObject()
-                        .endObject()
-                    .endObject()
-                .endObject())
-        .setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", between(1, 5)))
-        .execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .addMapping("test", "name", "type=string,term_vector=with_positions_offsets,store=" + (randomBoolean() ? "yes" : "no"))
+                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", between(1, 5))));
         ensureYellow();
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 6000; i++) {
             builder.append("abc").append(" ");
         }
         client().prepareIndex("test", "test", "1")
-            .setSource(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("name", builder.toString())
-                    .endObject())
-            .execute().actionGet();
+            .setSource("name", builder.toString())
+            .get();
         refresh();
-        SearchResponse search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "abc"))).addHighlightedField("name").execute().actionGet();
+        SearchResponse search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "abc"))).addHighlightedField("name").get();
         assertHighlight(search, 0, "name", 0, startsWith("<em>abc</em> <em>abc</em> <em>abc</em> <em>abc</em>"));
     }
 
-
     @Test
     public void testNgramHighlightingWithBrokenPositions() throws ElasticSearchException, IOException {
-        prepareCreate("test")
-        .addMapping("test", jsonBuilder()
-                .startObject()
-                    .startObject("test")
+        assertAcked(prepareCreate("test")
+                .addMapping("test", jsonBuilder()
+                        .startObject()
+                        .startObject("test")
                         .startObject("properties")
-                            .startObject("name")
-                                .startObject("fields")
-                                    .startObject("autocomplete")
-                                        .field("type", "string")
-                                        .field("index_analyzer", "autocomplete")
-                                        .field("search_analyzer", "search_autocomplete")
-                                        .field("term_vector", "with_positions_offsets")
-                                    .endObject()
-                                    .startObject("name")
-                                        .field("type", "string")
-                                    .endObject()
-                                .endObject()
-                                .field("type", "multi_field")
+                        .startObject("name")
+                        .startObject("fields")
+                        .startObject("autocomplete")
+                        .field("type", "string")
+                        .field("index_analyzer", "autocomplete")
+                        .field("search_analyzer", "search_autocomplete")
+                        .field("term_vector", "with_positions_offsets")
                         .endObject()
-                    .endObject()
-                .endObject())
-        .setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 1)
-                .put("analysis.tokenizer.autocomplete.max_gram", 20)
-                .put("analysis.tokenizer.autocomplete.min_gram", 1)
-                .put("analysis.tokenizer.autocomplete.token_chars", "letter,digit")
-                .put("analysis.tokenizer.autocomplete.type", "nGram")
-                .put("analysis.filter.wordDelimiter.type", "word_delimiter")
-                .putArray("analysis.filter.wordDelimiter.type_table",
-                        "& => ALPHANUM", "| => ALPHANUM", "! => ALPHANUM",
-                        "? => ALPHANUM", ". => ALPHANUM", "- => ALPHANUM", "# => ALPHANUM", "% => ALPHANUM",
-                        "+ => ALPHANUM", ", => ALPHANUM", "~ => ALPHANUM", ": => ALPHANUM", "/ => ALPHANUM",
-                        "^ => ALPHANUM", "$ => ALPHANUM", "@ => ALPHANUM", ") => ALPHANUM", "( => ALPHANUM",
-                        "] => ALPHANUM", "[ => ALPHANUM", "} => ALPHANUM", "{ => ALPHANUM")
-                        
-                .put("analysis.filter.wordDelimiter.type.split_on_numerics", false)
-                .put("analysis.filter.wordDelimiter.generate_word_parts", true)
-                .put("analysis.filter.wordDelimiter.generate_number_parts", false)
-                .put("analysis.filter.wordDelimiter.catenate_words", true)
-                .put("analysis.filter.wordDelimiter.catenate_numbers", true)
-                .put("analysis.filter.wordDelimiter.catenate_all", false)
+                        .startObject("name")
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .field("type", "multi_field")
+                        .endObject()
+                        .endObject()
+                        .endObject())
+                .setSettings(ImmutableSettings.settingsBuilder()
+                        .put("index.number_of_shards", 1)
+                        .put("analysis.tokenizer.autocomplete.max_gram", 20)
+                        .put("analysis.tokenizer.autocomplete.min_gram", 1)
+                        .put("analysis.tokenizer.autocomplete.token_chars", "letter,digit")
+                        .put("analysis.tokenizer.autocomplete.type", "nGram")
+                        .put("analysis.filter.wordDelimiter.type", "word_delimiter")
+                        .putArray("analysis.filter.wordDelimiter.type_table",
+                                "& => ALPHANUM", "| => ALPHANUM", "! => ALPHANUM",
+                                "? => ALPHANUM", ". => ALPHANUM", "- => ALPHANUM", "# => ALPHANUM", "% => ALPHANUM",
+                                "+ => ALPHANUM", ", => ALPHANUM", "~ => ALPHANUM", ": => ALPHANUM", "/ => ALPHANUM",
+                                "^ => ALPHANUM", "$ => ALPHANUM", "@ => ALPHANUM", ") => ALPHANUM", "( => ALPHANUM",
+                                "] => ALPHANUM", "[ => ALPHANUM", "} => ALPHANUM", "{ => ALPHANUM")
 
-                .put("analysis.analyzer.autocomplete.tokenizer", "autocomplete")
-                .putArray("analysis.analyzer.autocomplete.filter", "lowercase", "wordDelimiter")
-                .put("analysis.analyzer.search_autocomplete.tokenizer", "whitespace")
-                .putArray("analysis.analyzer.search_autocomplete.filter", "lowercase", "wordDelimiter"))
-        .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+                        .put("analysis.filter.wordDelimiter.type.split_on_numerics", false)
+                        .put("analysis.filter.wordDelimiter.generate_word_parts", true)
+                        .put("analysis.filter.wordDelimiter.generate_number_parts", false)
+                        .put("analysis.filter.wordDelimiter.catenate_words", true)
+                        .put("analysis.filter.wordDelimiter.catenate_numbers", true)
+                        .put("analysis.filter.wordDelimiter.catenate_all", false)
+
+                        .put("analysis.analyzer.autocomplete.tokenizer", "autocomplete")
+                        .putArray("analysis.analyzer.autocomplete.filter", "lowercase", "wordDelimiter")
+                        .put("analysis.analyzer.search_autocomplete.tokenizer", "whitespace")
+                        .putArray("analysis.analyzer.search_autocomplete.filter", "lowercase", "wordDelimiter")));
+        ensureYellow();
         client().prepareIndex("test", "test", "1")
-            .setSource(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field( "name", "ARCOTEL Hotels Deutschland")
-                    .endObject())
-            .setRefresh(true).execute().actionGet();
+            .setSource("name", "ARCOTEL Hotels Deutschland").get();
+        refresh();
         SearchResponse search = client().prepareSearch("test").setTypes("test").setQuery(matchQuery("name.autocomplete", "deut tel").operator(Operator.OR)).addHighlightedField("name.autocomplete").execute().actionGet();
         assertHighlight(search, 0, "name.autocomplete", 0, equalTo("ARCO<em>TEL</em> Ho<em>tel</em>s <em>Deut</em>schland"));
     }
@@ -168,44 +139,26 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
          * MultiPhraseQuery can literally kill an entire node if there are too many terms in the
          * query. We cut off and extract terms if there are more than 16 terms in the query
          */
-        XContentBuilder builder = jsonBuilder().
-                startObject().
-                    field("test").
-                    startObject().
-                        field("properties").
-                        startObject().
-                            field("body").
-                            startObject().
-                                field("type", "string").
-                                field("index_analyzer", "custom_analyzer").
-                                field("search_analyzer", "custom_analyzer").
-                                field("term_vector", "with_positions_offsets").
-                            endObject().
-                        endObject().
-                    endObject().
-                endObject();
-
-        assertAcked(prepareCreate("test").addMapping("test", builder).setSettings(
-                ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 0)
-                        .put("analysis.filter.wordDelimiter.type", "word_delimiter")
-                        .put("analysis.filter.wordDelimiter.type.split_on_numerics", false)
-                        .put("analysis.filter.wordDelimiter.generate_word_parts", true)
-                        .put("analysis.filter.wordDelimiter.generate_number_parts", true)
-                        .put("analysis.filter.wordDelimiter.catenate_words", true)
-                        .put("analysis.filter.wordDelimiter.catenate_numbers", true)
-                        .put("analysis.filter.wordDelimiter.catenate_all", false)
-                        .put("analysis.analyzer.custom_analyzer.tokenizer", "whitespace")
-                        .putArray("analysis.analyzer.custom_analyzer.filter", "lowercase", "wordDelimiter"))
+        assertAcked(prepareCreate("test")
+                .addMapping("test", "body", "type=string,index_analyzer=custom_analyzer,search_analyzer=custom_analyzer,term_vector=with_positions_offsets")
+                .setSettings(
+                        ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)
+                                .put("index.number_of_replicas", 0)
+                                .put("analysis.filter.wordDelimiter.type", "word_delimiter")
+                                .put("analysis.filter.wordDelimiter.type.split_on_numerics", false)
+                                .put("analysis.filter.wordDelimiter.generate_word_parts", true)
+                                .put("analysis.filter.wordDelimiter.generate_number_parts", true)
+                                .put("analysis.filter.wordDelimiter.catenate_words", true)
+                                .put("analysis.filter.wordDelimiter.catenate_numbers", true)
+                                .put("analysis.filter.wordDelimiter.catenate_all", false)
+                                .put("analysis.analyzer.custom_analyzer.tokenizer", "whitespace")
+                                .putArray("analysis.analyzer.custom_analyzer.filter", "lowercase", "wordDelimiter"))
         );
 
         ensureGreen();
         client().prepareIndex("test", "test", "1")
-            .setSource(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("body", "Test: http://www.facebook.com http://elasticsearch.org http://xing.com http://cnn.com http://quora.com http://twitter.com this is a test for highlighting feature Test: http://www.facebook.com http://elasticsearch.org http://xing.com http://cnn.com http://quora.com http://twitter.com this is a test for highlighting feature")
-                    .endObject())
-            .execute().actionGet();
+            .setSource("body", "Test: http://www.facebook.com http://elasticsearch.org http://xing.com http://cnn.com http://quora.com http://twitter.com this is a test for highlighting feature Test: http://www.facebook.com http://elasticsearch.org http://xing.com http://cnn.com http://quora.com http://twitter.com this is a test for highlighting feature")
+            .get();
         refresh();
         SearchResponse search = client().prepareSearch().setQuery(matchQuery("body", "Test: http://www.facebook.com ").type(Type.PHRASE)).addHighlightedField("body").execute().actionGet();
         assertHighlight(search, 0, "body", 0, startsWith("<em>Test: http://www.facebook.com</em>"));
@@ -215,455 +168,300 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
     
     @Test
     public void testNgramHighlightingPreLucene42() throws ElasticSearchException, IOException {
-        boolean[] doStore = {true, false};
-        for (boolean store : doStore) {
-            wipeIndex("test");
-            client().admin().indices().prepareCreate("test")
-            .addMapping("test", jsonBuilder()
-                    .startObject()
-                        .startObject("test")
-                            .startObject("properties")
-                                .startObject("name")
-                                    .field("type", "string")
-                                    .field("index_analyzer", "name_index_analyzer")
-                                    .field("search_analyzer", "name_search_analyzer")
-                                    .field("term_vector", "with_positions_offsets")
-                                    .field("store", store ? "yes" : "no")
-                                .endObject()
-                                .startObject("name2")
-                                    .field("type", "string")
-                                    .field("index_analyzer", "name2_index_analyzer")
-                                    .field("search_analyzer", "name_search_analyzer")
-                                    .field("term_vector", "with_positions_offsets")
-                                    .field("store", store ? "yes" : "no")
-                                .endObject()
-                            .endObject()
-                        .endObject()
-                    .endObject())
-            .setSettings(ImmutableSettings.settingsBuilder()
-                    .put("index.number_of_shards", 2)
-                    .put("analysis.filter.my_ngram.max_gram", 20)
-                    .put("analysis.filter.my_ngram.version", "4.1")
-                    .put("analysis.filter.my_ngram.min_gram", 1)
-                    .put("analysis.filter.my_ngram.type", "ngram")
-                    .put("analysis.tokenizer.my_ngramt.max_gram", 20)
-                    .put("analysis.tokenizer.my_ngramt.version", "4.1")
-                    .put("analysis.tokenizer.my_ngramt.min_gram", 1)
-                    .put("analysis.tokenizer.my_ngramt.type", "ngram")
-                    .put("analysis.analyzer.name_index_analyzer.tokenizer", "my_ngramt")
-                    .put("analysis.analyzer.name2_index_analyzer.tokenizer", "whitespace")
-                    .putArray("analysis.analyzer.name2_index_analyzer.filter", "lowercase", "my_ngram")
-                    .put("analysis.analyzer.name_search_analyzer.tokenizer", "whitespace")
-                    .put("analysis.analyzer.name_search_analyzer.filter", "lowercase"))
-            .execute().actionGet();
-            ensureYellow();
-            client().prepareIndex("test", "test", "1")
-                .setSource(XContentFactory.jsonBuilder()
-                        .startObject()
-                            .field("name", "logicacmg ehemals avinci - the know how company")
-                            .field("name2", "logicacmg ehemals avinci - the know how company")
-                        .endObject())
-                .execute().actionGet();
-            
-            client().prepareIndex("test", "test", "2")
-            .setSource(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("name", "avinci, unilog avinci, logicacmg, logica" )
-                        .field("name2", "avinci, unilog avinci, logicacmg, logica")
-                    .endObject())
-            .execute().actionGet();
-            refresh();
-           
-            SearchResponse search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica m"))).addHighlightedField("name").execute().actionGet();
-            assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
-            assertHighlight(search, 1, "name", 0, equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>"));
-            
-            search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica ma"))).addHighlightedField("name").execute()
-                    .actionGet();
-            assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
-            assertHighlight(search, 1, "name", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
-    
-            search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica"))).addHighlightedField("name").execute().actionGet();
-            assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
-            
-            search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica m"))).addHighlightedField("name2").execute().actionGet();
-            assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
-            assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>"));
-    
-            search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica ma"))).addHighlightedField("name2").execute()
-                    .actionGet();
-            assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
-            assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
-    
-    
-            search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica"))).addHighlightedField("name2").execute().actionGet();
-            assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
-            assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
-        }
+
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .addMapping("test",
+                        "name", "type=string,index_analyzer=name_index_analyzer,search_analyzer=name_search_analyzer," + randomStoreField() + "term_vector=with_positions_offsets",
+                        "name2", "type=string,index_analyzer=name2_index_analyzer,search_analyzer=name_search_analyzer," + randomStoreField() + "term_vector=with_positions_offsets")
+                .setSettings(ImmutableSettings.settingsBuilder()
+                        .put("index.number_of_shards", 2)
+                        .put("analysis.filter.my_ngram.max_gram", 20)
+                        .put("analysis.filter.my_ngram.version", "4.1")
+                        .put("analysis.filter.my_ngram.min_gram", 1)
+                        .put("analysis.filter.my_ngram.type", "ngram")
+                        .put("analysis.tokenizer.my_ngramt.max_gram", 20)
+                        .put("analysis.tokenizer.my_ngramt.version", "4.1")
+                        .put("analysis.tokenizer.my_ngramt.min_gram", 1)
+                        .put("analysis.tokenizer.my_ngramt.type", "ngram")
+                        .put("analysis.analyzer.name_index_analyzer.tokenizer", "my_ngramt")
+                        .put("analysis.analyzer.name2_index_analyzer.tokenizer", "whitespace")
+                        .putArray("analysis.analyzer.name2_index_analyzer.filter", "lowercase", "my_ngram")
+                        .put("analysis.analyzer.name_search_analyzer.tokenizer", "whitespace")
+                        .put("analysis.analyzer.name_search_analyzer.filter", "lowercase")));
+        ensureYellow();
+        client().prepareIndex("test", "test", "1")
+            .setSource("name", "logicacmg ehemals avinci - the know how company",
+                    "name2", "logicacmg ehemals avinci - the know how company").get();
+        client().prepareIndex("test", "test", "2")
+            .setSource("name", "avinci, unilog avinci, logicacmg, logica",
+                    "name2", "avinci, unilog avinci, logicacmg, logica").get();
+        refresh();
+
+        SearchResponse search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica m"))).addHighlightedField("name").get();
+        assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
+        assertHighlight(search, 1, "name", 0, equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>"));
+
+        search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica ma"))).addHighlightedField("name").get();
+        assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
+        assertHighlight(search, 1, "name", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
+
+        search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica"))).addHighlightedField("name").get();
+        assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
+
+        search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica m"))).addHighlightedField("name2").get();
+        assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
+        assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>"));
+
+        search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica ma"))).addHighlightedField("name2").get();
+        assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
+        assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
+
+        search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica"))).addHighlightedField("name2").get();
+        assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
+        assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
 
     }
     
     @Test
     public void testNgramHighlighting() throws ElasticSearchException, IOException {
-        client().admin().indices().prepareCreate("test")
-        .addMapping("test", jsonBuilder()
-                .startObject()
-                    .startObject("test")
-                        .startObject("properties")
-                            .startObject("name")
-                                .field("type", "string")
-                                .field("index_analyzer", "name_index_analyzer")
-                                .field("search_analyzer", "name_search_analyzer")
-                                .field("term_vector", "with_positions_offsets")
-                            .endObject()
-                            .startObject("name2")
-                                .field("type", "string")
-                                .field("index_analyzer", "name2_index_analyzer")
-                                .field("search_analyzer", "name_search_analyzer")
-                                .field("term_vector", "with_positions_offsets")
-                            .endObject()
-                        .endObject()
-                    .endObject()
-                .endObject())
-        .setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 2)
-                .put("analysis.filter.my_ngram.max_gram", 20)
-                .put("analysis.filter.my_ngram.min_gram", 1)
-                .put("analysis.filter.my_ngram.type", "ngram")
-                .put("analysis.tokenizer.my_ngramt.max_gram", 20)
-                .put("analysis.tokenizer.my_ngramt.min_gram", 1)
-                .put("analysis.tokenizer.my_ngramt.token_chars", "letter,digit")
-                .put("analysis.tokenizer.my_ngramt.type", "ngram")
-                .put("analysis.analyzer.name_index_analyzer.tokenizer", "my_ngramt")
-                .put("analysis.analyzer.name2_index_analyzer.tokenizer", "whitespace")
-                .put("analysis.analyzer.name2_index_analyzer.filter", "my_ngram")
-                .put("analysis.analyzer.name_search_analyzer.tokenizer", "whitespace"))
-        .execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .addMapping("test",
+                        "name", "type=string,index_analyzer=name_index_analyzer,search_analyzer=name_search_analyzer,term_vector=with_positions_offsets",
+                        "name2", "type=string,index_analyzer=name2_index_analyzer,search_analyzer=name_search_analyzer,term_vector=with_positions_offsets")
+                .setSettings(ImmutableSettings.settingsBuilder()
+                        .put("index.number_of_shards", 2)
+                        .put("analysis.filter.my_ngram.max_gram", 20)
+                        .put("analysis.filter.my_ngram.min_gram", 1)
+                        .put("analysis.filter.my_ngram.type", "ngram")
+                        .put("analysis.tokenizer.my_ngramt.max_gram", 20)
+                        .put("analysis.tokenizer.my_ngramt.min_gram", 1)
+                        .put("analysis.tokenizer.my_ngramt.token_chars", "letter,digit")
+                        .put("analysis.tokenizer.my_ngramt.type", "ngram")
+                        .put("analysis.analyzer.name_index_analyzer.tokenizer", "my_ngramt")
+                        .put("analysis.analyzer.name2_index_analyzer.tokenizer", "whitespace")
+                        .put("analysis.analyzer.name2_index_analyzer.filter", "my_ngram")
+                        .put("analysis.analyzer.name_search_analyzer.tokenizer", "whitespace")));
         client().prepareIndex("test", "test", "1")
-            .setSource(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("name", "logicacmg ehemals avinci - the know how company")
-                        .field("name2", "logicacmg ehemals avinci - the know how company")
-                    .endObject())
-            .execute().actionGet();
+            .setSource("name", "logicacmg ehemals avinci - the know how company",
+                       "name2", "logicacmg ehemals avinci - the know how company").get();
         refresh();
         ensureGreen();
-        SearchResponse search = client().prepareSearch().setQuery(matchQuery("name", "logica m")).addHighlightedField("name").execute().actionGet();
+        SearchResponse search = client().prepareSearch().setQuery(matchQuery("name", "logica m")).addHighlightedField("name").get();
         assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
         
-        search = client().prepareSearch().setQuery(matchQuery("name", "logica ma")).addHighlightedField("name").execute()
-                .actionGet();
+        search = client().prepareSearch().setQuery(matchQuery("name", "logica ma")).addHighlightedField("name").get();
         assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
 
-        search = client().prepareSearch().setQuery(matchQuery("name", "logica")).addHighlightedField("name").execute().actionGet();
+        search = client().prepareSearch().setQuery(matchQuery("name", "logica")).addHighlightedField("name").get();
         assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
         
-      
-        
-        search = client().prepareSearch().setQuery(matchQuery("name2", "logica m")).addHighlightedField("name2").execute().actionGet();
+        search = client().prepareSearch().setQuery(matchQuery("name2", "logica m")).addHighlightedField("name2").get();
         assertHighlight(search, 0, "name2", 0, equalTo("<em>logicacmg</em> <em>ehemals</em> avinci - the know how <em>company</em>"));
         
-        search = client().prepareSearch().setQuery(matchQuery("name2", "logica ma")).addHighlightedField("name2").execute()
-                .actionGet();
+        search = client().prepareSearch().setQuery(matchQuery("name2", "logica ma")).addHighlightedField("name2").get();
         assertHighlight(search, 0, "name2", 0, equalTo("<em>logicacmg</em> <em>ehemals</em> avinci - the know how company"));
 
-        search = client().prepareSearch().setQuery(matchQuery("name2", "logica")).addHighlightedField("name2").execute().actionGet();
+        search = client().prepareSearch().setQuery(matchQuery("name2", "logica")).addHighlightedField("name2").get();
         assertHighlight(search, 0, "name2", 0, equalTo("<em>logicacmg</em> ehemals avinci - the know how company"));
-
-        
     }
     
     @Test
     public void testEnsureNoNegativeOffsets() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        // we don't store title, now lets see if it works...
-                        .startObject("no_long_term").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").endObject()
-                        .startObject("long_term").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1",
+                        "no_long_term", "type=string,term_vector=with_positions_offsets",
+                        "long_term", "type=string,term_vector=with_positions_offsets"));
+        ensureYellow();
 
         client().prepareIndex("test", "type1", "1")
-                .setSource(XContentFactory.jsonBuilder().startObject()
-                        .startArray("no_long_term")
-                        .value("This is a test where foo is highlighed and should be highlighted")
-                        .endArray()
-                        .startArray("long_term")
-                        .value("This is a test thisisaverylongwordandmakessurethisfails where foo is highlighed and should be highlighted")
-                        .endArray()
-                        .endObject())
-                .setRefresh(true).execute().actionGet();
-
+                .setSource("no_long_term", "This is a test where foo is highlighed and should be highlighted",
+                        "long_term", "This is a test thisisaverylongwordandmakessurethisfails where foo is highlighed and should be highlighted")
+                .get();
+        refresh();
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(matchQuery("long_term", "thisisaverylongwordandmakessurethisfails foo highlighed"))
                 .addHighlightedField("long_term", 18, 1)
-                .execute().actionGet();
+                .get();
+        assertHighlight(search, 0, "long_term", 0, 1, equalTo("<em>thisisaverylongwordandmakessurethisfails</em>"));
 
-        assertThat(search.getHits().totalHits(), equalTo(1l));
-        assertThat(search.getHits().hits().length, equalTo(1));
-
-        assertThat(search.getHits().hits()[0].highlightFields().get("long_term").fragments().length, equalTo(1));
-        assertThat(search.getHits().hits()[0].highlightFields().get("long_term").fragments()[0].string(), equalTo("<em>thisisaverylongwordandmakessurethisfails</em>"));
-        
-        
         search = client().prepareSearch()
                 .setQuery(matchQuery("no_long_term", "test foo highlighed").type(Type.PHRASE).slop(3))
                 .addHighlightedField("no_long_term", 18, 1).setHighlighterPostTags("</b>").setHighlighterPreTags("<b>")
-                .execute().actionGet();
-        assertThat(search.getHits().totalHits(), equalTo(1l));
-        assertThat(search.getHits().hits().length, equalTo(1));
-        assertThat(search.getHits().hits()[0].highlightFields().size(), equalTo(0));
-       
+                .get();
+        assertNotHighlighted(search, 0, "no_long_term");
 
         search = client().prepareSearch()
                 .setQuery(matchQuery("no_long_term", "test foo highlighed").type(Type.PHRASE).slop(3))
                 .addHighlightedField("no_long_term", 30, 1).setHighlighterPostTags("</b>").setHighlighterPreTags("<b>")
-                .execute().actionGet();
-        
-        assertThat(search.getHits().totalHits(), equalTo(1l));
-        assertThat(search.getHits().hits().length, equalTo(1));
+                .get();
 
-        assertThat(search.getHits().hits()[0].highlightFields().get("no_long_term").fragments().length, equalTo(1));
-        assertThat(search.getHits().hits()[0].highlightFields().get("no_long_term").fragments()[0].string(), equalTo("a <b>test</b> where <b>foo</b> is <b>highlighed</b> and"));
+        assertHighlight(search, 0, "no_long_term", 0, 1, equalTo("a <b>test</b> where <b>foo</b> is <b>highlighed</b> and"));
     }
     
     @Test
     public void testSourceLookupHighlightingUsingPlainHighlighter() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         // we don't store title and don't use term vector, now lets see if it works...
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "no").endObject()
                         .startObject("attachments").startObject("properties").startObject("body").field("type", "string").field("store", "no").field("term_vector", "no").endObject().endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+                        .endObject().endObject().endObject()));
+        ensureYellow();
 
-        for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
                     .setSource(XContentFactory.jsonBuilder().startObject()
                             .field("title", "This is a test on the highlighting bug present in elasticsearch")
                             .startArray("attachments").startObject().field("body", "attachment 1").endObject().startObject().field("body", "attachment 2").endObject().endArray()
-                            .endObject())
-                    .setRefresh(true).execute().actionGet();
+                            .endObject());
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "bug"))
                 .addHighlightedField("title", -1, 0)
-                .execute().actionGet();
+                .get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
         }
 
         search = client().prepareSearch()
                 .setQuery(fieldQuery("attachments.body", "attachment"))
                 .addHighlightedField("attachments.body", -1, 0)
-                .execute().actionGet();
+                .get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            assertThat(hit.highlightFields().get("attachments.body").fragments()[0].string(), equalTo("<em>attachment</em> 1"));
-            assertThat(hit.highlightFields().get("attachments.body").fragments()[1].string(), equalTo("<em>attachment</em> 2"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "attachments.body", 0, equalTo("<em>attachment</em> 1"));
+            assertHighlight(search, i, "attachments.body", 1, equalTo("<em>attachment</em> 2"));
         }
     }
 
     @Test
     public void testSourceLookupHighlightingUsingFastVectorHighlighter() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         // we don't store title, now lets see if it works...
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").endObject()
                         .startObject("attachments").startObject("properties").startObject("body").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").endObject().endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+                        .endObject().endObject().endObject()));
+        ensureYellow();
 
-        for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
                     .setSource(XContentFactory.jsonBuilder().startObject()
                             .field("title", "This is a test on the highlighting bug present in elasticsearch")
                             .startArray("attachments").startObject().field("body", "attachment 1").endObject().startObject().field("body", "attachment 2").endObject().endArray()
-                            .endObject())
-                    .setRefresh(true).execute().actionGet();
+                            .endObject());
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "bug"))
                 .addHighlightedField("title", -1, 0)
-                .execute().actionGet();
+                .get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
         }
 
         search = client().prepareSearch()
                 .setQuery(fieldQuery("attachments.body", "attachment"))
                 .addHighlightedField("attachments.body", -1, 2)
-                .execute().actionGet();
+                .execute().get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            assertThat(hit.highlightFields().get("attachments.body").fragments()[0].string(), equalTo("<em>attachment</em> 1"));
-            assertThat(hit.highlightFields().get("attachments.body").fragments()[1].string(), equalTo("<em>attachment</em> 2"));
+        for (int i = 0; i < 5; i++) {
+            assertHighlight(search, i, "attachments.body", 0, equalTo("<em>attachment</em> 1"));
+            assertHighlight(search, i, "attachments.body", 1, equalTo("<em>attachment</em> 2"));
         }
     }
 
     @Test
     public void testSourceLookupHighlightingUsingPostingsHighlighter() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         // we don't store title, now lets see if it works...
                         .startObject("title").field("type", "string").field("store", "no").field("index_options", "offsets").endObject()
                         .startObject("attachments").startObject("properties").startObject("body").field("type", "string").field("store", "no").field("index_options", "offsets").endObject().endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+                        .endObject().endObject().endObject()));
+        ensureYellow();
 
-        for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
                     .setSource(XContentFactory.jsonBuilder().startObject()
                             .array("title", "This is a test on the highlighting bug present in elasticsearch. Hopefully it works.",
                                     "This is the second bug to perform highlighting on.")
                             .startArray("attachments").startObject().field("body", "attachment for this test").endObject().startObject().field("body", "attachment 2").endObject().endArray()
-                            .endObject())
-                    .setRefresh(true).execute().actionGet();
+                            .endObject());
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(matchQuery("title", "bug"))
                 //asking for the whole field to be highlighted
-                .addHighlightedField("title", -1, 0)
-                .execute().actionGet();
+                .addHighlightedField("title", -1, 0).get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            Text[] fragments = hit.highlightFields().get("title").fragments();
-            assertThat(fragments.length, equalTo(2));
-            assertThat(fragments[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch. Hopefully it works."));
-            assertThat(fragments[1].string(), equalTo("This is the second <em>bug</em> to perform highlighting on."));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch. Hopefully it works."));
+            assertHighlight(search, i, "title", 1, 2, equalTo("This is the second <em>bug</em> to perform highlighting on."));
         }
 
         search = client().prepareSearch()
                 .setQuery(matchQuery("title", "bug"))
                 //sentences will be generated out of each value
-                .addHighlightedField("title")
-                .execute().actionGet();
+                .addHighlightedField("title").get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            Text[] fragments = hit.highlightFields().get("title").fragments();
-            assertThat(fragments.length, equalTo(2));
-            assertThat(fragments[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch."));
-            assertThat(fragments[1].string(), equalTo("This is the second <em>bug</em> to perform highlighting on."));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch."));
+            assertHighlight(search, i, "title", 1, 2, equalTo("This is the second <em>bug</em> to perform highlighting on."));
         }
 
         search = client().prepareSearch()
                 .setQuery(matchQuery("attachments.body", "attachment"))
                 .addHighlightedField("attachments.body", -1, 2)
-                .execute().actionGet();
+                .get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            //shorter fragments are scored higher
-            assertThat(hit.highlightFields().get("attachments.body").fragments()[0].string(), equalTo("<em>attachment</em> for this test"));
-            assertThat(hit.highlightFields().get("attachments.body").fragments()[1].string(), equalTo("<em>attachment</em> 2"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "attachments.body", 0, equalTo("<em>attachment</em> for this test"));
+            assertHighlight(search, i, "attachments.body", 1, 2, equalTo("<em>attachment</em> 2"));
         }
     }
 
     @Test
     public void testHighlightIssue1994() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        // we don't store title, now lets see if it works...
-                        .startObject("title").field("type", "string").field("store", "no").endObject()
-                        .startObject("titleTV").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=no", "titleTV", "type=string,store=no,term_vector=with_positions_offsets"));
+        ensureYellow();
 
-        client().prepareIndex("test", "type1", "1")
-                .setSource(XContentFactory.jsonBuilder().startObject()
-                        .startArray("title")
-                        .value("This is a test on the highlighting bug present in elasticsearch")
-                        .value("The bug is bugging us")
-                        .endArray()
-                        .startArray("titleTV")
-                        .value("This is a test on the highlighting bug present in elasticsearch")
-                        .value("The bug is bugging us")
-                        .endArray()
-                        .endObject())
-                .setRefresh(true).execute().actionGet();
+        indexRandom(false, client().prepareIndex("test", "type1", "1")
+                .setSource("title", new String[]{"This is a test on the highlighting bug present in elasticsearch", "The bug is bugging us"},
+                        "titleTV", new String[]{"This is a test on the highlighting bug present in elasticsearch", "The bug is bugging us"}));
 
-
-        client().prepareIndex("test", "type1", "2")
-                .setSource(XContentFactory.jsonBuilder().startObject()
-                        .startArray("titleTV")
-                        .value("some text to highlight")
-                        .value("highlight other text")
-                        .endArray()
-                        .endObject())
-                .setRefresh(true).execute().actionGet();
+        indexRandom(true, client().prepareIndex("test", "type1", "2")
+                .setSource("titleTV", new String[]{"some text to highlight", "highlight other text"}));
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "bug"))
                 .addHighlightedField("title", -1, 2)
                 .addHighlightedField("titleTV", -1, 2)
-                .execute().actionGet();
+                .get();
 
-        assertThat(search.getHits().totalHits(), equalTo(1l));
-        assertThat(search.getHits().hits().length, equalTo(1));
-
-        assertThat(search.getHits().hits()[0].highlightFields().get("title").fragments().length, equalTo(2));
-        assertThat(search.getHits().hits()[0].highlightFields().get("title").fragments()[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
-        assertThat(search.getHits().hits()[0].highlightFields().get("title").fragments()[1].string(), equalTo("The <em>bug</em> is bugging us"));
-        assertThat(search.getHits().hits()[0].highlightFields().get("titleTV").fragments().length, equalTo(2));
-        assertThat(search.getHits().hits()[0].highlightFields().get("titleTV").fragments()[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
-//        assertThat(search.hits().hits()[0].highlightFields().get("titleTV").fragments()[0].string(), equalTo("highlighting <em>bug</em> present in elasticsearch")); // FastVectorHighlighter starts highlighting from startOffset - margin
-        assertThat(search.getHits().hits()[0].highlightFields().get("titleTV").fragments()[1].string(), equalTo("The <em>bug</em> is bugging us"));
+        assertHighlight(search, 0, "title", 0,  equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
+        assertHighlight(search, 0, "title", 1, 2, equalTo("The <em>bug</em> is bugging us"));
+        assertHighlight(search, 0, "titleTV", 0,  equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
+        assertHighlight(search, 0, "titleTV", 1, 2,  equalTo("The <em>bug</em> is bugging us"));
 
         search = client().prepareSearch()
                 .setQuery(fieldQuery("titleTV", "highlight"))
                 .addHighlightedField("titleTV", -1, 2)
-                .execute().actionGet();
+                .get();
 
-        assertThat(search.getHits().totalHits(), equalTo(1l));
-        assertThat(search.getHits().hits().length, equalTo(1));
-        assertThat(search.getHits().hits()[0].highlightFields().get("titleTV").fragments().length, equalTo(2));
-        assertThat(search.getHits().hits()[0].highlightFields().get("titleTV").fragments()[0].string(), equalTo("some text to <em>highlight</em>"));
-        assertThat(search.getHits().hits()[0].highlightFields().get("titleTV").fragments()[1].string(), equalTo("<em>highlight</em> other text"));
+        assertHighlight(search, 0, "titleTV", 0, equalTo("some text to <em>highlight</em>"));
+        assertHighlight(search, 0, "titleTV", 1, 2, equalTo("<em>highlight</em> other text"));
     }
 
     @Test
@@ -672,8 +470,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         ensureGreen();
 
         client().prepareIndex("test", "type1")
-                .setSource("field1", "this is a test", "field2", "this is another test")
-                .setRefresh(true).execute().actionGet();
+                .setSource("field1", "this is a test", "field2", "this is another test").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1 and field2 produces different tags");
         SearchSourceBuilder source = searchSource()
@@ -684,21 +482,19 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                         .field(new HighlightBuilder.Field("field2").preTags("<field2>").postTags("</field2>")));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <global>test</global>"));
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("this is another <field2>test</field2>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <global>test</global>"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("this is another <field2>test</field2>"));
     }
 
     @Test
     public void testHighlightingOnWildcardFields() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1")
-                .setSource("field1", "this is a test", "field2", "this is another test")
-                .setRefresh(true).execute().actionGet();
+                .setSource("field1", "this is a test", "field2", "this is another test").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field*");
         SearchSourceBuilder source = searchSource()
@@ -707,21 +503,19 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field*").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("this is another <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("this is another <xxx>test</xxx>"));
     }
 
     @Test
     public void testPlainHighlighter() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1")
-                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
-                .setRefresh(true).execute().actionGet();
+                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
@@ -730,10 +524,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
         logger.info("--> searching on _all, highlighting on field1");
         source = searchSource()
@@ -742,10 +534,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
@@ -754,10 +544,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
@@ -766,10 +554,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
         logger.info("--> searching on _all with constant score, highlighting on field2");
         source = searchSource()
@@ -778,10 +564,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
         logger.info("--> searching on _all with constant score, highlighting on field2");
         source = searchSource()
@@ -790,19 +574,17 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
     }
 
     @Test
     public void testFastVectorHighlighter() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()).execute().actionGet();
-        client().admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        ensureGreen();
 
         client().prepareIndex("test", "type1")
-                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
-                .setRefresh(true).execute().actionGet();
+                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
@@ -811,10 +593,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
         logger.info("--> searching on _all, highlighting on field1");
         source = searchSource()
@@ -823,11 +603,9 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
         // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
@@ -836,11 +614,9 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
         // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
@@ -849,18 +625,16 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
         // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
     }
 
     @Test
     @Slow
     public void testFastVectorHighlighterManyDocs() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()).execute().actionGet();
-        client().admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        ensureGreen();
 
         int COUNT = between(20, 100);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[COUNT];
@@ -875,12 +649,11 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setSize(COUNT)
                 .setQuery(termQuery("field1", "test"))
                 .addHighlightedField("field1", 100, 0)
-                .execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo((long) COUNT));
-        assertThat(searchResponse.getHits().hits().length, equalTo(COUNT));
-        for (SearchHit hit : searchResponse.getHits()) {
+                .get();
+        for (int i = 0; i < COUNT; i++) {
+            SearchHit hit = searchResponse.getHits().getHits()[i];
             // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-            assertThat(hit.highlightFields().get("field1").fragments()[0].string(), equalTo("<em>test</em> " + hit.id()));
+            assertHighlight(searchResponse, i, "field1", 0, 1, equalTo("<em>test</em> " + hit.id()));
         }
 
         logger.info("--> searching explicitly on field1 and highlighting on it, with DFS");
@@ -889,11 +662,10 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setSize(COUNT)
                 .setQuery(termQuery("field1", "test"))
                 .addHighlightedField("field1", 100, 0)
-                .execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo((long) COUNT));
-        assertThat(searchResponse.getHits().hits().length, equalTo(COUNT));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.highlightFields().get("field1").fragments()[0].string(), equalTo("<em>test</em> " + hit.id()));
+                .get();
+        for (int i = 0; i < COUNT; i++) {
+            SearchHit hit = searchResponse.getHits().getHits()[i];
+            assertHighlight(searchResponse, i, "field1", 0, 1, equalTo("<em>test</em> " + hit.id()));
         }
 
         logger.info("--> searching explicitly _all and highlighting on _all");
@@ -901,11 +673,10 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setSize(COUNT)
                 .setQuery(termQuery("_all", "test"))
                 .addHighlightedField("_all", 100, 0)
-                .execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo((long) COUNT));
-        assertThat(searchResponse.getHits().hits().length, equalTo(COUNT));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.highlightFields().get("_all").fragments()[0].string(), equalTo("<em>test</em> " + hit.id() + " "));
+                .get();
+        for (int i = 0; i < COUNT; i++) {
+            SearchHit hit = searchResponse.getHits().getHits()[i];
+            assertHighlight(searchResponse, i, "_all", 0, 1, equalTo("<em>test</em> " + hit.id() + " "));
         }
     }
 
@@ -921,176 +692,142 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
     @Test
     public void testSameContent() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets"));
+        ensureYellow();
 
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a test on the highlighting bug present in elasticsearch").setRefresh(true).execute().actionGet();
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a test on the highlighting bug present in elasticsearch");
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "bug"))
                 .addHighlightedField("title", -1, 0)
-                .execute().actionGet();
+                .get();
 
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-        assertThat(search.getFailedShards(), equalTo(0));
-
-        for (SearchHit hit : search.getHits()) {
-            // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
+        for (int i = 0; i < 5; i++) {
+            assertHighlight(search, i, "title", 0, 1, equalTo("This is a test on the highlighting <em>bug</em> present in elasticsearch"));
         }
     }
 
     @Test
     public void testFastVectorHighlighterOffsetParameter() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets").get());
+        ensureYellow();
 
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a test on the highlighting bug present in elasticsearch").setRefresh(true).execute().actionGet();
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a test on the highlighting bug present in elasticsearch");
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "bug"))
                 .addHighlightedField("title", 30, 1, 10)
-                .execute().actionGet();
+                .get();
 
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
+        for (int i = 0; i < 5; i++) {
             // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("highlighting <em>bug</em> present in elasticsearch"));
+            assertHighlight(search, i, "title", 0, 1, equalTo("highlighting <em>bug</em> present in elasticsearch"));
         }
     }
 
     @Test
     public void testEscapeHtml() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes")
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=yes"));
+        ensureYellow();
 
-        for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a html escaping highlighting test for *&? elasticsearch").setRefresh(true).execute().actionGet();
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a html escaping highlighting test for *&? elasticsearch");
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title", 50, 1, 10)
-                .execute().actionGet();
+                .get();
 
-        assertNoFailures(search);
-
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a html escaping highlighting <em>test</em> for *&amp;? elasticsearch"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, 1, equalTo("This is a html escaping highlighting <em>test</em> for *&amp;? elasticsearch"));
         }
     }
 
     @Test
     public void testEscapeHtml_vector() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets"));
+        ensureYellow();
 
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a html escaping highlighting test for *&? elasticsearch").setRefresh(true).execute().actionGet();
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a html escaping highlighting test for *&? elasticsearch");
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title", 30, 1, 10)
-                .execute().actionGet();
+                .get();
 
-
-        assertNoFailures(search);
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("highlighting <em>test</em> for *&amp;? elasticsearch"));
+        for (int i = 0; i < 5; i++) {
+            assertHighlight(search, i, "title", 0, 1, equalTo("highlighting <em>test</em> for *&amp;? elasticsearch"));
         }
     }
 
     @Test
     public void testMultiMapperVectorWithStore() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").field("analyzer", "classic").endObject()
                         .startObject("key").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").field("analyzer", "whitespace").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").execute().actionGet();
+        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
         refresh();
         // simple search on body with standard analyzer with a simple field query
         SearchResponse search = client().prepareSearch()
                 .setQuery(fieldQuery("title", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title", 50, 1)
-                .execute().actionGet();
-        
+                .get();
 
-        SearchHit hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("this is a <em>test</em>"));
+        assertHighlight(search, 0, "title", 0, 1, equalTo("this is a <em>test</em>"));
 
         // search on title.key and highlight on title
         search = client().prepareSearch()
                 .setQuery(fieldQuery("title.key", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title.key", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title.key").fragments()[0].string(), equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
+        assertHighlight(search, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
     }
 
     @Test
     public void testMultiMapperVectorFromSource() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").field("analyzer", "classic").endObject()
                         .startObject("key").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").field("analyzer", "whitespace").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-
+                        .endObject().endObject().endObject()));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").execute().actionGet();
+        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1098,37 +835,32 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setQuery(fieldQuery("title", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        SearchHit hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("this is a <em>test</em>"));
+        assertHighlight(search, 0, "title", 0, 1, equalTo("this is a <em>test</em>"));
 
         // search on title.key and highlight on title.key
         search = client().prepareSearch()
                 .setQuery(fieldQuery("title.key", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title.key", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title.key").fragments()[0].string(), equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
+        assertHighlight(search, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
     }
 
     @Test
     public void testMultiMapperNoVectorWithStore() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "no").field("analyzer", "classic").endObject()
                         .startObject("key").field("type", "string").field("store", "yes").field("term_vector", "no").field("analyzer", "whitespace").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").execute().actionGet();
+        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1136,37 +868,31 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setQuery(fieldQuery("title", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        SearchHit hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("this is a <em>test</em>"));
+        assertHighlight(search, 0, "title", 0, 1, equalTo("this is a <em>test</em>"));
 
         // search on title.key and highlight on title
         search = client().prepareSearch()
                 .setQuery(fieldQuery("title.key", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title.key", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title.key").fragments()[0].string(), equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
+        assertHighlight(search, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
     }
 
     @Test
     public void testMultiMapperNoVectorFromSource() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "no").field("analyzer", "classic").endObject()
                         .startObject("key").field("type", "string").field("store", "no").field("term_vector", "no").field("analyzer", "whitespace").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-
+                        .endObject().endObject().endObject()));
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").execute().actionGet();
+        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1174,44 +900,37 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setQuery(fieldQuery("title", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        SearchHit hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("this is a <em>test</em>"));
+        assertHighlight(search, 0, "title", 0, 1, equalTo("this is a <em>test</em>"));
 
         // search on title.key and highlight on title.key
         search = client().prepareSearch()
                 .setQuery(fieldQuery("title.key", "this is a test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title.key", 50, 1)
-                .execute().actionGet();
-        assertNoFailures(search);
+                .get();
 
-        hit = search.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title.key").fragments()[0].string(), equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
+        assertHighlight(search, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
     }
 
     @Test
     public void testFastVectorHighlighterShouldFailIfNoTermVectors() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "no").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=yes,term_vector=no"));
         ensureGreen();
 
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a test for the enabling fast vector highlighter").setRefresh(true).execute().actionGet();
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a test for the enabling fast vector highlighter");
         }
-        refresh();
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(matchPhraseQuery("title", "this is a test"))
                 .addHighlightedField("title", 50, 1, 10)
-                .execute().actionGet();
-
+                .get();
         assertNoFailures(search);
 
         search = client().prepareSearch()
@@ -1219,38 +938,30 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .addHighlightedField("title", 50, 1, 10)
                 .setHighlighterType("fast-vector-highlighter")
                 .execute().actionGet();
-
         assertThat(search.getFailedShards(), equalTo(2));
-
     }
 
     @Test
     public void testDisableFastVectorHighlighter() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").field("analyzer", "classic").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets,analyzer=classic"));
         ensureGreen();
-        
-        for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a test for the workaround for the fast vector highlighting SOLR-3724").execute().actionGet();
+
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a test for the workaround for the fast vector highlighting SOLR-3724");
         }
-        refresh();
+        indexRandom(true, indexRequestBuilders);
+
         SearchResponse search = client().prepareSearch()
                 .setQuery(matchPhraseQuery("title", "test for the workaround"))
                 .addHighlightedField("title", 50, 1, 10)
-                .execute().actionGet();
+                .get();
 
-        assertThat(Arrays.toString(search.getShardFailures()), search.getFailedShards(), equalTo(0));
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
             // Because of SOLR-3724 nothing is highlighted when FVH is used
-            assertThat(hit.highlightFields().isEmpty(), equalTo(true));
+            assertNotHighlighted(search, i, "title");
         }
 
         // Using plain highlighter instead of FVH
@@ -1258,16 +969,10 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setQuery(matchPhraseQuery("title", "test for the workaround"))
                 .addHighlightedField("title", 50, 1, 10)
                 .setHighlighterType("highlighter")
-                .execute().actionGet();
+                .get();
 
-        assertThat(Arrays.toString(search.getShardFailures()), search.getFailedShards(), equalTo(0));
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            // With plain highlighter terms are highlighted correctly
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a <em>test</em> for the <em>workaround</em> for the fast vector highlighting SOLR-3724"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, 1, equalTo("This is a <em>test</em> for the <em>workaround</em> for the fast vector highlighting SOLR-3724"));
         }
 
         // Using plain highlighter instead of FVH on the field level
@@ -1275,55 +980,40 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .setQuery(matchPhraseQuery("title", "test for the workaround"))
                 .addHighlightedField(new HighlightBuilder.Field("title").highlighterType("highlighter"))
                 .setHighlighterType("highlighter")
-                .execute().actionGet();
+                .get();
 
-        assertThat(Arrays.toString(search.getShardFailures()), search.getFailedShards(), equalTo(0));
-
-        assertThat(search.getHits().totalHits(), equalTo(5l));
-        assertThat(search.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : search.getHits()) {
-            // With plain highlighter terms are highlighted correctly
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a <em>test</em> for the <em>workaround</em> for the fast vector highlighting SOLR-3724"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(search, i, "title", 0, 1, equalTo("This is a <em>test</em> for the <em>workaround</em> for the fast vector highlighting SOLR-3724"));
         }
     }
 
     @Test
     public void testFSHHighlightAllMvFragments() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
                 .put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("tags").field("type", "string").field("term_vector", "with_positions_offsets").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                .addMapping("type1", "tags", "type=string,term_vector=with_positions_offsets"));
         ensureGreen();
         client().prepareIndex("test", "type1", "1")
-                .setSource(jsonBuilder().startObject().field("tags",
+                .setSource("tags", new String[]{
                         "this is a really long tag i would like to highlight",
-                        "here is another one that is very long and has the tag token near the end").endObject())
-                .execute().actionGet();
+                        "here is another one that is very long and has the tag token near the end"}).get();
         refresh();
-        
+
         SearchResponse response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.matchQuery("tags", "tag"))
-                .addHighlightedField("tags", -1, 0)
-                .execute().actionGet();
+                .addHighlightedField("tags", -1, 0).get();
 
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments().length, equalTo(2));
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments()[0].string(), equalTo("this is a really long <em>tag</em> i would like to highlight"));
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments()[1].string(), equalTo("here is another one that is very long and has the <em>tag</em> token near the end"));
+        assertHighlight(response, 0, "tags", 0, equalTo("this is a really long <em>tag</em> i would like to highlight"));
+        assertHighlight(response, 0, "tags", 1, 2, equalTo("here is another one that is very long and has the <em>tag</em> token near the end"));
     }
-    
     
     @Test
     public void testBoostingQuery() {
         createIndex("test");
         ensureGreen();
         client().prepareIndex("test", "type1")
-                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
-                .execute().actionGet();
+                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
         refresh();
-
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
@@ -1332,18 +1022,16 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<x>").postTags("</x>"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
     }
     
     @Test
     public void testBoostingQueryTermVector() throws ElasticSearchException, IOException {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()).execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
-                .execute().actionGet();
+                .get();
         refresh();
 
         logger.info("--> highlighting and searching on field1");
@@ -1354,13 +1042,9 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
         SearchResponse searchResponse = client().search(
                 searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
     }
-
 
     @Test
     public void testCommonTermsQuery() {
@@ -1369,7 +1053,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
         client().prepareIndex("test", "type1")
                 .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
-                .execute().actionGet();
+                .get();
         refresh();
 
         logger.info("--> highlighting and searching on field1");
@@ -1379,18 +1063,15 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<x>").postTags("</x>"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
     }
 
     @Test
     public void testCommonTermsTermVector() throws ElasticSearchException, IOException {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()).execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
 
-        client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
-                .execute().actionGet();
+        client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
         refresh();
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource().query(commonTerms("field2", "quick brown").cutoffFrequency(100)).from(0).size(60)
@@ -1398,13 +1079,9 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
         SearchResponse searchResponse = client().search(
                 searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
     }
-
 
     @Test
     public void testPhrasePrefix() throws ElasticSearchException, IOException {
@@ -1414,24 +1091,16 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         builder.put("index.analysis.filter.synonym.type", "synonym");
         builder.putArray("index.analysis.filter.synonym.synonyms", "quick => fast");
 
-        XContentBuilder type2Mapping = XContentFactory.jsonBuilder().startObject().startObject("type2")
-                .startObject("_all").field("store", "yes").field("termVector", "with_positions_offsets").endObject()
-                .startObject("properties")
-                .startObject("field4").field("type", "string").field("termVector", "with_positions_offsets").field("analyzer", "synonym").endObject()
-                .startObject("field3").field("type", "string").field("analyzer", "synonym").endObject()
-                .endObject()
-                .endObject().endObject();
-
-
-        client().admin().indices().prepareCreate("test").setSettings(builder.build()).addMapping("type1", type1TermVectorMapping()).addMapping("type2", type2Mapping).execute().actionGet();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(builder.build()).addMapping("type1", type1TermVectorMapping())
+                .addMapping("type2", "_all", "store=yes,termVector=with_positions_offsets",
+                        "field4", "type=string,term_vector=with_positions_offsets,analyzer=synonym",
+                        "field3", "type=string,analyzer=synonym"));
         ensureGreen();
 
         client().prepareIndex("test", "type1", "0")
-                .setSource("field0", "The quick brown fox jumps over the lazy dog", "field1", "The quick brown fox jumps over the lazy dog")
-                .execute().actionGet();
+                .setSource("field0", "The quick brown fox jumps over the lazy dog", "field1", "The quick brown fox jumps over the lazy dog").get();
         client().prepareIndex("test", "type1", "1")
-                .setSource("field1", "The quick browse button is a fancy thing, right bro?")
-                .execute().actionGet();
+                .setSource("field1", "The quick browse button is a fancy thing, right bro?").get();
         refresh();
         logger.info("--> highlighting and searching on field0");
         SearchSourceBuilder source = searchSource()
@@ -1440,10 +1109,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field0").order("score").preTags("<x>").postTags("</x>"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field0").fragments()[0].string(), equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field0", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
 
         logger.info("--> highlighting and searching on field1");
         source = searchSource()
@@ -1452,97 +1119,75 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1").order("score").preTags("<x>").postTags("</x>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("The <x>quick browse</x> button is a fancy thing, right bro?"));
-        assertThat(searchResponse.getHits().getAt(1).highlightFields().get("field1").fragments()[0].string(), equalTo("The <x>quick brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <x>quick browse</x> button is a fancy thing, right bro?"));
+        assertHighlight(searchResponse, 1, "field1", 0, 1, equalTo("The <x>quick brown</x> fox jumps over the lazy dog"));
 
         // with synonyms
         client().prepareIndex("test", "type2", "0")
-                .setSource("field4", "The quick brown fox jumps over the lazy dog", "field3", "The quick brown fox jumps over the lazy dog")
-                .setRefresh(true).execute().actionGet();
+                .setSource("field4", "The quick brown fox jumps over the lazy dog", "field3", "The quick brown fox jumps over the lazy dog").get();
         client().prepareIndex("test", "type2", "1")
-                .setSource("field4", "The quick browse button is a fancy thing, right bro?").setRefresh(true).execute().actionGet();
+                .setSource("field4", "The quick browse button is a fancy thing, right bro?").get();
         client().prepareIndex("test", "type2", "2")
-                .setSource("field4", "a quick fast blue car")
-                .setRefresh(true).execute().actionGet();
+                .setSource("field4", "a quick fast blue car").get();
+        refresh();
 
         source = searchSource().filter(FilterBuilders.typeFilter("type2")).query(matchPhrasePrefixQuery("field3", "fast bro")).from(0).size(60).explain(true)
                 .highlight(highlight().field("field3").order("score").preTags("<x>").postTags("</x>"));
 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field3").fragments()[0].string(),
-                equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field3", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
 
         logger.info("--> highlighting and searching on field4");
         source = searchSource().filter(FilterBuilders.typeFilter("type2")).query(matchPhrasePrefixQuery("field4", "the fast bro")).from(0).size(60).explain(true)
                 .highlight(highlight().field("field4").order("score").preTags("<x>").postTags("</x>"));
-
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field4").fragments()[0].string(),
-                equalTo("<x>The quick browse</x> button is a fancy thing, right bro?"));
-        assertThat(searchResponse.getHits().getAt(1).highlightFields().get("field4").fragments()[0].string(),
-                equalTo("<x>The quick brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field4", 0, 1, equalTo("<x>The quick browse</x> button is a fancy thing, right bro?"));
+        assertHighlight(searchResponse, 1, "field4", 0, 1, equalTo("<x>The quick brown</x> fox jumps over the lazy dog"));
 
         logger.info("--> highlighting and searching on field4");
         source = searchSource().filter(FilterBuilders.typeFilter("type2")).query(matchPhrasePrefixQuery("field4", "a fast quick blue ca")).from(0).size(60).explain(true)
                 .highlight(highlight().field("field4").order("score").preTags("<x>").postTags("</x>"));
-
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field4").fragments()[0].string(),
-                equalTo("<x>a quick fast blue car</x>"));
-
+        assertHighlight(searchResponse, 0, "field4", 0, 1, equalTo("<x>a quick fast blue car</x>"));
     }
 
     @Test
     public void testPlainHighlightDifferentFragmenter() throws Exception {
-        prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
+        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
                 .put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("tags").field("type", "string").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                .addMapping("type1", "tags", "type=string"));
         ensureGreen();
         client().prepareIndex("test", "type1", "1")
                 .setSource(jsonBuilder().startObject().field("tags",
                         "this is a really long tag i would like to highlight",
-                        "here is another one that is very long tag and has the tag token near the end").endObject())
-                .setRefresh(true).execute().actionGet();
+                        "here is another one that is very long tag and has the tag token near the end").endObject()).get();
+        refresh();
 
         SearchResponse response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQueryBuilder.Type.PHRASE))
                 .addHighlightedField(new HighlightBuilder.Field("tags")
-                        .fragmentSize(-1).numOfFragments(2).fragmenter("simple"))
-                .execute().actionGet();
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments().length, equalTo(2));
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments()[0].string(), equalTo("this is a really <em>long</em> <em>tag</em> i would like to highlight"));
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments()[1].string(), equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
+                        .fragmentSize(-1).numOfFragments(2).fragmenter("simple")).get();
+
+        assertHighlight(response, 0, "tags", 0, equalTo("this is a really <em>long</em> <em>tag</em> i would like to highlight"));
+        assertHighlight(response, 0, "tags", 1, 2, equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
 
         response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQueryBuilder.Type.PHRASE))
                 .addHighlightedField(new HighlightBuilder.Field("tags")
-                        .fragmentSize(-1).numOfFragments(2).fragmenter("span"))
-                .execute().actionGet();
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments().length, equalTo(2));
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments()[0].string(), equalTo("this is a really <em>long</em> <em>tag</em> i would like to highlight"));
-        assertThat(response.getHits().hits()[0].highlightFields().get("tags").fragments()[1].string(), equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
+                        .fragmentSize(-1).numOfFragments(2).fragmenter("span")).get();
+
+        assertHighlight(response, 0, "tags", 0, equalTo("this is a really <em>long</em> <em>tag</em> i would like to highlight"));
+        assertHighlight(response, 0, "tags", 1, 2, equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
 
         try {
             client().prepareSearch("test")
                     .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQueryBuilder.Type.PHRASE))
                     .addHighlightedField(new HighlightBuilder.Field("tags")
-                            .fragmentSize(-1).numOfFragments(2).fragmenter("invalid"))
-                    .execute().actionGet();
+                            .fragmentSize(-1).numOfFragments(2).fragmenter("invalid")).get();
             fail("Shouldn't get here");
         } catch (SearchPhaseExecutionException e) {
             assertThat(e.shardFailures()[0].status(), equalTo(RestStatus.BAD_REQUEST));
@@ -1562,11 +1207,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .addHighlightedField(new HighlightBuilder.Field("field1").preTags("<1>").postTags("</1>").requireFieldMatch(true))
                 .addHighlightedField(new HighlightBuilder.Field("field2").preTags("<2>").postTags("</2>").requireFieldMatch(false))
                 .get();
-        assertHitCount(response, 1l);
-        assertThat(response.getHits().hits()[0].highlightFields().get("field1").fragments().length, equalTo(1));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field1").fragments()[0].string(), equalTo("The <b>quick<b> brown <1>fox</1>"));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field2").fragments().length, equalTo(1));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field2").fragments()[0].string(), equalTo("The <b>slow<b> brown <2>fox</2>"));
+        assertHighlight(response, 0, "field1", 0, 1, equalTo("The <b>quick<b> brown <1>fox</1>"));
+        assertHighlight(response, 0, "field2", 0, 1, equalTo("The <b>slow<b> brown <2>fox</2>"));
     }
 
     @Test
@@ -1583,86 +1225,42 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .addHighlightedField(new HighlightBuilder.Field("field1").preTags("<1>").postTags("</1>").requireFieldMatch(true))
                 .addHighlightedField(new HighlightBuilder.Field("field2").preTags("<2>").postTags("</2>").requireFieldMatch(false))
                 .get();
-        assertHitCount(response, 1l);
-        assertThat(response.getHits().hits()[0].highlightFields().get("field1").fragments().length, equalTo(1));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field1").fragments()[0].string(), equalTo("The <b>quick<b> brown <1>fox</1>"));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field2").fragments().length, equalTo(1));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field2").fragments()[0].string(), equalTo("The <b>slow<b> brown <2>fox</2>"));
+        assertHighlight(response, 0, "field1", 0, 1, equalTo("The <b>quick<b> brown <1>fox</1>"));
+        assertHighlight(response, 0, "field2", 0, 1, equalTo("The <b>slow<b> brown <2>fox</2>"));
     }
 
     @Test
     public void testMissingStoredField() throws Exception {
-        prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
+        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
                 .put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("highlight_field").field("type", "string").field("store", "yes").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                .addMapping("type1", "highlight_field", "type=string,store=yes"));
         ensureGreen();
         client().prepareIndex("test", "type1", "1")
                 .setSource(jsonBuilder().startObject()
-                    .field("field", "highlight")
-                .endObject())
-                .setRefresh(true).execute().actionGet();
+                        .field("field", "highlight")
+                        .endObject()).get();
+        refresh();
 
         // This query used to fail when the field to highlight was absent
         SearchResponse response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.matchQuery("field", "highlight").type(MatchQueryBuilder.Type.BOOLEAN))
                 .addHighlightedField(new HighlightBuilder.Field("highlight_field")
-                        .fragmentSize(-1).numOfFragments(1).fragmenter("simple"))
-                .execute().actionGet();
+                        .fragmentSize(-1).numOfFragments(1).fragmenter("simple")).get();
         assertThat(response.getHits().hits()[0].highlightFields().isEmpty(), equalTo(true));
     }
 
     @Test
     // https://github.com/elasticsearch/elasticsearch/issues/3211
     public void testNumericHighlighting() throws Exception {
-        wipeIndex("test");
-        prepareCreate("test")
-        .addMapping("test", jsonBuilder()
-                .startObject()
-                    .startObject("test")
-                        .startObject("properties")
-                            .startObject("text")
-                                .field("type", "string")
-                                .field("index", "analyzed")
-                            .endObject()
-                            .startObject("byte")
-                                .field("type", "byte")
-                            .endObject()
-                            .startObject("short")
-                                .field("type", "short")
-                            .endObject()
-                            .startObject("int")
-                                .field("type", "integer")
-                            .endObject()
-                            .startObject("long")
-                                .field("type", "long")
-                            .endObject()
-                            .startObject("float")
-                                .field("type", "float")
-                            .endObject()
-                            .startObject("double")
-                                .field("type", "double")
-                            .endObject()
-                        .endObject()
-                    .endObject()
-                .endObject())
-        .execute().actionGet();
-
+        assertAcked(prepareCreate("test")
+                .addMapping("test", "text", "type=string,index=analyzed",
+                        "byte", "type=byte", "short", "type=short", "int", "type=integer", "long", "type=long",
+                        "float", "type=float", "double", "type=double"));
         ensureGreen();
 
-        client().prepareIndex("test", "test", "1")
-        .setSource(jsonBuilder().startObject()
-            .field("text", "elasticsearch test")
-            .field("byte", 25)
-            .field("short", 42)
-            .field("int", 100)
-            .field("long", -1)
-            .field("float", 3.2f)
-            .field("double", 42.42)
-        .endObject())
-        .setRefresh(true).execute().actionGet();
+        client().prepareIndex("test", "test", "1").setSource("text", "elasticsearch test",
+                "byte", 25, "short", 42, "int", 100, "long", -1, "float", 3.2f, "double", 42.42).get();
+        refresh();
 
         SearchResponse response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.matchQuery("text", "test").type(MatchQueryBuilder.Type.BOOLEAN))
@@ -1673,55 +1271,37 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .addHighlightedField("long")
                 .addHighlightedField("float")
                 .addHighlightedField("double")
-                .execute().actionGet();
-        assertThat(response.getHits().totalHits(), equalTo(1L));
+                .get();
         // Highlighting of numeric fields is not supported, but it should not raise errors
         // (this behavior is consistent with version 0.20)
-        assertThat(response.getFailedShards(), equalTo(0));
+        assertHitCount(response, 1l);
     }
 
     @Test
     // https://github.com/elasticsearch/elasticsearch/issues/3200
     public void testResetTwice() throws Exception {
-        prepareCreate("test")
-            .setSettings(ImmutableSettings.builder()
-                .put("analysis.analyzer.my_analyzer.type", "pattern")
-                .put("analysis.analyzer.my_analyzer.pattern", "\\s+")
-            .build())
-            .addMapping("type", jsonBuilder()
-                .startObject()
-                    .startObject("type")
-                        .startObject("properties")
-                            .startObject("text")
-                                .field("type", "string")
-                                .field("analyzer", "my_analyzer")
-                            .endObject()
-                        .endObject()
-                    .endObject()
-                .endObject())
-            .execute().actionGet();
-
+        assertAcked(prepareCreate("test")
+                .setSettings(ImmutableSettings.builder()
+                        .put("analysis.analyzer.my_analyzer.type", "pattern")
+                        .put("analysis.analyzer.my_analyzer.pattern", "\\s+")
+                        .build())
+                .addMapping("type", "text", "type=string,analyzer=my_analyzer"));
         ensureGreen();
         client().prepareIndex("test", "type", "1")
-            .setSource(jsonBuilder().startObject()
-                    .field("text", "elasticsearch test")
-                .endObject())
-            .setRefresh(true)
-            .execute().actionGet();
+                .setSource("text", "elasticsearch test").get();
+        refresh();
 
         SearchResponse response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.matchQuery("text", "test").type(MatchQueryBuilder.Type.BOOLEAN))
                 .addHighlightedField("text").execute().actionGet();
-        assertThat(response.getHits().totalHits(), equalTo(1L));
         // PatternAnalyzer will throw an exception if it is resetted twice
-        assertThat(response.getFailedShards(), equalTo(0));
+        assertHitCount(response, 1l);
     }
 
     @Test
     public void testHighlightUsesHighlightQuery() throws IOException {
-        prepareCreate("test")
-                .addMapping("type1", "text", "type=string,store=yes,term_vector=with_positions_offsets")
-                .get();
+        assertAcked(prepareCreate("test")
+                .addMapping("type1", "text", "type=string,store=yes,term_vector=with_positions_offsets"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "some stuff stuff stuff stuff stuff to highlight against the stuff phrase");
@@ -1779,11 +1359,10 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         return "";
     }
 
+    @Test
     public void testHighlightNoMatchSize() throws IOException {
-
-        prepareCreate("test")
-            .addMapping("type1", "text", "type=string," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets")
-            .get();
+        assertAcked(prepareCreate("test")
+                .addMapping("type1", "text", "type=string," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"));
         ensureGreen();
 
         String text = "I am pretty long so some of me should get cut off. Second sentence";
@@ -1891,9 +1470,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
     @Test
     public void testHighlightNoMatchSizeWithMultivaluedFields() throws IOException {
-        prepareCreate("test")
-            .addMapping("type1", "text", "type=string," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets")
-            .get();
+        assertAcked(prepareCreate("test")
+                .addMapping("type1", "text", "type=string," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"));
         ensureGreen();
 
         String text1 = "I am pretty long so some of me should get cut off. We'll see how that goes.";
@@ -2005,9 +1583,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
     @Test
     public void testHighlightNoMatchSizeNumberOfFragments() throws IOException {
-        prepareCreate("test")
-                .addMapping("type1", "text", "type=string," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets")
-                .get();
+        assertAcked(prepareCreate("test")
+                .addMapping("type1", "text", "type=string," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"));
         ensureGreen();
 
         String text1 = "This is the first sentence. This is the second sentence.";
@@ -2054,21 +1631,20 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
     @Test
     public void testPostingsHighlighter() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
-                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy quick dog").setRefresh(true).get();
+                .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy quick dog").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
                 .query(termQuery("field1", "test"))
                 .highlight(highlight().field("field1").preTags("<xxx>").postTags("</xxx>"));
-
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
         logger.info("--> searching on _all, highlighting on field1");
         source = searchSource()
@@ -2076,9 +1652,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field1").fragments()[0].string(), equalTo("this is a <xxx>test</xxx>"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
@@ -2086,9 +1661,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy <xxx>quick</xxx> dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy <xxx>quick</xxx> dog"));
 
         logger.info("--> searching on _all, highlighting on field2");
         source = searchSource()
@@ -2096,9 +1670,9 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").preTags("<xxx>").postTags("</xxx>"));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
+
         //phrase query results in highlighting all different terms regardless of their positions
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> <xxx>brown</xxx> fox jumps over the lazy <xxx>quick</xxx> dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> <xxx>brown</xxx> fox jumps over the lazy <xxx>quick</xxx> dog"));
 
         //lets fall back to the standard highlighter then, what people would do to highlight query matches
         logger.info("--> searching on _all, highlighting on field2, falling back to the plain highlighter");
@@ -2107,9 +1681,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2").preTags("<xxx>").postTags("</xxx>").highlighterType("highlighter"));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(), equalTo("The <xxx>quick</xxx> <xxx>brown</xxx> fox jumps over the lazy quick dog"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> <xxx>brown</xxx> fox jumps over the lazy quick dog"));
     }
 
     @Test
@@ -2125,22 +1698,19 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .addHighlightedField(new HighlightBuilder.Field("field1").preTags("<1>").postTags("</1>").requireFieldMatch(true))
                 .addHighlightedField(new HighlightBuilder.Field("field2").preTags("<2>").postTags("</2>").requireFieldMatch(false))
                 .get();
-        assertHitCount(response, 1l);
-        assertThat(response.getHits().hits()[0].highlightFields().get("field1").fragments().length, equalTo(1));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field1").fragments()[0].string(), equalTo("The <b>quick<b> brown <1>fox</1>."));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field2").fragments().length, equalTo(1));
-        assertThat(response.getHits().hits()[0].highlightFields().get("field2").fragments()[0].string(), equalTo("The <b>slow<b> brown <2>fox</2>."));
+        assertHighlight(response, 0, "field1", 0, 1, equalTo("The <b>quick<b> brown <1>fox</1>."));
+        assertHighlight(response, 0, "field2", 0, 1, equalTo("The <b>slow<b> brown <2>fox</2>."));
     }
 
     @Test
     public void testPostingsHighlighterNumberOfFragments() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1", "1")
                 .setSource("field1", "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. The quick brown dog jumps over the lazy fox.",
-                        "field2", "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. The quick brown dog jumps over the lazy fox.")
-                .setRefresh(true).get();
+                        "field2", "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. The quick brown dog jumps over the lazy fox.").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
@@ -2150,26 +1720,17 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                         .field(new HighlightBuilder.Field("field2").numOfFragments(2).preTags("<field2>").postTags("</field2>")));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
+        assertHighlight(searchResponse, 0, "field1", 0, equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field1", 1, equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
+        assertHighlight(searchResponse, 0, "field1", 2, 3, equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
 
-        Map<String,HighlightField> highlightFieldMap = searchResponse.getHits().getAt(0).highlightFields();
-        assertThat(highlightFieldMap.size(), equalTo(2));
-        HighlightField field1 = highlightFieldMap.get("field1");
-        assertThat(field1.fragments().length, equalTo(3));
-        assertThat(field1.fragments()[0].string(), equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
-        assertThat(field1.fragments()[1].string(), equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
-        assertThat(field1.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
-
-        HighlightField field2 = highlightFieldMap.get("field2");
-        assertThat(field2.fragments().length, equalTo(2));
-        assertThat(field2.fragments()[0].string(), equalTo("The quick brown <field2>fox</field2> jumps over the lazy dog."));
-        assertThat(field2.fragments()[1].string(), equalTo("The lazy red <field2>fox</field2> jumps over the quick dog."));
-
+        assertHighlight(searchResponse, 0, "field2", 0, equalTo("The quick brown <field2>fox</field2> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field2", 1, 2, equalTo("The lazy red <field2>fox</field2> jumps over the quick dog."));
 
         client().prepareIndex("test", "type1", "2")
-                .setSource("field1", new String[]{"The quick brown fox jumps over the lazy dog. Second sentence not finished", "The lazy red fox jumps over the quick dog.", "The quick brown dog jumps over the lazy fox."})
-                .setRefresh(true).get();
+                .setSource("field1", new String[]{"The quick brown fox jumps over the lazy dog. Second sentence not finished", "The lazy red fox jumps over the quick dog.", "The quick brown dog jumps over the lazy fox."}).get();
+        refresh();
 
         source = searchSource()
                 .query(termQuery("field1", "fox"))
@@ -2180,18 +1741,12 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         assertHitCount(searchResponse, 2l);
 
         for (SearchHit searchHit : searchResponse.getHits()) {
-            highlightFieldMap = searchHit.highlightFields();
-            assertThat(highlightFieldMap.size(), equalTo(1));
-            field1 = highlightFieldMap.get("field1");
-            assertThat(field1, notNullValue());
             if ("1".equals(searchHit.id())) {
-                assertThat(field1.fragments().length, equalTo(1));
-                assertThat(field1.fragments()[0].string(), equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog. The lazy red <field1>fox</field1> jumps over the quick dog. The quick brown dog jumps over the lazy <field1>fox</field1>."));
+                assertHighlight(searchHit, "field1", 0, 1, equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog. The lazy red <field1>fox</field1> jumps over the quick dog. The quick brown dog jumps over the lazy <field1>fox</field1>."));
             } else if ("2".equals(searchHit.id())) {
-                assertThat(field1.fragments().length, equalTo(3));
-                assertThat(field1.fragments()[0].string(), equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog. Second sentence not finished"));
-                assertThat(field1.fragments()[1].string(), equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
-                assertThat(field1.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
+                assertHighlight(searchHit, "field1", 0, equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog. Second sentence not finished"));
+                assertHighlight(searchHit, "field1", 1, equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
+                assertHighlight(searchHit, "field1", 2, 3, equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
             } else {
                 fail("Only hits with id 1 and 2 are returned");
             }
@@ -2200,13 +1755,13 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
     @Test
     public void testPostingsHighlighterRequireFieldMatch() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
                 .setSource("field1", "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. The quick brown dog jumps over the lazy fox.",
-                        "field2", "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. The quick brown dog jumps over the lazy fox.")
-                .setRefresh(true).get();
+                        "field2", "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. The quick brown dog jumps over the lazy fox.").get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
@@ -2216,17 +1771,12 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                         .field(new HighlightBuilder.Field("field2").requireFieldMatch(true).preTags("<field2>").postTags("</field2>")));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
         //field2 is not returned highlighted because of the require field match option set to true
-        Map<String,HighlightField> highlightFieldMap = searchResponse.getHits().getAt(0).highlightFields();
-        assertThat(highlightFieldMap.size(), equalTo(1));
-        HighlightField field1 = highlightFieldMap.get("field1");
-        assertThat(field1.fragments().length, equalTo(3));
-        assertThat(field1.fragments()[0].string(), equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
-        assertThat(field1.fragments()[1].string(), equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
-        assertThat(field1.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
-
+        assertNotHighlighted(searchResponse, 0, "field2");
+        assertHighlight(searchResponse, 0, "field1", 0, equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field1", 1, equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
+        assertHighlight(searchResponse, 0, "field1", 2, 3, equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
 
         logger.info("--> highlighting and searching on field1 and field2 - require field match set to false");
         source = searchSource()
@@ -2236,23 +1786,15 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                         .field(new HighlightBuilder.Field("field2").requireFieldMatch(false).preTags("<field2>").postTags("</field2>")));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
-        //field2 is now returned highlighted thanks to the multi_match query on both fields
-        highlightFieldMap = searchResponse.getHits().getAt(0).highlightFields();
-        assertThat(highlightFieldMap.size(), equalTo(2));
-        field1 = highlightFieldMap.get("field1");
-        assertThat(field1.fragments().length, equalTo(3));
-        assertThat(field1.fragments()[0].string(), equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
-        assertThat(field1.fragments()[1].string(), equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
-        assertThat(field1.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
+        assertHighlight(searchResponse, 0, "field1", 0, equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field1", 1, equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
+        assertHighlight(searchResponse, 0, "field1", 2, 3, equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
 
-        HighlightField field2 = highlightFieldMap.get("field2");
-        assertThat(field2.fragments().length, equalTo(3));
-        assertThat(field2.fragments()[0].string(), equalTo("The quick brown <field2>fox</field2> jumps over the lazy dog."));
-        assertThat(field2.fragments()[1].string(), equalTo("The lazy red <field2>fox</field2> jumps over the quick dog."));
-        assertThat(field2.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field2>fox</field2>."));
-
+        //field2 is now returned highlighted thanks to require_field_match set to false
+        assertHighlight(searchResponse, 0, "field2", 0, equalTo("The quick brown <field2>fox</field2> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field2", 1, equalTo("The lazy red <field2>fox</field2> jumps over the quick dog."));
+        assertHighlight(searchResponse, 0, "field2", 2, 3, equalTo("The quick brown dog jumps over the lazy <field2>fox</field2>."));
 
         logger.info("--> highlighting and searching on field1 and field2 via multi_match query");
         source = searchSource()
@@ -2264,32 +1806,25 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
         assertHitCount(searchResponse, 1l);
 
+        assertHighlight(searchResponse, 0, "field1", 0, equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field1", 1, equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
+        assertHighlight(searchResponse, 0, "field1", 2, 3, equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
         //field2 is now returned highlighted thanks to the multi_match query on both fields
-        highlightFieldMap = searchResponse.getHits().getAt(0).highlightFields();
-        assertThat(highlightFieldMap.size(), equalTo(2));
-        field1 = highlightFieldMap.get("field1");
-        assertThat(field1.fragments().length, equalTo(3));
-        assertThat(field1.fragments()[0].string(), equalTo("The quick brown <field1>fox</field1> jumps over the lazy dog."));
-        assertThat(field1.fragments()[1].string(), equalTo("The lazy red <field1>fox</field1> jumps over the quick dog."));
-        assertThat(field1.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
-
-        field2 = highlightFieldMap.get("field2");
-        assertThat(field2.fragments().length, equalTo(3));
-        assertThat(field2.fragments()[0].string(), equalTo("The quick brown <field2>fox</field2> jumps over the lazy dog."));
-        assertThat(field2.fragments()[1].string(), equalTo("The lazy red <field2>fox</field2> jumps over the quick dog."));
-        assertThat(field2.fragments()[2].string(), equalTo("The quick brown dog jumps over the lazy <field2>fox</field2>."));
+        assertHighlight(searchResponse, 0, "field2", 0, equalTo("The quick brown <field2>fox</field2> jumps over the lazy dog."));
+        assertHighlight(searchResponse, 0, "field2", 1, equalTo("The lazy red <field2>fox</field2> jumps over the quick dog."));
+        assertHighlight(searchResponse, 0, "field2", 2, 3, equalTo("The quick brown dog jumps over the lazy <field2>fox</field2>."));
     }
 
     @Test
     public void testPostingsHighlighterOrderByScore() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
                 .setSource("field1", new String[]{"This sentence contains one match, not that short. This sentence contains two sentence matches. This one contains no matches.",
-                "This is the second value's first sentence. This one contains no matches. This sentence contains three sentence occurrences (sentence).",
-                "One sentence match here and scored lower since the text is quite long, not that appealing. This one contains no matches."})
-                .setRefresh(true).get();
+                        "This is the second value's first sentence. This one contains no matches. This sentence contains three sentence occurrences (sentence).",
+                        "One sentence match here and scored lower since the text is quite long, not that appealing. This one contains no matches."}).get();
+        refresh();
 
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource()
@@ -2297,7 +1832,6 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1").order("score"));
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
         Map<String,HighlightField> highlightFieldMap = searchResponse.getHits().getAt(0).highlightFields();
         assertThat(highlightFieldMap.size(), equalTo(1));
@@ -2315,46 +1849,37 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field1", -1, 0).order("score"));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
-
-        highlightFieldMap = searchResponse.getHits().getAt(0).highlightFields();
-        assertThat(highlightFieldMap.size(), equalTo(1));
-        field1 = highlightFieldMap.get("field1");
-        assertThat(field1.fragments().length, equalTo(3));
-        assertThat(field1.fragments()[0].string(), equalTo("This is the second value's first <em>sentence</em>. This one contains no matches. This <em>sentence</em> contains three <em>sentence</em> occurrences (<em>sentence</em>)."));
-        assertThat(field1.fragments()[1].string(), equalTo("This <em>sentence</em> contains one match, not that short. This <em>sentence</em> contains two <em>sentence</em> matches. This one contains no matches."));
-        assertThat(field1.fragments()[2].string(), equalTo("One <em>sentence</em> match here and scored lower since the text is quite long, not that appealing. This one contains no matches."));
+        assertHighlight(searchResponse, 0, "field1", 0, equalTo("This is the second value's first <em>sentence</em>. This one contains no matches. This <em>sentence</em> contains three <em>sentence</em> occurrences (<em>sentence</em>)."));
+        assertHighlight(searchResponse, 0, "field1", 1, equalTo("This <em>sentence</em> contains one match, not that short. This <em>sentence</em> contains two <em>sentence</em> matches. This one contains no matches."));
+        assertHighlight(searchResponse, 0, "field1", 2, 3, equalTo("One <em>sentence</em> match here and scored lower since the text is quite long, not that appealing. This one contains no matches."));
     }
 
     @Test
     public void testPostingsHighlighterEscapeHtml() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("title").field("type", "string").field("store", "yes").field("index_options", "offsets").endObject()
-                        .endObject().endObject().endObject())
-                .get();
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+                .addMapping("type1", "title", "type=string," + randomStoreField() + "index_options=offsets"));
         ensureYellow();
+
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a html escaping highlighting test for *&? elasticsearch").setRefresh(true).execute().actionGet();
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a html escaping highlighting test for *&? elasticsearch");
         }
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(matchQuery("title", "test"))
                 .setHighlighterEncoder("html")
                 .addHighlightedField("title").get();
 
-        assertHitCount(searchResponse, 5l);
-        assertThat(searchResponse.getHits().hits().length, equalTo(5));
-
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("This is a html escaping highlighting <em>test</em> for *&amp;?"));
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            assertHighlight(searchResponse, i, "title", 0, 1, equalTo("This is a html escaping highlighting <em>test</em> for *&amp;?"));
         }
     }
 
     @Test
     public void testPostingsHighlighterMultiMapperWithStore() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1")
                         //just to make sure that we hit the stored fields rather than the _source
                         .startObject("_source").field("enabled", false).endObject()
@@ -2363,8 +1888,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                         .startObject("title").field("type", "string").field("store", "yes").field("index_options", "offsets").field("analyzer", "classic").endObject()
                         .startObject("key").field("type", "string").field("store", "yes").field("index_options", "offsets").field("analyzer", "whitespace").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
         ensureGreen();
         client().prepareIndex("test", "type1", "1").setSource("title", "this is a test . Second sentence.").get();
         refresh();
@@ -2377,9 +1901,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         assertHitCount(searchResponse, 1l);
         SearchHit hit = searchResponse.getHits().getAt(0);
         assertThat(hit.source(), nullValue());
-
         //stopwords are not highlighted since not indexed
-        assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("this is a <em>test</em> ."));
+        assertHighlight(hit, "title", 0, 1, equalTo("this is a <em>test</em> ."));
 
         // search on title.key and highlight on title
         searchResponse = client().prepareSearch()
@@ -2387,21 +1910,19 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .addHighlightedField("title.key").get();
         assertHitCount(searchResponse, 1l);
 
-        hit = searchResponse.getHits().getAt(0);
         //stopwords are now highlighted since we used only whitespace analyzer here
-        assertThat(hit.highlightFields().get("title.key").fragments()[0].string(), equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em> ."));
+        assertHighlight(searchResponse, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em> ."));
     }
 
     @Test
     public void testPostingsHighlighterMultiMapperFromSource() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "no").field("index_options", "offsets").field("analyzer", "classic").endObject()
                         .startObject("key").field("type", "string").field("store", "no").field("index_options", "offsets").field("analyzer", "whitespace").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .get();
+                        .endObject().endObject().endObject()));
         ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
@@ -2411,38 +1932,32 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(matchQuery("title", "this is a test"))
                 .addHighlightedField("title")
-                .execute().actionGet();
+                .get();
 
-        assertHitCount(searchResponse, 1l);
-
-        SearchHit hit = searchResponse.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title").fragments()[0].string(), equalTo("this is a <em>test</em>"));
+        assertHighlight(searchResponse, 0, "title", 0, 1, equalTo("this is a <em>test</em>"));
 
         // search on title.key and highlight on title.key
         searchResponse = client().prepareSearch()
                 .setQuery(matchQuery("title.key", "this is a test"))
-                .addHighlightedField("title.key")
-                .get();
-        assertHitCount(searchResponse, 1l);
+                .addHighlightedField("title.key").get();
 
-        hit = searchResponse.getHits().getAt(0);
-        assertThat(hit.highlightFields().get("title.key").fragments()[0].string(), equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
+        assertHighlight(searchResponse, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em>"));
     }
 
     @Test
     public void testPostingsHighlighterShouldFailIfNoOffsets() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "string").field("store", "yes").field("index_options", "docs").endObject()
-                        .endObject().endObject().endObject())
-                .get();
+                        .endObject().endObject().endObject()));
         ensureGreen();
 
-        for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
-                    .setSource("title", "This is a test for the postings highlighter").setRefresh(true).get();
+        IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
+        for (int i = 0; i < indexRequestBuilders.length; i++) {
+            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+                    .setSource("title", "This is a test for the postings highlighter");
         }
-        refresh();
+        indexRandom(true, indexRequestBuilders);
 
         SearchResponse search = client().prepareSearch()
                 .setQuery(matchQuery("title", "this is a test"))
@@ -2474,7 +1989,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
 
     @Test
     public void testPostingsHighlighterBoostingQuery() throws ElasticSearchException, IOException {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.")
                 .get();
@@ -2484,17 +1999,14 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         SearchSourceBuilder source = searchSource()
                 .query(boostingQuery().positive(termQuery("field2", "brown")).negative(termQuery("field2", "foobar")).negativeBoost(0.5f))
                 .highlight(highlight().field("field2").preTags("<x>").postTags("</x>"));
-
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                equalTo("The quick <x>brown</x> fox jumps over the lazy dog!"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog!"));
     }
 
     @Test
     public void testPostingsHighlighterCommonTermsQuery() throws ElasticSearchException, IOException {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2502,12 +2014,10 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource().query(commonTerms("field2", "quick brown").cutoffFrequency(100))
                 .highlight(highlight().field("field2").preTags("<x>").postTags("</x>"));
-
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
         assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog!"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog!"));
     }
 
     public XContentBuilder type1PostingsffsetsMapping() throws IOException {
@@ -2537,10 +2047,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                     .highlight(highlight().field("field2"));
             SearchResponse searchResponse = client().search(searchRequest("test").source(source)
                     .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
-            assertHitCount(searchResponse, 1l);
-
-            assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                    equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
+            assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
         }
     }
 
@@ -2556,10 +2063,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2"));
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)
                 .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
     }
 
     @Test
@@ -2575,10 +2080,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                     .highlight(highlight().field("field2"));
             SearchResponse searchResponse = client().search(searchRequest("test").source(source)
                     .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
-            assertHitCount(searchResponse, 1l);
 
-            assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                    equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
+            assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
         }
     }
 
@@ -2595,10 +2098,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                     .highlight(highlight().field("field2"));
             SearchResponse searchResponse = client().search(searchRequest("test").source(source)
                     .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
-            assertHitCount(searchResponse, 1l);
 
-            assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                    equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
+            assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
 
             source = searchSource().query(wildcardQuery("field2", "qu*k").rewrite(rewriteMethod))
                     .highlight(highlight().field("field2"));
@@ -2606,9 +2107,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                     .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
             assertHitCount(searchResponse, 1l);
 
-            assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                    equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
-
+            assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
         }
     }
 
@@ -2624,10 +2123,8 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                 .highlight(highlight().field("field2"));
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)
                 .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
-        assertHitCount(searchResponse, 1l);
 
-        assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                equalTo("<em>aaab</em>"));
+        assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("<em>aaab</em>"));
     }
 
     @Test
@@ -2643,17 +2140,15 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
                     .highlight(highlight().field("field2"));
             SearchResponse searchResponse = client().search(searchRequest("test").source(source)
                     .searchType(randomBoolean() ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)).get();
-            assertHitCount(searchResponse, 1l);
 
-            assertThat(searchResponse.getHits().getAt(0).highlightFields().get("field2").fragments()[0].string(),
-                    equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
+            assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
         }
     }
 
     @Test
     @Slow
     public void testPostingsHighlighterManyDocs() throws Exception {
-        client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         int COUNT = between(20, 100);
@@ -2681,7 +2176,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         assertThat(searchResponse.getHits().hits().length, equalTo(COUNT));
         for (SearchHit hit : searchResponse.getHits()) {
             String prefix = prefixes.get(hit.id());
-            assertThat(hit.highlightFields().get("field1").fragments()[0].string(), equalTo("Sentence " + prefix + " <em>test</em>."));
+            assertHighlight(hit, "field1", 0, 1, equalTo("Sentence " + prefix + " <em>test</em>."));
         }
 
         logger.info("--> searching explicitly on field1 and highlighting on it, with DFS");
@@ -2695,7 +2190,7 @@ public class HighlighterSearchTests extends AbstractIntegrationTest {
         assertThat(searchResponse.getHits().hits().length, equalTo(COUNT));
         for (SearchHit hit : searchResponse.getHits()) {
             String prefix = prefixes.get(hit.id());
-            assertThat(hit.highlightFields().get("field1").fragments()[0].string(), equalTo("Sentence " + prefix + " <em>test</em>."));
+            assertHighlight(hit, "field1", 0, 1, equalTo("Sentence " + prefix + " <em>test</em>."));
         }
     }
 }

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -200,13 +200,25 @@ public class ElasticsearchAssertions {
         assertHighlight(resp, hit, field, fragment, equalTo(totalFragments), matcher);
     }
 
+    public static void assertHighlight(SearchHit hit, String field, int fragment, Matcher<String> matcher) {
+        assertHighlight(hit, field, fragment, greaterThan(fragment), matcher);
+    }
+
+    public static void assertHighlight(SearchHit hit, String field, int fragment, int totalFragments, Matcher<String> matcher) {
+        assertHighlight(hit, field, fragment, equalTo(totalFragments), matcher);
+    }
+
     private static void assertHighlight(SearchResponse resp, int hit, String field, int fragment, Matcher<Integer> fragmentsMatcher, Matcher<String> matcher) {
         assertNoFailures(resp);
         assertThat("not enough hits", resp.getHits().hits().length, greaterThan(hit));
-        assertThat(resp.getHits().hits()[hit].getHighlightFields(), hasKey(field));
-        assertThat(resp.getHits().hits()[hit].getHighlightFields().get(field).fragments().length, fragmentsMatcher);
-        assertThat(resp.getHits().hits()[hit].highlightFields().get(field).fragments()[fragment].string(), matcher);
+        assertHighlight(resp.getHits().hits()[hit], field, fragment, fragmentsMatcher, matcher);
         assertVersionSerializable(resp);
+    }
+
+    private static void assertHighlight(SearchHit hit, String field, int fragment, Matcher<Integer> fragmentsMatcher, Matcher<String> matcher) {
+        assertThat(hit.getHighlightFields(), hasKey(field));
+        assertThat(hit.getHighlightFields().get(field).fragments().length, fragmentsMatcher);
+        assertThat(hit.highlightFields().get(field).fragments()[fragment].string(), matcher);
     }
 
     public static void assertNotHighlighted(SearchResponse resp, int hit, String field) {


### PR DESCRIPTION
Fixed fetch subphase to not recreate the HitContext for each hit, so that the object cache stays the same

Fixed also bug in the fast vector highlighter which was raised by enabling the object cache, due to null FieldQuery (NPE) in case the objects are taken from the cache

Added tests to check if there are issues when highlighting multiple fields at the same time

Closes #4106
