### PR TITLE
Completion suggest mechanism: Update lucene trunk

### DIFF
--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -218,6 +218,11 @@ The following parameters are supported:
     Minimum length of the input, which is not
     checked for fuzzy alternatives, defaults to `1`
 
+`unicode_aware`::
+    Sets all are measurements (like edit distance,
+    transpositions and lengths) in unicode code points
+    (actual letters) instead of bytes.
+
 NOTE: If you want to stick with the default values, but
       still use fuzzy, you can either use `fuzzy: {}`
       or `fuzzy: true`.

--- a/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/Completion090PostingsFormat.java
@@ -362,5 +362,6 @@ public class Completion090PostingsFormat extends PostingsFormat {
     public static abstract class LookupFactory {
         public abstract Lookup getLookup(FieldMapper<?> mapper, CompletionSuggestionContext suggestionContext);
         public abstract CompletionStats stats(String ... fields);
+        abstract AnalyzingCompletionLookupProvider.AnalyzingSuggestHolder getAnalyzingSuggestHolder(FieldMapper<?> mapper);
     }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
@@ -68,6 +68,8 @@ public class CompletionSuggestParser implements SuggestContextParser {
                             suggestion.setFuzzyMinLength(parser.intValue());
                         } else if ("prefix_length".equals(fuzzyConfigName) || "prefixLength".equals(fuzzyConfigName)) {
                             suggestion.setFuzzyPrefixLength(parser.intValue());
+                        } else if ("unicode_aware".equals(fuzzyConfigName) || "unicodeAware".equals(fuzzyConfigName)) {
+                            suggestion.setFuzzyUnicodeAware(parser.booleanValue());
                         }
                     }
                 }

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -34,6 +34,7 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
     private int fuzzyMinLength = XFuzzySuggester.DEFAULT_MIN_FUZZY_LENGTH;
     private int fuzzyPrefixLength = XFuzzySuggester.DEFAULT_NON_FUZZY_PREFIX;
     private boolean fuzzy = false;
+    private boolean fuzzyUnicodeAware = XFuzzySuggester.DEFAULT_UNICODE_AWARE;
 
     public CompletionSuggestionContext(Suggester suggester) {
         super(suggester);
@@ -85,5 +86,13 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
 
     public boolean isFuzzy() {
         return fuzzy;
+    }
+
+    public void setFuzzyUnicodeAware(boolean fuzzyUnicodeAware) {
+        this.fuzzyUnicodeAware = fuzzyUnicodeAware;
+    }
+
+    public boolean isFuzzyUnicodeAware() {
+        return fuzzyUnicodeAware;
     }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionFuzzyBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionFuzzyBuilder.java
@@ -38,6 +38,7 @@ public class CompletionSuggestionFuzzyBuilder extends SuggestBuilder.SuggestionB
     private boolean fuzzyTranspositions = XFuzzySuggester.DEFAULT_TRANSPOSITIONS;
     private int fuzzyMinLength = XFuzzySuggester.DEFAULT_MIN_FUZZY_LENGTH;
     private int fuzzyPrefixLength = XFuzzySuggester.DEFAULT_NON_FUZZY_PREFIX;
+    private boolean unicodeAware = XFuzzySuggester.DEFAULT_UNICODE_AWARE;
 
     public int getFuzzyEditDistance() {
         return fuzzyEditDistance;
@@ -75,6 +76,15 @@ public class CompletionSuggestionFuzzyBuilder extends SuggestBuilder.SuggestionB
         return this;
     }
 
+    public boolean isUnicodeAware() {
+        return unicodeAware;
+    }
+
+    public CompletionSuggestionFuzzyBuilder setUnicodeAware(boolean unicodeAware) {
+        this.unicodeAware = unicodeAware;
+        return this;
+    }
+
     @Override
     protected XContentBuilder innerToXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject("fuzzy");
@@ -90,6 +100,9 @@ public class CompletionSuggestionFuzzyBuilder extends SuggestBuilder.SuggestionB
         }
         if (fuzzyPrefixLength != XFuzzySuggester.DEFAULT_NON_FUZZY_PREFIX) {
             builder.field("prefix_length", fuzzyPrefixLength);
+        }
+        if (unicodeAware != XFuzzySuggester.DEFAULT_UNICODE_AWARE) {
+            builder.field("unicode_aware", unicodeAware);
         }
 
         builder.endObject();

--- a/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
@@ -68,10 +68,11 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
     private final String INDEX = RandomStrings.randomAsciiOfLength(getRandom(), 10).toLowerCase(Locale.ROOT);
     private final String TYPE = RandomStrings.randomAsciiOfLength(getRandom(), 10).toLowerCase(Locale.ROOT);
     private final String FIELD = RandomStrings.randomAsciiOfLength(getRandom(), 10).toLowerCase(Locale.ROOT);
