### PR TITLE
Add wildcard support to field resolving in the Get Field Mapping API

### DIFF
--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -38,7 +38,7 @@ For which the response is (assuming `text` is a default string field):
 The get field mapping API can be used to get the mapping of multiple fields from more than one index or type
 with a single call. General usage of the API follows the
 following syntax: `host:port/{index}/{type}/_mapping/field/{field}` where
-`{index}`, `{type}` and `{field}` can stand for comma-separated list of names. To
+`{index}`, `{type}` and `{field}` can stand for comma-separated list of names or wild cards. To
 get mappings for all indices you can use `_all` for `{index}`. The
 following are some examples:
 
@@ -47,12 +47,15 @@ following are some examples:
 curl -XGET 'http://localhost:9200/twitter,kimchy/_mapping/field/message'
 
 curl -XGET 'http://localhost:9200/_all/tweet,book/_mapping/field/message,user.id'
+
+curl -XGET 'http://localhost:9200/_all/tw*/_mapping/field/*.id'
 --------------------------------------------------
 
 [float]
 === Specifying fields
 
-The get mapping api allows you to specify fields using any of the following:
+The get mapping api allows you to specify one or more fields separated with by a comma.
+You can also use wildcards. The field names can be any of the following:
 
 [horizontal]
 Full names:: the full path, including any parent object name the field is


### PR DESCRIPTION
Closes #4367

Note that using `curl -XGET "http://localhost:9200/index/type/_mapping/field/*"` will also give you mappings for the root mappers `_all` , `_id` , `_source` etc. 
