### PR TITLE
multi_match query supports fields as single string and array

### DIFF
--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -2268,4 +2268,20 @@ public class SimpleIndexQueryParserTests extends ElasticsearchTestCase {
         Query parsedQuery = queryParser.parse(query).query();
         assertThat((double) (parsedQuery.getBoost()), Matchers.closeTo(3.0, 1.e-7));
     }
+
+    @Test
+    public void testMultiMatchQuery() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/multiMatch-query-simple.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(DisjunctionMaxQuery.class));
+    }
+
+    @Test
+    public void testMultiMatchQueryWithFieldsAsString() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/multiMatch-query-fields-as-string.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(BooleanQuery.class));
+    }
 }

--- a/src/test/java/org/elasticsearch/index/query/multiMatch-query-fields-as-string.json
+++ b/src/test/java/org/elasticsearch/index/query/multiMatch-query-fields-as-string.json
@@ -1,0 +1,6 @@
+{
+    "multi_match": {
+        "query": "foo bar",
+        "fields": "myField"
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/multiMatch-query-simple.json
+++ b/src/test/java/org/elasticsearch/index/query/multiMatch-query-simple.json
@@ -1,0 +1,6 @@
+{
+    "multi_match": {
+        "query": "foo bar",
+        "fields": [ "myField", "otherField" ]
+    }
+}


### PR DESCRIPTION
The multi_match query accepted only an array in the fields parameter. This patch allows to use a single string as well.

Also added tests for parsing in both cases.

Closes #4164
