### PR TITLE
CAT api: Minor changes for consistent behaviour

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHelpAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHelpAction.java
@@ -54,6 +54,7 @@ public class RestHelpAction extends BaseRestHandler {
         s.append("/_cat/nodes\n");
         s.append("/_cat/pending_tasks\n");
         s.append("/_cat/recovery\n");
+        s.append("/_cat/recovery/{index}\n");
         s.append("/_cat/shards\n");
         s.append("/_cat/shards/{index}\n");
         channel.sendResponse(new StringRestResponse(RestStatus.OK, s.toString()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -63,7 +63,7 @@ public class RestIndicesAction extends BaseRestHandler {
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
             public void onResponse(final ClusterStateResponse clusterStateResponse) {
-                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndicesIgnoreMissing(indices);
+                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(indices);
                 ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest(concreteIndices);
                 clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
                 client.admin().cluster().health(clusterHealthRequest, new ActionListener<ClusterHealthResponse>() {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -179,7 +179,7 @@ public class RestNodesAction extends BaseRestHandler {
             table.addCell(info == null ? null : info.getOs().mem() == null ? null : info.getOs().mem().total()); // sigar fails to load in IntelliJ
             table.addCell(stats == null ? null : stats.getOs() == null ? null : stats.getOs().getLoadAverage().length < 1 ? null : stats.getOs().getLoadAverage()[0]);
             table.addCell(stats == null ? null : stats.getJvm().uptime());
-            table.addCell(node.clientNode() ? "c" : node.dataNode() ? "d" : null);
+            table.addCell(node.clientNode() ? "c" : node.dataNode() ? "d" : "-");
             table.addCell(masterId.equals(node.id()) ? "*" : node.masterNode() ? "m" : "-");
             table.addCell(node.name());
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -60,7 +60,7 @@ public class RestShardsAction extends BaseRestHandler {
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
             public void onResponse(final ClusterStateResponse clusterStateResponse) {
-                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndicesIgnoreMissing(indices);
+                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(indices);
                 IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
                 indicesStatsRequest.clear().docs(true).store(true);
                 client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {


### PR DESCRIPTION
- Added cat help documentation for /recovery/{index}
- Made behaviour on specifying non-existing indices consistent to always return 404 if one index does not exist
- Returning '-' in NodesAction if neither client nor data node in order to prevent an empty column (makes it hard to parse)
