### PR TITLE
XBooleanFilter changes

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/XBooleanFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XBooleanFilter.java
@@ -1,21 +1,22 @@
-package org.elasticsearch.common.lucene.search;
-
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+
+package org.elasticsearch.common.lucene.search;
 
 import org.apache.lucene.index.AtomicReader;
 import org.apache.lucene.index.AtomicReaderContext;
@@ -25,36 +26,53 @@ import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.FixedBitSet;
-import org.elasticsearch.common.lucene.docset.AllDocIdSet;
-import org.elasticsearch.common.lucene.docset.DocIdSets;
-import org.elasticsearch.common.lucene.docset.NotDocIdSet;
+import org.elasticsearch.common.lucene.docset.*;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Similar to {@link org.apache.lucene.queries.BooleanFilter}.
  * <p/>
- * Our own variance mainly differs by the fact that we pass the acceptDocs down to the filters
- * and don't filter based on them at the end. Our logic is a bit different, and we filter based on that
- * at the top level filter chain.
+ * But with the following major differences:
+ * <ol>
+ * <li> The order of the clauses is re-ordered based on rudimentary heuristics in order to execute the bool filter
+ * is efficient as possible. The ordering is based on whether a filter is based on {@link FixedBitSet}, the
+ * the estimated cost which is fetched from {@link org.apache.lucene.search.DocIdSetIterator#cost()} and whether a
+ * clause has a must_not as occur.
+ * <li> The minimal should clauses that must match with each doc is configurable.
+ * </ol>
  */
 public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
 
-    final List<FilterClause> clauses = new ArrayList<FilterClause>();
+    public static XBooleanFilter booleanFilter() {
+        XBooleanFilter booleanFilter = new XBooleanFilter();
+        booleanFilter.setMinimumShouldMatch(1);
+        return booleanFilter;
+    }
 
-    /**
-     * Returns the a DocIdSetIterator representing the Boolean composition
-     * of the filters that have been added.
-     */
+    private final List<FilterClause> clauses = new ArrayList<FilterClause>();
+    private int minimumShouldMatch;
+
+    private int numShouldClauses;
+    private int numMustNotClauses;
+    private int numMustClauses;
+
     @Override
     public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
-        FixedBitSet res = null;
-        final AtomicReader reader = context.reader();
+        int size = clauses.size();
+        if (size == 0) {
+            return null;
+        }
 
-        // optimize single case...
-        if (clauses.size() == 1) {
+        AtomicReader reader = context.reader();
+        // shortcut when only have one clause...
+        if (size == 1) {
             FilterClause clause = clauses.get(0);
             DocIdSet set = clause.getFilter().getDocIdSet(context, acceptDocs);
             if (clause.getOccur() == Occur.MUST_NOT) {
@@ -71,241 +89,93 @@ public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
             return set;
         }
 
-        // first, go over and see if we can shortcut the execution
-        // and gather Bits if we need to
-        List<ResultClause> results = new ArrayList<ResultClause>(clauses.size());
-        boolean hasShouldClauses = false;
-        boolean hasNonEmptyShouldClause = false;
-        boolean hasMustClauses = false;
-        boolean hasMustNotClauses = false;
-        for (int i = 0; i < clauses.size(); i++) {
-            FilterClause clause = clauses.get(i);
-            DocIdSet set = clause.getFilter().getDocIdSet(context, acceptDocs);
-            if (clause.getOccur() == Occur.MUST) {
-                hasMustClauses = true;
-                if (DocIdSets.isEmpty(set)) {
+        List<ResultClause> resultClauses = new ArrayList<ResultClause>(clauses.size());
+        int numEmptyShouldClauses = 0;
+        int numEmptyMustNotClauses = 0;
+        int numBitsBasedClauses = 0;
+        for (FilterClause clause : clauses) {
+            Occur occur = clause.getOccur();
+            if (occur == Occur.SHOULD && minimumShouldMatch == 0 && (numMustClauses > 0)) {
+                continue;
+            }
+
+            DocIdSet docIdSet = clause.getFilter().getDocIdSet(context, acceptDocs);
+            if (DocIdSets.isEmpty(docIdSet)) {
+                if (occur == Occur.MUST) {
                     return null;
-                }
-            } else if (clause.getOccur() == Occur.SHOULD) {
-                hasShouldClauses = true;
-                if (DocIdSets.isEmpty(set)) {
+                } else if (occur == Occur.MUST_NOT) {
+                    numEmptyMustNotClauses++;
                     continue;
-                }
-                hasNonEmptyShouldClause = true;
-            } else if (clause.getOccur() == Occur.MUST_NOT) {
-                hasMustNotClauses = true;
-                if (DocIdSets.isEmpty(set)) {
-                    // we mark empty ones as null for must_not, handle it in the next run...
-                    results.add(new ResultClause(null, null, clause));
+                } else if (occur == Occur.SHOULD) {
+                    numEmptyShouldClauses++;
                     continue;
                 }
             }
+
+            DocIdSetIterator iterator = docIdSet.iterator();
+            if (iterator == null) {
+                if (occur == Occur.MUST) {
+                    return null;
+                } else if (occur == Occur.MUST_NOT) {
+                    numEmptyMustNotClauses++;
+                    continue;
+                } else if (occur == Occur.SHOULD) {
+                    numEmptyShouldClauses++;
+                    continue;
+                }
+            }
+
             Bits bits = null;
-            if (!DocIdSets.isFastIterator(set)) {
-                bits = set.bits();
+            if (!DocIdSets.isFastIterator(docIdSet)) {
+                bits = docIdSet.bits();
+                numBitsBasedClauses++;
             }
-            results.add(new ResultClause(set, bits, clause));
+            resultClauses.add(new ResultClause(bits, docIdSet, clause, iterator));
         }
 
-        if (hasShouldClauses && !hasNonEmptyShouldClause) {
-            return null;
-        }
-
-        // now, go over the clauses and apply the "fast" ones first...
-        hasNonEmptyShouldClause = false;
-        boolean hasBits = false;
-        // But first we need to handle the "fast" should clauses, otherwise a should clause can unset docs
-        // that don't match with a must or must_not clause.
-        List<ResultClause> fastOrClauses = new ArrayList<ResultClause>();
-        for (int i = 0; i < results.size(); i++) {
-            ResultClause clause = results.get(i);
-            // we apply bits in based ones (slow) in the second run
-            if (clause.bits != null) {
-                hasBits = true;
-                continue;
-            }
-            if (clause.clause.getOccur() == Occur.SHOULD) {
-                if (hasMustClauses || hasMustNotClauses) {
-                    fastOrClauses.add(clause);
-                } else if (res == null) {
-                    DocIdSetIterator it = clause.docIdSet.iterator();
-                    if (it != null) {
-                        hasNonEmptyShouldClause = true;
-                        res = new FixedBitSet(reader.maxDoc());
-                        res.or(it);
-                    }
-                } else {
-                    DocIdSetIterator it = clause.docIdSet.iterator();
-                    if (it != null) {
-                        hasNonEmptyShouldClause = true;
-                        res.or(it);
-                    }
-                }
-            }
-        }
-
-        // Now we safely handle the "fast" must and must_not clauses.
-        for (int i = 0; i < results.size(); i++) {
-            ResultClause clause = results.get(i);
-            // we apply bits in based ones (slow) in the second run
-            if (clause.bits != null) {
-                hasBits = true;
-                continue;
-            }
-            if (clause.clause.getOccur() == Occur.MUST) {
-                DocIdSetIterator it = clause.docIdSet.iterator();
-                if (it == null) {
-                    return null;
-                }
-                if (res == null) {
-                    res = new FixedBitSet(reader.maxDoc());
-                    res.or(it);
-                } else {
-                    res.and(it);
-                }
-            } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
-                if (res == null) {
-                    res = new FixedBitSet(reader.maxDoc());
-                    res.set(0, reader.maxDoc()); // NOTE: may set bits on deleted docs
-                }
-                if (clause.docIdSet != null) {
-                    DocIdSetIterator it = clause.docIdSet.iterator();
-                    if (it != null) {
-                        res.andNot(it);
-                    }
-                }
-            }
-        }
-
-        if (!hasBits) {
-            if (!fastOrClauses.isEmpty()) {
-                DocIdSetIterator it = res.iterator();
-                at_least_one_should_clause_iter:
-                for (int setDoc = it.nextDoc(); setDoc != DocIdSetIterator.NO_MORE_DOCS; setDoc = it.nextDoc()) {
-                    for (ResultClause fastOrClause : fastOrClauses) {
-                        DocIdSetIterator clauseIterator = fastOrClause.iterator();
-                        if (clauseIterator == null) {
-                            continue;
-                        }
-                        if (iteratorMatch(clauseIterator, setDoc)) {
-                            hasNonEmptyShouldClause = true;
-                            continue at_least_one_should_clause_iter;
-                        }
-                    }
-                    res.clear(setDoc);
-                }
-            }
-
-            if (hasShouldClauses && !hasNonEmptyShouldClause) {
-                return null;
-            } else {
-                return res;
-            }
-        }
-
-        // we have some clauses with bits, apply them...
-        // we let the "res" drive the computation, and check Bits for that
-        List<ResultClause> slowOrClauses = new ArrayList<ResultClause>();
-        for (int i = 0; i < results.size(); i++) {
-            ResultClause clause = results.get(i);
-            if (clause.bits == null) {
-                continue;
-            }
-            if (clause.clause.getOccur() == Occur.SHOULD) {
-                if (hasMustClauses || hasMustNotClauses) {
-                    slowOrClauses.add(clause);
-                } else {
-                    if (res == null) {
-                        DocIdSetIterator it = clause.docIdSet.iterator();
-                        if (it == null) {
-                            continue;
-                        }
-                        hasNonEmptyShouldClause = true;
-                        res = new FixedBitSet(reader.maxDoc());
-                        res.or(it);
-                    } else {
-                        for (int doc = 0; doc < reader.maxDoc(); doc++) {
-                            if (!res.get(doc) && clause.bits.get(doc)) {
-                                hasNonEmptyShouldClause = true;
-                                res.set(doc);
-                            }
-                        }
-                    }
-                }
-            } else if (clause.clause.getOccur() == Occur.MUST) {
-                if (res == null) {
-                    // nothing we can do, just or it...
-                    res = new FixedBitSet(reader.maxDoc());
-                    DocIdSetIterator it = clause.docIdSet.iterator();
-                    if (it == null) {
-                        return null;
-                    }
-                    res.or(it);
-                } else {
-                    Bits bits = clause.bits;
-                    // use the "res" to drive the iteration
-                    DocIdSetIterator it = res.iterator();
-                    for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-                        if (!bits.get(doc)) {
-                            res.clear(doc);
-                        }
-                    }
-                }
-            } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
-                if (res == null) {
-                    res = new FixedBitSet(reader.maxDoc());
-                    res.set(0, reader.maxDoc()); // NOTE: may set bits on deleted docs
-                    DocIdSetIterator it = clause.docIdSet.iterator();
-                    if (it != null) {
-                        res.andNot(it);
-                    }
-                } else {
-                    Bits bits = clause.bits;
-                    // let res drive the iteration
-                    DocIdSetIterator it = res.iterator();
-                    for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-                        if (bits.get(doc)) {
-                            res.clear(doc);
-                        }
-                    }
-                }
-            }
-        }
-
-        // From a boolean_logic behavior point of view a should clause doesn't have impact on a bool filter if there
-        // is already a must or must_not clause. However in the current ES bool filter behaviour at least one should
-        // clause must match in order for a doc to be a match. What we do here is checking if matched docs match with
-        // any should filter. TODO: Add an option to have disable minimum_should_match=1 behaviour
-        if (!slowOrClauses.isEmpty() || !fastOrClauses.isEmpty()) {
-            DocIdSetIterator it = res.iterator();
-            at_least_one_should_clause_iter:
-            for (int setDoc = it.nextDoc(); setDoc != DocIdSetIterator.NO_MORE_DOCS; setDoc = it.nextDoc()) {
-                for (ResultClause fastOrClause : fastOrClauses) {
-                    DocIdSetIterator clauseIterator = fastOrClause.iterator();
-                    if (it == null) {
-                        continue;
-                    }
-                    if (iteratorMatch(clauseIterator, setDoc)) {
-                        hasNonEmptyShouldClause = true;
-                        continue at_least_one_should_clause_iter;
-                    }
-                }
-                for (ResultClause slowOrClause : slowOrClauses) {
-                    if (slowOrClause.bits.get(setDoc)) {
-                        hasNonEmptyShouldClause = true;
-                        continue at_least_one_should_clause_iter;
-                    }
-                }
-                res.clear(setDoc);
-            }
-        }
-
-        if (hasShouldClauses && !hasNonEmptyShouldClause) {
-            return null;
+        // This is consistent with BQ: if msm == 0 and no must and have should and must not, the msm should be 1.
+        final int minimumShouldMatch;
+        if (this.minimumShouldMatch == 0 && numMustClauses == 0 && numMustNotClauses > 0 && numShouldClauses > 0) {
+            minimumShouldMatch = 1;
         } else {
-            return res;
+            minimumShouldMatch = this.minimumShouldMatch;
         }
 
+        if (numShouldClauses > 0 && (numShouldClauses - numEmptyShouldClauses) < minimumShouldMatch) {
+            return null;
+        }
+
+        final ResultClausesProcessor processor;
+        if (numShouldClauses == 0) {
+            if (numMustNotClauses == 0) {
+                if (numBitsBasedClauses == resultClauses.size()) {
+                    processor = new SlowOnlyMustClausesProcessor(resultClauses, reader);
+                } else {
+                    // OnlyMustClausesProcessor seem to be faster if all clauses are slow than using SlowOnlyMustClausesProcessor
+                    processor = new OnlyMustClausesProcessor(resultClauses, reader);
+                }
+            } else {
+                processor = new MustAndMustNotClausesProcessor(resultClauses, reader, numEmptyMustNotClauses);
+            }
+        } else {
+            if (numMustClauses == 0 && numMustNotClauses == 0 && minimumShouldMatch <= 1) {
+                if (numBitsBasedClauses == resultClauses.size()) {
+                    processor = new SlowOnlyShouldClausesProcessor(resultClauses, reader);
+                } else {
+                    processor = new OnlyShouldClausesProcessor(resultClauses, reader);
+                }
+            } else {
+                if (minimumShouldMatch == 0) {
+                    processor = new MustAndMustNotClausesProcessor(resultClauses, reader, numEmptyMustNotClauses);
+                } else if (minimumShouldMatch == 1) {
+                    processor = new AllClausesProcessor(resultClauses, reader, numEmptyMustNotClauses);
+                } else {
+                    processor = new MinimumShouldMatchAllClausesProcessor(resultClauses, reader, minimumShouldMatch, numEmptyMustNotClauses);
+                }
+            }
+        }
+
+        return processor.process();
     }
 
     /**
@@ -314,6 +184,13 @@ public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
      * @param filterClause A FilterClause object containing a Filter and an Occur parameter
      */
     public void add(FilterClause filterClause) {
+        if (filterClause.getOccur() == Occur.MUST) {
+            numMustClauses++;
+        } else if (filterClause.getOccur() == Occur.MUST_NOT) {
+            numMustNotClauses++;
+        } else if (filterClause.getOccur() == Occur.SHOULD) {
+            numShouldClauses++;
+        }
         clauses.add(filterClause);
     }
 
@@ -329,10 +206,19 @@ public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
     }
 
     /**
+     * Sets the minimum should clauses that must match with each document in order for that document to be considered
+     * as a match.
+     */
+    public void setMinimumShouldMatch(int minimumShouldMatch) {
+        this.minimumShouldMatch = minimumShouldMatch;
+    }
+
+    /**
      * Returns an iterator on the clauses in this query. It implements the {@link Iterable} interface to
      * make it possible to do:
      * <pre class="prettyprint">for (FilterClause clause : booleanFilter) {}</pre>
      */
+    @Override
     public final Iterator<FilterClause> iterator() {
         return clauses().iterator();
     }
@@ -348,12 +234,15 @@ public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
         }
 
         final XBooleanFilter other = (XBooleanFilter) obj;
+        if (minimumShouldMatch != other.minimumShouldMatch) {
+            return false;
+        }
         return clauses.equals(other.clauses);
     }
 
     @Override
     public int hashCode() {
-        return 657153718 ^ clauses.hashCode();
+        return 657153718 ^ clauses.hashCode() + minimumShouldMatch;
     }
 
     /**
@@ -369,46 +258,506 @@ public class XBooleanFilter extends Filter implements Iterable<FilterClause> {
             }
             buffer.append(c);
         }
-        return buffer.append(')').toString();
+        buffer.append(')');
+        if (minimumShouldMatch > 0) {
+            buffer.append('~').append(minimumShouldMatch);
+        }
+        return buffer.toString();
     }
 
-    static class ResultClause {
+    static abstract class ResultClausesProcessor {
 
-        public final DocIdSet docIdSet;
-        public final Bits bits;
-        public final FilterClause clause;
+        private final static Comparator<ResultClause> COMPARATOR = new Comparator<ResultClause>() {
+            @Override
+            public int compare(ResultClause first, ResultClause second) {
+                if (first.bits != null && second.bits == null) {
+                    return 1;
+                } else if (first.bits == null && second.bits != null) {
+                    return -1;
+                }
 
-        DocIdSetIterator docIdSetIterator;
+                // TODO: IF FBS we can use cardinality to order clauses. Although #cost() and #cardinality() are unequal in
+                // FBS, it is just about re-ordering the clauses. However for this we need to somehow cache FBS#cardinality()
 
-        ResultClause(DocIdSet docIdSet, Bits bits, FilterClause clause) {
-            this.docIdSet = docIdSet;
-            this.bits = bits;
-            this.clause = clause;
+                // must_not clause with higher cost is of more interest, b/c the set bits get inversed.
+                boolean revert = first.clause.getOccur() != Occur.MUST_NOT && second.clause.getOccur() == Occur.MUST_NOT;
+                long cmpCost = first.iterator.cost() - second.iterator.cost();
+                if (cmpCost < 0) {
+                    return revert ? 1 : -1;
+                } else if (cmpCost > 0) {
+                    return revert ? -1 : 1;
+                } else {
+                    return 0;
+                }
+            }
+        };
+
+        protected final List<ResultClause> resultClauses;
+        protected final AtomicReader reader;
+
+        protected final int minimumShouldMatch;
+        protected final int numEmptyMustNotClauses;
+
+        protected ResultClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader,
+                                         int minimumShouldMatch, int numEmptyMustNotClauses) {
+            this.resultClauses = resultClauses;
+            this.reader = reader;
+            this.minimumShouldMatch = minimumShouldMatch;
+            this.numEmptyMustNotClauses = numEmptyMustNotClauses;
         }
 
-        /**
-         * @return An iterator, but caches it for subsequent usage. Don't use if iterator is consumed in one invocation.
-         */
-        DocIdSetIterator iterator() throws IOException {
-            if (docIdSetIterator != null) {
-                return docIdSetIterator;
-            } else {
-                return docIdSetIterator = docIdSet.iterator();
+        public DocIdSet process() throws IOException {
+            CollectionUtil.timSort(resultClauses, comparator());
+            return doProcess();
+        }
+
+        protected abstract DocIdSet doProcess() throws IOException;
+
+        protected Comparator<ResultClause> comparator() {
+            return COMPARATOR;
+        }
+
+    }
+
+    final static class MinimumShouldMatchAllClausesProcessor extends ResultClausesProcessor {
+
+        private MinimumShouldMatchAllClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader,
+                                                      int minimumShouldMatch, int numEmptyMustNotClauses) {
+            super(resultClauses, reader, minimumShouldMatch, numEmptyMustNotClauses);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            ResultBuilder builder = new ResultBuilder(reader, numEmptyMustNotClauses);
+            List<ResultClause> shouldClauses = new ArrayList<ResultClause>();
+
+            int i = 0;
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                if (clause.bits != null) {
+                    break;
+                }
+
+                if (clause.clause.getOccur() == Occur.SHOULD) {
+                    shouldClauses.add(clause);
+                    continue;
+                }
+
+                if (clause.clause.getOccur() == Occur.MUST) {
+                    builder.must(clause.iterator);
+                } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
+                    builder.mustNot(clause.iterator);
+                }
+            }
+
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+
+                if (clause.clause.getOccur() == Occur.SHOULD) {
+                    shouldClauses.add(clause);
+                    continue;
+                }
+
+                if (clause.clause.getOccur() == Occur.MUST) {
+                    builder.must(clause.iterator, clause.bits);
+                } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
+                    builder.mustNot(clause.iterator, clause.bits);
+                }
+            }
+
+            CollectionUtil.timSort(shouldClauses, comparator());
+            builder.shouldWithMinimumShouldMatch(shouldClauses, minimumShouldMatch);
+
+            return builder.build();
+        }
+
+    }
+
+    final static class AllClausesProcessor extends ResultClausesProcessor {
+
+        AllClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader, int numEmptyMustNotClauses) {
+            super(resultClauses, reader, -1, numEmptyMustNotClauses);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            ResultBuilder builder = new ResultBuilder(reader, numEmptyMustNotClauses);
+            List<ResultClause> shouldClauses = new ArrayList<ResultClause>();
+
+            int i = 0;
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                if (clause.bits != null) {
+                    break;
+                }
+
+                if (clause.clause.getOccur() == Occur.SHOULD) {
+                    shouldClauses.add(clause);
+                    continue;
+                }
+
+                if (clause.clause.getOccur() == Occur.MUST) {
+                    builder.must(clause.iterator);
+                } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
+                    builder.mustNot(clause.iterator);
+                }
+            }
+
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+
+                if (clause.clause.getOccur() == Occur.SHOULD) {
+                    shouldClauses.add(clause);
+                    continue;
+                }
+
+                if (clause.clause.getOccur() == Occur.MUST) {
+                    builder.must(clause.iterator, clause.bits);
+                } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
+                    builder.mustNot(clause.iterator, clause.bits);
+                }
+            }
+
+            if (!shouldClauses.isEmpty()) {
+                CollectionUtil.timSort(shouldClauses, comparator());
+                builder.should(shouldClauses);
+            }
+            return builder.build();
+        }
+
+    }
+
+    private final static class MustAndMustNotClausesProcessor extends ResultClausesProcessor {
+
+        private MustAndMustNotClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader, int numEmptyMustNotClauses) {
+            super(resultClauses, reader, -1, numEmptyMustNotClauses);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            ResultBuilder builder = new ResultBuilder(reader, numEmptyMustNotClauses);
+
+            int i = 0;
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                if (clause.bits != null) {
+                    break;
+                }
+
+                if (clause.clause.getOccur() == Occur.MUST) {
+                    builder.must(clause.iterator);
+                } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
+                    builder.mustNot(clause.iterator);
+                }
+            }
+
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                if (clause.clause.getOccur() == Occur.MUST) {
+                    builder.must(clause.iterator, clause.bits);
+                } else if (clause.clause.getOccur() == Occur.MUST_NOT) {
+                    builder.mustNot(clause.iterator, clause.bits);
+                }
+            }
+
+            return builder.build();
+        }
+    }
+
+    // TODO: potentially when all clauses are FBS, we can only pick the clause with lowest cardinality and omit the
+    // other clauses.
+    private final static class OnlyShouldClausesProcessor extends ResultClausesProcessor {
+
+        private OnlyShouldClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader) {
+            super(resultClauses, reader, -1, -1);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            ResultBuilder builder = new ResultBuilder(reader, 0);
+
+            int i = 0;
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                if (clause.bits != null) {
+                    break;
+                }
+                builder.should(clause.iterator);
+            }
+
+            if (i < resultClauses.size()) {
+                builder.shouldSlowClausesOnly(resultClauses.subList(i, resultClauses.size()));
+            }
+            return builder.build();
+        }
+    }
+
+    final static class SlowOnlyShouldClausesProcessor extends ResultClausesProcessor {
+
+        private SlowOnlyShouldClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader) {
+            super(resultClauses, reader, -1, -1);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            DocIdSet[] docIdSets = new DocIdSet[resultClauses.size()];
+            for (int i = 0; i < docIdSets.length; i++) {
+                docIdSets[i] = resultClauses.get(i).docIdSet;
+            }
+            return new OrDocIdSet(docIdSets);
+        }
+    }
+
+    final static class OnlyMustClausesProcessor extends ResultClausesProcessor {
+
+        private OnlyMustClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader) {
+            super(resultClauses, reader, -1, -1);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            ResultBuilder builder = new ResultBuilder(reader, 0);
+
+            int i = 0;
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                if (clause.bits != null) {
+                    break;
+                }
+                builder.must(clause.iterator);
+            }
+
+            for (; i < resultClauses.size(); i++) {
+                ResultClause clause = resultClauses.get(i);
+                builder.must(clause.iterator, clause.bits);
+            }
+
+            return builder.build();
+        }
+    }
+
+    final static class SlowOnlyMustClausesProcessor extends ResultClausesProcessor {
+
+        private SlowOnlyMustClausesProcessor(List<ResultClause> resultClauses, AtomicReader reader) {
+            super(resultClauses, reader, -1, -1);
+        }
+
+        @Override
+        public DocIdSet doProcess() throws IOException {
+            DocIdSet[] docIdSets = new DocIdSet[resultClauses.size()];
+            for (int i = 0; i < docIdSets.length; i++) {
+                docIdSets[i] = resultClauses.get(i).docIdSet;
+            }
+            return new AndDocIdSet(docIdSets);
+        }
+    }
+
+    final static class ResultClause {
+
+        final Bits bits;
+        final DocIdSet docIdSet;
+        final FilterClause clause;
+        final DocIdSetIterator iterator;
+
+        ResultClause(Bits bits, DocIdSet docIdSet, FilterClause clause, DocIdSetIterator iterator) {
+            this.bits = bits;
+            this.docIdSet = docIdSet;
+            this.clause = clause;
+            this.iterator = iterator;
+        }
+
+    }
+
+    final static class ResultBuilder {
+
+        private final AtomicReader reader;
+        private FixedBitSet result;
+
+        ResultBuilder(AtomicReader reader, int numEmptyMustNotClauses) {
+            this.reader = reader;
+            if (numEmptyMustNotClauses > 0) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.set(0, reader.maxDoc());
             }
         }
 
