### PR TITLE
Apply slop correctly if phrase query is wrapped in a filtered query.

### DIFF
--- a/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.*;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryParseContext;
@@ -849,6 +850,9 @@ public class MapperQueryParser extends QueryParser {
     }
 
     private void applySlop(Query q, int slop) {
+        if (q instanceof XFilteredQuery) {
+            applySlop(((XFilteredQuery)q).getQuery(), slop);
+        }
         if (q instanceof PhraseQuery) {
             ((PhraseQuery) q).setSlop(slop);
         } else if (q instanceof MultiPhraseQuery) {

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -125,7 +125,7 @@ public class QueryStringQueryParser implements QueryParser {
                 if ("query".equals(currentFieldName)) {
                     qpSettings.queryString(parser.text());
                 } else if ("default_field".equals(currentFieldName) || "defaultField".equals(currentFieldName)) {
-                    qpSettings.defaultField(parseContext.indexName(parser.text()));
+                    qpSettings.defaultField(parser.text());
                 } else if ("default_operator".equals(currentFieldName) || "defaultOperator".equals(currentFieldName)) {
                     String op = parser.text();
                     if ("or".equalsIgnoreCase(op)) {
@@ -201,7 +201,6 @@ public class QueryStringQueryParser implements QueryParser {
         }
 
         qpSettings.queryTypes(parseContext.queryTypes());
-
         Query query = parseContext.indexCache().queryParserCache().get(qpSettings);
         if (query != null) {
             return query;


### PR DESCRIPTION
If a phrase query is wrapped in a filtered query due to type filtering
slop was not applied correctly. Also if the default field required a
type filter the filter was not applied.

Closes #4356
