### PR TITLE
Start elasticsearch in the foreground by default

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # OPTIONS:
-#   -f: start in the foreground
+#   -d: daemonize, start in the background
 #   -p <filename>: log the pid to a file (useful to kill it later)
 
 # CONTROLLING STARTUP:
@@ -127,7 +127,7 @@ esac
 launch_service()
 {
     pidpath=$1
-    foreground=$2
+    daemonized=$2
     props=$3
     es_parms="-Delasticsearch"
 
@@ -135,8 +135,8 @@ launch_service()
         es_parms="$es_parms -Des.pidfile=$pidpath"
     fi
 
-    # The es-foreground option will tell ElasticSearch not to close stdout/stderr, but it's up to us not to background.
-    if [ "x$foreground" != "x" ]; then
+    # The es-foreground option will tell ElasticSearch not to close stdout/stderr, but it's up to us not to daemonize.
+    if [ "x$daemonized" == "x" ]; then
         es_parms="$es_parms -Des.foreground=yes"
         exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS $es_parms -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" $props \
                 org.elasticsearch.bootstrap.ElasticSearch
@@ -151,7 +151,7 @@ launch_service()
 }
 
 # Parse any command line options.
-args=`getopt vfhp:D:X: "$@"`
+args=`getopt vdhp:D:X: "$@"`
 eval set -- "$args"
 
 while true; do
@@ -165,12 +165,12 @@ while true; do
             pidfile="$2"
             shift 2
         ;;
-        -f)
-            foreground="yes"
+        -d)
+            daemonized="yes"
             shift
         ;;
         -h)
-            echo "Usage: $0 [-f] [-h] [-p pidfile]"
+            echo "Usage: $0 [-d] [-h] [-p pidfile]"
             exit 0
         ;;
         -D)
@@ -193,6 +193,6 @@ while true; do
 done
 
 # Start up the service
-launch_service "$pidfile" "$foreground" "$properties"
+launch_service "$pidfile" "$daemonized" "$properties"
 
 exit $?

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -19,12 +19,12 @@ After link:/download[downloading] the latest release and extracting it,
 $ bin/elasticsearch
 --------------------------------------------------
 
-Under *nix system, the command will start the process in the background.
-To run it in the foreground, add the `-f` switch to it:
+Under *nix system, the command will start the process in the foreground.
+To run it in the background, add the `-d` switch to it:
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -f
+$ bin/elasticsearch -d
 --------------------------------------------------
 
 ElasticSearch is built using Java, and requires at least
@@ -44,7 +44,7 @@ script. When set, both override anything set using either `JAVA_OPTS` or
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.store.type=memory
+$ bin/elasticsearch -Xmx2g -Xms2g -Des.index.store.type=memory
 --------------------------------------------------
 *************************************************************************
 --

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -157,7 +157,7 @@ command, for example:
 
 [source,sh]
 --------------------------------------------------
-$ elasticsearch -f -Des.network.host=10.0.0.4
+$ elasticsearch -Des.network.host=10.0.0.4
 --------------------------------------------------
 
 Another option is to set `es.default.` prefix instead of `es.` prefix,
@@ -181,7 +181,7 @@ system property:
 
 [source,sh]
 --------------------------------------------------
-$ elasticsearch -f -Des.config=/path/to/config/file
+$ elasticsearch -Des.config=/path/to/config/file
 --------------------------------------------------
 
 [float]
@@ -221,7 +221,7 @@ above can also be set as a "collapsed" setting, for example:
 
 [source,sh]
 --------------------------------------------------
-$ elasticsearch -f -Des.index.store.type=memory
+$ elasticsearch -Des.index.store.type=memory
 --------------------------------------------------
 
 All of the index level configuration can be found within each

--- a/docs/reference/setup/installation.asciidoc
+++ b/docs/reference/setup/installation.asciidoc
@@ -9,12 +9,12 @@ After link:/download[downloading] the latest release and extracting it,
 $ bin/elasticsearch
 --------------------------------------------------
 
-Under *nix system, the command will start the process in the background.
-To run it in the foreground, add the `-f` switch to it:
+Under *nix system, the command will start the process in the foreground.
+To run it in the background, add the `-d` switch to it:
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -f
+$ bin/elasticsearch -d
 --------------------------------------------------
 
 ElasticSearch is built using Java, and requires at least
@@ -34,6 +34,6 @@ script. When set, both override anything set using either `JAVA_OPTS` or
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -f -Xmx2g -Xms2g -Des.index.store.type=memory
+$ bin/elasticsearch -Xmx2g -Xms2g -Des.index.store.type=memory
 --------------------------------------------------
 *************************************************************************

--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -103,7 +103,7 @@ fi
 # Define other required variables
 PID_FILE=/var/run/$NAME.pid
 DAEMON=$ES_HOME/bin/elasticsearch
-DAEMON_OPTS="-p $PID_FILE -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR"
+DAEMON_OPTS="-d -p $PID_FILE -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR"
 
 export ES_HEAP_SIZE
 export ES_HEAP_NEWSIZE

--- a/src/rpm/init.d/elasticsearch
+++ b/src/rpm/init.d/elasticsearch
@@ -85,7 +85,7 @@ start() {
     fi
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-    daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+    daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/src/rpm/systemd/elasticsearch.service
+++ b/src/rpm/systemd/elasticsearch.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/sysconfig/elasticsearch
 User=elasticsearch
 Group=elasticsearch
 PIDFile=/var/run/elasticsearch/elasticsearch.pid
-ExecStart=/usr/share/elasticsearch/bin/elasticsearch -p /var/run/elasticsearch/elasticsearch.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
 # See MAX_OPEN_FILES in sysconfig
 LimitNOFILE=65535
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true


### PR DESCRIPTION
Instead of using the '-f' parameter to start elasticsearch in the
foreground, this is now the default modus.

In order to start elasticsearch in the background, the '-d' parameter
can be used.

Closes #4392