-    }
-
-    static boolean iteratorMatch(DocIdSetIterator docIdSetIterator, int target) throws IOException {
-        assert docIdSetIterator != null;
-        int current = docIdSetIterator.docID();
-        if (current == DocIdSetIterator.NO_MORE_DOCS || target < current) {
-            return false;
-        } else {
-            if (current == target) {
-                return true;
+        void must(DocIdSetIterator iterator) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.or(iterator);
             } else {
-                return docIdSetIterator.advance(target) == target;
+                result.and(iterator);
+            }
+        }
+
+        void must(DocIdSetIterator iterator, Bits bits) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.or(iterator);
+            } else {
+                // use the "res" to drive the iteration
+                DocIdSetIterator it = result.iterator();
+                for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+                    if (!bits.get(doc)) {
+                        result.clear(doc);
+                    }
+                }
+            }
+        }
+
+        void mustNot(DocIdSetIterator iterator) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.set(0, reader.maxDoc());
+            }
+            result.andNot(iterator);
+        }
+
+        void mustNot(DocIdSetIterator iterator, Bits bits) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.set(0, reader.maxDoc());
+                result.andNot(iterator);
+            } else {
+                // let res drive the iteration
+                DocIdSetIterator it = result.iterator();
+                for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+                    if (bits.get(doc)) {
+                        result.clear(doc);
+                    }
+                }
+            }
+        }
+
+        void should(DocIdSetIterator iterator) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+            }
+            result.or(iterator);
+        }
+
+        void shouldSlowClausesOnly(List<ResultClause> shouldClauses) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.set(0, reader.maxDoc());
+            }
+
+            int nextSetDoc;
+            DocIdSetIterator it = result.iterator();
+            for (int prevSetDoc = -1; prevSetDoc != DocIdSetIterator.NO_MORE_DOCS; prevSetDoc = nextSetDoc) {
+                nextSetDoc = it.nextDoc();
+                int end = nextSetDoc;
+                if (nextSetDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                    end = reader.maxDoc();
+                }
+
+                outer: for (int doc = prevSetDoc + 1; doc < end; doc++) {
+                    for (ResultClause shouldClause : shouldClauses) {
+                        if (shouldClause.bits.get(doc)) {
+                            result.set(doc);
+                            continue outer;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Iterates over all matching docs once and unsets matching docs if not matching with any should clauses.
+        void should(List<ResultClause> shouldClauses) throws IOException {
+            if (result == null) {
+                result = new FixedBitSet(reader.maxDoc());
+                result.set(0, reader.maxDoc());
+            }
+
+            DocIdSetIterator resultIterator = result.iterator();
+            outer:
+            for (int setDoc = resultIterator.nextDoc(); setDoc != DocIdSetIterator.NO_MORE_DOCS; setDoc = resultIterator.nextDoc()) {
+                for (ResultClause shouldClause : shouldClauses) {
+                    if (shouldClause.bits != null) {
+                        if (shouldClause.bits.get(setDoc)) {
+                            continue outer;
+                        }
+                    } else {
+                        int current = shouldClause.iterator.docID();
+                        if (current == DocIdSetIterator.NO_MORE_DOCS) {
+                            continue; // maybe remove these clauses from execution?
+                        }
+                        if (current == setDoc) {
+                            continue outer;
+                        } else if (setDoc > current && shouldClause.iterator.advance(setDoc) == setDoc) {
+                            continue outer;
+                        }
+                    }
+                }
+                result.clear(setDoc);
+            }
+        }
+
+        void shouldWithMinimumShouldMatch(List<ResultClause> shouldClauses, int minimumShouldMatch) throws IOException {
+            int initialMatchedShouldClauses = 0;
+            if (result == null) {
+
+                result = new FixedBitSet(reader.maxDoc());
+                if (shouldClauses.size() == minimumShouldMatch) {
+                    // at least one of the result clauses needs to match, so we pick the first one and let that one drive the result.
+                    Iterator<ResultClause> iterator = shouldClauses.iterator();
+                    int numAllowedNoResultClauses = shouldClauses.size() - minimumShouldMatch;
+                    while (true){
+                        result.or(iterator.next().iterator);
+                        iterator.remove();
+                        if (result.cardinality() > 0) {
+                            break;
+                        }
+                        if (--numAllowedNoResultClauses < 0) {
+                            return;
+                        }
+                    }
+
+                    // Nothing has matched before, so we safely assume that each matching doc has already
+                    // a should match clause count of 1.
+                    initialMatchedShouldClauses = 1;
+                } else {
+                    // Bummer we have to check all the docs in this segment...
+                    result.set(0, reader.maxDoc());
+                }
+            }
+
+            DocIdSetIterator resultIterator = result.iterator();
+            outer:
+            for (int setDoc = resultIterator.nextDoc(); setDoc != DocIdSetIterator.NO_MORE_DOCS; setDoc = resultIterator.nextDoc()) {
+                int matchingShouldClauses = initialMatchedShouldClauses;
+                for (ResultClause shouldClause : shouldClauses) {
+                    if (shouldClause.bits != null) {
+                        if (shouldClause.bits.get(setDoc)) {
+                            matchingShouldClauses++;
+                        }
+                    } else {
+                        int current = shouldClause.iterator.docID();
+                        if (current == DocIdSetIterator.NO_MORE_DOCS) {
+                            continue; // maybe remove these clauses from execution?
+                        }
+                        if (current == setDoc) {
+                            matchingShouldClauses++;
+                        } else if (setDoc > current && shouldClause.iterator.advance(setDoc) == setDoc) {
+                            matchingShouldClauses++;
+                        }
+                    }
+                    if (matchingShouldClauses >= minimumShouldMatch) {
+                        continue outer;
+                    }
+                }
+
+                if (matchingShouldClauses < minimumShouldMatch) {
+                    result.clear(setDoc);
+                }
+            }
+        }
+
+        FixedBitSet build() {
+            if (result == null) {
+                return null;
+            } else {
+                return result.cardinality() == 0 ? null : result;
             }
         }
     }

--- a/src/main/java/org/elasticsearch/index/aliases/IndexAliasesService.java
+++ b/src/main/java/org/elasticsearch/index/aliases/IndexAliasesService.java
@@ -95,7 +95,7 @@ public class IndexAliasesService extends AbstractIndexComponent implements Itera
             return indexAlias.parsedFilter();
         } else {
             // we need to bench here a bit, to see maybe it makes sense to use OrFilter
-            XBooleanFilter combined = new XBooleanFilter();
+            XBooleanFilter combined = XBooleanFilter.booleanFilter();
             for (String alias : aliases) {
                 IndexAlias indexAlias = alias(alias);
                 if (indexAlias == null) {

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -469,7 +469,7 @@ public class MapperService extends AbstractIndexComponent implements Iterable<Do
             }
         } else {
             // Current bool filter requires that at least one should clause matches, even with a must clause.
-            XBooleanFilter bool = new XBooleanFilter();
+            XBooleanFilter bool = XBooleanFilter.booleanFilter();
             for (String type : types) {
                 DocumentMapper docMapper = documentMapper(type);
                 if (docMapper == null) {

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -224,7 +224,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         if (queryTypes.size() == 1) {
             return new PrefixFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(Iterables.getFirst(queryTypes, null), BytesRefs.toBytesRef(value))));
         }
-        XBooleanFilter filter = new XBooleanFilter();
+        XBooleanFilter filter = XBooleanFilter.booleanFilter();
         for (String queryType : queryTypes) {
             filter.add(new PrefixFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(queryType, BytesRefs.toBytesRef(value)))), BooleanClause.Occur.SHOULD);
         }
@@ -263,7 +263,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
         if (queryTypes.size() == 1) {
             return new RegexpFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(Iterables.getFirst(queryTypes, null), BytesRefs.toBytesRef(value))), flags);
         }
