### PR TITLE
Use tokenizer's settings in a setting of SynonymTokenFilter

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/SynonymTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SynonymTokenFilterFactory.java
@@ -80,7 +80,12 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         if (tokenizerFactoryFactory == null) {
             throw new ElasticSearchIllegalArgumentException("failed to find tokenizer [" + tokenizerName + "] for synonym token filter");
         }
-        final TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, settings);
+        Map<String, Settings> tokenizersSettings = indexSettings.getGroups("index.analysis.tokenizer");
+        Settings tokenizerSettings = tokenizersSettings.get(tokenizerName);
+        if (tokenizerSettings == null) {
+            tokenizerSettings = settings;
+        }
+        final TokenizerFactory tokenizerFactory = tokenizerFactoryFactory.create(tokenizerName, tokenizerSettings);
 
         Analyzer analyzer = new Analyzer() {
             @Override


### PR DESCRIPTION
In the following index setting, synonymTest uses own settings, not bigramTokenizer's one (synonymTest does not use min_gram and max_gram). I think that it's better to use bigramTokenizer's setting.

```
curl -XPUT localhost:9200/test -d '{
  "settings" : {
    "analysis" : {
      "analyzer" : {
        "bigram_analyzer" : {
          "type" : "custom",
          "tokenizer" : "bigramTokenizer",
          "filter" : ["synonymTest"]
        }
      },
      "tokenizer" : {
          "bigramTokenizer" : {
          "type" : "ngram",
          "min_gram" : 2,
          "max_gram" : 2
        }
      },
      "filter" : {
        "synonymTest" : {
          "type" : "synonym",
          "synonyms_path" : "synonym.txt",
          "tokenizer" : "bigramTokenizer"
        }
      }
    }
  }
}'
```
