### PR TITLE
Simplify usage of nodes info API

### DIFF
--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -6,10 +6,6 @@ the cluster nodes information.
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/_cluster/nodes'
-curl -XGET 'http://localhost:9200/_cluster/nodes/nodeId1,nodeId2'
-
-# Shorter Format
 curl -XGET 'http://localhost:9200/_nodes'
 curl -XGET 'http://localhost:9200/_nodes/nodeId1,nodeId2'
 --------------------------------------------------
@@ -19,22 +15,22 @@ The second command selectively retrieves nodes information of only
 `nodeId1` and `nodeId2`. All the nodes selective options are explained
 <<cluster-nodes,here>>.
 
-By default, it just returns the attributes and core settings for a node.
-It also allows to get information on `settings`, `os`, `process`, `jvm`,
+By default, it just returns all attributes and core settings for a node.
+It also allows to get only information on `settings`, `os`, `process`, `jvm`,
 `thread_pool`, `network`, `transport`, `http` and `plugin`:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/_nodes?os=true&process=true'
-curl -XGET 'http://localhost:9200/_nodes/10.0.0.1/?os=true&process=true'
-
-# Or, specific type endpoint:
-
 curl -XGET 'http://localhost:9200/_nodes/process'
-curl -XGET 'http://localhost:9200/_nodes/10.0.0.1/process'
+curl -XGET 'http://localhost:9200/_nodes/_all/process'
+curl -XGET 'http://localhost:9200/_nodes/nodeId1,nodeId2/jvm,process'
+# same as above
+curl -XGET 'http://localhost:9200/_nodes/nodeId1,nodeId2/info/jvm,process'
+
+curl -XGET 'http://localhost:9200/_nodes/nodeId1,nodeId2/_all
 --------------------------------------------------
 
-The `all` flag can be set to return all the information.
+The `all` flag can be set to return all the information - or you can simply omit it.
 
 `plugin` - if set, the result will contain details about the loaded
 plugins per node:

--- a/rest-api-spec/api/cluster.node_info.json
+++ b/rest-api-spec/api/cluster.node_info.json
@@ -3,62 +3,12 @@
     "documentation": "http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-info/",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/nodes",
-      "paths": ["/_cluster/nodes", "/_cluster/nodes/{node_id}", "/_nodes", "/_nodes/{node_id}", "/_nodes/settings", "/_nodes/{node_id}/settings", "/_nodes/os", "/_nodes/{node_id}/os", "/_nodes/process", "/_nodes/{node_id}/process", "/_nodes/jvm", "/_nodes/{node_id}/jvm", "/_nodes/thread_pool", "/_nodes/{node_id}/thread_pool", "/_nodes/network", "/_nodes/{node_id}/network", "/_nodes/transport", "/_nodes/{node_id}/transport", "/_nodes/http", "/_nodes/{node_id}/http", "/_nodes/plugin", "/_nodes/{node_id}/plugin"],
+      "path": "/_nodes",
+      "paths": ["/_nodes", "/_nodes/{node_id}", "/_nodes/settings", "/_nodes/{node_id}/settings", "/_nodes/os", "/_nodes/{node_id}/os", "/_nodes/process", "/_nodes/{node_id}/process", "/_nodes/jvm", "/_nodes/{node_id}/jvm", "/_nodes/thread_pool", "/_nodes/{node_id}/thread_pool", "/_nodes/network", "/_nodes/{node_id}/network", "/_nodes/transport", "/_nodes/{node_id}/transport", "/_nodes/http", "/_nodes/{node_id}/http", "/_nodes/plugin", "/_nodes/{node_id}/plugin"],
       "parts": {
         "node_id": {
           "type" : "list",
           "description" : "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
-        }
-      },
-      "params": {
-        "all": {
-          "type" : "boolean",
-          "description" : "Return all available information"
-        },
-        "clear": {
-          "type" : "boolean",
-          "description" : "Reset the default settings"
-        },
-        "http": {
-          "type" : "boolean",
-          "description" : "Return information about HTTP"
-        },
-        "jvm": {
-          "type" : "boolean",
-          "description" : "Return information about the JVM"
-        },
-        "network": {
-          "type" : "boolean",
-          "description" : "Return information about network"
-        },
-        "os": {
-          "type" : "boolean",
-          "description" : "Return information about the operating system"
-        },
-        "plugin": {
-          "type" : "boolean",
-          "description" : "Return information about plugins"
-        },
-        "process": {
-          "type" : "boolean",
-          "description" : "Return information about the Elasticsearch process"
-        },
-        "settings": {
-          "type" : "boolean",
-          "description" : "Return information about node settings"
-        },
-        "thread_pool": {
-          "type" : "boolean",
-          "description" : "Return information about the thread pool"
-        },
-        "timeout": {
-          "type" : "time",
-          "description" : "Explicit operation timeout"
-        },
-        "transport": {
-          "type" : "boolean",
-          "description" : "Return information about transport"
         }
       }
     },

