### PR TITLE
Making SearchRequest in PutWarmerRequest mandatory & validated

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -81,14 +80,18 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> {
         return this;
     }
 
-    @Nullable
     SearchRequest searchRequest() {
         return this.searchRequest;
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        ActionRequestValidationException validationException = searchRequest.validate();
+        ActionRequestValidationException validationException = null;
+        if (searchRequest == null) {
+            validationException = addValidationError("search request is missing", validationException);
+        } else {
+            validationException = searchRequest.validate();
+        }
         if (name == null) {
             validationException = addValidationError("name is missing", validationException);
         }

--- a/src/test/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.action.admin.indices.warmer.put;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -28,7 +29,10 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 public class PutWarmerRequestTests extends ElasticsearchTestCase {
 
@@ -72,5 +76,13 @@ public class PutWarmerRequestTests extends ElasticsearchTestCase {
         assertThat(inRequest.name(), equalTo("warmer1"));
         //timeout is default as we don't read it from the received buffer
         assertThat(inRequest.timeout().millis(), equalTo(outRequest.timeout().millis()));
+    }
+
+    @Test // issue 4196
+    public void testThatValidationWithoutSpecifyingSearchRequestFails() {
+        PutWarmerRequest putWarmerRequest = new PutWarmerRequest("foo");
+        ActionRequestValidationException validationException = putWarmerRequest.validate();
+        assertThat(validationException.validationErrors(), hasSize(1));
+        assertThat(validationException.getMessage(), containsString("search request is missing"));
     }
 }


### PR DESCRIPTION
The search request inside of a put warmer request was nullable, but actually we have to have that request in the transport action.
Validation and appropriate test added.

Closes #4196
