### PR TITLE
Removing EOL client rubberband and adding official php client

### DIFF
--- a/docs/community/clients.asciidoc
+++ b/docs/community/clients.asciidoc
@@ -45,11 +45,14 @@ See the http://www.elasticsearch.org/guide/en/elasticsearch/client/ruby-api/curr
 * https://github.com/wireframe/elastic_searchable/[elastic_searchable]:
   Ruby client + Rails integration.
 
+* https://github.com/ddnexus/flex[Flex]:
+  Ruby Client.
+
 
 [[community-php]]
 === PHP
 
-See the http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/current/index.html[offical Elasticsearch Php client
+See the http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/current/index.html[official Elasticsearch Php client]
 
 * http://github.com/ruflin/Elastica[Elastica]:
   PHP client.
@@ -59,6 +62,8 @@ See the http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/curre
 * http://github.com/polyfractal/Sherlock[Sherlock]:
   PHP client, one-to-one mapping with query DSL, fluid interface.
 
+* https://github.com/nervetattoo/elasticsearch[elasticsearch]
+  PHP 5.3 client
 
 [[community-java]]
 === Java
@@ -179,3 +184,7 @@ See the http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/curre
 * https://github.com/jasonfill/ColdFusion-ElasticSearch-Client[ColdFusion-ElasticSearch-Client]
   Cold Fusion client for Elasticsearch
 
+[[community-nodejs]]
+=== NodeJS
+* https://github.com/phillro/node-elasticsearch-client[Node-Elasticsearch-Client]
+  A node.js client for elasticsearch

--- a/docs/community/clients.asciidoc
+++ b/docs/community/clients.asciidoc
@@ -39,9 +39,6 @@ See the http://www.elasticsearch.org/guide/en/elasticsearch/client/ruby-api/curr
 * http://github.com/karmi/tire[Tire]:
   Ruby API & DSL, with ActiveRecord/ActiveModel integration.
 
-* http://github.com/grantr/rubberband[rubberband]:
-  Ruby client.
-
 * https://github.com/PoseBiz/stretcher[stretcher]:
   Ruby client.
 
@@ -51,6 +48,8 @@ See the http://www.elasticsearch.org/guide/en/elasticsearch/client/ruby-api/curr
 
 [[community-php]]
 === PHP
+
+See the http://www.elasticsearch.org/guide/en/elasticsearch/client/php-api/current/index.html[offical Elasticsearch Php client
 
 * http://github.com/ruflin/Elastica[Elastica]:
   PHP client.


### PR DESCRIPTION
- Removing EOL client rubberband ( see https://github.com/grantr/rubberband )
- Adding official php client

Update 1:
- Fix typo
- Add some more clients
