### PR TITLE
Fix bug in explain for function_score queries.

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -202,15 +202,15 @@ public class FiltersFunctionScoreQuery extends Query {
                 factor = filterExplanations.get(0).getValue();
                 break;
             case Max:
-                double maxFactor = Double.NEGATIVE_INFINITY;
+                factor = Double.NEGATIVE_INFINITY;
                 for (int i = 0; i < filterExplanations.size(); i++) {
-                    factor = Math.max(filterExplanations.get(i).getValue(), maxFactor);
+                    factor = Math.max(filterExplanations.get(i).getValue(), factor);
                 }
                 break;
             case Min:
-                double minFactor = Double.POSITIVE_INFINITY;
+                factor = Double.POSITIVE_INFINITY;
                 for (int i = 0; i < filterExplanations.size(); i++) {
-                    factor = Math.min(filterExplanations.get(i).getValue(), minFactor);
+                    factor = Math.min(filterExplanations.get(i).getValue(), factor);
                 }
                 break;
             case Multiply:


### PR DESCRIPTION
The explain output for function_score queries with score_mode=max or
score_mode=min was incorrect, returning instead the value of the last
function.  This change fixes this.

For example, for the query:

```
{
  "explain": true,
  "query": {
    "function_score": {
      "query": {
        "match_all": {}
      },
      "score_mode": "max",
      "functions": [
        {
          "boost_factor": 1
        },
        {
          "boost_factor": 3
        },
        {
          "boost_factor": 2
        }
      ]
    }
  }
}
```

Results are returned containing

```
hits: [
  {
   _score: 3,
   ...
   _explanation: {
      value: 2
      ...
  }
]
```

Similarly, if "score_mode": "min" is used, the value in the explanation is still 2.

I would expect the value in _explanation object to be the same as the _score value, and with this patch applied it is.
