### PR TITLE
Disable auto pretty print for main REST action

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -72,7 +72,7 @@ public class RestMainAction extends BaseRestHandler {
                 }
 
                 try {
-                    XContentBuilder builder = RestXContentBuilder.restContentBuilder(request).prettyPrint();
+                    XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
                     builder.field("ok", true);
                     builder.field("status", status.getStatus());


### PR DESCRIPTION
Not a big deal but for the sake of consistency I find it strange that the main REST action is the only one to be auto pretty printed.

If it is on purpose maybe it would be better to at least add the call to the .lfAtEnd() that is called when setting the pretty param to true.