-        XBooleanFilter filter = new XBooleanFilter();
+        XBooleanFilter filter = XBooleanFilter.booleanFilter();
         for (String queryType : queryTypes) {
             filter.add(new RegexpFilter(new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(queryType, BytesRefs.toBytesRef(value))), flags), BooleanClause.Occur.SHOULD);
         }

--- a/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolFilterParser.java
@@ -49,7 +49,7 @@ public class BoolFilterParser implements FilterParser {
     public Filter parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
-        XBooleanFilter boolFilter = new XBooleanFilter();
+        XBooleanFilter boolFilter = XBooleanFilter.booleanFilter();
 
         boolean cache = false;
         CacheKeyFilter.Key cacheKey = null;

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -90,7 +90,7 @@ public class ExistsFilterParser implements FilterParser {
         }
         MapperService.SmartNameFieldMappers nonNullFieldMappers = null;
 
-        XBooleanFilter boolFilter = new XBooleanFilter();
+        XBooleanFilter boolFilter = XBooleanFilter.booleanFilter();
         for (String field : fields) {
             MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(field);
             if (smartNameFieldMappers != null) {

--- a/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentFilterParser.java
@@ -149,7 +149,7 @@ public class HasParentFilterParser implements FilterParser {
             DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypes.iterator().next());
             parentFilter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
         } else {
-            XBooleanFilter parentsFilter = new XBooleanFilter();
+            XBooleanFilter parentsFilter = XBooleanFilter.booleanFilter();
             for (String parentTypeStr : parentTypes) {
                 DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypeStr);
                 Filter filter = parseContext.cacheFilter(documentMapper.typeFilter(), null);

--- a/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -148,7 +148,7 @@ public class HasParentQueryParser implements QueryParser {
             DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypes.iterator().next());
             parentFilter = parseContext.cacheFilter(documentMapper.typeFilter(), null);
         } else {
-            XBooleanFilter parentsFilter = new XBooleanFilter();
+            XBooleanFilter parentsFilter = XBooleanFilter.booleanFilter();
             for (String parentTypeStr : parentTypes) {
                 DocumentMapper documentMapper = parseContext.mapperService().documentMapper(parentTypeStr);
                 Filter filter = parseContext.cacheFilter(documentMapper.typeFilter(), null);

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -109,7 +109,7 @@ public class MissingFilterParser implements FilterParser {
         MapperService.SmartNameFieldMappers nonNullFieldMappers = null;
 
         if (existence) {
-            XBooleanFilter boolFilter = new XBooleanFilter();
+            XBooleanFilter boolFilter = XBooleanFilter.booleanFilter();
             for (String field : fields) {
                 MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(field);
                 if (smartNameFieldMappers != null) {
@@ -149,7 +149,7 @@ public class MissingFilterParser implements FilterParser {
         Filter filter;
         if (nullFilter != null) {
             if (existenceFilter != null) {
-                XBooleanFilter combined = new XBooleanFilter();
+                XBooleanFilter combined = XBooleanFilter.booleanFilter();
                 combined.add(existenceFilter, BooleanClause.Occur.SHOULD);
                 combined.add(nullFilter, BooleanClause.Occur.SHOULD);
                 // cache the not filter as well, so it will be faster

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -209,7 +209,7 @@ public class TermsFilterParser implements FilterParser {
                     filter = parseContext.cacheFilter(filter, cacheKey);
                 }
             } else if ("bool".equals(execution)) {
-                XBooleanFilter boolFiler = new XBooleanFilter();
+                XBooleanFilter boolFiler = XBooleanFilter.booleanFilter();
                 if (fieldMapper != null) {
                     for (Object term : terms) {
                         boolFiler.add(parseContext.cacheFilter(fieldMapper.termFilter(term, parseContext), null), BooleanClause.Occur.SHOULD);
@@ -225,7 +225,7 @@ public class TermsFilterParser implements FilterParser {
                     filter = parseContext.cacheFilter(filter, cacheKey);
                 }
             } else if ("bool_nocache".equals(execution)) {
-                XBooleanFilter boolFiler = new XBooleanFilter();
+                XBooleanFilter boolFiler = XBooleanFilter.booleanFilter();
                 if (fieldMapper != null) {
                     for (Object term : terms) {
                         boolFiler.add(fieldMapper.termFilter(term, parseContext), BooleanClause.Occur.SHOULD);

--- a/src/test/java/org/elasticsearch/benchmark/bool/BoolFilterBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/bool/BoolFilterBenchmark.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.benchmark.bool;
+
+import com.carrotsearch.hppc.ObjectOpenHashSet;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.*;
+import org.apache.lucene.queries.FilterClause;
+import org.apache.lucene.queries.TermsFilter;
+import org.apache.lucene.search.*;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.lucene.search.XBooleanFilter;
+import org.elasticsearch.common.lucene.search.XBooleanFilterTests;
+import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
+import org.elasticsearch.common.unit.SizeValue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.apache.lucene.search.BooleanClause.Occur.MUST;
+import static org.apache.lucene.search.BooleanClause.Occur.MUST_NOT;
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+
+/**
+ * Run with the following jvm args: -Xms2G -Xmx2G -server
+ */
+public class BoolFilterBenchmark {
+
+    static final Random random = new Random();
+    static final long numUniqueValues = SizeValue.parseSizeValue("50k").singles();
+    static final long numDocs = SizeValue.parseSizeValue("1m").singles();
+    static final long numQueries = SizeValue.parseSizeValue("20k").singles();
+    static final long warmUp = SizeValue.parseSizeValue("10k").singles();
+
+    public static void main(String[] args) throws Exception {
+        FSDirectory dir = FSDirectory.open(new File("work/test"));
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.VERSION, Lucene.STANDARD_ANALYZER));
+
+        final IndexReader reader;
+        final String[] uniqueValuesLookup;
+        if (writer.numDocs() != numDocs) {
+            ObjectOpenHashSet<String> uniqueValues = new ObjectOpenHashSet<String>();
+            while (uniqueValues.size() != numUniqueValues) {
+                uniqueValues.add(Strings.randomBase64UUID());
+            }
+            uniqueValuesLookup = uniqueValues.toArray(String.class);
+
+            StopWatch watch = new StopWatch().start();
+            System.out.println("Indexing " + numDocs + " docs with " + numUniqueValues + " unique values...");
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("0", uniqueValuesLookup[random.nextInt(uniqueValuesLookup.length)], Field.Store.NO));
+                doc.add(new StringField("1", uniqueValuesLookup[random.nextInt(uniqueValuesLookup.length)], Field.Store.NO));
+                doc.add(new StringField("2", uniqueValuesLookup[random.nextInt(uniqueValuesLookup.length)], Field.Store.NO));
+                doc.add(new StringField("3", uniqueValuesLookup[random.nextInt(uniqueValuesLookup.length)], Field.Store.NO));
+                writer.addDocument(doc);
+                if (random.nextInt(1000) == 456) {
+                    writer.commit();
+                }
+            }
+            System.out.println("Done indexing, took " + watch.stop().lastTaskTime());
+            reader = DirectoryReader.open(writer, true);
+        } else {
+            System.out.println("Using existing index");
+            ObjectOpenHashSet<String> uniqueValues = new ObjectOpenHashSet<String>();
+            reader = DirectoryReader.open(writer, true);
+            AtomicReader slowReader = SlowCompositeReaderWrapper.wrap(reader);
+            for (String field : slowReader.fields()) {
+                Terms terms = slowReader.terms(field);
+                TermsEnum termsEnum = terms.iterator(null);
+                for (BytesRef term = termsEnum.next(); term != null; term = termsEnum.next()) {
+                    uniqueValues.add(term.utf8ToString());
+                }
+            }
+
+            if (uniqueValues.size() != numUniqueValues) {
+                System.err.println("Not all unique values have been loaded");
+            }
+            uniqueValuesLookup = uniqueValues.toArray(String.class);
+        }
+
+        IndexSearcher searcher = new IndexSearcher(reader);
+        warmUp(searcher, uniqueValuesLookup);
+
+        checkPerformance("Only must fast", searcher, uniqueValuesLookup, ExecutionType.FAST, FilterType.ONLY_MUST);
+        checkPerformance("Only must slow", searcher, uniqueValuesLookup, ExecutionType.SLOW, FilterType.ONLY_MUST);
+        checkPerformance("Only must random", searcher, uniqueValuesLookup, ExecutionType.RANDOM, FilterType.ONLY_MUST);
+
+        checkPerformance("must, must_not fast", searcher, uniqueValuesLookup, ExecutionType.FAST, FilterType.MUST_MOST_NOT);
+        checkPerformance("must, must_not slow", searcher, uniqueValuesLookup, ExecutionType.SLOW, FilterType.MUST_MOST_NOT);
+        checkPerformance("must, must_not random", searcher, uniqueValuesLookup, ExecutionType.RANDOM, FilterType.MUST_MOST_NOT);
+
+        checkPerformance("Only should fast", searcher, uniqueValuesLookup, ExecutionType.FAST, FilterType.ONLY_SHOULD);
+        checkPerformance("Only should slow", searcher, uniqueValuesLookup, ExecutionType.SLOW, FilterType.ONLY_SHOULD);
+        checkPerformance("Only should random slow", searcher, uniqueValuesLookup, ExecutionType.RANDOM, FilterType.ONLY_SHOULD);
+
+        checkPerformance("Must,must_not,should fast", searcher, uniqueValuesLookup, ExecutionType.FAST, FilterType.MUST_MUST_NOT_SHOULD);
+        checkPerformance("Must,must_not,should slow", searcher, uniqueValuesLookup, ExecutionType.SLOW, FilterType.MUST_MUST_NOT_SHOULD);
+        checkPerformance("Must,must_not,should random slow", searcher, uniqueValuesLookup, ExecutionType.RANDOM, FilterType.MUST_MUST_NOT_SHOULD);
+
+        reader.close();
+        writer.close();
+    }
+
+    public static void checkPerformance(String label, IndexSearcher searcher, String[] uniqueValuesLookup, ExecutionType executionType, FilterType filterType) throws IOException {
+        int maxNumClauses = 3;
+        long totalTime = 0;
+        int numErrors = 0;
+        for (int i = 0; i < numQueries; i++) {
+            XBooleanFilter booleanFilter = filterType.filter(maxNumClauses, executionType, uniqueValuesLookup);
+            booleanFilter.setMinimumShouldMatch(1);
+
+            XConstantScoreQuery query = new XConstantScoreQuery(booleanFilter);
+            long startTime = System.nanoTime();
+            TotalHitCountCollector hitCountCollector = new TotalHitCountCollector();
+            searcher.search(query, hitCountCollector);
+            long result = hitCountCollector.getTotalHits();
+            long timeTook = System.nanoTime() - startTime;
+            totalTime += timeTook;
+
+            BooleanQuery booleanQuery = new BooleanQuery();
+            boolean hasShould = false;
+            boolean hasMust = false;
+            boolean hasMustNot = false;
+            for (FilterClause filterClause : booleanFilter) {
+                BooleanClause.Occur occur = filterClause.getOccur();
+                if (occur == SHOULD) {
+                    hasShould = true;
+                } else if (occur == MUST) {
+                    hasMust = true;
+                } else if (occur == MUST_NOT) {
+                    hasMustNot = true;
+                }
+                booleanQuery.add(new XConstantScoreQuery(filterClause.getFilter()), filterClause.getOccur());
+            }
+            if (hasShould) {
+                booleanQuery.setMinimumNumberShouldMatch(1);
+            }
+            if (hasMustNot && !hasMust && !hasShould) {  // pure negative
+                booleanQuery.add(new BooleanClause(new MatchAllDocsQuery(), MUST));
+            }
+
+            searcher.search(booleanQuery, hitCountCollector = new TotalHitCountCollector());
+            long control = hitCountCollector.getTotalHits();
+            if (result != control) {
+                numErrors++;
+            }
+        }
+
+        if (numErrors > 0) {
+            System.err.printf("Result and control were not equal %d times.\n", numErrors);
+        }
+
+        double totalTimeInS = totalTime / (1000 * 1000 * 1000);
+        System.out.printf("[%s] Total time %f s | avg time per query %f s\n", label, totalTimeInS, (totalTimeInS / numQueries));
+    }
+
+    public static void warmUp(IndexSearcher searcher, String[] uniqueValuesLookup) throws IOException {
+        int maxNumClauses = 3;
+        for (ExecutionType executionType : ExecutionType.values()) {
+            for (FilterType filterType : FilterType.values()) {
+                for (int i = 0; i < warmUp; i++) {
+                    XBooleanFilter booleanFilter = filterType.filter(maxNumClauses, executionType, uniqueValuesLookup);
+                    booleanFilter.setMinimumShouldMatch(1);
+
+                    XConstantScoreQuery query = new XConstantScoreQuery(booleanFilter);
+                    TotalHitCountCollector hitCountCollector = new TotalHitCountCollector();
+                    searcher.search(query, hitCountCollector);
+                }
+            }
+        }
+    }
+
+    enum ExecutionType {
+
+        FAST(),
+        SLOW(),
+        RANDOM();
+
+        public boolean fast() {
+            if (this == FAST) {
+                return true;
+            } else if (this == SLOW) {
+                return false;
+            } else {
+                return random.nextInt(3) == 2;
+            }
+        }
+
+    }
+
+    enum FilterType {
+
+        ONLY_SHOULD {
+            @Override
+            public XBooleanFilter filter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup) {
+                return createFilter(maxNumClauses, executionType, uniqueValuesLookup, BooleanClause.Occur.SHOULD);
+            }
+        },
+        MUST_MUST_NOT_SHOULD {
+            @Override
+            public XBooleanFilter filter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup) {
+                return createFilter(maxNumClauses, executionType, uniqueValuesLookup, BooleanClause.Occur.MUST, BooleanClause.Occur.MUST_NOT, BooleanClause.Occur.SHOULD);
+            }
+        },
+        MUST_MOST_NOT {
+            @Override
+            public XBooleanFilter filter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup) {
+                return createFilter(maxNumClauses, executionType, uniqueValuesLookup, BooleanClause.Occur.MUST, BooleanClause.Occur.MUST_NOT);
+            }
+        },
+        ONLY_MUST {
+            @Override
+            public XBooleanFilter filter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup) {
+                return createFilter(maxNumClauses, executionType, uniqueValuesLookup, BooleanClause.Occur.MUST);
+            }
+        },
+        ONLY_MUST_NOT {
+            @Override
+            public XBooleanFilter filter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup) {
+                return createFilter(maxNumClauses, executionType, uniqueValuesLookup, BooleanClause.Occur.MUST_NOT);
+            }
+        };
+
+        public abstract XBooleanFilter filter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup);
+
+        private static XBooleanFilter createFilter(int maxNumClauses, ExecutionType executionType, String[] uniqueValuesLookup, BooleanClause.Occur... occurs) {
+            XBooleanFilter booleanFilter = new XBooleanFilter();
+            List<BooleanClause.Occur> suffledOccurs = Arrays.asList(occurs);
+            Collections.shuffle(suffledOccurs);
+            int numClauses = 1 + random.nextInt(maxNumClauses);
+            for (int i = 0; i < numClauses; i++) {
+                String field = Integer.toString(i);
+                String randomValue = uniqueValuesLookup[random.nextInt(uniqueValuesLookup.length)];
+
+                final Filter filter;
+                if (executionType.fast()) {
+                    // TermsFilter always result into FBS, TermFilter not.
+                    filter = new TermsFilter(new Term(field, randomValue));
+                } else {
+                    filter = new XBooleanFilterTests.PrettyPrintFieldCacheTermsFilter(field, randomValue);
+                }
+                booleanFilter.add(filter, suffledOccurs.get(i % suffledOccurs.size()));
+            }
+            return booleanFilter;
+        }
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/common/lucene/search/XBooleanClausesOrderingTests.java
+++ b/src/test/java/org/elasticsearch/common/lucene/search/XBooleanClausesOrderingTests.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.elasticsearch.common.lucene.search;
+
+import org.apache.lucene.queries.FilterClause;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.test.ElasticsearchLuceneTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class XBooleanClausesOrderingTests extends ElasticsearchLuceneTestCase {
+
+    final static FilterClause must = new FilterClause(null, BooleanClause.Occur.MUST);
+    final static FilterClause mustNot = new FilterClause(null, BooleanClause.Occur.MUST_NOT);
+    final static FilterClause should = new FilterClause(null, BooleanClause.Occur.SHOULD);
+
+    @Test
+    public void testOrdering() throws Exception {
+        List<XBooleanFilter.ResultClause> clauses = new ArrayList<XBooleanFilter.ResultClause>();
+        XBooleanFilter.ResultClause resultClause1 = new XBooleanFilter.ResultClause(mockBits, null, must, new MockIterator(10));
+        clauses.add(resultClause1);
+        XBooleanFilter.ResultClause resultClause2 = new XBooleanFilter.ResultClause(null, null, must, new MockIterator(10));
+        clauses.add(resultClause2);
+        XBooleanFilter.ResultClause resultClause3 = new XBooleanFilter.ResultClause(mockBits, null, should, new MockIterator(5));
+        clauses.add(resultClause3);
+        XBooleanFilter.ResultClause resultClause4 = new XBooleanFilter.ResultClause(null, null, should, new MockIterator(5));
+        clauses.add(resultClause4);
+
+        Comparator<XBooleanFilter.ResultClause> comparator = new XBooleanFilter.AllClausesProcessor(null, null, -1).comparator();
+        CollectionUtil.timSort(clauses, comparator);
+        assertSame(resultClause4, clauses.get(0));
+        assertSame(resultClause2, clauses.get(1));
+        assertSame(resultClause3, clauses.get(2));
+        assertSame(resultClause1, clauses.get(3));
+    }
+
+    @Test
+    public void testOrdering_withMustNot() throws Exception {
+        List<XBooleanFilter.ResultClause> clauses = new ArrayList<XBooleanFilter.ResultClause>();
+        XBooleanFilter.ResultClause resultClause1 = new XBooleanFilter.ResultClause(mockBits, null, mustNot, new MockIterator(10));
+        clauses.add(resultClause1);
+        XBooleanFilter.ResultClause resultClause2 = new XBooleanFilter.ResultClause(null, null, mustNot, new MockIterator(10));
+        clauses.add(resultClause2);
+        XBooleanFilter.ResultClause resultClause3 = new XBooleanFilter.ResultClause(mockBits, null, must, new MockIterator(5));
+        clauses.add(resultClause3);
+        XBooleanFilter.ResultClause resultClause4 = new XBooleanFilter.ResultClause(null, null, should, new MockIterator(5));
+        clauses.add(resultClause4);
+
+        Comparator<XBooleanFilter.ResultClause> comparator = new XBooleanFilter.AllClausesProcessor(null, null, -1).comparator();
+        CollectionUtil.timSort(clauses, comparator);
+        assertSame(resultClause2, clauses.get(0));
+        assertSame(resultClause4, clauses.get(1));
+        assertSame(resultClause1, clauses.get(2));
+        assertSame(resultClause3, clauses.get(3));
+    }
+
+
+    Bits mockBits = new Bits() {
+
+        @Override
+        public boolean get(int index) {
+            return false;
+        }
+
+        @Override
+        public int length() {
+            return 0;
+        }
+    };
+
+
+    class MockIterator extends DocIdSetIterator {
+
+        final long cost;
+
+        MockIterator(long cost) {
+            this.cost = cost;
+        }
+
+        @Override
+        public int docID() {
+            return 0;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return 0;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return 0;
+        }
+
+        @Override
+        public long cost() {
+            return cost;
+        }
+    }
+
+
+}

--- a/src/test/java/org/elasticsearch/common/lucene/search/XBooleanFilterLuceneTests.java
+++ b/src/test/java/org/elasticsearch/common/lucene/search/XBooleanFilterLuceneTests.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
@@ -129,19 +128,19 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testShould() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.SHOULD);
         tstFilterCard("Should retrieves only 1 doc", 1, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getWrappedTermQuery("price", "030"), BooleanClause.Occur.SHOULD);
         tstFilterCard("Should retrieves only 1 doc", 1, booleanFilter);
     }
 
     @Test
     public void testShoulds() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "010", "020"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getRangeFilter("price", "020", "030"), BooleanClause.Occur.SHOULD);
         tstFilterCard("Shoulds are Ored together", 5, booleanFilter);
@@ -149,7 +148,7 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testShouldsAndMustNot() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "010", "020"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getRangeFilter("price", "020", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("inStock", "N"), BooleanClause.Occur.MUST_NOT);
@@ -159,7 +158,7 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
         tstFilterCard("Shoulds Ored but AndNots", 3, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "010", "020"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getRangeFilter("price", "020", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getWrappedTermQuery("inStock", "N"), BooleanClause.Occur.MUST_NOT);
@@ -171,14 +170,14 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testShouldsAndMust() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "010", "020"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getRangeFilter("price", "020", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
         tstFilterCard("Shoulds Ored but MUST", 3, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "010", "020"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getRangeFilter("price", "020", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getWrappedTermQuery("accessRights", "admin"), BooleanClause.Occur.MUST);
@@ -187,7 +186,7 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testShouldsAndMusts() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "010", "020"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getRangeFilter("price", "020", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
@@ -197,7 +196,7 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testShouldsAndMustsAndMustNot() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "030", "040"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
         booleanFilter.add(getRangeFilter("date", "20050101", "20051231"), BooleanClause.Occur.MUST);
@@ -205,7 +204,7 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
         tstFilterCard("Shoulds Ored but MUSTs ANDED and MustNot", 0, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getRangeFilter("price", "030", "040"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getWrappedTermQuery("accessRights", "admin"), BooleanClause.Occur.MUST);
         booleanFilter.add(getRangeFilter("date", "20050101", "20051231"), BooleanClause.Occur.MUST);
@@ -215,37 +214,37 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testJustMust() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
         tstFilterCard("MUST", 3, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getWrappedTermQuery("accessRights", "admin"), BooleanClause.Occur.MUST);
         tstFilterCard("MUST", 3, booleanFilter);
     }
 
     @Test
     public void testJustMustNot() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("inStock", "N"), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("MUST_NOT", 4, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getWrappedTermQuery("inStock", "N"), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("MUST_NOT", 4, booleanFilter);
     }
 
     @Test
     public void testMustAndMustNot() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("inStock", "N"), BooleanClause.Occur.MUST);
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("MUST_NOT wins over MUST for same docs", 0, booleanFilter);
 
         // same with a real DISI (no OpenBitSetIterator)
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getWrappedTermQuery("inStock", "N"), BooleanClause.Occur.MUST);
         booleanFilter.add(getWrappedTermQuery("price", "030"), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("MUST_NOT wins over MUST for same docs", 0, booleanFilter);
@@ -253,38 +252,38 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testEmpty() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         tstFilterCard("empty XBooleanFilter returns no results", 0, booleanFilter);
     }
 
     @Test
     public void testCombinedNullDocIdSets() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.MUST);
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.MUST);
         tstFilterCard("A MUST filter that returns a null DIS should never return documents", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.MUST);
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.MUST);
         tstFilterCard("A MUST filter that returns a null DISI should never return documents", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.SHOULD);
         tstFilterCard("A SHOULD filter that returns a null DIS should be invisible", 1, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.SHOULD);
         tstFilterCard("A SHOULD filter that returns a null DISI should be invisible", 1, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.MUST);
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("A MUST_NOT filter that returns a null DIS should be invisible", 1, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("price", "030"), BooleanClause.Occur.MUST);
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("A MUST_NOT filter that returns a null DISI should be invisible", 1, booleanFilter);
@@ -292,44 +291,44 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testJustNullDocIdSets() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.MUST);
         tstFilterCard("A MUST filter that returns a null DIS should never return documents", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.MUST);
         tstFilterCard("A MUST filter that returns a null DISI should never return documents", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.SHOULD);
         tstFilterCard("A single SHOULD filter that returns a null DIS should never return documents", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.SHOULD);
         tstFilterCard("A single SHOULD filter that returns a null DISI should never return documents", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("A single MUST_NOT filter that returns a null DIS should be invisible", 5, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.MUST_NOT);
         tstFilterCard("A single MUST_NOT filter that returns a null DIS should be invisible", 5, booleanFilter);
     }
 
     @Test
     public void testNonMatchingShouldsAndMusts() throws Exception {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getEmptyFilter(), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
         tstFilterCard(">0 shoulds with no matches should return no docs", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISFilter(), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
         tstFilterCard(">0 shoulds with no matches should return no docs", 0, booleanFilter);
 
-        booleanFilter = new XBooleanFilter();
+        booleanFilter = booleanFilter();
         booleanFilter.add(getNullDISIFilter(), BooleanClause.Occur.SHOULD);
         booleanFilter.add(getTermsFilter("accessRights", "admin"), BooleanClause.Occur.MUST);
         tstFilterCard(">0 shoulds with no matches should return no docs", 0, booleanFilter);
@@ -337,36 +336,40 @@ public class XBooleanFilterLuceneTests extends ElasticsearchTestCase {
 
     @Test
     public void testToStringOfBooleanFilterContainingTermsFilter() {
-        XBooleanFilter booleanFilter = new XBooleanFilter();
+        XBooleanFilter booleanFilter = booleanFilter();
         booleanFilter.add(getTermsFilter("inStock", "N"), BooleanClause.Occur.MUST);
         booleanFilter.add(getTermsFilter("isFragile", "Y"), BooleanClause.Occur.MUST);
 
-        assertThat("BooleanFilter(+inStock:N +isFragile:Y)", equalTo(booleanFilter.toString()));
+        assertThat("BooleanFilter(+inStock:N +isFragile:Y)~1", equalTo(booleanFilter.toString()));
     }
 
     @Test
     public void testToStringOfWrappedBooleanFilters() {
-        XBooleanFilter orFilter = new XBooleanFilter();
+        XBooleanFilter orFilter = booleanFilter();
 
-        XBooleanFilter stockFilter = new XBooleanFilter();
+        XBooleanFilter stockFilter = booleanFilter();
         stockFilter.add(new FilterClause(getTermsFilter("inStock", "Y"), BooleanClause.Occur.MUST));
         stockFilter.add(new FilterClause(getTermsFilter("barCode", "12345678"), BooleanClause.Occur.MUST));
 
         orFilter.add(new FilterClause(stockFilter, BooleanClause.Occur.SHOULD));
 
-        XBooleanFilter productPropertyFilter = new XBooleanFilter();
+        XBooleanFilter productPropertyFilter = booleanFilter();
         productPropertyFilter.add(new FilterClause(getTermsFilter("isHeavy", "N"), BooleanClause.Occur.MUST));
         productPropertyFilter.add(new FilterClause(getTermsFilter("isDamaged", "Y"), BooleanClause.Occur.MUST));
 
         orFilter.add(new FilterClause(productPropertyFilter, BooleanClause.Occur.SHOULD));
 
-        XBooleanFilter composedFilter = new XBooleanFilter();
+        XBooleanFilter composedFilter = booleanFilter();
         composedFilter.add(new FilterClause(orFilter, BooleanClause.Occur.MUST));
 
         assertThat(
-                "BooleanFilter(+BooleanFilter(BooleanFilter(+inStock:Y +barCode:12345678) BooleanFilter(+isHeavy:N +isDamaged:Y)))",
+                "BooleanFilter(+BooleanFilter(BooleanFilter(+inStock:Y +barCode:12345678)~1 BooleanFilter(+isHeavy:N +isDamaged:Y)~1)~1)~1",
                 equalTo(composedFilter.toString())
         );
+    }
+    
+    private static XBooleanFilter booleanFilter() {
+        return XBooleanFilter.booleanFilter();
     }
 
 }

--- a/src/test/java/org/elasticsearch/common/lucene/search/XBooleanFilterTests.java
+++ b/src/test/java/org/elasticsearch/common/lucene/search/XBooleanFilterTests.java
@@ -6,7 +6,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.queries.FilterClause;
-import org.apache.lucene.queries.TermFilter;
+import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.*;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.FixedBitSet;
@@ -18,7 +18,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.lucene.search.BooleanClause.Occur.*;
@@ -68,17 +67,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     public void testWithTwoClausesOfEachOccur_allFixedBitsetFilters() throws Exception {
         List<XBooleanFilter> booleanFilters = new ArrayList<XBooleanFilter>();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, false),
+                1, newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, false),
                 newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, false),
                 newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, false)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, false),