--- a/rest-api-spec/api/cluster.node_stats.json
+++ b/rest-api-spec/api/cluster.node_stats.json
@@ -3,10 +3,8 @@
     "documentation": "http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-stats/",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/nodes/stats",
+      "path": "/_nodes/stats",
       "paths": [
-        "/_cluster/nodes/stats",
-        "/_cluster/nodes/{node_id}/stats",
         "/_nodes/stats",
         "/_nodes/{node_id}/stats",
         "/_nodes/stats/{metric_family}",
@@ -35,53 +33,9 @@
         }
       },
       "params": {
-        "all": {
-          "type" : "boolean",
-          "description" : "Return all available information"
-        },
-        "clear": {
-          "type" : "boolean",
-          "description" : "Reset the default level of detail"
-        },
         "fields": {
           "type" : "list",
           "description" : "A comma-separated list of fields for `fielddata` metric (supports wildcards)"
-        },
-        "fs": {
-          "type" : "boolean",
-          "description" : "Return information about the filesystem"
-        },
-        "http": {
-          "type" : "boolean",
-          "description" : "Return information about HTTP"
-        },
-        "indices": {
-          "type" : "boolean",
-          "description" : "Return information about indices"
-        },
-        "jvm": {
-          "type" : "boolean",
-          "description" : "Return information about the JVM"
-        },
-        "network": {
-          "type" : "boolean",
-          "description" : "Return information about network"
-        },
-        "os": {
-          "type" : "boolean",
-          "description" : "Return information about the operating system"
-        },
-        "process": {
-          "type" : "boolean",
-          "description" : "Return information about the Elasticsearch process"
-        },
-        "thread_pool": {
-          "type" : "boolean",
-          "description" : "Return information about the thread pool"
-        },
-        "transport": {
-          "type" : "boolean",
-          "description" : "Return information about transport"
         }
       }
     },

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -30,15 +30,15 @@ import java.io.IOException;
  */
 public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
 
-    private boolean settings = false;
-    private boolean os = false;
-    private boolean process = false;
-    private boolean jvm = false;
-    private boolean threadPool = false;
-    private boolean network = false;
-    private boolean transport = false;
-    private boolean http = false;
-    private boolean plugin = false;
+    private boolean settings = true;
+    private boolean os = true;
+    private boolean process = true;
+    private boolean jvm = true;
+    private boolean threadPool = true;
+    private boolean network = true;
+    private boolean transport = true;
+    private boolean http = true;
+    private boolean plugin = true;
 
     public NodesInfoRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -104,7 +104,7 @@ public class NodesInfoResponse extends NodesOperationResponse<NodeInfo> implemen
 
             if (nodeInfo.getSettings() != null) {
                 builder.startObject("settings");
-                Settings settings = settingsFilter.filterSettings(nodeInfo.getSettings());
+                Settings settings = settingsFilter != null ? settingsFilter.filterSettings(nodeInfo.getSettings()) : nodeInfo.getSettings();
                 for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
                     builder.field(entry.getKey(), entry.getValue(), XContentBuilder.FieldCaseConversion.NONE);
                 }

--- a/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
+++ b/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
@@ -129,7 +129,7 @@ public class SimpleNodesInfoTests extends ElasticsearchIntegrationTest {
         ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus()).actionGet();
         logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
 
-        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().setPlugin(true).execute().actionGet();
+        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
         logger.info("--> full json answer, status " + response.toString());
 
         assertNodeContainsPlugins(response, server1NodeId, Collections.EMPTY_LIST, Collections.EMPTY_LIST,


### PR DESCRIPTION
Important: This breaks backwards compatibility with 0.90
- Removed endpoints: /_cluster/nodes, /_cluster/nodes/nodeId1,nodeId2
- Disallow usage of parameters, but make them required part of URI instead
- Changed NodesInfoRequest to return everything by default
- Fixed NPE in NodesInfoResponse

Closes #4055

**Note**: Before this should is going to be pushed, #4057 must be changed as well, because some URLs overlap and are not returned correctly
