### PR TITLE
Remove 'term_index_interval' and 'term_index_divisor'

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -36,24 +36,6 @@ otherwise it is written in non-compound format.  added[0.90.2]
     in compound format or non-compound format? Defaults to `true`.
     This is a dynamic setting.
 
-`index.term_index_interval`::
-
-	Set the interval between indexed terms.
-	Large values cause less memory to be used by a reader / searcher, but
-	slow random-access to terms. Small values cause more memory to be used
-	by a reader / searcher, and speed random-access to terms. Defaults to
-	`128`.
-
-`index.term_index_divisor`::
-	Subsamples which indexed terms are loaded
-	into RAM. This has the same effect as `index.term_index_interval` except
-	that setting must be done at indexing time while this setting can be set
-	per reader / searcher. When set to N, then one in every
-	N*termIndexInterval terms in the index is loaded into memory. By setting
-	this to a value > 1 you can reduce memory usage, at the expense of
-	higher latency when loading a TermInfo. The default value is 1. Set this
-	to -1 to skip loading the terms index entirely.
-
 `index.refresh_interval`::
 	A time setting controlling how often the
 	refresh operation will be executed. Defaults to `1s`. Can be set to `-1`

--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -53,12 +53,6 @@ settings API:
 `index.refresh_interval`::
     The async refresh interval of a shard.
 
-`index.term_index_interval`::
-    The Lucene index term interval. Only applies to newly created docs.
-
-`index.term_index_divisor`::
-    The Lucene reader term index divisor.
-
 `index.index_concurrency`::
     Defaults to `8`.
 

--- a/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
@@ -77,8 +77,6 @@ public class IndexDynamicSettingsModule extends AbstractModule {
         indexDynamicSettings.addDynamicSetting(LogDocMergePolicyProvider.INDEX_MERGE_POLICY_MAX_MERGE_DOCS, Validator.POSITIVE_INTEGER);
         indexDynamicSettings.addDynamicSetting(LogDocMergePolicyProvider.INDEX_MERGE_POLICY_MERGE_FACTOR, Validator.INTEGER_GTE_2);
         indexDynamicSettings.addDynamicSetting(LogDocMergePolicyProvider.INDEX_COMPOUND_FORMAT);
-        indexDynamicSettings.addDynamicSetting(RobinEngine.INDEX_TERM_INDEX_INTERVAL, Validator.POSITIVE_INTEGER);
-        indexDynamicSettings.addDynamicSetting(RobinEngine.INDEX_TERM_INDEX_DIVISOR, Validator.POSITIVE_INTEGER);
         indexDynamicSettings.addDynamicSetting(RobinEngine.INDEX_INDEX_CONCURRENCY, Validator.NON_NEGATIVE_INTEGER);
         indexDynamicSettings.addDynamicSetting(RobinEngine.INDEX_COMPOUND_ON_FLUSH, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(RobinEngine.INDEX_GC_DELETES, Validator.TIME);


### PR DESCRIPTION
These settings are no longer relevant since they are codec /
postingsformat level settings since Lucene 4.0

Closes #3912