+                1, newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, false),
                 newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, false),
                 newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, false)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, false),
+                1, newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, false),
                 newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, false),
                 newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, false)
         ));
@@ -97,17 +96,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     public void testWithTwoClausesOfEachOccur_allBitsBasedFilters() throws Exception {
         List<XBooleanFilter> booleanFilters = new ArrayList<XBooleanFilter>();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, true),
+                1, newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, true),
                 newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, true),
                 newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, true)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, true),
+                1, newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, true),
                 newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, true),
                 newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, true)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, true),
+                1, newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, true),
                 newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, true),
                 newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, true)
         ));
@@ -126,17 +125,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     public void testWithTwoClausesOfEachOccur_allFilterTypes() throws Exception {
         List<XBooleanFilter> booleanFilters = new ArrayList<XBooleanFilter>();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, false),
+                1, newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, false),
                 newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, false),
                 newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, false)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, false),
+                1, newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, false),
                 newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, false),
                 newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, false)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, false),
+                1, newFilterClause(2, 'c', SHOULD, true), newFilterClause(3, 'd', SHOULD, false),
                 newFilterClause(4, 'e', MUST_NOT, true), newFilterClause(5, 'f', MUST_NOT, false),
                 newFilterClause(0, 'a', MUST, true), newFilterClause(1, 'b', MUST, false)
         ));
