### PR TITLE
Fixes #4323 - Debug logging can hide trace logging

### DIFF
--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGatewayService.java
@@ -209,9 +209,7 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                     recoveryStatus.time(System.currentTimeMillis() - recoveryStatus.startTime());
                     recoveryStatus.updateStage(RecoveryStatus.Stage.DONE);
 
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("recovery completed from [{}], took [{}]", shardGateway, timeValueMillis(recoveryStatus.time()));
-                    } else if (logger.isTraceEnabled()) {
+                    if (logger.isTraceEnabled()) {
                         StringBuilder sb = new StringBuilder();
                         sb.append("recovery completed from ").append(shardGateway).append(", took [").append(timeValueMillis(recoveryStatus.time())).append("]\n");
                         sb.append("    index    : files           [").append(recoveryStatus.index().numberOfFiles()).append("] with total_size [").append(new ByteSizeValue(recoveryStatus.index().totalSize())).append("], took[").append(TimeValue.timeValueMillis(recoveryStatus.index().time())).append("]\n");
@@ -220,6 +218,8 @@ public class IndexShardGatewayService extends AbstractIndexShardComponent implem
                         sb.append("    start    : took [").append(TimeValue.timeValueMillis(recoveryStatus.start().time())).append("], check_index [").append(timeValueMillis(recoveryStatus.start().checkIndexTime())).append("]\n");
                         sb.append("    translog : number_of_operations [").append(recoveryStatus.translog().currentTranslogOperations()).append("], took [").append(TimeValue.timeValueMillis(recoveryStatus.translog().time())).append("]");
                         logger.trace(sb.toString());
+                    } else if (logger.isDebugEnabled()) {
+                        logger.debug("recovery completed from [{}], took [{}]", shardGateway, timeValueMillis(recoveryStatus.time()));
                     }
                     listener.onRecoveryDone();
                     scheduleSnapshotIfNeeded();

--- a/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -188,10 +188,10 @@ public class MapperService extends AbstractIndexComponent implements Iterable<Do
                     "}";
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("using dynamic[{}], default mapping: default_mapping_location[{}], loaded_from[{}], default percolator mapping: location[{}], loaded_from[{}]", dynamic, defaultMappingLocation, defaultMappingUrl, percolatorMappingLocation, percolatorMappingUrl);
-        } else if (logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled()) {
             logger.trace("using dynamic[{}], default mapping: default_mapping_location[{}], loaded_from[{}] and source[{}], default percolator mapping: location[{}], loaded_from[{}] and source[{}]", dynamic, defaultMappingLocation, defaultMappingUrl, defaultMappingSource, percolatorMappingLocation, percolatorMappingUrl, defaultPercolatorMappingSource);
+        } else if (logger.isDebugEnabled()) {
+            logger.debug("using dynamic[{}], default mapping: default_mapping_location[{}], loaded_from[{}], default percolator mapping: location[{}], loaded_from[{}]", dynamic, defaultMappingLocation, defaultMappingUrl, percolatorMappingLocation, percolatorMappingUrl);
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -220,9 +220,7 @@ public class RecoveryTarget extends AbstractComponent {
                 return;
             }
             stopWatch.stop();
-            if (logger.isDebugEnabled()) {
-                logger.debug("recovery completed from [{}], took [{}]", request.shardId(), request.sourceNode(), stopWatch.totalTime());
-            } else if (logger.isTraceEnabled()) {
+            if (logger.isTraceEnabled()) {
                 StringBuilder sb = new StringBuilder();
                 sb.append('[').append(request.shardId().index().name()).append(']').append('[').append(request.shardId().id()).append("] ");
                 sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(stopWatch.totalTime()).append("]\n");
@@ -237,6 +235,8 @@ public class RecoveryTarget extends AbstractComponent {
                 sb.append("   phase3: recovered [").append(recoveryResponse.phase3Operations).append("]").append(" transaction log operations")
                         .append(", took [").append(timeValueMillis(recoveryResponse.phase3Time)).append("]");
                 logger.trace(sb.toString());
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("recovery completed from [{}], took [{}]", request.shardId(), request.sourceNode(), stopWatch.totalTime());
             }
             removeAndCleanOnGoingRecovery(recoveryStatus);
             listener.onRecoveryDone();


### PR DESCRIPTION
I swapped the order of the `isTraceEnabled` and `isDebugEnabled` checks to ensure that the trace log message is used if trace is enabled.
