### PR TITLE
Made parsing of ByteSizeValue case independent

### DIFF
--- a/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.Streamable;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Locale;
 
 /**
  *
@@ -143,19 +144,20 @@ public class ByteSizeValue implements Serializable, Streamable {
         }
         long bytes;
         try {
-            if (sValue.endsWith("k") || sValue.endsWith("K")) {
+            String lastTwoChars = sValue.substring(sValue.length() - Math.min(2, sValue.length())).toLowerCase(Locale.ROOT);
+            if (lastTwoChars.endsWith("k")) {
                 bytes = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * ByteSizeUnit.C1);
-            } else if (sValue.endsWith("kb")) {
+            } else if (lastTwoChars.endsWith("kb")) {
                 bytes = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 2)) * ByteSizeUnit.C1);
-            } else if (sValue.endsWith("m") || sValue.endsWith("M")) {
+            } else if (lastTwoChars.endsWith("m")) {
                 bytes = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * ByteSizeUnit.C2);
-            } else if (sValue.endsWith("mb")) {
+            } else if (lastTwoChars.endsWith("mb")) {
                 bytes = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 2)) * ByteSizeUnit.C2);
-            } else if (sValue.endsWith("g") || sValue.endsWith("G")) {
+            } else if (lastTwoChars.endsWith("g")) {
                 bytes = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * ByteSizeUnit.C3);
-            } else if (sValue.endsWith("gb")) {
+            } else if (lastTwoChars.endsWith("gb")) {
                 bytes = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 2)) * ByteSizeUnit.C3);
-            } else if (sValue.endsWith("b")) {
+            } else if (lastTwoChars.endsWith("b")) {
                 bytes = Long.parseLong(sValue.substring(0, sValue.length() - 1));
             } else {
                 bytes = Long.parseLong(sValue);

--- a/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.unit;
 
+import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -52,5 +53,27 @@ public class ByteSizeValueTests extends ElasticsearchTestCase {
         assertThat("1.5mb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.KB).toString()));
         assertThat("1.5gb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.MB).toString()));
         assertThat("1536gb", is(new ByteSizeValue((long) (1024 * 1.5), ByteSizeUnit.GB).toString()));
+    }
+
+    @Test
+    public void testParsing() {
+        assertThat(ByteSizeValue.parseBytesSizeValue("12gb").toString(), is("12gb"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("12G").toString(), is("12gb"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("12GB").toString(), is("12gb"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("12M").toString(), is("12mb"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("1b").toString(), is("1b"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("23kb").toString(), is("23kb"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("23k").toString(), is("23kb"));
+        assertThat(ByteSizeValue.parseBytesSizeValue("23").toString(), is("23b"));
+    }
+
+    @Test(expected = ElasticSearchParseException.class)
+    public void testFailOnEmptyParsing() {
+        assertThat(ByteSizeValue.parseBytesSizeValue("").toString(), is("23kb"));
+    }
+
+    @Test(expected = ElasticSearchParseException.class)
+    public void testFailOnEmptyNumberParsing() {
+        assertThat(ByteSizeValue.parseBytesSizeValue("g").toString(), is("23b"));
     }
 }


### PR DESCRIPTION
This allows to parse '12GB' as well as '12gb'. This has already been done with a few units, but not with all of them, which can be confusing for the user.

Closes #4442
