### PR TITLE
IndexShardGatewayService should not call post_recovery if shard is in STARTED state

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -382,8 +382,9 @@ public class AllocationService extends AbstractComponent {
             // this means that after relocation, the state will be started and the currentNodeId will be
             // the node we relocated to
 
-            if (relocatingNodeId == null)
+            if (relocatingNodeId == null) {
                 continue;
+            }
 
             RoutingNode sourceRoutingNode = routingNodes.nodesToShards().get(relocatingNodeId);
             if (sourceRoutingNode != null) {
@@ -408,7 +409,7 @@ public class AllocationService extends AbstractComponent {
      * require relocation.
      */
     private boolean applyFailedShard(RoutingAllocation allocation, ShardRouting failedShard, boolean addToIgnoreList) {
-        // create a copy of the failed shard, since we assume we can change possible refernces to it without
+        // create a copy of the failed shard, since we assume we can change possible references to it without
         // changing the state of failed shard
         failedShard = new ImmutableShardRouting(failedShard);
 

--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -178,8 +178,13 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                     lastTranslogLength = 0;
                     lastTotalTranslogOperations = recoveryStatus.translog().currentTranslogOperations();
 
-                    // start the shard if the gateway has not started it already
-                    if (indexShard.state() != IndexShardState.POST_RECOVERY) {
+                    // start the shard if the gateway has not started it already. Note that if the gateway
+                    // moved shard to POST_RECOVERY, it may have been started as well if:
+                    // 1) master sent a new cluster state indicating shard is initializing
+                    // 2) IndicesClusterStateService#applyInitializingShard will send a shard started event
+                    // 3) Master will mark shard as started and this will be processed locally.
+                    IndexShardState shardState = indexShard.state();
+                    if (shardState != IndexShardState.POST_RECOVERY && shardState != IndexShardState.STARTED) {
                         indexShard.postRecovery("post recovery from gateway");
                     }
                     // refresh the shard


### PR DESCRIPTION
At the end recovery, the IndexShardGatewayService will double check the gateway has moved the shard to POST_RECOVERY and if not, do it it self.
The shard state could have already move to started, causing the post_recovery call to throw an exception and the entire shard recovery to fail.

This can happened if, after the gateway moved the shard to POST_RECOVERY:
1) master sent a new cluster state indicating shard is initializing
2) IndicesClusterStateService#applyInitializingShard will send a shard started event
3) Master will mark shard as started and this will be processed quickly and move the shard to STARTED.
