### PR TITLE
Preference only_node with unknown nodeId returns useful exception

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/operation/plain/PlainOperationRouting.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/operation/plain/PlainOperationRouting.java
@@ -219,7 +219,9 @@ public class PlainOperationRouting extends AbstractComponent implements Operatio
                 return indexShard.onlyNodeActiveInitializingShardsIt(localNodeId);
             }
             if (preference.startsWith("_only_node:")) {
-                return indexShard.onlyNodeActiveInitializingShardsIt(preference.substring("_only_node:".length()));
+                String nodeId = preference.substring("_only_node:".length());
+                ensureNodeIdExists(nodes, nodeId);
+                return indexShard.onlyNodeActiveInitializingShardsIt(nodeId);
             }
         }
         // if not, then use it as the index
@@ -283,5 +285,11 @@ public class PlainOperationRouting extends AbstractComponent implements Operatio
             throw new ElasticSearchIllegalArgumentException("Can't route an operation with no type and having type part of the routing (for backward comp)");
         }
         return hashFunction.hash(type, id);
+    }
+
+    private void ensureNodeIdExists(DiscoveryNodes nodes, String nodeId) {
+        if (!nodes.dataNodes().keys().contains(nodeId)) {
+            throw new ElasticSearchIllegalArgumentException("No data node with id[" + nodeId + "] found");
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/search/preference/SearchPreferenceTests.java
+++ b/src/test/java/org/elasticsearch/search/preference/SearchPreferenceTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.preference;
 
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
@@ -95,5 +96,13 @@ public class SearchPreferenceTests extends ElasticsearchIntegrationTest {
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("1234").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+    }
+
+    @Test (expected = ElasticSearchIllegalArgumentException.class)
+    public void testThatSpecifyingNonExistingNodesReturnsUsefulError() throws Exception {
+        createIndex("test");
+        ensureGreen();
+
+        client().prepareSearch().setQuery(matchAllQuery()).setPreference("_only_node:DOES-NOT-EXIST").execute().actionGet();
     }
 }


### PR DESCRIPTION
When the search preference is set to only node, but this node is not a
data (or does not exist), we return a search exception, which indicates,
that this is actually a server problem.

However specifying a non-existing node id is a client problem
and should return a more useful error message than
{"error":"SearchPhaseExecutionException[Failed to execute phase [query_fetch], all shards failed]","status":503}

I am not a hundred percent sure, if this introduces some sort of special handling again and we should drop it therefore, but I think it improves the user experience by knowing what is going on.