@@ -152,17 +151,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
 
         booleanFilters.clear();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, true),
+                1, newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, true),
                 newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, true),
                 newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, true)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, true),
+                1, newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, true),
                 newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, true),
                 newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, true)
         ));
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, true),
+                1, newFilterClause(2, 'c', SHOULD, false), newFilterClause(3, 'd', SHOULD, true),
                 newFilterClause(4, 'e', MUST_NOT, false), newFilterClause(5, 'f', MUST_NOT, true),
                 newFilterClause(0, 'a', MUST, false), newFilterClause(1, 'b', MUST, true)
         ));
@@ -181,7 +180,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     public void testWithTwoClausesOfEachOccur_singleClauseOptimisation() throws Exception {
         List<XBooleanFilter> booleanFilters = new ArrayList<XBooleanFilter>();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'b', MUST, true)
+                1, newFilterClause(1, 'b', MUST, true)
         ));
 
         for (XBooleanFilter booleanFilter : booleanFilters) {
@@ -195,7 +194,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
 
         booleanFilters.clear();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'c', MUST_NOT, true)
+                1, newFilterClause(1, 'c', MUST_NOT, true)
         ));
         for (XBooleanFilter booleanFilter : booleanFilters) {
             FixedBitSet result = new FixedBitSet(reader.maxDoc());
@@ -208,7 +207,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
 
         booleanFilters.clear();
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(2, 'c', SHOULD, true)
+                1, newFilterClause(2, 'c', SHOULD, true)
         ));
         for (XBooleanFilter booleanFilter : booleanFilters) {
             FixedBitSet result = new FixedBitSet(reader.maxDoc());
@@ -226,17 +225,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
         // 2 slow filters
         // This case caused: https://github.com/elasticsearch/elasticsearch/issues/2826
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'a', SHOULD, true),
+                1, newFilterClause(1, 'a', SHOULD, true),
                 newFilterClause(1, 'b', SHOULD, true)
         ));
         // 2 fast filters
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'a', SHOULD, false),
+                1, newFilterClause(1, 'a', SHOULD, false),
                 newFilterClause(1, 'b', SHOULD, false)
         ));
         // 1 fast filters, 1 slow filter
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'a', SHOULD, true),
+                1, newFilterClause(1, 'a', SHOULD, true),
                 newFilterClause(1, 'b', SHOULD, false)
         ));
 
