### PR TITLE
Remove hard-coded "ok": true from REST responses

### DIFF
--- a/rest-api-spec/test/cluster.node_info/10_basic.yaml
+++ b/rest-api-spec/test/cluster.node_info/10_basic.yaml
@@ -2,7 +2,6 @@
 "node_info test":
   - do:
       cluster.node_info: {}
-  
-  - is_true: ok
+
   - is_true: nodes
   - is_true: cluster_name

--- a/rest-api-spec/test/cluster.reroute/10_basic.yaml
+++ b/rest-api-spec/test/cluster.reroute/10_basic.yaml
@@ -2,5 +2,3 @@
 "Basic sanity check":
   - do:
       cluster.reroute: {}
-
-  - is_true: ok

--- a/rest-api-spec/test/create/10_with_id.yaml
+++ b/rest-api-spec/test/create/10_with_id.yaml
@@ -7,7 +7,6 @@
           id:     1
           body:   { foo: bar }
 
- - is_true:   ok
  - match:   { _index:   test_1 }
  - match:   { _type:    test }
  - match:   { _id:      "1"}

--- a/rest-api-spec/test/create/15_without_id.yaml
+++ b/rest-api-spec/test/create/15_without_id.yaml
@@ -6,7 +6,6 @@
           type:   test
           body:   { foo: bar }
 
- - is_true:   ok
  - is_true:   _id
  - match:   { _index:   test_1 }
  - match:   { _type:    test   }
@@ -24,4 +23,3 @@
  - match:   { _id:      $id    }
  - match:   { _version: 1      }
  - match:   { _source: { foo: bar }}
-

--- a/rest-api-spec/test/delete/10_basic.yaml
+++ b/rest-api-spec/test/delete/10_basic.yaml
@@ -8,7 +8,6 @@
           id:     1
           body:   { foo: bar }
 
- - is_true:   ok
  - match:   { _version: 1 }
 
  - do:

--- a/rest-api-spec/test/delete_by_query/10_basic.yaml
+++ b/rest-api-spec/test/delete_by_query/10_basic.yaml
@@ -32,8 +32,6 @@
             match:
               foo: bar
 
-  - is_true: ok
-
   - do:
       indices.refresh: {}
 

--- a/rest-api-spec/test/explain/10_basic.yaml
+++ b/rest-api-spec/test/explain/10_basic.yaml
@@ -20,6 +20,4 @@
               match_all: {}
 
   - is_true: matched
-  - is_true: ok
   - match: { explanation.value: 1 }
-

--- a/rest-api-spec/test/index/10_with_id.yaml
+++ b/rest-api-spec/test/index/10_with_id.yaml
@@ -8,7 +8,6 @@
           id:     1
           body:   { foo: bar }
 
- - is_true:   ok
  - match:   { _index:   test-weird-index-中文 }
  - match:   { _type:    weird.type }
  - match:   { _id:      "1"}
@@ -25,4 +24,3 @@
  - match:   { _id:      "1"}
  - match:   { _version: 1}
  - match:   { _source: { foo: bar }}
-

--- a/rest-api-spec/test/index/15_without_id.yaml
+++ b/rest-api-spec/test/index/15_without_id.yaml
@@ -7,7 +7,6 @@
           type:   test
           body:   { foo: bar }
 
- - is_true:   ok
  - is_true:   _id
  - match:   { _index:   test_1 }
  - match:   { _type:    test   }
@@ -25,4 +24,3 @@
  - match:   { _id:      $id    }
  - match:   { _version: 1      }
  - match:   { _source: { foo: bar }}
-

--- a/rest-api-spec/test/indices.clear_cache/10_basic.yaml
+++ b/rest-api-spec/test/indices.clear_cache/10_basic.yaml
@@ -2,5 +2,3 @@
 "clear_cache test":
   - do:
       indices.clear_cache: {}
-  
-  - is_true: ok

--- a/rest-api-spec/test/indices.optimize/10_basic.yaml
+++ b/rest-api-spec/test/indices.optimize/10_basic.yaml
@@ -8,5 +8,3 @@
       indices.optimize:
         index: testing
         max_num_segments: 1
-
-  - is_true: ok

