### PR TITLE
Renamed boost name to path

### DIFF
--- a/docs/reference/mapping/fields/boost-field.asciidoc
+++ b/docs/reference/mapping/fields/boost-field.asciidoc
@@ -4,16 +4,18 @@
 Boosting is the process of enhancing the relevancy of a document or
 field. Field level mapping allows to define explicit boost level on a
 specific field. The boost field mapping (applied on the
-<<mapping-root-object-type,root object>>) allows
-to define a boost field mapping where *its content will control the
-boost level of the document*. For example, consider the following
-mapping:
+<<mapping-root-object-type,root object>>) allows to define
+a boost field mapping where *its content will control the boost level
+of the document*. `name` can be used to specify a field  name where the
+boost value will be taken from for each
+document deprecated[0.90.8,Replaced with `path`]. For example, consider
+the following mapping:
 
 [source,js]
 --------------------------------------------------
 {
     "tweet" : {
-        "_boost" : {"name" : "my_boost", "null_value" : 1.0}
+        "_boost" : {"path" : "my_boost", "null_value" : 1.0}
     }
 }
 --------------------------------------------------
@@ -30,3 +32,4 @@ following JSON document will be indexed with a boost value of `2.2`:
     "message" : "This is a tweet!"
 }
 --------------------------------------------------
+

--- a/docs/reference/mapping/fields/boost-field.asciidoc
+++ b/docs/reference/mapping/fields/boost-field.asciidoc
@@ -6,9 +6,8 @@ field. Field level mapping allows to define explicit boost level on a
 specific field. The boost field mapping (applied on the
 <<mapping-root-object-type,root object>>) allows to define
 a boost field mapping where *its content will control the boost level
-of the document*. `name` can be used to specify a field  name where the
-boost value will be taken from for each
-document deprecated[0.90.8,Replaced with `path`]. For example, consider
+of the document*. `path` can be used to specify a field  name where the
+boost value will be taken from for each document. For example, consider
 the following mapping:
 
 [source,js]

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -62,7 +62,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     public static final String NAME = "_boost";
 
     public static class Defaults extends NumberFieldMapper.Defaults {
-        public static final String NAME = "_boost";
+        public static final String PATH = "_boost";
         public static final Float NULL_VALUE = null;
 
         public static final FieldType FIELD_TYPE = new FieldType(NumberFieldMapper.Defaults.FIELD_TYPE);
@@ -97,9 +97,10 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            String name = node.get("name") == null ? BoostFieldMapper.Defaults.NAME : node.get("name").toString();
-            BoostFieldMapper.Builder builder = MapperBuilders.boost(name);
-            parseNumberField(builder, name, node, parserContext);
+            String name = node.get("name") == null ? BoostFieldMapper.Defaults.PATH : node.get("name").toString();
+            String path = node.get("path") == null ? name : node.get("path").toString();
+            BoostFieldMapper.Builder builder = MapperBuilders.boost(path);
+            parseNumberField(builder, path, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {
                 String propName = Strings.toUnderscoreCase(entry.getKey());
                 Object propNode = entry.getValue();
@@ -114,7 +115,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     private final Float nullValue;
 
     public BoostFieldMapper() {
-        this(Defaults.NAME, Defaults.NAME);
+        this(Defaults.PATH, Defaults.PATH);
     }
 
     protected BoostFieldMapper(String name, String indexName) {
@@ -287,15 +288,15 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
         boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
 
         // all are defaults, don't write it at all
-        if (!includeDefaults && name().equals(Defaults.NAME) && nullValue == null &&
+        if (!includeDefaults && name().equals(Defaults.PATH) && nullValue == null &&
                 fieldType.indexed() == Defaults.FIELD_TYPE.indexed() &&
                 fieldType.stored() == Defaults.FIELD_TYPE.stored() &&
                 customFieldDataSettings == null) {
             return builder;
         }
         builder.startObject(contentType());
-        if (includeDefaults || !name().equals(Defaults.NAME)) {
-            builder.field("name", name());
+        if (includeDefaults || !name().equals(Defaults.PATH)) {
+            builder.field("path", name());
         }
         if (includeDefaults || nullValue != null) {
             builder.field("null_value", nullValue);

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -97,8 +97,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            String name = node.get("name") == null ? BoostFieldMapper.Defaults.PATH : node.get("name").toString();
-            String path = node.get("path") == null ? name : node.get("path").toString();
+            String path = node.get("path") == null ? BoostFieldMapper.Defaults.PATH : node.get("path").toString();
             BoostFieldMapper.Builder builder = MapperBuilders.boost(path);
             parseNumberField(builder, path, node, parserContext);
             for (Map.Entry<String, Object> entry : node.entrySet()) {

--- a/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingTests.java
@@ -53,27 +53,6 @@ public class BoostMappingTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testCustomName() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("_boost").field("name", "custom_boost").endObject()
-                .endObject().endObject().string();
-
-        DocumentMapper mapper = MapperTestUtils.newParser().parse(mapping);
-
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
-                .field("field", "a")
-                .field("_boost", 2.0f)
-                .endObject().bytes());
-        assertThat(doc.rootDoc().getField("field").boost(), equalTo(1.0f));
-
-        doc = mapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
-                .field("field", "a")
-                .field("custom_boost", 2.0f)
-                .endObject().bytes());
-        assertThat(doc.rootDoc().getField("field").boost(), equalTo(2.0f));
-    }
-
-    @Test
     public void testCustomPath() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_boost").field("path", "custom_boost").endObject()

--- a/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/boost/BoostMappingTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.index.mapper.internal.BoostFieldMapper;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -57,6 +56,27 @@ public class BoostMappingTests extends ElasticsearchTestCase {
     public void testCustomName() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_boost").field("name", "custom_boost").endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = MapperTestUtils.newParser().parse(mapping);
+
+        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+                .field("field", "a")
+                .field("_boost", 2.0f)
+                .endObject().bytes());
+        assertThat(doc.rootDoc().getField("field").boost(), equalTo(1.0f));
+
+        doc = mapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+                .field("field", "a")
+                .field("custom_boost", 2.0f)
+                .endObject().bytes());
+        assertThat(doc.rootDoc().getField("field").boost(), equalTo(2.0f));
+    }
+
+    @Test
+    public void testCustomPath() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("_boost").field("path", "custom_boost").endObject()
                 .endObject().endObject().string();
 
         DocumentMapper mapper = MapperTestUtils.newParser().parse(mapping);

--- a/src/test/java/org/elasticsearch/index/mapper/simple/test-mapping.json
+++ b/src/test/java/org/elasticsearch/index/mapper/simple/test-mapping.json
@@ -17,7 +17,7 @@
             name:"_type"
         },
         _boost:{
-            name:"_boost",
+            path:"_boost",
             null_value:2.0
         },
         properties:{


### PR DESCRIPTION
First commit makes the change in a backwards compatible manner, keeping the name around (Part that will be backported).
Second commit is only for master: removes the boost name and updates the docs accordingly.

Closes #3315
