### PR TITLE
Start the task timeout checking *after* adding it to the execution queue of PrioritizedEsThreadPoolExecutor

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -62,6 +62,7 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
         } else if (!(command instanceof PrioritizedFutureTask)) { // it might be a callable wrapper...
             command = new TieBreakingPrioritizedRunnable(command, Priority.NORMAL, insertionOrder.incrementAndGet());
         }
+        super.execute(command);
         if (timeout.nanos() >= 0) {
             final Runnable fCommand = command;
             timer.schedule(new Runnable() {
@@ -74,7 +75,6 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
                 }
             }, timeout.nanos(), TimeUnit.NANOSECONDS);
         }
-        super.execute(command);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -83,7 +83,7 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         clusterService1.submitStateUpdateTask("test2", new TimeoutClusterStateUpdateTask() {
             @Override
             public TimeValue timeout() {
-                return TimeValue.timeValueMillis(100);
+                return TimeValue.timeValueMillis(2);
             }
 
             @Override
@@ -102,7 +102,7 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
             }
         });
 
-        assertThat(timedOut.await(1000, TimeUnit.MILLISECONDS), equalTo(true));
+        assertThat(timedOut.await(500, TimeUnit.MILLISECONDS), equalTo(true));
         block.countDown();
         Thread.sleep(100); // sleep a bit to double check that execute on the timed out update task is not called...
         assertThat(executeCalled.get(), equalTo(false));


### PR DESCRIPTION
This prevents missing very short timeouts which fire before the calling thread had the chance to add the task to the queue and are therefore ignored. This is mostly of importance for testing where we explicitly want tasks to timeout and set it to a very low value.
