### PR TITLE
Cat API: Improve help and execute help before sending server requests

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -21,6 +21,7 @@ package org.elasticsearch.rest.action;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.action.admin.cluster.health.RestClusterHealthAction;
 import org.elasticsearch.rest.action.admin.cluster.node.hotthreads.RestNodesHotThreadsAction;
@@ -207,17 +208,20 @@ public class RestActionModule extends AbstractModule {
 
         bind(RestExplainAction.class).asEagerSingleton();
 
-        bind(RestAllocationAction.class).asEagerSingleton();
-        bind(RestShardsAction.class).asEagerSingleton();
-        bind(RestMasterAction.class).asEagerSingleton();
-        bind(RestNodesAction.class).asEagerSingleton();
-        bind(RestIndicesAction.class).asEagerSingleton();
+        // cat API
+        Multibinder<AbstractCatAction> catActionMultibinder = Multibinder.newSetBinder(binder(), AbstractCatAction.class);
+        catActionMultibinder.addBinding().to(RestAllocationAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestShardsAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestMasterAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestNodesAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestIndicesAction.class).asEagerSingleton();
         // Fully qualified to prevent interference with rest.action.count.RestCountAction
-        bind(org.elasticsearch.rest.action.cat.RestCountAction.class).asEagerSingleton();
-        bind(RestRecoveryAction.class).asEagerSingleton();
-        bind(RestHealthAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(org.elasticsearch.rest.action.cat.RestCountAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestRecoveryAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestHealthAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(org.elasticsearch.rest.action.cat.RestPendingClusterTasksAction.class).asEagerSingleton();
+        // no abstract cat action
         bind(RestCatAction.class).asEagerSingleton();
         bind(RestHelpAction.class).asEagerSingleton();
-        bind(org.elasticsearch.rest.action.cat.RestPendingClusterTasksAction.class).asEagerSingleton();
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest.action.cat;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Table;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.*;
+
+import static org.elasticsearch.rest.action.support.RestTable.buildHelpWidths;
+import static org.elasticsearch.rest.action.support.RestTable.pad;
+
+/**
+ *
+ */
+public abstract class AbstractCatAction extends BaseRestHandler {
+
+    public AbstractCatAction(Settings settings, Client client) {
+        super(settings, client);
+    }
+
+    abstract void doRequest(final RestRequest request, final RestChannel channel);
+    abstract void documentation(StringBuilder sb);
+    abstract Table getTableWithHeader(final RestRequest request);
+
+    @Override
+    public void handleRequest(final RestRequest request, final RestChannel channel) {
+        boolean helpWanted = request.paramAsBoolean("h", false);
+        if (helpWanted) {
+            Table table = getTableWithHeader(request);
+            int[] width = buildHelpWidths(table, request, false);
+            StringBuilder out = new StringBuilder();
+            for (Table.Cell cell : table.getHeaders()) {
+                // need to do left-align always, so create new cells
+                pad(new Table.Cell(cell.value), width[0], request, out);
+                out.append(" ");
+                pad(new Table.Cell(cell.attr.containsKey("desc") ? cell.attr.get("desc") : "not available"), width[1], request, out);
+                out.append("\n");
+            }
+            channel.sendResponse(new StringRestResponse(RestStatus.OK, out.toString()));
+        } else {
+            doRequest(request, channel);
+        }
+    }
+
+
+}

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHelpAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHelpAction.java
@@ -20,42 +20,33 @@
 package org.elasticsearch.rest.action.cat;
 
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.inject.Guice;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
+
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 
 public class RestHelpAction extends BaseRestHandler {
 
+    StringBuilder sb = new StringBuilder();
+
     @Inject
-    public RestHelpAction(Settings settings, Client client, RestController controller) {
+    public RestHelpAction(Settings settings, Client client, RestController controller, Set<AbstractCatAction> catActions) {
         super(settings, client);
         controller.registerHandler(GET, "/_cat/help", this);
         controller.registerHandler(GET, "/_cat/halp", this);
+        sb.append("Try:\n\n");
+        sb.append("/_cat/help\n");
+        for (AbstractCatAction catAction : catActions) {
+            catAction.documentation(sb);
+        }
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        // Maybe build this list from a classloader or the RestActionModule injector
-
-        StringBuilder s = new StringBuilder();
-        s.append("Try:\n\n");
-        s.append("/_cat/allocation\n");
-        s.append("/_cat/count\n");
-        s.append("/_cat/count/{index}\n");
-        s.append("/_cat/health\n");
-        s.append("/_cat/indices\n");
-        s.append("/_cat/indices/{index}\n");
-        s.append("/_cat/master\n");
-        s.append("/_cat/nodes\n");
-        s.append("/_cat/pending_tasks\n");
-        s.append("/_cat/recovery\n");
-        s.append("/_cat/shards\n");
-        s.append("/_cat/shards/{index}\n");
-        channel.sendResponse(new StringRestResponse(RestStatus.OK, s.toString()));
+        channel.sendResponse(new StringRestResponse(RestStatus.OK, sb.toString()));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
@@ -127,7 +127,7 @@ public class RestTable {
         return display;
     }
 
-    private static int[] buildHelpWidths(Table table, RestRequest request, boolean verbose) {
+    public static int[] buildHelpWidths(Table table, RestRequest request, boolean verbose) {
         int[] width = new int[2];
         for (Table.Cell cell : table.getHeaders()) {
             String v = renderValue(request, cell.value);
@@ -170,7 +170,7 @@ public class RestTable {
         return width;
     }
 
-    private static void pad(Table.Cell cell, int width, RestRequest request, StringBuilder out) {
+    public static void pad(Table.Cell cell, int width, RestRequest request, StringBuilder out) {
         String sValue = renderValue(request, cell.value);
         int length = sValue == null ? 0 : sValue.length();
         byte leftOver = (byte) (width - length);


### PR DESCRIPTION
Just a quick afternoon try to not send the actual requests when you only want to get the help for an endpoint. Still need to take a closer look at the whole API and its design on source code level to be sure, this is the correct approach. @drewr maybe you can have a look...
- Force the cat API classes to have simple help available by extending from a AbstractCatAction
- Use a set binder on guice creation to create the help on node start up
- Make sure that the help/field info is returned without querying any data
