### PR TITLE
Packaging: Ensure setting of sysctl vm.max_map_count

### DIFF
--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -15,8 +15,9 @@ Each package features a configuration file, which allows you to set the followin
 `ES_HEAP_SIZE`::          The heap size to start with
 `ES_HEAP_NEWSIZE`::       The size of the new generation heap
 `ES_DIRECT_SIZE`::        The maximum size of the direct memory
-`MAX_OPEN_FILES`::       Maximum number of open files, defaults to `65535`
+`MAX_OPEN_FILES`::        Maximum number of open files, defaults to `65535`
 `MAX_LOCKED_MEMORY`::     Maximum locked memory size. Set to "unlimited" if you use the bootstrap.mlockall option in elasticsearch.yml. You must also set ES_HEAP_SIZE.
+`MAX_MAP_COUNT`::         Maximum number of memory map areas a process may have. If you use `mmapfs` as index store type, make sure this is set to a high value. For more information, check the https://github.com/torvalds/linux/blob/master/Documentation/sysctl/vm.txt[linux kernel documentation] about `max_map_count`. This is set via `sysctl` before starting elasticsearch. Defaults to `65535`
 `LOG_DIR`::               Log directory, defaults to `/var/log/elasticsearch`
 `DATA_DIR`::              Data directory, defaults to `/var/lib/elasticsearch`
 `WORK_DIR`::              Work directory, defaults to `/tmp/elasticsearch`
@@ -52,3 +53,4 @@ RedHat based distributions are using `chkconfig` to enable and disable services.
 
 SuSe does not use the `chkconfig` tool to register services, but rather `systemd` and its command `/bin/systemctl` to start and stop services. The configuration file is also placed at `/etc/sysconfig/elasticsearch`.
 
+Also note that changing the `MAX_MAP_COUNT` setting in `/etc/sysconfig/elasticsearch` does not have any effect, you will have to change it in `/usr/lib/sysctl.d/elasticsearch.conf` in order to have it applied at startup.

--- a/pom.xml
+++ b/pom.xml
@@ -802,6 +802,19 @@
                                 </source>
                             </sources>
                         </mapping>
+                         <mapping>
+                            <directory>/usr/lib/sysctl.d/</directory>
+                            <filemode>755</filemode>
+                            <configuration>true</configuration>
+                            <sources>
+                                <source>
+                                    <location>src/rpm/systemd/sysctl.d</location>
+                                    <includes>
+                                        <include>elasticsearch.conf</include>
+                                    </includes>
+                                </source>
+                            </sources>
+                        </mapping>
                         <mapping>
                             <directory>/etc/tmpfiles.d/</directory>
                             <configuration>true</configuration>

--- a/src/deb/default/elasticsearch
+++ b/src/deb/default/elasticsearch
@@ -19,6 +19,9 @@
 # ES_HEAP_SIZE.
 #MAX_LOCKED_MEMORY=unlimited
 
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+#MAX_MAP_COUNT=65535
+
 # ElasticSearch log directory
 #LOG_DIR=/var/log/elasticsearch
 

--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -90,6 +90,9 @@ CONF_DIR=/etc/$NAME
 # ElasticSearch configuration file (elasticsearch.yml)
 CONF_FILE=$CONF_DIR/elasticsearch.yml
 
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+MAX_MAP_COUNT=65535
+
 # End of variables that can be overwritten in $DEFAULT
 
 # overwrite settings from default file
@@ -151,6 +154,10 @@ case "$1" in
 
 	if [ -n "$MAX_LOCKED_MEMORY" ]; then
 		ulimit -l $MAX_LOCKED_MEMORY
+	fi
+
+	if [ -n "$MAX_MAP_COUNT" ]; then
+		sysctl -qw vm.max_map_count=$MAX_MAP_COUNT
 	fi
 
 	# Start Daemon

--- a/src/rpm/init.d/elasticsearch
+++ b/src/rpm/init.d/elasticsearch
@@ -76,6 +76,9 @@ start() {
     if [ -n "$MAX_LOCKED_MEMORY" ]; then
         ulimit -l $MAX_LOCKED_MEMORY
     fi
+    if [ -n "$MAX_MAP_COUNT" ]; then
+        sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
+    fi
     if [ -n "$WORK_DIR" ]; then
         mkdir -p "$WORK_DIR"
         chown "$ES_USER":"$ES_GROUP" "$WORK_DIR"

--- a/src/rpm/sysconfig/elasticsearch
+++ b/src/rpm/sysconfig/elasticsearch
@@ -19,6 +19,9 @@ MAX_OPEN_FILES=65535
 # Maximum amount of locked memory
 #MAX_LOCKED_MEMORY=
 
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+MAX_MAP_COUNT=65535
+
 # ElasticSearch log directory
 LOG_DIR=/var/log/elasticsearch
 

--- a/src/rpm/systemd/sysctl.d/elasticsearch.conf
+++ b/src/rpm/systemd/sysctl.d/elasticsearch.conf
@@ -1,0 +1,1 @@
+vm.max_map_count=65535


### PR DESCRIPTION
In order to be sure that memory mapped lucene directories are working
one can configure the kernel about how many memory mapped areas
a process may have. This setting ensure for the debian and redhat initscripts
as well as the systemd startup, that this setting is set high enough.

Closes #4397
