### PR TITLE
Update to shade plugin 2.2 to shade test artifact as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.carrotsearch.randomizedtesting</groupId>
+            <artifactId>randomizedtesting-runner</artifactId>
+            <version>2.0.10</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
             <version>${lucene.version}</version>
@@ -432,7 +439,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -442,7 +449,9 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <shadeTestJar>true</shadeTestJar>
                     <minimizeJar>true</minimizeJar>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                     <artifactSet>
                         <includes>
                             <include>com.google.guava:guava</include>
@@ -987,6 +996,7 @@
                 <version>2.3.2</version>
                 <executions>
                     <execution>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>


### PR DESCRIPTION
When we want to use test artifact in other projects, dependencies
are not shaded as for core artifact.

Issue opened in maven shade project: [MSHADE-158](http://jira.codehaus.org/browse/MSHADE-158)

**Don't merge this PR until shade plugin 2.2 is released!**

Vote in progress: http://markmail.org/message/pg565rgqhxwai56u. Released will probably happen on friday november, 29th.

When using it in other projects, you basically need to change your `pom.xml` file:

``` xml
<dependency>
    <groupId>org.elasticsearch</groupId>
    <artifactId>elasticsearch</artifactId>
    <version>${elasticsearch.version}</version>
    <type>test-jar</type>
    <scope>test</scope>
</dependency>
```

You can also define some properties:

``` xml
<properties>
    <tests.jvms>1</tests.jvms>
    <tests.shuffle>true</tests.shuffle>
    <tests.output>onerror</tests.output>
    <tests.client.ratio></tests.client.ratio>
    <es.logger.level>INFO</es.logger.level>
</properties>
```
