### PR TITLE
Update the Wonderdog repo URL

### DIFF
--- a/docs/community/integrations.asciidoc
+++ b/docs/community/integrations.asciidoc
@@ -23,7 +23,7 @@
 * http://code.google.com/p/terrastore/wiki/Search_Integration[Terrastore Search]:
   http://code.google.com/p/terrastore/[Terrastore] integration module with elasticsearch.
 
-* https://github.com/infochimps/wonderdog[Wonderdog]:
+* https://github.com/infochimps-labs/wonderdog[Wonderdog]:
   Hadoop bulk loader into elasticsearch.
 
 * http://geeks.aretotally.in/play-framework-module-elastic-search-distributed-searching-with-json-http-rest-or-java[Play!Framework]:


### PR DESCRIPTION
I discovered that the Wonderdog repo was relocated; I didn't try the rest of the repo links, so I can't attest to their accuracy.
