### PR TITLE
Do not start packages on installation

### DIFF
--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -30,6 +30,14 @@ Each package features a configuration file, which allows you to set the followin
 
 The debian package ships with everything you need as it uses standard debian tools like update `update-rc.d` to define the runlevels it runs on. The init script is placed at `/etc/init.d/elasticsearch` is you would expect it. The configuration file is placed at `/etc/default/elasticsearch`.
 
+The debian package does not start up the service by default. The reason for this is to prevent the instance to accidentally join a cluster, without being configured appropriately. After installing using `dpkg -i` you can use the following commands to ensure, that elasticsearch starts when the system is booted and then start up elasticsearch:
+
+[source,sh]
+--------------------------------------------------
+sudo update-rc.d elasticsearch defaults 95 10
+sudo /etc/init.d/elasticsearch start
+--------------------------------------------------
+
 ===== Installing the oracle JDK
 
 The usual recommendation is to run the Oracle JDK with elasticsearch. However Ubuntu and Debian only ship the OpenJDK due to license issues. You can easily install the oracle installer package though. In case you are missing the `add-apt-repository` command under Debian GNU/Linux, make sure have at least Debian Wheezy and the package `python-software-properties` installed
@@ -45,12 +53,28 @@ java -version
 The last command should verify a successful installation of the Oracle JDK.
 
 
-==== RedHat/Centos/Fedora
+==== RPM based distributions 
 
-RedHat based distributions are using `chkconfig` to enable and disable services. The init script is at `/etc/init.d/elasticsearch`, where as the configuration file is placed at `/etc/sysconfig/elasticsearch`.
+===== Using chkconfig
 
-==== SuSe
+Some RPM based distributions are using `chkconfig` to enable and disable services. The init script is located at `/etc/init.d/elasticsearch`, where as the configuration file is placed at `/etc/sysconfig/elasticsearch`. Like the debian package the RPM package is not started by default after installation, you have to do this manually by entering the following commands
 
-SuSe does not use the `chkconfig` tool to register services, but rather `systemd` and its command `/bin/systemctl` to start and stop services. The configuration file is also placed at `/etc/sysconfig/elasticsearch`.
+[source,sh]
+--------------------------------------------------
+sudo /sbin/chkconfig --add elasticsearch
+sudo service elasticsearch start
+--------------------------------------------------
+
+
+===== Using systemd
+
+Distributions like SuSe do not use the `chkconfig` tool to register services, but rather `systemd` and its command `/bin/systemctl` to start and stop services (at least in newer versions, otherwise use the `chkconfig` commands above). The configuration file is also placed at `/etc/sysconfig/elasticsearch`. After installing the RPM, you have to change the systemd configuration and then start up elasticsearch
+
+[source,sh]
+--------------------------------------------------
+sudo /bin/systemctl daemon-reload
+sudo /bin/systemctl enable elasticsearch.service
+sudo /bin/systemctl start elasticsearch.service
+--------------------------------------------------
 
 Also note that changing the `MAX_MAP_COUNT` setting in `/etc/sysconfig/elasticsearch` does not have any effect, you will have to change it in `/usr/lib/sysctl.d/elasticsearch.conf` in order to have it applied at startup.

--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -36,13 +36,15 @@ case "$1" in
 	chmod 755 /etc/elasticsearch
 	chmod 644 /etc/elasticsearch/*
 	
-	update-rc.d elasticsearch defaults 95 10 >/dev/null
 	# if $2 is set, this is an upgrade
 	if ( [ -n $2 ] && [ "$RESTART_ON_UPGRADE" = "true" ] ) ; then
 		startElasticsearch
-	# this is a fresh installation, start anyway
+	# this is a fresh installation
 	elif [ -z $2 ] ; then
-		startElasticsearch
+        echo "### NOT starting elasticsearch by default on bootup, please execute"
+        echo " sudo update-rc.d elasticsearch defaults 95 10"
+        echo "### In order to start elasticsearch, execute"
+        echo " sudo /etc/init.d/elasticsearch start"
 	fi
 	;;
 esac

--- a/src/rpm/scripts/postinstall
+++ b/src/rpm/scripts/postinstall
@@ -29,13 +29,20 @@ stopElasticsearch() {
 if [ $1 -eq 1 ] ; then
 
     if [ -x /bin/systemctl ] ; then
-        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
-        /bin/systemctl enable elasticsearch.service
+        echo "### NOT starting on installation, please execute the following statements to configure elasticsearch to start automatically using systemd"
+        echo " sudo /bin/systemctl daemon-reload"
+        echo " sudo /bin/systemctl enable elasticsearch.service"
+        echo "### You can start elasticsearch by executing"
+        echo " sudo /bin/systemctl start elasticsearch.service"
+        
+        
     elif [ -x /sbin/chkconfig ] ; then
-        /sbin/chkconfig --add elasticsearch
+        echo "### NOT starting on installation, please execute the following statements to configure elasticsearch to start automatically using chkconfig"
+        echo " sudo /sbin/chkconfig --add elasticsearch"
+        echo "### You can start elasticsearch by executing"
+        echo " sudo service elasticsearch start"
     fi
 
-	startElasticsearch
 elif [ $1 -ge 2 -a "$RESTART_ON_UPGRADE" == "true" ] ; then
 	stopElasticsearch
 	startElasticsearch


### PR DESCRIPTION
The reason to not start packages on installation is to allow to configure
them before starting up (setting heap, cluster.name etc)

Also the documentation was updated in order to show, which statements need
to be executed to start up elasticsearch and configure it to fire up automatically on boot.
In addition, these statements are also printed out when the package is
installed, depending on whether chkconfig, system or update-rc.d is used.

Closes #3722
