### PR TITLE
Allow to provide parameters not only through -D but as long parameters

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -150,8 +150,24 @@ launch_service()
     fi
 }
 
+# Parse any long getopt options and put them into properties before calling getopt below
+# Be dash compatible to make sure running under ubuntu works
+ARGV=""
+while [ $# -gt 0 ]
+do
+    case $1 in
+      --*=*) properties="$properties -Des.${1#--}"
+           shift 1
+           ;;
+      --*) properties="$properties -Des.${1#--}=$2"
+           shift 2
+           ;;
+      *) ARGV="$ARGV $1" ; shift
+    esac
+done
+
 # Parse any command line options.
-args=`getopt vdhp:D:X: "$@"`
+args=`getopt vfhp:D:X: $ARGV`
 eval set -- "$args"
 
 while true; do

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -38,13 +38,13 @@ There are added features when using the `elasticsearch` shell script.
 The first, which was explained earlier, is the ability to easily run the
 process either in the foreground or the background.
 
-Another feature is the ability to pass `-X` and `-D` directly to the
-script. When set, both override anything set using either `JAVA_OPTS` or
-`ES_JAVA_OPTS`. For example:
+Another feature is the ability to pass `-X` and `-D` or getopt long style
+configuration parameters directly to the script. When set, all override
+anything set using either `JAVA_OPTS` or `ES_JAVA_OPTS`. For example:
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -Xmx2g -Xms2g -Des.index.store.type=memory
+$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.store.type=memory --node.name=my-node
 --------------------------------------------------
 *************************************************************************
 --

--- a/docs/reference/setup/installation.asciidoc
+++ b/docs/reference/setup/installation.asciidoc
@@ -28,12 +28,12 @@ There are added features when using the `elasticsearch` shell script.
 The first, which was explained earlier, is the ability to easily run the
 process either in the foreground or the background.
 
-Another feature is the ability to pass `-X` and `-D` directly to the
-script. When set, both override anything set using either `JAVA_OPTS` or
-`ES_JAVA_OPTS`. For example:
+Another feature is the ability to pass `-X` and `-D` or getopt long style
+configuration parameters directly to the script. When set, all override
+anything set using either `JAVA_OPTS` or `ES_JAVA_OPTS`. For example:
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -Xmx2g -Xms2g -Des.index.store.type=memory
+$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.store.type=memory --node.name=my-node
 --------------------------------------------------
 *************************************************************************


### PR DESCRIPTION
All getopt long style parameters are now set as es. properties,

elasticsearch --path.data=/some/path

results in -Des.path.data=/some/path

Closes #4393

Tested with ubuntu and ubuntu lts (because they use dash, not bash), centos, opensuse and a debian 7.
