### PR TITLE
Fix computation of explanations for AllTermQuery.

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -46,15 +46,8 @@ import static org.apache.lucene.analysis.payloads.PayloadHelper.decodeFloat;
  */
 public class AllTermQuery extends SpanTermQuery {
 
-    private boolean includeSpanScore;
-
     public AllTermQuery(Term term) {
-        this(term, true);
-    }
-
-    public AllTermQuery(Term term, boolean includeSpanScore) {
         super(term);
-        this.includeSpanScore = includeSpanScore;
     }
 
     @Override
@@ -127,7 +120,7 @@ public class AllTermQuery extends SpanTermQuery {
              */
             @Override
             public float score() throws IOException {
-                return includeSpanScore ? getSpanScore() * getPayloadScore() : getPayloadScore();
+                return getSpanScore() * getPayloadScore();
             }
 
             /**
@@ -189,10 +182,7 @@ public class AllTermQuery extends SpanTermQuery {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + (includeSpanScore ? 1231 : 1237);
-        return result;
+        return super.hashCode() + 1;
     }
 
     @Override
@@ -202,9 +192,6 @@ public class AllTermQuery extends SpanTermQuery {
         if (!super.equals(obj))
             return false;
         if (getClass() != obj.getClass())
-            return false;
-        AllTermQuery other = (AllTermQuery) obj;
-        if (includeSpanScore != other.includeSpanScore)
             return false;
         return true;
     }

--- a/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -19,16 +19,15 @@
 
 package org.elasticsearch.common.lucene.all;
 
-import org.apache.lucene.search.similarities.Similarity.SimScorer;
-
-import org.apache.lucene.index.AtomicReader;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.DocsAndPositionsEnum;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.ComplexExplanation;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.search.similarities.Similarity.SimScorer;
 import org.apache.lucene.search.spans.SpanScorer;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.search.spans.SpanWeight;
@@ -70,7 +69,7 @@ public class AllTermQuery extends SpanTermQuery {
         }
 
         @Override
-        public Scorer scorer(AtomicReaderContext context, boolean scoreDocsInOrder,
+        public AllTermSpanScorer scorer(AtomicReaderContext context, boolean scoreDocsInOrder,
                 boolean topScorer, Bits acceptDocs) throws IOException {
             if (this.stats == null) {
                 return null;
@@ -96,18 +95,19 @@ public class AllTermQuery extends SpanTermQuery {
                 }
                 doc = spans.doc();
                 freq = 0.0f;
+                numMatches = 0;
                 payloadScore = 0;
                 payloadsSeen = 0;
-                while (more && doc == spans.doc()) {
+                do {
                     int matchLength = spans.end() - spans.start();
 
                     freq += docScorer.computeSlopFactor(matchLength);
+                    numMatches++;
                     processPayload();
 
-                    more = spans.next();// this moves positions to the next match in this
-                    // document
-                }
-                return more || (freq != 0);
+                    more = spans.next();// this moves positions to the next match
+                } while (more && (doc == spans.doc()));
+                return true;
             }
 
             protected void processPayload() throws IOException {
@@ -154,11 +154,11 @@ public class AllTermQuery extends SpanTermQuery {
         
         @Override
         public Explanation explain(AtomicReaderContext context, int doc) throws IOException{
-            AllTermSpanScorer scorer = (AllTermSpanScorer) scorer(context, true, false, context.reader().getLiveDocs());
+            AllTermSpanScorer scorer = scorer(context, true, false, context.reader().getLiveDocs());
             if (scorer != null) {
               int newDoc = scorer.advance(doc);
               if (newDoc == doc) {
-                float freq = scorer.freq();
+                float freq = scorer.sloppyFreq();
                 SimScorer docScorer = similarity.simScorer(stats, context);
                 ComplexExplanation inner = new ComplexExplanation();
                 inner.setDescription("weight("+getQuery()+" in "+doc+") [" + similarity.getClass().getSimpleName() + "], result of:");


### PR DESCRIPTION
With this commit, numMatches is now updated in `setFreqCurrentDoc` and `sloppyFreq` is used instead of `freq` to compute the score of the explanation.
