### PR TITLE
Resolve potential deadlock state during EsThreadPoolExecutor shutdown

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -53,8 +53,8 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
             } else {
                 this.listener = listener;
             }
-            shutdown();
         }
+        shutdown();
     }
 
     @Override


### PR DESCRIPTION
Fixes #4334

The deadlock occurs between monitor object of EsThreadPoolExecutor and mainLock of ThreadPoolExecutor. The shutdown method of EsThreadPoolExecutor obtains the lock on monitor first and waits for mainLock of ThreadPoolExecutor in ThreadPoolExecutor#shutdown for part of the processing, while EsThreadPoolExecutor#terminated is executed under mainLock and tries to obtain monitor to notify listeners.