+    private final CompletionMappingBuilder completionMappingBuilder = new CompletionMappingBuilder();
 
     @Test
     public void testSimple() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
         String[][] input = {{"Foo Fighters"}, {"Foo Fighters"}, {"Foo Fighters"}, {"Foo Fighters"},
                 {"Generator", "Foo Fighters Generator"}, {"Learn to Fly", "Foo Fighters Learn to Fly"},
                 {"The Prodigy"}, {"The Prodigy"}, {"The Prodigy"}, {"Firestarter", "The Prodigy Firestarter"},
@@ -95,7 +96,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSuggestFieldWithPercolateApi() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
         String[][] input = {{"Foo Fighters"}, {"Foo Fighters"}, {"Foo Fighters"}, {"Foo Fighters"},
                 {"Generator", "Foo Fighters Generator"}, {"Learn to Fly", "Foo Fighters Learn to Fly"},
                 {"The Prodigy"}, {"The Prodigy"}, {"The Prodigy"}, {"Firestarter", "The Prodigy Firestarter"},
@@ -125,7 +126,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testBasicPrefixSuggestion() throws Exception {
-        createIndexAndMapping();
+        completionMappingBuilder.payloads(true);
+        createIndexAndMapping(completionMappingBuilder);
         for (int i = 0; i < 2; i++) {
             createData(i == 0);
             assertSuggestions("f", "Firestarter - The Prodigy", "Foo Fighters", "Generator - Foo Fighters", "Learn to Fly - Foo Fighters");
@@ -137,7 +139,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatWeightsAreWorking() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
 
         List<String> similarNames = Lists.newArrayList("the", "The Prodigy", "The Verve", "The the");
         // the weight is 1000 divided by string length, so the results are easy to to check
@@ -157,7 +159,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatWeightMustBeAnInteger() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
 
         try {
             client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
@@ -174,7 +176,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatInputCanBeAStringInsteadOfAnArray() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -190,7 +192,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatPayloadsAreArbitraryJsonObjects() throws Exception {
-        createIndexAndMapping();
+        completionMappingBuilder.payloads(true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -223,7 +226,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPayloadAsNumeric() throws Exception {
-        createIndexAndMapping();
+        completionMappingBuilder.payloads(true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -250,7 +254,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPayloadAsString() throws Exception {
-        createIndexAndMapping();
+        completionMappingBuilder.payloads(true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -277,7 +282,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test(expected = MapperException.class)
     public void testThatExceptionIsThrownWhenPayloadsAreDisabledButInIndexRequest() throws Exception {
-        createIndexAndMapping("simple", "simple", false, false, true);
+        completionMappingBuilder.payloads(false);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -290,7 +296,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDisabledPreserveSeperators() throws Exception {
-        createIndexAndMapping("simple", "simple", true, false, true);
+        completionMappingBuilder.preserveSeparators(false);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -313,7 +320,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testEnabledPreserveSeperators() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        completionMappingBuilder.preserveSeparators(true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -334,7 +342,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatMultipleInputsAreSupported() throws Exception {
-        createIndexAndMapping("simple", "simple", false, false, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -351,7 +359,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatShortSyntaxIsWorking() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startArray(FIELD)
@@ -368,7 +376,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testThatDisablingPositionIncrementsWorkForStopwords() throws Exception {
         // analyzer which removes stopwords... so may not be the simple one
-        createIndexAndMapping("classic", "classic", false, false, false);
+        completionMappingBuilder.searchAnalyzer("classic").indexAnalyzer("classic").preservePositionIncrements(false);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -389,7 +398,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
                 .putArray("analysis.analyzer.suggest_analyzer_synonyms.filter", "standard", "lowercase", "my_synonyms")
                 .put("analysis.filter.my_synonyms.type", "synonym")
                 .putArray("analysis.filter.my_synonyms.synonyms", "foo,renamed");
-        createIndexAndMappingAndSettings(settingsBuilder, "suggest_analyzer_synonyms", "suggest_analyzer_synonyms", false, false, true);
+        completionMappingBuilder.searchAnalyzer("suggest_analyzer_synonyms").indexAnalyzer("suggest_analyzer_synonyms");
+        createIndexAndMappingAndSettings(settingsBuilder, completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -451,7 +461,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatFuzzySuggesterWorks() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -474,7 +484,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatFuzzySuggesterSupportsEditDistances() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -499,7 +509,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatFuzzySuggesterSupportsTranspositions() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -522,7 +532,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatFuzzySuggesterSupportsMinPrefixLength() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -545,7 +555,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatFuzzySuggesterSupportsNonPrefixLength() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -568,7 +578,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatFuzzySuggesterIsUnicodeAware() throws Exception {
-        createIndexAndMapping("simple", "simple", true, true, true);
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -642,7 +652,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatSortingOnCompletionFieldReturnsUsefulException() throws Exception {
-        createIndexAndMapping();
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -668,7 +678,11 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
                 .put("index.analysis.filter.suggest_stop_filter.type", "stop")
                 .put("index.analysis.filter.suggest_stop_filter.remove_trailing", false);
 
-        createIndexAndMappingAndSettings(settingsBuilder, "simple", "stoptest", true, true, true);
+        CompletionMappingBuilder completionMappingBuilder = new CompletionMappingBuilder();
+        completionMappingBuilder.preserveSeparators(true).preservePositionIncrements(true);
+        completionMappingBuilder.searchAnalyzer("stoptest");
+        completionMappingBuilder.indexAnalyzer("simple");
+        createIndexAndMappingAndSettings(settingsBuilder, completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().field(FIELD, "Feed trolls").endObject()
@@ -694,7 +708,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test(expected = MapperParsingException.class)
     public void testThatIndexingInvalidFieldsInCompletionFieldResultsInException() throws Exception {
-        createIndexAndMapping();
+        CompletionMappingBuilder completionMappingBuilder = new CompletionMappingBuilder();
+        createIndexAndMapping(completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -763,11 +778,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         return names;
     }
 
-    private void createIndexAndMapping() throws IOException {
-        createIndexAndMapping("simple", "simple", true, false, true);
-    }
-
-    private void createIndexAndMappingAndSettings(Settings.Builder settingsBuilder, String indexAnalyzer, String searchAnalyzer, boolean payloads, boolean preserveSeparators, boolean preservePositionIncrements) throws IOException {
+    private void createIndexAndMappingAndSettings(Settings.Builder settingsBuilder, CompletionMappingBuilder completionMappingBuilder) throws IOException {
         client().admin().indices().prepareCreate(INDEX)
                 .setSettings(settingsBuilder)
                 .get();
@@ -775,11 +786,11 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
                 .startObject(TYPE).startObject("properties")
                 .startObject(FIELD)
                 .field("type", "completion")
-                .field("index_analyzer", indexAnalyzer)
-                .field("search_analyzer", searchAnalyzer)
-                .field("payloads", payloads)
-                .field("preserve_separators", preserveSeparators)
-                .field("preserve_position_increments", preservePositionIncrements)
+                .field("index_analyzer", completionMappingBuilder.indexAnalyzer)
+                .field("search_analyzer", completionMappingBuilder.searchAnalyzer)
+                .field("payloads", completionMappingBuilder.payloads)
+                .field("preserve_separators", completionMappingBuilder.preserveSeparators)
+                .field("preserve_position_increments", completionMappingBuilder.preservePositionIncrements)
                 .endObject()
                 .endObject().endObject()
                 .endObject())
@@ -788,8 +799,8 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
         ensureYellow();
     }
 
-    private void createIndexAndMapping(String indexAnalyzer, String searchAnalyzer, boolean payloads, boolean preserveSeparators, boolean preservePositionIncrements) throws IOException {
-        createIndexAndMappingAndSettings(createDefaultSettings(), indexAnalyzer, searchAnalyzer, payloads, preserveSeparators, preservePositionIncrements);
+    private void createIndexAndMapping(CompletionMappingBuilder completionMappingBuilder) throws IOException {
+        createIndexAndMappingAndSettings(createDefaultSettings(), completionMappingBuilder);
     }
 
     private ImmutableSettings.Builder createDefaultSettings() {
@@ -841,7 +852,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test // see #3555
     public void testPrunedSegments() throws IOException {
-        createIndexAndMappingAndSettings(settingsBuilder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0), "standard", "standard", false, false, false);
+        createIndexAndMappingAndSettings(settingsBuilder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0), completionMappingBuilder);
 
         client().prepareIndex(INDEX, TYPE, "1").setSource(jsonBuilder()
                 .startObject().startObject(FIELD)
@@ -967,5 +978,34 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
             }
         }
         return new String(charArray);
+    }
+
+    private static class CompletionMappingBuilder {
+        private String searchAnalyzer = "simple";
+        private String indexAnalyzer = "simple";
+        private Boolean payloads = getRandom().nextBoolean();
+        private Boolean preserveSeparators = getRandom().nextBoolean();
+        private Boolean preservePositionIncrements = getRandom().nextBoolean();
+
+        public CompletionMappingBuilder searchAnalyzer(String searchAnalyzer) {
+            this.searchAnalyzer = searchAnalyzer;
+            return this;
+        }
+        public CompletionMappingBuilder indexAnalyzer(String indexAnalyzer) {
+            this.indexAnalyzer = indexAnalyzer;
+            return this;
+        }
+        public CompletionMappingBuilder payloads(Boolean payloads) {
+            this.payloads = payloads;
+            return this;
+        }
+        public CompletionMappingBuilder preserveSeparators(Boolean preserveSeparators) {
+            this.preserveSeparators = preserveSeparators;
+            return this;
+        }
+        public CompletionMappingBuilder preservePositionIncrements(Boolean preservePositionIncrements) {
+            this.preservePositionIncrements = preservePositionIncrements;
+            return this;
+        }
     }
 }


### PR DESCRIPTION
The analyzing suggester and the fuzzysuggester got a couple of updates on lucene trunk, which have been incorporated here.

This required a backwards compatible postings format, so a new version has been created as well as tests checking for this.

Also the CompletionSuggestSearchTests now are more randomized now (would have helped me finding a bug faster).