--- a/rest-api-spec/test/indices.put_alias/10_basic.yaml
+++ b/rest-api-spec/test/indices.put_alias/10_basic.yaml
@@ -16,8 +16,6 @@
         index: test_index
         name: test_alias
 
-  - is_true: ok
-
   - do:
       indices.exists_alias:
         name: test_alias

--- a/rest-api-spec/test/indices.put_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.put_template/10_basic.yaml
@@ -9,8 +9,6 @@
             number_of_shards:   1
             number_of_replicas: 0
 
-  - is_true: ok
-
   - do:
       indices.get_template:
         name: test

--- a/rest-api-spec/test/indices.put_warmer/10_basic.yaml
+++ b/rest-api-spec/test/indices.put_warmer/10_basic.yaml
@@ -7,7 +7,7 @@
   - do:
       cluster.health:
         wait_for_status: yellow
-  
+
   - do:
       catch: missing
       indices.get_warmer:
@@ -22,8 +22,6 @@
           query:
             match_all: {}
 
-  - is_true: ok
-
   - do:
       indices.get_warmer:
         index: test_index
@@ -34,8 +32,6 @@
   - do:
       indices.delete_warmer:
         index: test_index
-
-  - is_true: ok
 
   - do:
       catch: missing

--- a/rest-api-spec/test/indices.segments/10_basic.yaml
+++ b/rest-api-spec/test/indices.segments/10_basic.yaml
@@ -3,5 +3,3 @@
   - do:
       indices.segments:
         allow_no_indices: true
-  
-  - is_true: ok

--- a/rest-api-spec/test/indices.snapshot_index/10_basic.yaml
+++ b/rest-api-spec/test/indices.snapshot_index/10_basic.yaml
@@ -2,5 +2,3 @@
 "snapshot_index test":
   - do:
       indices.snapshot_index: {}
-  
-  - is_true: ok

--- a/rest-api-spec/test/indices.stats/10_basic.yaml
+++ b/rest-api-spec/test/indices.stats/10_basic.yaml
@@ -2,5 +2,3 @@
 "stats test":
   - do:
       indices.stats: {}
-  
-  - is_true: ok

--- a/rest-api-spec/test/indices.status/10_basic.yaml
+++ b/rest-api-spec/test/indices.status/10_basic.yaml
@@ -3,10 +3,7 @@
   - do:
       indices.status: {}
 
-  - is_true: ok
-
   - do:
       catch: missing
       indices.status:
         index: not_here
-

--- a/rest-api-spec/test/indices.update_aliases/10_basic.yaml
+++ b/rest-api-spec/test/indices.update_aliases/10_basic.yaml
@@ -20,8 +20,6 @@
                 alias: test_alias
                 routing: routing_value
 
-  - is_true: ok
-
   - do:
       indices.exists_alias:
         name: test_alias
@@ -34,4 +32,3 @@
         name: test_alias
 
   - match: {test_index.aliases.test_alias: {'index_routing': 'routing_value', 'search_routing': 'routing_value'}}
-

--- a/rest-api-spec/test/info/10_info.yaml
+++ b/rest-api-spec/test/info/10_info.yaml
@@ -2,10 +2,7 @@
 "Info":
     - do:         {info: {}}
     - match:      {status: 200}
-    - is_true:    ok
     - is_true:    name
     - is_true:    tagline
     - is_true:    version
     - is_true:    version.number
-
-

