### PR TITLE
Support postings highlighter in percolate api.

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
@@ -22,10 +22,7 @@ import com.google.common.collect.Maps;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoringRewrite;
-import org.apache.lucene.search.TopTermsRewrite;
+import org.apache.lucene.search.*;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.postingshighlight.CustomPassageFormatter;
 import org.apache.lucene.search.postingshighlight.CustomPostingsHighlighter;
@@ -108,8 +105,9 @@ public class PostingsHighlighter implements Highlighter {
 
             //we highlight every value separately calling the highlight method multiple times, only if we need to have back a snippet per value (whole value)
             int values = mergeValues ? 1 : textsToHighlight.size();
+            IndexSearcher segmentSearcher = new IndexSearcher(hitContext.reader());
             for (int i = 0; i < values; i++) {
-                Snippet[] fieldSnippets = highlighter.highlightDoc(fieldMapper.names().indexName(), mapperHighlighterEntry.filteredQueryTerms, context.searcher(), hitContext.topLevelDocId(), numberOfFragments);
+                Snippet[] fieldSnippets = highlighter.highlightDoc(fieldMapper.names().indexName(), mapperHighlighterEntry.filteredQueryTerms, segmentSearcher, hitContext.docId(), numberOfFragments);
                 if (fieldSnippets != null) {
                     for (Snippet fieldSnippet : fieldSnippets) {
                         if (Strings.hasText(fieldSnippet.getText())) {

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -1314,6 +1314,19 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
                                     .endObject().endObject()
                     )
                     .execute().actionGet();
+        } else if (randomBoolean()) {
+            // positions hl
+            client.admin().indices().preparePutMapping("test").setType("type")
+                    .setSource(
+                            jsonBuilder().startObject().startObject("type")
+                                    .startObject("properties")
+                                    .startObject("field1").field("type", "string")
+                                        .field("index_options", "offsets")
+                                    .endObject()
+                                    .endObject()
+                                    .endObject().endObject()
+                    )
+                    .execute().actionGet();
         }
 
         logger.info("--> register a queries");


### PR DESCRIPTION
The postings hl now uses a searcher that only encapsulate the view of segment the document being highlighted is in, this should be better than using the top level engine searcher.
