### PR TITLE
Expose `dist`/`pre`/`post` options for SpanNotQuery

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -33,6 +33,12 @@ public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBu
 
     private SpanQueryBuilder exclude;
 
+    private int dist = -1;
+
+    private int pre = -1;
+
+    private int post = -1;
+
     private float boost = -1;
 
     private String queryName;
@@ -44,6 +50,21 @@ public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBu
 
     public SpanNotQueryBuilder exclude(SpanQueryBuilder exclude) {
         this.exclude = exclude;
+        return this;
+    }
+
+    public SpanNotQueryBuilder dist(int dist) {
+        this.dist = dist;
+        return this;
+    }
+
+    public SpanNotQueryBuilder pre(int pre) {
+        this.pre = pre;
+        return this;
+    }
+
+    public SpanNotQueryBuilder post(int post) {
+        this.post = post;
         return this;
     }
 
@@ -68,11 +89,25 @@ public class SpanNotQueryBuilder extends BaseQueryBuilder implements SpanQueryBu
         if (exclude == null) {
             throw new ElasticsearchIllegalArgumentException("Must specify exclude when using spanNot query");
         }
+
+        if ((dist != -1 && (pre != -1 || post != -1)) || (pre != -1 && post == -1) || (pre == -1 && post != -1))  {
+            throw new ElasticSearchIllegalArgumentException("spanNot can either use [dist] or [pre] & [post] (or none)");
+        }
+
         builder.startObject(SpanNotQueryParser.NAME);
         builder.field("include");
         include.toXContent(builder, params);
         builder.field("exclude");
         exclude.toXContent(builder, params);
+        if (dist != -1) {
+            builder.field("dist", dist);
+        }
+        if (pre != -1) {
+            builder.field("pre", pre);
+        }
+        if (post != -1) {
+            builder.field("post", post);
+        }
         if (boost != -1) {
             builder.field("boost", boost);
         }

--- a/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -35,6 +35,8 @@ public class SpanNotQueryParser implements QueryParser {
 
     public static final String NAME = "span_not";
 
+    public static final int NOT_SET = -1;
+
     @Inject
     public SpanNotQueryParser() {
     }
@@ -53,9 +55,9 @@ public class SpanNotQueryParser implements QueryParser {
         SpanQuery include = null;
         SpanQuery exclude = null;
 
-        int dist = -1;
-        int pre  = -1;
-        int post = -1;
+        int dist = NOT_SET;
+        int pre  = NOT_SET;
+        int post = NOT_SET;
 
         String queryName = null;
 
@@ -102,14 +104,14 @@ public class SpanNotQueryParser implements QueryParser {
         if (exclude == null) {
             throw new QueryParsingException(parseContext.index(), "spanNot must have [exclude] span query clause");
         }
-        if ((dist != -1 && (pre != -1 || post != -1)) || (pre != -1 && post == -1) || (pre == -1 && post != -1))  {
+        if (dist != NOT_SET && (pre != NOT_SET || post != NOT_SET)) {
             throw new QueryParsingException(parseContext.index(), "spanNot can either use [dist] or [pre] & [post] (or none)");
         }
 
         SpanNotQuery query;
-        if (pre != -1 && post != -1) {
+        if (pre != NOT_SET && post != NOT_SET) {
             query = new SpanNotQuery(include, exclude, pre, post);
-        } else if (dist != -1) {
+        } else if (dist != NOT_SET) {
             query = new SpanNotQuery(include, exclude, dist);
         } else {
             query = new SpanNotQuery(include, exclude);


### PR DESCRIPTION
Lucene 4.5 provides more options for the SpanNotQuery. Not sure if to update the docs with the pull request or not. If accepted and I knew the potential elasticsearch version which might contain it, I can add the appropriate "Added in ..." message in the documentation.
