### PR TITLE
Support 'yaml' as a format for the Analyze API

### DIFF
--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -48,11 +48,3 @@ mapping for `obj1.field1` (and if not, the default index analyzer).
 
 Also, the text can be provided as part of the request body, and not as a
 parameter.
-
-[float]
-[[format]]
-=== Format
-
-By default, the format the tokens are returned in are in json and its
-called `detailed`. The `text` format value provides the analyzed data in
-a text stream that is a bit more readable.

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
@@ -119,37 +119,17 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        String format = params.param("format", "detailed");
-        if ("detailed".equals(format) || "yaml".equals(format)) {
-            builder.startArray("tokens");
-            for (AnalyzeToken token : tokens) {
-                builder.startObject();
-                builder.field("token", token.getTerm());
-                builder.field("start_offset", token.getStartOffset());
-                builder.field("end_offset", token.getEndOffset());
-                builder.field("type", token.getType());
-                builder.field("position", token.getPosition());
-                builder.endObject();
-            }
-            builder.endArray();
-        } else if ("text".equals(format)) {
-            StringBuilder sb = new StringBuilder();
-            int lastPosition = 0;
-            for (AnalyzeToken token : tokens) {
-                if (lastPosition != token.getPosition()) {
-                    if (lastPosition != 0) {
-                        sb.append("\n").append(token.getPosition()).append(": \n");
-                    }
-                    lastPosition = token.getPosition();
-                }
-                sb.append('[')
-                        .append(token.getTerm()).append(":")
-                        .append(token.getStartOffset()).append("->").append(token.getEndOffset()).append(":")
-                        .append(token.getType())
-                        .append("]\n");
-            }
-            builder.field("tokens", sb);
+        builder.startArray("tokens");
+        for (AnalyzeToken token : tokens) {
+            builder.startObject();
+            builder.field("token", token.getTerm());
+            builder.field("start_offset", token.getStartOffset());
+            builder.field("end_offset", token.getEndOffset());
+            builder.field("type", token.getType());
+            builder.field("position", token.getPosition());
+            builder.endObject();
         }
+        builder.endArray();
         return builder;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,14 +120,14 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startArray("tokens");
+        builder.startArray(Fields.TOKENS);
         for (AnalyzeToken token : tokens) {
             builder.startObject();
-            builder.field("token", token.getTerm());
-            builder.field("start_offset", token.getStartOffset());
-            builder.field("end_offset", token.getEndOffset());
-            builder.field("type", token.getType());
-            builder.field("position", token.getPosition());
+            builder.field(Fields.TOKEN, token.getTerm());
+            builder.field(Fields.START_OFFSET, token.getStartOffset());
+            builder.field(Fields.END_OFFSET, token.getEndOffset());
+            builder.field(Fields.TYPE, token.getType());
+            builder.field(Fields.POSITION, token.getPosition());
             builder.endObject();
         }
         builder.endArray();
@@ -150,5 +151,14 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
         for (AnalyzeToken token : tokens) {
             token.writeTo(out);
         }
+    }
+
+    static final class Fields {
+        static final XContentBuilderString TOKENS = new XContentBuilderString("tokens");
+        static final XContentBuilderString TOKEN = new XContentBuilderString("token");
+        static final XContentBuilderString START_OFFSET = new XContentBuilderString("start_offset");
+        static final XContentBuilderString END_OFFSET = new XContentBuilderString("end_offset");
+        static final XContentBuilderString TYPE = new XContentBuilderString("type");
+        static final XContentBuilderString POSITION = new XContentBuilderString("position");
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
@@ -120,7 +120,7 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         String format = params.param("format", "detailed");
-        if ("detailed".equals(format)) {
+        if ("detailed".equals(format) || "yaml".equals(format)) {
             builder.startArray("tokens");
             for (AnalyzeToken token : tokens) {
                 builder.startObject();


### PR DESCRIPTION
Fixes #4311.

Copies the format of the `detailed` format, because putting the `text` format into yaml doesn't make much sense to me.