@@ -255,17 +254,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
         List<XBooleanFilter> booleanFilters = new ArrayList<XBooleanFilter>();
         // Slow filters
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(3, 'd', MUST, true),
+                1, newFilterClause(3, 'd', MUST, true),
                 newFilterClause(3, 'd', MUST, true)
         ));
         // 2 fast filters
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(3, 'd', MUST, false),
+                1, newFilterClause(3, 'd', MUST, false),
                 newFilterClause(3, 'd', MUST, false)
         ));
         // 1 fast filters, 1 slow filter
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(3, 'd', MUST, true),
+                1, newFilterClause(3, 'd', MUST, true),
                 newFilterClause(3, 'd', MUST, false)
         ));
         for (XBooleanFilter booleanFilter : booleanFilters) {
@@ -283,17 +282,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
         List<XBooleanFilter> booleanFilters = new ArrayList<XBooleanFilter>();
         // Slow filters
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'a', MUST_NOT, true),
+                1, newFilterClause(1, 'a', MUST_NOT, true),
                 newFilterClause(1, 'a', MUST_NOT, true)
         ));
         // 2 fast filters
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'a', MUST_NOT, false),
+                1, newFilterClause(1, 'a', MUST_NOT, false),
                 newFilterClause(1, 'a', MUST_NOT, false)
         ));
         // 1 fast filters, 1 slow filter
         booleanFilters.add(createBooleanFilter(
-                newFilterClause(1, 'a', MUST_NOT, true),
+                1, newFilterClause(1, 'a', MUST_NOT, true),
                 newFilterClause(1, 'a', MUST_NOT, false)
         ));
         for (XBooleanFilter booleanFilter : booleanFilters) {
@@ -309,7 +308,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     @Test
     public void testNonMatchingSlowShouldWithMatchingMust() throws Exception {
         XBooleanFilter booleanFilter = createBooleanFilter(
-                newFilterClause(0, 'a', MUST, false),
+                1, newFilterClause(0, 'a', MUST, false),
                 newFilterClause(0, 'b', SHOULD, true)
         );
 
@@ -320,7 +319,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     @Test
     public void testSlowShouldClause_atLeastOneShouldMustMatch() throws Exception {
         XBooleanFilter booleanFilter = createBooleanFilter(
-                newFilterClause(0, 'a', MUST, false),
+                1, newFilterClause(0, 'a', MUST, false),
                 newFilterClause(1, 'a', SHOULD, true)
         );
 
@@ -332,7 +331,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
         assertThat(result.get(2), equalTo(true));
 
         booleanFilter = createBooleanFilter(
-                newFilterClause(0, 'a', MUST, false),
+                1, newFilterClause(0, 'a', MUST, false),
                 newFilterClause(1, 'a', SHOULD, true),
                 newFilterClause(4, 'z', SHOULD, true)
         );
@@ -349,7 +348,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     // See issue: https://github.com/elasticsearch/elasticsearch/issues/4130
     public void testOneFastMustNotOneFastShouldAndOneSlowShould() throws Exception {
         XBooleanFilter booleanFilter = createBooleanFilter(
-                newFilterClause(4, 'v', MUST_NOT, false),
+                1, newFilterClause(4, 'v', MUST_NOT, false),
                 newFilterClause(4, 'z', SHOULD, false),
                 newFilterClause(4, 'x', SHOULD, true)
         );
@@ -365,7 +364,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     @Test
     public void testOneFastShouldClauseAndOneSlowShouldClause() throws Exception {
         XBooleanFilter booleanFilter = createBooleanFilter(
-                newFilterClause(4, 'z', SHOULD, false),
+                1, newFilterClause(4, 'z', SHOULD, false),
                 newFilterClause(4, 'x', SHOULD, true)
         );
 
@@ -380,7 +379,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
     @Test
     public void testOneMustClauseOneFastShouldClauseAndOneSlowShouldClause() throws Exception {
         XBooleanFilter booleanFilter = createBooleanFilter(
-                newFilterClause(0, 'a', MUST, false),
+                1, newFilterClause(0, 'a', MUST, false),
                 newFilterClause(4, 'z', SHOULD, false),
                 newFilterClause(4, 'x', SHOULD, true)
         );
@@ -399,13 +398,15 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
             filter = new PrettyPrintFieldCacheTermsFilter(String.valueOf(field), String.valueOf(character));
         } else {
             Term term = new Term(String.valueOf(field), String.valueOf(character));
-            filter = new TermFilter(term);
+            // TermsFilter always result into FBS, TermFilter never, this will then also test: DocIdSets#isFastIterator()
+            filter = new TermsFilter(term);
         }
         return new FilterClause(filter, occur);
     }
 
-    private static XBooleanFilter createBooleanFilter(FilterClause... clauses) {
+    private static XBooleanFilter createBooleanFilter(int minimumShouldMatch, FilterClause... clauses) {
         XBooleanFilter booleanFilter = new XBooleanFilter();
+        booleanFilter.setMinimumShouldMatch(minimumShouldMatch);
         for (FilterClause clause : clauses) {
             booleanFilter.add(clause);
         }
@@ -419,7 +420,6 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
             int numClauses = 1 + random().nextInt(10);
             FilterClause[] clauses = new FilterClause[numClauses];
             BooleanQuery topLevel = new BooleanQuery();
-            BooleanQuery orQuery = new BooleanQuery();
             boolean hasMust = false;
             boolean hasShould = false;
             boolean hasMustNot = false;
@@ -442,7 +442,7 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
                     case 1:
                         hasShould = true;
                         clauses[i] = newFilterClause(field, value, SHOULD, random().nextBoolean());
-                        orQuery.add(new BooleanClause(new TermQuery(new Term(String.valueOf(field), String.valueOf(value))), SHOULD));
+                        topLevel.add(new BooleanClause(new TermQuery(new Term(String.valueOf(field), String.valueOf(value))), SHOULD));
                         break;
                     case 0:
                         hasMustNot = true;
@@ -452,13 +452,17 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
 
                 }
             }
-            if (orQuery.getClauses().length > 0) {
-                topLevel.add(new BooleanClause(orQuery, MUST));
-            }
             if (hasMustNot && !hasMust && !hasShould) {  // pure negative
                 topLevel.add(new BooleanClause(new MatchAllDocsQuery(), MUST));
             }
-            XBooleanFilter booleanFilter = createBooleanFilter(clauses);
+
+            // BQ can only deal with msm if there are should clauses
+            int minimumShouldMatch = 0;
+            if (hasShould) {
+                minimumShouldMatch = numClauses / 2;
+            }
+            topLevel.setMinimumNumberShouldMatch(minimumShouldMatch);
+            XBooleanFilter booleanFilter = createBooleanFilter(minimumShouldMatch, clauses);
 
             FixedBitSet leftResult = new FixedBitSet(reader.maxDoc());
             FixedBitSet rightResult = new FixedBitSet(reader.maxDoc());
@@ -466,10 +470,10 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
             DocIdSet right = new QueryWrapperFilter(topLevel).getDocIdSet(reader.getContext(), reader.getLiveDocs());
             if (left == null || right == null) {
                 if (left == null && right != null) {
-                    assertThat(errorMsg(clauses, topLevel), (right.iterator() == null ? DocIdSetIterator.NO_MORE_DOCS : right.iterator().nextDoc()), equalTo(DocIdSetIterator.NO_MORE_DOCS));
+                    assertThat(errorMsg(iter, booleanFilter, topLevel), (right.iterator() == null ? DocIdSetIterator.NO_MORE_DOCS : right.iterator().nextDoc()), equalTo(DocIdSetIterator.NO_MORE_DOCS));
                 }
                 if (left != null && right == null) {
-                    assertThat(errorMsg(clauses, topLevel), (left.iterator() == null ? DocIdSetIterator.NO_MORE_DOCS : left.iterator().nextDoc()), equalTo(DocIdSetIterator.NO_MORE_DOCS));
+                    assertThat(errorMsg(iter, booleanFilter, topLevel), (left.iterator() == null ? DocIdSetIterator.NO_MORE_DOCS : left.iterator().nextDoc()), equalTo(DocIdSetIterator.NO_MORE_DOCS));
                 }
             } else {
                 DocIdSetIterator leftIter = left.iterator();
@@ -482,16 +486,16 @@ public class XBooleanFilterTests extends ElasticsearchLuceneTestCase {
                     rightResult.or(rightIter);
                 }
 
-                assertThat(leftResult.cardinality(), equalTo(rightResult.cardinality()));
+                assertThat(errorMsg(iter, booleanFilter, topLevel), leftResult.cardinality(), equalTo(rightResult.cardinality()));
                 for (int i = 0; i < reader.maxDoc(); i++) {
-                    assertThat(errorMsg(clauses, topLevel) + " -- failed at index " + i, leftResult.get(i), equalTo(rightResult.get(i)));
+                    assertThat(errorMsg(iter, booleanFilter, topLevel) + " -- failed at index " + i, leftResult.get(i), equalTo(rightResult.get(i)));
                 }
             }
         }
     }
 
-    private String errorMsg(FilterClause[] clauses, BooleanQuery query) {
-        return query.toString() + " vs. " + Arrays.toString(clauses);
+    private String errorMsg(int iter, XBooleanFilter filter, BooleanQuery query) {
+        return "iter:" + Integer.toString(iter) + " " + query.toString() + " vs. " + filter.toString();
     }
 
 

--- a/src/test/java/org/elasticsearch/index/aliases/IndexAliasesServiceTests.java
+++ b/src/test/java/org/elasticsearch/index/aliases/IndexAliasesServiceTests.java
@@ -52,7 +52,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -108,7 +107,7 @@ public class IndexAliasesServiceTests extends ElasticsearchTestCase {
         assertThat(indexAliasesService.hasAlias("turtles"), equalTo(false));
 
         assertThat(indexAliasesService.aliasFilter("cats").toString(), equalTo("cache(animal:cat)"));
-        assertThat(indexAliasesService.aliasFilter("cats", "dogs").toString(), equalTo("BooleanFilter(cache(animal:cat) cache(animal:dog))"));
+        assertThat(indexAliasesService.aliasFilter("cats", "dogs").toString(), equalTo("BooleanFilter(cache(animal:cat) cache(animal:dog))~1"));
 
         // Non-filtering alias should turn off all filters because filters are ORed
         assertThat(indexAliasesService.aliasFilter("all"), nullValue());
@@ -117,7 +116,7 @@ public class IndexAliasesServiceTests extends ElasticsearchTestCase {
 
         indexAliasesService.add("cats", filter(termFilter("animal", "feline")));
         indexAliasesService.add("dogs", filter(termFilter("animal", "canine")));
-        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:canine) cache(animal:feline))"));
+        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:canine) cache(animal:feline))~1"));
     }
 
     @Test
@@ -128,12 +127,12 @@ public class IndexAliasesServiceTests extends ElasticsearchTestCase {
 
         assertThat(indexAliasesService.aliasFilter(), nullValue());
         assertThat(indexAliasesService.aliasFilter("dogs").toString(), equalTo("cache(animal:dog)"));
-        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:dog) cache(animal:cat))"));
+        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:dog) cache(animal:cat))~1"));
 
         indexAliasesService.add("cats", filter(termFilter("animal", "feline")));
         indexAliasesService.add("dogs", filter(termFilter("animal", "canine")));
 
-        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:canine) cache(animal:feline))"));
+        assertThat(indexAliasesService.aliasFilter("dogs", "cats").toString(), equalTo("BooleanFilter(cache(animal:canine) cache(animal:feline))~1"));
     }
 
     @Test(expected = InvalidAliasNameException.class)


### PR DESCRIPTION
- Reordered logic in XBooleanFilter to support notion of a strategy on how to best execute the clauses.
- Added the or and and filter as a strategy to XBooleanFilter.
- Added minimum should match support to XBooleanFilter.
- Made sure that all places where XBooleanFilter is used, that minimum_should_match=1 in order to maintain the bw comp. with the previous version of this filter (forced implicit minimum_should_match=1).
