### PR TITLE
Deciders shouldn't loop over all shards.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -122,7 +122,9 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                             inactiveShardCount++;
                         }
                     } else {
-                        unassigned.add(new MutableShardRouting(shard));
+                        MutableShardRouting sr = new MutableShardRouting(shard);
+                        replicaSet.add( sr );
+                        unassigned.add( sr );
                         if ( shard.primary() )
                             unassignedPrimaryCount++;
 
@@ -315,12 +317,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         if ( shards == null ) {
             shards = newArrayList();
         }
-        for (int i = 0; i < unassigned.size(); i++) {
-            MutableShardRouting shardRouting = unassigned.get(i);
-            if (shardRouting.index().equals(index) && shardRouting.id() == shardId) {
-                shards.add(shardRouting);
-            }
-        }
+        // no need to check unassigned array, since the ShardRoutings are in the replica set.
         return shards;
     }
 

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -88,7 +88,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable> {
     }
 
     public RoutingNodes routingNodes(ClusterState state) {
-        return new RoutingNodes(state);
+        return RoutingNodes.createInstance(state);
     }
 
     public RoutingTable validateRaiseException(MetaData metaData) throws RoutingValidationException {

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.elasticsearch.cluster.routing.MutableShardRouting;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.inject.Inject;
@@ -88,34 +89,26 @@ public class ClusterRebalanceAllocationDecider extends AllocationDecider {
     @Override
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
         if (type == ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE) {
-            for (MutableShardRouting shard : allocation.routingNodes().unassigned()) {
-                if (shard.primary()) {
-                    return Decision.NO;
-                }
+            // check if there are unassigned primaries.
+            if ( RoutingNodes.getInstance().hasUnassignedPrimaries() ) {
+                return Decision.NO;
             }
-            for (RoutingNode node : allocation.routingNodes()) {
-                List<MutableShardRouting> shards = node.shards();
-                for (int i = 0; i < shards.size(); i++) {
-                    MutableShardRouting shard = shards.get(i);
-                    if (shard.primary() && !shard.active() && shard.relocatingNodeId() == null) {
-                        return Decision.NO;
-                    }
-                }
+            // check if there are initializing primaries that don't have a relocatingNodeId entry.
+            if ( RoutingNodes.getInstance().hasInactivePrimaries() ) {
+                return Decision.NO;
             }
+
             return Decision.YES;
         }
         if (type == ClusterRebalanceType.INDICES_ALL_ACTIVE) {
-            if (!allocation.routingNodes().unassigned().isEmpty()) {
+            // check if there are unassigned shards.
+            if ( RoutingNodes.getInstance().hasUnassignedShards() ) {
                 return Decision.NO;
             }
-            for (RoutingNode node : allocation.routingNodes()) {
-                List<MutableShardRouting> shards = node.shards();
-                for (int i = 0; i < shards.size(); i++) {
-                    MutableShardRouting shard = shards.get(i);
-                    if (!shard.active() && shard.relocatingNodeId() == null) {
-                        return Decision.NO;
-                    }
-                }
+            // in case all indices are assigned, are there initializing shards which
+            // are not relocating?
+            if ( RoutingNodes.getInstance().hasInactiveShards() ) {
+                return Decision.NO;
             }
         }
         // type == Type.ALWAYS

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.elasticsearch.cluster.routing.MutableShardRouting;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -72,15 +73,7 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
         if (clusterConcurrentRebalance == -1) {
             return Decision.YES;
         }
-        int rebalance = 0;
-        for (RoutingNode node : allocation.routingNodes()) {
-            List<MutableShardRouting> shards = node.shards();
-            for (int i = 0; i < shards.size(); i++) {
-                if (shards.get(i).state() == ShardRoutingState.RELOCATING) {
-                    rebalance++;
-                }
-            }
-        }
+        int rebalance = RoutingNodes.getInstance().getRelocatingShardCount();
         if (rebalance >= clusterConcurrentRebalance) {
             return Decision.NO;
         }

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/MassiveClusterRebalanceRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/MassiveClusterRebalanceRoutingTests.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
+import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTests.newNode;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MassiveClusterRebalanceRoutingTests extends ElasticsearchTestCase {
+
+    private final ESLogger logger = Loggers.getLogger(ClusterRebalanceRoutingTests.class);
+
+    @Test
+    public void testAlways() {
+
+        int numIndices  = 5 * 365; // five years
+        int numShards   = 6;
+        int numReplicas = 2;
+        AllocationService strategy = new AllocationService(settingsBuilder()
+             .put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString() )
+             .put("cluster.routing.allocation.node_initial_primaries_recoveries", 16384 )     
+             .put("cluster.routing.allocation.node_concurrent_recoveries", 16384 )     
+        .build());
+
+
+        long start = System.currentTimeMillis();
+        logger.info( "Start massive cluster test." );
+        MetaData.Builder mb = MetaData.builder();
+        for ( int i = 1; i <= numIndices; i++ )
+            mb.put(IndexMetaData.builder("test_" + i).numberOfShards( numShards ).numberOfReplicas( numReplicas ));
+
+        MetaData metaData = mb.build();
+
+        logger.info( "Buidling MetaData took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+
+
+        RoutingTable.Builder rb = RoutingTable.builder();
+        for ( int i = 1; i <= numIndices; i++ )
+            rb.addAsNew(metaData.index("test_" + i));
+
+        RoutingTable routingTable = rb.build();
+
+        logger.info( "Buidling RoutingTable took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+
+        ClusterState clusterState = ClusterState.builder().metaData(metaData).routingTable(routingTable).build();
+        
+        logger.info( "Buidling ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+
+        logger.info("start two nodes");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2"))).build();
+        logger.info( "Buidling ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        
+        RoutingTable prevRoutingTable = routingTable;
+
+        routingTable = strategy.reroute(clusterState).routingTable();
+        logger.info( "Buidling new RoutingTable took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        logger.info( "Buidling new ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+
+        //logger.info( clusterState.toString() );
+        //logger.info( routingTable.toString() );
+        
+
+        for (int i = 0; i < routingTable.index("test_1").shards().size(); i++) {
+            assertThat(routingTable.index("test_1").shard(i).shards().size(), equalTo( numReplicas + 1 ));
+            assertThat(routingTable.index("test_1").shard(i).primaryShard().state(), equalTo(INITIALIZING));
+            assertThat(routingTable.index("test_1").shard(i).replicaShards().get(0).state(), equalTo(UNASSIGNED));
+        }
+
+        for (int i = 0; i < routingTable.index("test_" + numIndices).shards().size(); i++) {
+            assertThat(routingTable.index("test_" + numIndices).shard(i).shards().size(), equalTo( numReplicas + 1 ));
+            assertThat(routingTable.index("test_" + numIndices).shard(i).primaryShard().state(), equalTo(INITIALIZING));
+            assertThat(routingTable.index("test_"+ numIndices).shard(i).replicaShards().get(0).state(), equalTo(UNASSIGNED));
+        }
+
+        logger.info("start all the primary shards for test1, replicas will start initializing");
+        RoutingNodes routingNodes = clusterState.routingNodes();
+        prevRoutingTable = routingTable;
+        routingTable = strategy.applyStartedShards(clusterState, routingNodes.shardsWithState("test_1", INITIALIZING)).routingTable();
+        logger.info( "Buidling new RoutingTable took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        logger.info( "Buidling new ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        routingNodes = clusterState.routingNodes();
+
+        for (int i = 0; i < routingTable.index("test_1").shards().size(); i++) {
+            assertThat(routingTable.index("test_1").shard(i).shards().size(), equalTo( numReplicas + 1 ));
+//            assertThat(routingTable.index("test1").shard(i).primaryShard().state(), equalTo(STARTED));
+            assertThat(routingTable.index("test_1").shard(i).replicaShards().get(0).state(), equalTo(INITIALIZING));
+        }
+
+        for (int i = 0; i < routingTable.index("test_" + numIndices).shards().size(); i++) {
+            assertThat(routingTable.index("test_" + numIndices).shard(i).shards().size(), equalTo( numReplicas + 1 ));
+            assertThat(routingTable.index("test_" + numIndices).shard(i).primaryShard().state(), equalTo(INITIALIZING));
+            assertThat(routingTable.index("test_" + numIndices).shard(i).replicaShards().get(0).state(), equalTo(UNASSIGNED));
+        }
+
+        logger.info("start the test1 replica shards");
+        routingNodes = clusterState.routingNodes();
+        prevRoutingTable = routingTable;
+        routingTable = strategy.applyStartedShards(clusterState, routingNodes.shardsWithState("test_1", INITIALIZING)).routingTable();
+        logger.info( "Buidling new RoutingTable took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        logger.info( "Buidling new ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        routingNodes = clusterState.routingNodes();
+
+
+        logger.info("now, start 1 more node, check that rebalancing will happen (for test1) because we set it to always");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes())
+                .put(newNode("node3")))
+                .build();
+        prevRoutingTable = routingTable;
+        routingTable = strategy.reroute(clusterState).routingTable();
+        logger.info( "Buidling new RoutingTable took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        logger.info( "Buidling new ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        routingNodes = clusterState.routingNodes();
+
+        // assertThat(routingNodes.node("node3").shards().size(), equalTo( ( numIndices * numShards * ( numReplicas + 1 ) ) / 3 /* nodes */  ));
+        // this one tests implementation, not logic ?!
+        assertThat(routingNodes.node("node3").shards().get(0).shardId().index().name(), equalTo("test_1"));
+        
+        logger.info("now, start 33 more node, check that rebalancing will happen (for test1) because we set it to always");
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes())
+                .put(newNode("node4"))
+                .put(newNode("node5"))
+                .put(newNode("node6"))
+                .put(newNode("node7"))
+                .put(newNode("node8"))
+                .put(newNode("node9"))
+                .put(newNode("node10"))
+                .put(newNode("node11"))
+                .put(newNode("node12"))
+                .put(newNode("node13"))
+                .put(newNode("node15"))
+                .put(newNode("node16"))
+                .put(newNode("node17"))
+                .put(newNode("node18"))
+                .put(newNode("node19"))
+                .put(newNode("node20"))
+                .put(newNode("node21"))
+                .put(newNode("node22"))
+                .put(newNode("node23"))
+                .put(newNode("node24"))
+                .put(newNode("node25"))
+                .put(newNode("node26"))
+                .put(newNode("node27"))
+                .put(newNode("node28"))
+                .put(newNode("node29"))
+                .put(newNode("node30"))
+                .put(newNode("node31"))
+                .put(newNode("node32"))
+                .put(newNode("node33"))
+                .put(newNode("node34"))
+                .put(newNode("node35"))
+                .put(newNode("node36")))
+                .build();
+        prevRoutingTable = routingTable;
+        routingTable = strategy.reroute(clusterState).routingTable();
+        logger.info( "Buidling new RoutingTable took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        logger.info( "Buidling new ClusterState took " + ( System.currentTimeMillis() - start ) + "ms." );
+        start = System.currentTimeMillis();
+        routingNodes = clusterState.routingNodes();
+
+    }
+
+
+}


### PR DESCRIPTION
Instead of using loops over all ShardRoutings, do accounting in RoutingNodes.

Speeds up recalculating cluster state on large clusters. This is the background of the patch - we have 20k+ shards in the cluster and the master sits at 100% CPU for minutes trying to apply cluster state changed events.

routing.allocation related tests pass. Compilation problem with head pulled into my master to apply changes on top? (org.elasticsearch.common.inject.Inject)
There is certainly not much elegance with the approach of using a Singleton - but this class is instantiated in one place only anyhow. There is even less elegance of using the notification from MutableShardRouting to RoutingNodes. but i guess this is what can be done without a major refactoring. 