--- a/src/main/java/org/elasticsearch/rest/AcknowledgedRestResponseActionListener.java
+++ b/src/main/java/org/elasticsearch/rest/AcknowledgedRestResponseActionListener.java
@@ -41,7 +41,6 @@ public class AcknowledgedRestResponseActionListener<T extends AcknowledgedRespon
         try {
             XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
             builder.startObject()
-                    .field(Fields.OK, true)
                     .field(Fields.ACKNOWLEDGED, response.isAcknowledged());
             addCustomFields(builder, response);
             builder.endObject();
@@ -60,7 +59,6 @@ public class AcknowledgedRestResponseActionListener<T extends AcknowledgedRespon
     }
 
     static final class Fields {
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
         static final XContentBuilderString ACKNOWLEDGED = new XContentBuilderString("acknowledged");
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -116,7 +116,6 @@ public class RestNodesInfoAction extends BaseRestHandler {
                     response.settingsFilter(settingsFilter);
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
                     response.toXContent(builder, request);
                     builder.endObject();
                     channel.sendResponse(new XContentRestResponse(request, RestStatus.OK, builder));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
@@ -70,7 +70,6 @@ public class RestClusterSearchShardsAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
                     response.toXContent(builder, request);
                     builder.endObject();
                     channel.sendResponse(new XContentRestResponse(request, RestStatus.OK, builder));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -106,7 +106,6 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
 
                     buildBroadcastShardsHeader(builder, response);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -73,7 +73,6 @@ public class RestFlushAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
 
                     buildBroadcastShardsHeader(builder, response);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/gateway/snapshot/RestGatewaySnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/gateway/snapshot/RestGatewaySnapshotAction.java
@@ -61,7 +61,6 @@ public class RestGatewaySnapshotAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
 
                     buildBroadcastShardsHeader(builder, response);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -87,7 +87,6 @@ public class RestOptimizeAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
 
                     buildBroadcastShardsHeader(builder, response);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -72,7 +72,6 @@ public class RestRefreshAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
 
                     buildBroadcastShardsHeader(builder, response);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -66,7 +66,6 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
                     buildBroadcastShardsHeader(builder, response);
                     response.toXContent(builder, request);
                     builder.endObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -105,7 +105,6 @@ public class RestIndicesStatsAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
                     buildBroadcastShardsHeader(builder, response);
                     response.toXContent(builder, request);
                     builder.endObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/status/RestIndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/status/RestIndicesStatusAction.java
@@ -75,7 +75,6 @@ public class RestIndicesStatusAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-                    builder.field("ok", true);
                     buildBroadcastShardsHeader(builder, response);
                     response.toXContent(builder, request, settingsFilter);
                     builder.endObject();

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -125,7 +125,6 @@ public class RestBulkAction extends BaseRestHandler {
                             builder.field(Fields.STATUS, itemResponse.getFailure().getStatus().getStatus());
                             builder.field(Fields.ERROR, itemResponse.getFailure().getMessage());
                         } else {
-                            builder.field(Fields.OK, true);
                             if (itemResponse.getResponse() instanceof DeleteResponse) {
                                 DeleteResponse deleteResponse = itemResponse.getResponse();
                                 if (deleteResponse.isNotFound()) {
@@ -181,7 +180,6 @@ public class RestBulkAction extends BaseRestHandler {
         static final XContentBuilderString _ID = new XContentBuilderString("_id");
         static final XContentBuilderString STATUS = new XContentBuilderString("status");
         static final XContentBuilderString ERROR = new XContentBuilderString("error");
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
         static final XContentBuilderString TOOK = new XContentBuilderString("took");
         static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
         static final XContentBuilderString FOUND = new XContentBuilderString("found");

--- a/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -80,7 +80,6 @@ public class RestDeleteAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject()
-                            .field(Fields.OK, true)
                             .field(Fields.FOUND, !result.isNotFound())
                             .field(Fields._INDEX, result.getIndex())
                             .field(Fields._TYPE, result.getType())
@@ -109,7 +108,6 @@ public class RestDeleteAction extends BaseRestHandler {
     }
 
     static final class Fields {
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
         static final XContentBuilderString FOUND = new XContentBuilderString("found");
         static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -100,8 +100,7 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     RestStatus restStatus = result.status();
-                    builder.startObject().field("ok", restStatus == RestStatus.OK);
-
+                    builder.startObject();
                     builder.startObject("_indices");
                     for (IndexDeleteByQueryResponse indexDeleteByQueryResponse : result.getIndices().values()) {
                         builder.startObject(indexDeleteByQueryResponse.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
@@ -115,7 +114,6 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
                         builder.endObject();
                     }
                     builder.endObject();
-
                     builder.endObject();
                     channel.sendResponse(new XContentRestResponse(request, restStatus, builder));
                 } catch (Throwable e) {

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -110,8 +110,7 @@ public class RestExplainAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = restContentBuilder(request);
                     builder.startObject();
-                    builder.field(Fields.OK, response.isExists())
-                            .field(Fields._INDEX, explainRequest.index())
+                    builder.field(Fields._INDEX, explainRequest.index())
                             .field(Fields._TYPE, explainRequest.type())
                             .field(Fields._ID, explainRequest.id())
                             .field(Fields.MATCHED, response.isMatch());
@@ -161,7 +160,6 @@ public class RestExplainAction extends BaseRestHandler {
     }
 
     static class Fields {
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
         static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
         static final XContentBuilderString _ID = new XContentBuilderString("_id");

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -109,7 +109,6 @@ public class RestIndexAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject()
-                            .field(Fields.OK, true)
                             .field(Fields._INDEX, response.getIndex())
                             .field(Fields._TYPE, response.getType())
                             .field(Fields._ID, response.getId())
@@ -137,7 +136,6 @@ public class RestIndexAction extends BaseRestHandler {
     }
 
     static final class Fields {
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
         static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
         static final XContentBuilderString _ID = new XContentBuilderString("_id");

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -80,7 +80,6 @@ public class RestMainAction extends BaseRestHandler {
                     }
 
                     builder.startObject();
-                    builder.field("ok", true);
                     builder.field("status", status.getStatus());
                     if (settings.get("name") != null) {
                         builder.field("name", settings.get("name"));

--- a/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -61,7 +61,6 @@ public class RestClearScrollAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = restContentBuilder(request);
                     builder.startObject();
-                    builder.field(Fields.OK, response.isSucceeded());
                     builder.endObject();
                     channel.sendResponse(new XContentRestResponse(request, OK, builder));
                 } catch (Throwable e) {
@@ -85,11 +84,5 @@ public class RestClearScrollAction extends BaseRestHandler {
             return Strings.EMPTY_ARRAY;
         }
         return Strings.splitStringByCommaToArray(scrollIds);
-    }
-
-    static final class Fields {
-
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
-
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -131,7 +131,6 @@ public class RestUpdateAction extends BaseRestHandler {
                 try {
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject()
-                            .field(Fields.OK, true)
                             .field(Fields._INDEX, response.getIndex())
                             .field(Fields._TYPE, response.getType())
                             .field(Fields._ID, response.getId())
@@ -166,7 +165,6 @@ public class RestUpdateAction extends BaseRestHandler {
     }
 
     static final class Fields {
-        static final XContentBuilderString OK = new XContentBuilderString("ok");
         static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
         static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
         static final XContentBuilderString _ID = new XContentBuilderString("_id");

--- a/src/main/java/org/elasticsearch/river/RiversService.java
+++ b/src/main/java/org/elasticsearch/river/RiversService.java
@@ -147,7 +147,6 @@ public class RiversService extends AbstractLifecycleComponent<RiversService> {
             river.start();
 
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-            builder.field("ok", true);
 
             builder.startObject("node");
             builder.field("id", clusterService.localNode().id());

--- a/src/test/java/org/elasticsearch/test/rest/test/TestSectionParserTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/test/TestSectionParserTests.java
@@ -262,13 +262,12 @@ public class TestSectionParserTests extends AbstractParserTests {
                 "  - do:\n" +
                 "      cluster.node_info: {}\n" +
                 "  \n" +
-                "  - is_true: ok\n" +
                 "  - is_true: nodes\n" +
                 "  - is_true: cluster_name\n");
         RestTestSectionParser testSectionParser = new RestTestSectionParser();
         TestSection testSection = testSectionParser.parse(new RestTestSuiteParseContext("api", "suite", parser, "0.90.5"));
         assertThat(testSection, notNullValue());
         assertThat(testSection.getName(), equalTo("node_info test"));
-        assertThat(testSection.getExecutableSections().size(), equalTo(4));
+        assertThat(testSection.getExecutableSections().size(), equalTo(3));
     }
 }


### PR DESCRIPTION
Fixes #4310.

I chose to remove only the `{"ok": true}` messages where the `true` was hard-coded, there are still 3 places where the `ok` field could be different: RestDeleteByQueryAction, RestExplainAction, and RestClearScrollAction. In these the actual success of the action is returned.

I'm happy to remove those if we decide we don't want them.
