### PR TITLE
Query String caching could cause matched_filters not working

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -204,6 +204,9 @@ public class QueryStringQueryParser implements QueryParser {
 
         Query query = parseContext.indexCache().queryParserCache().get(qpSettings);
         if (query != null) {
+            if (queryName != null) {
+                parseContext.addNamedQuery(queryName, query);
+            }
             return query;
         }
 

--- a/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesTests.java
+++ b/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesTests.java
@@ -203,4 +203,52 @@ public class MatchedQueriesTests extends ElasticsearchIntegrationTest {
             }
         }
     }
+
+    /**
+     * Test case for issue #4361: https://github.com/elasticsearch/elasticsearch/issues/4361
+     */
+    @Test
+    public void testMatchedWithShould() throws Exception {
+        createIndex("test");
+        ensureGreen();
+
+        client().prepareIndex("test", "type1", "1").setSource("content", "Lorem ipsum dolor sit amet").get();
+        client().prepareIndex("test", "type1", "2").setSource("content", "consectetur adipisicing elit").get();
+        refresh();
+
+        // Execute search a first time to load it in cache
+        client().prepareSearch()
+                .setQuery(
+                        boolQuery()
+                            .minimumNumberShouldMatch(1)
+                            .should(queryString("dolor").queryName("dolor"))
+                            .should(queryString("elit").queryName("elit"))
+                )
+                .setPreference("_primary")
+                .get();
+
+        SearchResponse searchResponse = client().prepareSearch()
+                .setQuery(
+                        boolQuery()
+                                .minimumNumberShouldMatch(1)
+                                .should(queryString("dolor").queryName("dolor"))
+                                .should(queryString("elit").queryName("elit"))
+                )
+                .setPreference("_primary")
+                .get();
+
+        //_primary
+        assertHitCount(searchResponse, 2l);
+        for (SearchHit hit : searchResponse.getHits()) {
+            if (hit.id().equals("1")) {
+                assertThat(hit.matchedQueries().length, equalTo(1));
+                assertThat(hit.matchedQueries(), hasItemInArray("dolor"));
+            } else if (hit.id().equals("2")) {
+                assertThat(hit.matchedQueries().length, equalTo(1));
+                assertThat(hit.matchedQueries(), hasItemInArray("elit"));
+            } else {
+                fail("Unexpected document returned with id " + hit.id());
+            }
+        }
+    }
 }


### PR DESCRIPTION
PR for #4361.

When searching with a query containing query_strings inside a bool query, the specified _name is randomly missing from the results due to caching.
