### PR TITLE
Added support for external query in postings highlighter

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
@@ -80,13 +80,13 @@ public class FastVectorHighlighter implements Highlighter {
             if (field.requireFieldMatch()) {
                 if (cache.fieldMatchFieldQuery == null) {
                     // we use top level reader to rewrite the query against all readers, with use caching it across hits (and across readers...)
-                    cache.fieldMatchFieldQuery = new CustomFieldQuery(highlighterContext.highlightQuery, hitContext.topLevelReader(), true, field.requireFieldMatch());
+                    cache.fieldMatchFieldQuery = new CustomFieldQuery(highlighterContext.query.originalQuery(), hitContext.topLevelReader(), true, field.requireFieldMatch());
                 }
                 fieldQuery = cache.fieldMatchFieldQuery;
             } else {
                 if (cache.noFieldMatchFieldQuery == null) {
                     // we use top level reader to rewrite the query against all readers, with use caching it across hits (and across readers...)
-                    cache.noFieldMatchFieldQuery = new CustomFieldQuery(highlighterContext.highlightQuery, hitContext.topLevelReader(), true, field.requireFieldMatch());
+                    cache.noFieldMatchFieldQuery = new CustomFieldQuery(highlighterContext.query.originalQuery(), hitContext.topLevelReader(), true, field.requireFieldMatch());
                 }
                 fieldQuery = cache.noFieldMatchFieldQuery;
             }

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.highlight;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.index.FieldInfo;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
@@ -108,11 +107,11 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                     throw new ElasticSearchIllegalArgumentException("unknown highlighter type [" + field.highlighterType() + "] for the field [" + fieldName + "]");
                 }
 
-                Query highlightQuery = field.highlightQuery();
-                if (highlightQuery == null) {
-                    // Don't use the context.query() since it might be rewritten, and we need to pass the non rewritten queries to
-                    // let the highlighter handle MultiTerm ones
-                    highlightQuery = context.parsedQuery().query();
+                HighlighterContext.HighlightQuery highlightQuery;
+                if (field.highlightQuery() == null) {
+                    highlightQuery = new HighlighterContext.HighlightQuery(context.parsedQuery().query(), context.query(), context.queryRewritten());
+                } else {
+                    highlightQuery = new HighlighterContext.HighlightQuery(field.highlightQuery(), field.highlightQuery(), false);
                 }
                 HighlighterContext highlighterContext = new HighlighterContext(fieldName, field, fieldMapper, context, hitContext, highlightQuery);
                 HighlightField highlightField = highlighter.highlight(highlighterContext);

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
@@ -33,15 +33,39 @@ public class HighlighterContext {
     public final FieldMapper<?> mapper;
     public final SearchContext context;
     public final FetchSubPhase.HitContext hitContext;
-    public final Query highlightQuery;
+    public final HighlightQuery query;
 
     public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper<?> mapper, SearchContext context,
-            FetchSubPhase.HitContext hitContext, Query highlightQuery) {
+            FetchSubPhase.HitContext hitContext, HighlightQuery query) {
         this.fieldName = fieldName;
         this.field = field;
         this.mapper = mapper;
         this.context = context;
         this.hitContext = hitContext;
-        this.highlightQuery = highlightQuery;
+        this.query = query;
+    }
+
+    static class HighlightQuery {
+        private final Query originalQuery;
+        private final Query query;
+        private final boolean queryRewritten;
+
+        HighlightQuery(Query originalQuery, Query query, boolean queryRewritten) {
+            this.originalQuery = originalQuery;
+            this.query = query;
+            this.queryRewritten = queryRewritten;
+        }
+
+        public boolean queryRewritten() {
+            return queryRewritten;
+        }
+
+        public Query originalQuery() {
+            return originalQuery;
+        }
+
+        public Query query() {
+            return query;
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -68,7 +68,7 @@ public class PlainHighlighter implements Highlighter {
 
         org.apache.lucene.search.highlight.Highlighter entry = cache.get(mapper);
         if (entry == null) {
-            Query query = highlighterContext.highlightQuery;
+            Query query = highlighterContext.query.originalQuery();
             QueryScorer queryScorer = new CustomQueryScorer(query, field.requireFieldMatch() ? mapper.names().indexName() : null);
             queryScorer.setExpandMultiTermQuery(true);
             Fragmenter fragmenter;

--- a/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
@@ -71,7 +71,7 @@ public class PostingsHighlighter implements Highlighter {
             //get the non rewritten query and rewrite it
             Query query;
             try {
-                query = rewrite(context, hitContext.topLevelReader());
+                query = rewrite(highlighterContext, hitContext.topLevelReader());
             } catch (IOException e) {
                 throw new FetchPhaseExecutionException(context, "Failed to highlight field [" + highlighterContext.fieldName + "]", e);
             }
@@ -146,11 +146,11 @@ public class PostingsHighlighter implements Highlighter {
         return null;
     }
 
-    private static Query rewrite(SearchContext searchContext, IndexReader reader) throws IOException {
+    private static Query rewrite(HighlighterContext highlighterContext, IndexReader reader) throws IOException {
         //rewrite is expensive: if the query was already rewritten we try not to rewrite
-        boolean mustRewrite = !searchContext.queryRewritten();
+        boolean mustRewrite = !highlighterContext.query.queryRewritten();
 
-        Query original = searchContext.parsedQuery().query();
+        Query original = highlighterContext.query.originalQuery();
 
         MultiTermQuery originalMultiTermQuery = null;
         MultiTermQuery.RewriteMethod originalRewriteMethod = null;
@@ -166,7 +166,7 @@ public class PostingsHighlighter implements Highlighter {
 
         if (!mustRewrite) {
             //return the rewritten query
-            return searchContext.query();
+            return highlighterContext.query.query();
         }
 
         Query query = original;


### PR DESCRIPTION
It is now possible to highlight an external query using the postings highlighter, relates to #3630

Closes #4121
