### PR TITLE
Added `execution` option to `range` filter and deprecated `numeric_range` filter.

### DIFF
--- a/docs/reference/query-dsl/filters/range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/range-filter.asciidoc
@@ -33,7 +33,24 @@ The `range` filter accepts the following parameters:
 deprecated[0.90.4,The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`]
 
 [float]
+==== Execution
+
+added[1.0.0.Beta2]
+
+The `execution` option controls how the range filter internally executes. The `execution` option accepts the following values:
+
+[horizontal]
+`index`::       Uses field's inverted in order to determine of documents fall with in the range filter's from and to range
+`fielddata`::   Uses field data in order to determine of documents fall with in the range filter's from and to range.
+
+In general for small ranges the `index` execution is faster and for longer ranges the `fielddata` execution is faster.
+
+The `fielddata` execution as the same suggests uses field data and therefor requires more memory, so make you have
+sufficient memory on your nodes in order to use this execution mode. It usually makes sense to use it on fields  you're
+already faceting or sorting by.
+
+[float]
 ==== Caching
 
-The result of the filter is automatically cached by default. The
+The result of the filter is only automatically cached by default if the `execution` is set to `index`. The
 `_cache` can be set to `false` to turn it off.

--- a/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
@@ -300,7 +300,10 @@ public abstract class FilterBuilders {
      * field data cache (loading all the values for the specified field into memory)
      *
      * @param name The field name
+     * @deprecated The numeric_range filter will be removed at some point in time in favor for the range filter with
+     *             the execution mode <code>fielddata</code>.
      */
+    @Deprecated
     public static NumericRangeFilterBuilder numericRangeFilter(String name) {
         return new NumericRangeFilterBuilder(name);
     }

--- a/src/main/java/org/elasticsearch/index/query/NumericRangeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/NumericRangeFilterBuilder.java
@@ -28,8 +28,10 @@ import java.io.IOException;
  * <p/>
  * <p>Uses the field data cache (loading all the values for the specified field into memory).
  *
- *
+ * @deprecated This filter will be removed at some point in time in favor for the range filter with the execution
+ *             mode <code>fielddata</code>.
  */
+@Deprecated
 public class NumericRangeFilterBuilder extends BaseFilterBuilder {
 
     private final String name;

--- a/src/main/java/org/elasticsearch/index/query/NumericRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NumericRangeFilterParser.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFi
 /**
  *
  */
+@Deprecated
 public class NumericRangeFilterParser implements FilterParser {
 
     public static final String NAME = "numeric_range";

--- a/src/main/java/org/elasticsearch/index/query/RangeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterBuilder.java
@@ -45,6 +45,8 @@ public class RangeFilterBuilder extends BaseFilterBuilder {
 
     private String filterName;
 
+    private String execution;
+
     /**
      * A filter that restricts search results to values that are within the given range.
      *
@@ -351,6 +353,24 @@ public class RangeFilterBuilder extends BaseFilterBuilder {
         return this;
     }
 
+    /**
+     * Sets the execution mode that controls how the range filter is executed. Valid values are: "index" and "fielddata".
+     * <ol>
+     * <li> The <code>index</code> execution uses the field's inverted in order to determine of documents fall with in
+     *      the range filter's from and to range.
+     * <li> The <code>fielddata</code> execution uses field data in order to determine of documents fall with in the
+     *      range filter's from and to range. Since field data is an in memory data structure, you need to have
+     *      sufficient memory on your nodes in order to use this execution mode.
+     * </ol>
+     *
+     * In general for small ranges the <code>index</code> execution is faster and for longer ranges the
+     * <code>fielddata</code> execution is faster.
+     */
+    public RangeFilterBuilder setExecution(String execution) {
+        this.execution = execution;
+        return this;
+    }
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(RangeFilterParser.NAME);
@@ -370,6 +390,9 @@ public class RangeFilterBuilder extends BaseFilterBuilder {
         }
         if (cacheKey != null) {
             builder.field("_cache_key", cacheKey);
+        }
+        if (execution != null) {
+            builder.field("execution", execution);
         }
 
         builder.endObject();

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -923,6 +923,21 @@ public class SimpleIndexQueryParserTests extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testRangeFilteredQueryBuilder_executionFieldData() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        Query parsedQuery = queryParser.parse(filteredQuery(termQuery("name.first", "shay"), rangeFilter("age").from(23).to(54).includeLower(true).includeUpper(false).setExecution("fielddata"))).query();
+        assertThat(parsedQuery, instanceOf(XFilteredQuery.class));
+        Filter filter = ((XFilteredQuery) parsedQuery).getFilter();
+        assertThat(filter, instanceOf(NumericRangeFieldDataFilter.class));
+        NumericRangeFieldDataFilter<Number> rangeFilter = (NumericRangeFieldDataFilter<Number>) filter;
+        assertThat(rangeFilter.getField(), equalTo("age"));
+        assertThat(rangeFilter.getLowerVal().intValue(), equalTo(23));
+        assertThat(rangeFilter.getUpperVal().intValue(), equalTo(54));
+        assertThat(rangeFilter.isIncludeLower(), equalTo(true));
+        assertThat(rangeFilter.isIncludeUpper(), equalTo(false));
+    }
+
+    @Test
     public void testNumericRangeFilteredQuery() throws IOException {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/numeric_range-filter.json");

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -51,6 +51,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.count.query.SimpleQueryTests.rangeFilter;
 import static org.elasticsearch.index.query.FilterBuilders.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
@@ -1480,16 +1481,16 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareRefresh().execute().actionGet();
         SearchResponse response = client().prepareSearch("test").setFilter(
                 FilterBuilders.boolFilter()
-                        .should(FilterBuilders.rangeFilter("num_long").from(1).to(2))
-                        .should(FilterBuilders.rangeFilter("num_long").from(3).to(4))
+                        .should(rangeFilter("num_long", 1, 2))
+                        .should(rangeFilter("num_long", 3, 4))
         ).execute().actionGet();
         assertThat(response.getHits().totalHits(), equalTo(4l));
 
         // This made 2826 fail! (only with bit based filters)
         response = client().prepareSearch("test").setFilter(
                 FilterBuilders.boolFilter()
-                        .should(FilterBuilders.numericRangeFilter("num_long").from(1).to(2))
-                        .should(FilterBuilders.numericRangeFilter("num_long").from(3).to(4))
+                        .should(rangeFilter("num_long", 1, 2))
+                        .should(rangeFilter("num_long", 3, 4))
         ).execute().actionGet();
 
         assertThat(response.getHits().totalHits(), equalTo(4l));
@@ -1498,8 +1499,8 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         response = client().prepareSearch("test").setFilter(
                 FilterBuilders.boolFilter()
                         .must(FilterBuilders.termFilter("field1", "test1"))
-                        .should(FilterBuilders.rangeFilter("num_long").from(1).to(2))
-                        .should(FilterBuilders.rangeFilter("num_long").from(3).to(4))
+                        .should(rangeFilter("num_long", 1, 2))
+                        .should(rangeFilter("num_long", 3, 4))
         ).execute().actionGet();
 
         assertThat(response.getHits().totalHits(), equalTo(2l));


### PR DESCRIPTION
Relates to #4034
