### PR TITLE
Add transport.publish_port setting

### DIFF
--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -25,6 +25,12 @@ TCP. It allows for the following settings:
 |Setting |Description
 |`transport.tcp.port` |A bind port range. Defaults to `9300-9400`.
 
+|`transport.publish_port` |The port that other nodes in the cluster
+should use when communicating with this node. Useful when a cluster node
+is behind a proxy or firewall and the `transport.tcp.port` is not directly
+addressable from the outside. Defaults to the actual port assigned via
+`transport.tcp.port`.
+
 |`transport.tcp.connect_timeout` |The socket connect timeout setting (in
 time setting format). Defaults to `2s`.
 

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -114,6 +114,8 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
 
     final String publishHost;
 
+    final int publishPort;
+
     final boolean compress;
 
     final TimeValue connectTimeout;
@@ -179,6 +181,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         this.port = componentSettings.get("port", settings.get("transport.tcp.port", "9300-9400"));
         this.bindHost = componentSettings.get("bind_host", settings.get("transport.bind_host", settings.get("transport.host")));
         this.publishHost = componentSettings.get("publish_host", settings.get("transport.publish_host", settings.get("transport.host")));
+        this.publishPort = componentSettings.getAsInt("publish_port", settings.getAsInt("transport.publish_port", 0));
         this.compress = settings.getAsBoolean(TransportSettings.TRANSPORT_TCP_COMPRESS, false);
         this.connectTimeout = componentSettings.getAsTime("connect_timeout", settings.getAsTime("transport.tcp.connect_timeout", settings.getAsTime(TCP_CONNECT_TIMEOUT, TCP_DEFAULT_CONNECT_TIMEOUT)));
         this.tcpNoDelay = componentSettings.getAsBoolean("tcp_no_delay", settings.getAsBoolean(TCP_NO_DELAY, true));
@@ -381,8 +384,12 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
 
         InetSocketAddress boundAddress = (InetSocketAddress) serverChannel.getLocalAddress();
         InetSocketAddress publishAddress;
+        int publishPort = this.publishPort;
+        if (0 == publishPort) {
+            publishPort = boundAddress.getPort();
+        }
         try {
-            publishAddress = new InetSocketAddress(networkService.resolvePublishHostAddress(publishHost), boundAddress.getPort());
+            publishAddress = new InetSocketAddress(networkService.resolvePublishHostAddress(publishHost), publishPort);
         } catch (Exception e) {
             throw new BindTransportException("Failed to resolve publish address", e);
         }


### PR DESCRIPTION
Add transport.publish_port setting to allow users to specify the port
other cluster members should use when connecting to an instance. This
is needed for systems such as OpenShift, where cluster communication
needs to use a publicly accessibly proxy port, because the normal port
(9300) is bound to a private loopback IP address.
