### PR TITLE
Prevent modification or deletion of repositories while snapshots are running

### DIFF
--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -423,6 +423,24 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
         }
     }
 
+    /**
+     * Checks if a repository is currently in use by one of the snapshots
+     * @param clusterState cluster state
+     * @param repository repository id
+     * @return true if repository is currently in use by one of the running snapshots
+     */
+    public static boolean isRepositoryInUse(ClusterState clusterState, String repository) {
+        MetaData metaData = clusterState.metaData();
+        RestoreMetaData snapshots = metaData.custom(RestoreMetaData.TYPE);
+        if (snapshots != null) {
+            for(RestoreMetaData.Entry snapshot : snapshots.entries()) {
+                if(repository.equals(snapshot.snapshotId().getRepository())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     /**
      * Restore snapshot request

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -901,7 +901,7 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
                 ShardRouting primary = indexRoutingTable.shard(i).primaryShard();
                 if (primary == null || !primary.assignedToNode()) {
                     //TODO: Should we bailout completely or just mark this shard as failed?
-                    builder.put(shardId, new SnapshotMetaData.ShardSnapshotStatus(primary.currentNodeId(), State.FAILED, "primary shard is not allocated"));
+                    builder.put(shardId, new SnapshotMetaData.ShardSnapshotStatus(null, State.FAILED, "primary shard is not allocated"));
                 } else if (!primary.started()) {
                     builder.put(shardId, new SnapshotMetaData.ShardSnapshotStatus(primary.currentNodeId(), State.FAILED, "primary shard hasn't been started yet"));
                 } else {

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -292,8 +292,7 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
                         }
                     }
                     mdBuilder.putCustom(SnapshotMetaData.TYPE, new SnapshotMetaData(entries.build()));
-                    ClusterState newState = ClusterState.builder(currentState).metaData(mdBuilder).build();
-                    return newState;
+                    return ClusterState.builder(currentState).metaData(mdBuilder).build();
                 }
 
                 @Override
@@ -841,6 +840,25 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
     }
 
     /**
+     * Checks if a repository is currently in use by one of the snapshots
+     * @param clusterState cluster state
+     * @param repository repository id
+     * @return true if repository is currently in use by one of the running snapshots
+     */
+    public static boolean isRepositoryInUse(ClusterState clusterState, String repository) {
+        MetaData metaData = clusterState.metaData();
+        SnapshotMetaData snapshots = metaData.custom(SnapshotMetaData.TYPE);
+        if (snapshots != null) {
+            for(SnapshotMetaData.Entry snapshot : snapshots.entries()) {
+                if(repository.equals(snapshot.snapshotId().getRepository())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Deletes snapshot from repository
      *
      * @param snapshotId snapshot id
@@ -941,8 +959,6 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
 
         /**
          * Called if delete operation failed
-         *
-         * @param t
          */
         void onFailure(Throwable t);
     }

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.snapshots;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.client.Client;

--- a/src/test/java/org/elasticsearch/test/store/MockRamDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/MockRamDirectoryService.java
@@ -29,13 +29,13 @@ import org.elasticsearch.index.store.DirectoryService;
 
 import java.io.IOException;
 
-public class MockRamDirecorySerivce extends AbstractIndexShardComponent implements DirectoryService {
+public class MockRamDirectoryService extends AbstractIndexShardComponent implements DirectoryService {
 
     private final MockDirectoryHelper helper;
     private final DirectoryService delegateService;
 
     @Inject
-    public MockRamDirecorySerivce(ShardId shardId, Settings indexSettings, ByteBufferCache byteBufferCache) {
+    public MockRamDirectoryService(ShardId shardId, Settings indexSettings, ByteBufferCache byteBufferCache) {
         super(shardId, indexSettings);
         helper = new MockDirectoryHelper(shardId, indexSettings, logger);
         delegateService = helper.randomRamDirecoryService(byteBufferCache);

--- a/src/test/java/org/elasticsearch/test/store/MockRamIndexStore.java
+++ b/src/test/java/org/elasticsearch/test/store/MockRamIndexStore.java
@@ -45,7 +45,7 @@ public class MockRamIndexStore extends AbstractIndexStore{
 
     @Override
     public Class<? extends DirectoryService> shardDirectory() {
-        return MockRamDirecorySerivce.class;
+        return MockRamDirectoryService.class;
     }
 
     @Override


### PR DESCRIPTION
It shouldn't be possible to delete or modify parameters of a repository that is currently in use by one of the running snapshots.
