### PR TITLE
Added mlockall setting to process info output

### DIFF
--- a/src/main/java/org/elasticsearch/common/jna/Natives.java
+++ b/src/main/java/org/elasticsearch/common/jna/Natives.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.common.jna;
 
-import java.util.Locale;
-
 import com.sun.jna.Native;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+
+import java.util.Locale;
 
 /**
  *
@@ -31,13 +31,17 @@ import org.elasticsearch.common.logging.Loggers;
 public class Natives {
 
     private static ESLogger logger = Loggers.getLogger(Natives.class);
+    public static boolean LOCAL_MLOCKALL_CONFIGURED = false;
 
     public static void tryMlockall() {
         int errno = Integer.MIN_VALUE;
         try {
             int result = CLibrary.mlockall(CLibrary.MCL_CURRENT);
-            if (result != 0)
+            if (result != 0) {
                 errno = Native.getLastError();
+            } else {
+                LOCAL_MLOCKALL_CONFIGURED = true;
+            }
         } catch (UnsatisfiedLinkError e) {
             // this will have already been logged by CLibrary, no need to repeat it
             return;

--- a/src/main/java/org/elasticsearch/monitor/process/ProcessInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/process/ProcessInfo.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.monitor.process;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.jna.Natives;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
@@ -40,6 +42,8 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
 
     private long maxFileDescriptors = -1;
 
+    private boolean mlockall;
+
     ProcessInfo() {
 
     }
@@ -47,6 +51,7 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
     public ProcessInfo(long id, long maxFileDescriptors) {
         this.id = id;
         this.maxFileDescriptors = maxFileDescriptors;
+        this.mlockall = Natives.LOCAL_MLOCKALL_CONFIGURED;
     }
 
     public long refreshInterval() {
@@ -79,11 +84,20 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
         return maxFileDescriptors;
     }
 
+    public boolean mlockAll() {
+        return mlockall;
+    }
+
+    public boolean isMlockall() {
+        return mlockall;
+    }
+
     static final class Fields {
         static final XContentBuilderString PROCESS = new XContentBuilderString("process");
         static final XContentBuilderString REFRESH_INTERVAL = new XContentBuilderString("refresh_interval");
         static final XContentBuilderString ID = new XContentBuilderString("id");
         static final XContentBuilderString MAX_FILE_DESCRIPTORS = new XContentBuilderString("max_file_descriptors");
+        static final XContentBuilderString MLOCKALL = new XContentBuilderString("mlockall");
     }
 
     @Override
@@ -92,6 +106,7 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
         builder.field(Fields.REFRESH_INTERVAL, refreshInterval);
         builder.field(Fields.ID, id);
         builder.field(Fields.MAX_FILE_DESCRIPTORS, maxFileDescriptors);
+        builder.field(Fields.MLOCKALL, mlockall);
         builder.endObject();
         return builder;
     }
@@ -107,6 +122,9 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
         refreshInterval = in.readLong();
         id = in.readLong();
         maxFileDescriptors = in.readLong();
+        if (in.getVersion().after(Version.V_0_90_7)) {
+            mlockall = in.readBoolean();
+        }
     }
 
     @Override
@@ -114,5 +132,8 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
         out.writeLong(refreshInterval);
         out.writeLong(id);
         out.writeLong(maxFileDescriptors);
+        if (out.getVersion().after(Version.V_0_90_7)) {
+            out.writeBoolean(mlockall);
+        }
     }
 }


### PR DESCRIPTION
Right now we only log a 'configuration error' in the logfile upon start up if mlockall is not configured. I would like see this in the infos as well and added it to the process info in order to get hold of it more easily.

Not the most elegant way, definately open for nicer solutions.
