### PR TITLE
Allow GetAliasRequest to retrieve all aliases

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -78,11 +78,7 @@ public class GetAliasesRequest extends MasterNodeOperationRequest<GetAliasesRequ
 
     @Override
     public ActionRequestValidationException validate() {
-        if (aliases.length == 0) {
-            return addValidationError("No alias specified", null);
-        } else {
-            return null;
-        }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -274,6 +274,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             return ImmutableOpenMap.of();
         }
 
+        boolean matchAllAliases = aliases.length == 0;
         ImmutableOpenMap.Builder<String, ImmutableList<AliasMetaData>> mapBuilder = ImmutableOpenMap.builder();
         Iterable<String> intersection = HppcMaps.intersection(ObjectOpenHashSet.from(concreteIndices), indices.keys());
         for (String index : intersection) {
@@ -281,7 +282,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             List<AliasMetaData> filteredValues = Lists.newArrayList();
             for (ObjectCursor<AliasMetaData> cursor : indexMetaData.getAliases().values()) {
                 AliasMetaData value = cursor.value;
-                if (Regex.simpleMatch(aliases, value.alias())) {
+                if (matchAllAliases || Regex.simpleMatch(aliases, value.alias())) {
                     filteredValues.add(value);
                 }
             }

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -52,6 +52,7 @@ import static com.google.common.collect.Sets.newHashSet;
 import static org.elasticsearch.client.Requests.*;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
+import static org.elasticsearch.test.hamcrest.CollectionAssertions.hasKey;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -826,6 +827,20 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
             assertThat(e.validationErrors(), notNullValue());
             assertThat(e.validationErrors().size(), equalTo(2));
         }
+    }
+
+    @Test
+    public void testGetAllAliasesWorks() {
+        createIndex("index1");
+        createIndex("index2");
+
+        ensureYellow();
+
+        admin().indices().prepareAliases().addAlias("index1", "alias1").addAlias("index2", "alias2").get();
+
+        GetAliasesResponse response = admin().indices().prepareGetAliases().get();
+        assertThat(response.getAliases(), hasKey("index1"));
+        assertThat(response.getAliases(), hasKey("index1"));
     }
 
     private void assertHits(SearchHits hits, String... ids) {

--- a/src/test/java/org/elasticsearch/test/hamcrest/CollectionAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/CollectionAssertions.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.hamcrest;
+
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.hamcrest.Matcher;
+
+/**
+ * Assertions for easier handling of our custom collections,
+ * for example ImmutableOpenMap
+ */
+public class CollectionAssertions {
+
+    public static Matcher<ImmutableOpenMap> hasKey(final String key) {
+        return new CollectionMatchers.ImmutableOpenMapHasKeyMatcher(key);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/hamcrest/CollectionMatchers.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/CollectionMatchers.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.hamcrest;
+
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matchers for easier handling of our custom collections,
+ * for example ImmutableOpenMap
+ */
+public class CollectionMatchers {
+
+    public static class ImmutableOpenMapHasKeyMatcher extends TypeSafeMatcher<ImmutableOpenMap> {
+
+        private final String key;
+
+        public ImmutableOpenMapHasKeyMatcher(String key) {
+            this.key = key;
+        }
+
+        @Override
+        protected boolean matchesSafely(ImmutableOpenMap item) {
+            return item.containsKey(key);
+        }
+
+        @Override
+        public void describeMismatchSafely(final ImmutableOpenMap map, final Description mismatchDescription) {
+            if (map.size() == 0) {
+                mismatchDescription.appendText("was empty");
+            } else {
+                mismatchDescription.appendText(" was ").appendValue(map);
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("ImmutableOpenMap should contain key " + key);
+        }
+    }
+
+}


### PR DESCRIPTION
Results in less data being sent over the wire, as the Cat API does not
need to have the whole cluster state.

Also added matchers for hasKey() for immutable open map (I think we should
add more of those to have map style assertions).

Closes #4455
