### PR TITLE
Improve allocation of unassigned shards with early termination

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/MutableShardRouting.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/MutableShardRouting.java
@@ -147,5 +147,14 @@ public class MutableShardRouting extends ImmutableShardRouting {
         primary = false;
     }
 
+    private long hashVersion = version-1;
+    private int hashCode = 0;
+
+    @Override
+    public int hashCode() {
+        hashCode = (hashVersion != version ? super.hashCode() : hashCode);
+        hashVersion = version;
+        return hashCode;
+    }
 }
 

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -584,6 +584,14 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         public void copyAll(Collection<MutableShardRouting> others) {
             others.addAll(unassigned);
         }
+
+        public MutableShardRouting[] drain() {
+            MutableShardRouting[] mutableShardRoutings = unassigned.toArray(new MutableShardRouting[unassigned.size()]);
+            unassigned.clear();
+            primaries = 0;
+            transactionId++;
+            return mutableShardRoutings;
+        }
     }
 
 

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -34,9 +34,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -56,16 +54,6 @@ public class AllocationService extends AbstractComponent {
     private final AllocationDeciders allocationDeciders;
     private final ClusterInfoService clusterInfoService;
     private final ShardsAllocators shardsAllocators;
-
-    public AllocationService() {
-        this(ImmutableSettings.Builder.EMPTY_SETTINGS);
-    }
-
-    public AllocationService(Settings settings) {
-        this(settings,
-                new AllocationDeciders(settings, new NodeSettingsService(ImmutableSettings.Builder.EMPTY_SETTINGS)),
-                new ShardsAllocators(settings), ClusterInfoService.EMPTY);
-    }
 
     @Inject
     public AllocationService(Settings settings, AllocationDeciders allocationDeciders, ShardsAllocators shardsAllocators, ClusterInfoService clusterInfoService) {

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -64,4 +64,20 @@ public abstract class AllocationDecider extends AbstractComponent {
     public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         return Decision.ALWAYS;
     }
+
+    /**
+     * Returns a {@link Decision} whether the given shard routing can be allocated at all at this state of the
+     * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
+     */
+    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    /**
+     * Returns a {@link Decision} whether the given node can allow any allocation at all at this state of the
+     * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
+     */
+    public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.util.Set;
 
@@ -37,59 +35,14 @@ public class AllocationDeciders extends AllocationDecider {
 
     private final AllocationDecider[] allocations;
 
-    /**
-     * Create a new {@link AllocationDeciders} instance. The different deciders
-     * should be added in order, as looping over them will stop when the first 
-     * return a {@link Decision#THROTTLE} or {@link Decision#NO}. For performance
-     * reasons, those more likely to return either of these, and those with
-     * cheap execution should be executed first.
-     *
-     * Performance characteristics:
-     * {@link ConcurrentRebalanceAllocationDecider} numerical comparison of a counter in {@link org.elasticsearch.cluster.routing.RoutingNodes},
-     * constant performance, likely to be triggered.
-     * {@link DisableAllocationDecider} lookup of setting. Constant performance, not as
-     * likely to be triggered.
-     * {@link ClusterRebalanceAllocationDecider} checks for unassigned primaries, inactive primaries and
-     * a rebalance already happening in replica set. 
-     * {@link DiskThresholdDecider} one numerical comparison per node in cluster.
-     * {@link SnapshotInProgressAllocationDecider} status lookup, unlikely.
-     * {@link FilterAllocationDecider} checks all allocation include/exclude filters in the cluster against the 
-     * node's attributes.
-     * {@link RebalanceOnlyWhenActiveAllocationDecider} checks if all shards are active.
-     * {@link ReplicaAfterPrimaryActiveAllocationDecider} finds primary in replica set, checks whether it
-     * is started.
-     * {@link ShardsLimitAllocationDecider} loops over shards allocated on a node, filters out non-relocating
-     * shards of the same index to do a count comparison.
-     * {@link AwarenessAllocationDecider} loops over all shards in cluster.
-     * {@link SameShardAllocationDecider} loops over shards on node.
-     * {@link ThrottlingAllocationDecider} checks primaries initializing (looping over shards on node) for a primary
-     * to be allocated, for replicas loops over all shards on node.
-     *
-     * @param settings            settings to use
-     * @param nodeSettingsService per-node settings to use
-     */
-    public AllocationDeciders(Settings settings, NodeSettingsService nodeSettingsService) {
-        this(settings, ImmutableSet.<AllocationDecider>builder()
-                .add(new ConcurrentRebalanceAllocationDecider(settings, nodeSettingsService))
-                .add(new DisableAllocationDecider(settings, nodeSettingsService))
-                .add(new ClusterRebalanceAllocationDecider(settings))
-                .add(new DiskThresholdDecider(settings, nodeSettingsService))
-                .add(new SnapshotInProgressAllocationDecider(settings))
-                .add(new FilterAllocationDecider(settings, nodeSettingsService))
-                .add(new RebalanceOnlyWhenActiveAllocationDecider(settings))
-                .add(new ReplicaAfterPrimaryActiveAllocationDecider(settings))
-                .add(new ShardsLimitAllocationDecider(settings))
-                .add(new AwarenessAllocationDecider(settings, nodeSettingsService))
-                .add(new SameShardAllocationDecider(settings))
-                .add(new ThrottlingAllocationDecider(settings, nodeSettingsService))
-                .build()
-        );
+    public AllocationDeciders(Settings settings, AllocationDecider[] allocations) {
+        super(settings);
+        this.allocations = allocations;
     }
 
     @Inject
     public AllocationDeciders(Settings settings, Set<AllocationDecider> allocations) {
-        super(settings);
-        this.allocations = allocations.toArray(new AllocationDecider[allocations.size()]);
+        this(settings, allocations.toArray(new AllocationDecider[allocations.size()]));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -153,4 +153,32 @@ public class AllocationDeciders extends AllocationDecider {
         }
         return ret;
     }
+
+    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
+        Decision.Multi ret = new Decision.Multi();
+        for (AllocationDecider allocationDecider : allocations) {
+            Decision decision = allocationDecider.canAllocate(shardRouting, allocation);
+            // short track if a NO is returned.
+            if (decision == Decision.NO) {
+                return decision;
+            } else if (decision != Decision.ALWAYS) {
+                ret.add(decision);
+            }
+        }
+        return ret;
+    }
+
+    public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
+        Decision.Multi ret = new Decision.Multi();
+        for (AllocationDecider allocationDecider : allocations) {
+            Decision decision = allocationDecider.canAllocate(node, allocation);
+            // short track if a NO is returned.
+            if (decision == Decision.NO) {
+                return decision;
+            } else if (decision != Decision.ALWAYS) {
+                ret.add(decision);
+            }
+        }
+        return ret;
+    }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersModule.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersModule.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.Multibinder;
@@ -51,22 +52,27 @@ public class AllocationDecidersModule extends AbstractModule {
     @Override
     protected void configure() {
         Multibinder<AllocationDecider> allocationMultibinder = Multibinder.newSetBinder(binder(), AllocationDecider.class);
-        allocationMultibinder.addBinding().to(SameShardAllocationDecider.class);
-        allocationMultibinder.addBinding().to(FilterAllocationDecider.class);
-        allocationMultibinder.addBinding().to(ReplicaAfterPrimaryActiveAllocationDecider.class);
-        allocationMultibinder.addBinding().to(ThrottlingAllocationDecider.class);
-        allocationMultibinder.addBinding().to(RebalanceOnlyWhenActiveAllocationDecider.class);
-        allocationMultibinder.addBinding().to(ClusterRebalanceAllocationDecider.class);
-        allocationMultibinder.addBinding().to(ConcurrentRebalanceAllocationDecider.class);
-        allocationMultibinder.addBinding().to(DisableAllocationDecider.class);
-        allocationMultibinder.addBinding().to(AwarenessAllocationDecider.class);
-        allocationMultibinder.addBinding().to(ShardsLimitAllocationDecider.class);
-        allocationMultibinder.addBinding().to(DiskThresholdDecider.class);
-        allocationMultibinder.addBinding().to(SnapshotInProgressAllocationDecider.class);
+        for (Class<? extends AllocationDecider> deciderClass : DEFAULT_ALLOCATION_DECIDERS) {
+            allocationMultibinder.addBinding().to(deciderClass);
+        }
         for (Class<? extends AllocationDecider> allocation : allocations) {
             allocationMultibinder.addBinding().to(allocation);
         }
 
         bind(AllocationDeciders.class).asEagerSingleton();
     }
+
+    public static final ImmutableSet<Class<? extends AllocationDecider>> DEFAULT_ALLOCATION_DECIDERS = ImmutableSet.<Class<? extends AllocationDecider>>builder().
+            add(SameShardAllocationDecider.class).
+            add(FilterAllocationDecider.class).
+            add(ReplicaAfterPrimaryActiveAllocationDecider.class).
+            add(ThrottlingAllocationDecider.class).
+            add(RebalanceOnlyWhenActiveAllocationDecider.class).
+            add(ClusterRebalanceAllocationDecider.class).
+            add(ConcurrentRebalanceAllocationDecider.class).
+            add(DisableAllocationDecider.class).
+            add(AwarenessAllocationDecider.class).
+            add(ShardsLimitAllocationDecider.class).
+            add(DiskThresholdDecider.class).
+            add(SnapshotInProgressAllocationDecider.class).build();
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -110,7 +110,7 @@ public class DiskThresholdDecider extends AllocationDecider {
     }
 
     @Inject
-    protected DiskThresholdDecider(Settings settings, NodeSettingsService nodeSettingsService) {
+    public DiskThresholdDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
         String lowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "0.7");
         String highWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "0.85");

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
@@ -38,6 +38,10 @@ public class ReplicaAfterPrimaryActiveAllocationDecider extends AllocationDecide
 
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return canAllocate(shardRouting, allocation);
+    }
+
+    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
         if (shardRouting.primary()) {
             return Decision.YES;
         }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -77,7 +77,7 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
                 // primary is unassigned, means we are going to do recovery from gateway
                 // count *just the primary* currently doing recovery on the node and check against concurrent_recoveries
                 int primariesInRecovery = 0;
-                for (MutableShardRouting shard : node) {;
+                for (MutableShardRouting shard : node) {
                     // when a primary shard is INITIALIZING, it can be because of *initial recovery* or *relocation from another node*
                     // we only count initial recoveries here, so we need to make sure that relocating node is null
                     if (shard.state() == ShardRoutingState.INITIALIZING && shard.primary() && shard.relocatingNodeId() == null) {
@@ -95,13 +95,16 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
         // either primary or replica doing recovery (from peer shard)
 
         // count the number of recoveries on the node, its for both target (INITIALIZING) and source (RELOCATING)
+        return canAllocate(node, allocation);
+    }
+
+    public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
         int currentRecoveries = 0;
         for (MutableShardRouting shard : node) {
             if (shard.state() == ShardRoutingState.INITIALIZING || shard.state() == ShardRoutingState.RELOCATING) {
                 currentRecoveries++;
             }
         }
-
         if (currentRecoveries >= concurrentRecoveries) {
             return Decision.THROTTLE;
         } else {

--- a/src/test/java/org/elasticsearch/benchmark/cluster/ClusterAllocationRerouteBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/cluster/ClusterAllocationRerouteBenchmark.java
@@ -39,7 +39,7 @@ public class ClusterAllocationRerouteBenchmark {
     private static final ESLogger logger = Loggers.getLogger(ClusterAllocationRerouteBenchmark.class);
 
     public static void main(String[] args) {
-        final int numberOfRuns = 10;
+        final int numberOfRuns = 1;
         final int numIndices = 5 * 365; // five years
         final int numShards = 6;
         final int numReplicas = 2;

--- a/src/test/java/org/elasticsearch/benchmark/cluster/ClusterAllocationRerouteBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/cluster/ClusterAllocationRerouteBenchmark.java
@@ -28,11 +28,14 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
+
+import java.util.Random;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTests.newNode;
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 public class ClusterAllocationRerouteBenchmark {
 
@@ -45,8 +48,7 @@ public class ClusterAllocationRerouteBenchmark {
         final int numReplicas = 2;
         final int numberOfNodes = 30;
         final int numberOfTags = 2;
-
-        AllocationService strategy = new AllocationService(settingsBuilder().build());
+        AllocationService strategy = ElasticsearchAllocationTestCase.createAllocationService(ImmutableSettings.EMPTY, new Random(1));
 
         MetaData.Builder mb = MetaData.builder();
         for (int i = 1; i <= numIndices; i++) {

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/AddIncrementallyTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/AddIncrementallyTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllo
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -23,14 +23,14 @@ import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTests.newNode;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
-public class AddIncrementallyTests extends ElasticsearchTestCase {
+public class AddIncrementallyTests extends ElasticsearchAllocationTestCase {
     private final ESLogger logger = Loggers.getLogger(AddIncrementallyTests.class);
 
     @Test
     public void testAddNodesAndIndices() {
         ImmutableSettings.Builder settings = settingsBuilder();
         settings.put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString());
-        AllocationService service = new AllocationService(settings.build());
+        AllocationService service = createAllocationService(settings.build());
 
         ClusterState clusterState = initCluster(service, 1, 3, 3, 1);
         assertThat(clusterState.routingNodes().node("node0").shardsWithState(STARTED).size(), Matchers.equalTo(9));
@@ -75,7 +75,7 @@ public class AddIncrementallyTests extends ElasticsearchTestCase {
         ImmutableSettings.Builder settings = settingsBuilder();
         settings.put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString())
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 2);
-        AllocationService service = new AllocationService(settings.build());
+        AllocationService service = createAllocationService(settings.build());
 
         ClusterState clusterState = initCluster(service, 1, 3, 3, 1);
         assertThat(clusterState.routingNodes().node("node0").shardsWithState(STARTED).size(), Matchers.equalTo(9));
@@ -146,7 +146,7 @@ public class AddIncrementallyTests extends ElasticsearchTestCase {
         settings.put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString())
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 100)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 100);
-        AllocationService service = new AllocationService(settings.build());
+        AllocationService service = createAllocationService(settings.build());
 
         ClusterState clusterState = initCluster(service, 1, 3, 3, 1);
         assertThat(clusterState.routingNodes().node("node0").shardsWithState(STARTED).size(), Matchers.equalTo(9));

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocatePostApiFlagTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocatePostApiFlagTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -36,13 +36,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class AllocatePostApiFlagTests extends ElasticsearchTestCase {
+public class AllocatePostApiFlagTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(AllocatePostApiFlagTests.class);
 
     @Test
     public void simpleFlagTests() {
-        AllocationService allocation = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService allocation = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("creating an index with 1 shard, no replica");
         MetaData metaData = MetaData.builder()

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -51,13 +51,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class AllocationCommandsTests extends ElasticsearchTestCase {
+public class AllocationCommandsTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(AllocationCommandsTests.class);
 
     @Test
     public void moveShardCommand() {
-        AllocationService allocation = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService allocation = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("creating an index with 1 shard, no replica");
         MetaData metaData = MetaData.builder()
@@ -101,7 +101,7 @@ public class AllocationCommandsTests extends ElasticsearchTestCase {
 
     @Test
     public void allocateCommand() {
-        AllocationService allocation = new AllocationService(settingsBuilder()
+        AllocationService allocation = createAllocationService(settingsBuilder()
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, true)
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)
                 .build());
@@ -182,7 +182,7 @@ public class AllocationCommandsTests extends ElasticsearchTestCase {
 
     @Test
     public void cancelCommand() {
-        AllocationService allocation = new AllocationService(settingsBuilder()
+        AllocationService allocation = createAllocationService(settingsBuilder()
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, true)
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -39,13 +39,13 @@ import static org.hamcrest.Matchers.*;
 
 /**
  */
-public class AwarenessAllocationTests extends ElasticsearchTestCase {
+public class AwarenessAllocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(AwarenessAllocationTests.class);
 
     @Test
     public void moveShardOnceNewNodeWithAttributeAdded1() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.attributes", "rack_id")
@@ -114,7 +114,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void moveShardOnceNewNodeWithAttributeAdded2() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.attributes", "rack_id")
@@ -184,7 +184,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void moveShardOnceNewNodeWithAttributeAdded3() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -285,7 +285,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void moveShardOnceNewNodeWithAttributeAdded4() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -381,7 +381,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void moveShardOnceNewNodeWithAttributeAdded5() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.attributes", "rack_id")
@@ -460,7 +460,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void moveShardOnceNewNodeWithAttributeAdded6() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.attributes", "rack_id")
@@ -541,7 +541,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void fullAwareness1() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.force.rack_id.values", "1,2")
@@ -609,7 +609,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void fullAwareness2() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.force.rack_id.values", "1,2")
@@ -678,7 +678,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void fullAwareness3() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -763,7 +763,7 @@ public class AwarenessAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void testUnbalancedZones() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.awareness.force.zone.values", "a,b")
                 .put("cluster.routing.allocation.awareness.attributes", "zone")
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -36,13 +36,13 @@ import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTest
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
-public class ClusterRebalanceRoutingTests extends ElasticsearchTestCase {
+public class ClusterRebalanceRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ClusterRebalanceRoutingTests.class);
 
     @Test
     public void testAlways() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))
@@ -128,7 +128,7 @@ public class ClusterRebalanceRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testClusterPrimariesActive1() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))
@@ -232,7 +232,7 @@ public class ClusterRebalanceRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testClusterPrimariesActive2() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))
@@ -316,7 +316,7 @@ public class ClusterRebalanceRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testClusterAllActive1() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))
@@ -439,7 +439,7 @@ public class ClusterRebalanceRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testClusterAllActive2() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))
@@ -523,7 +523,7 @@ public class ClusterRebalanceRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testClusterAllActive3() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ConcurrentRebalanceRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ConcurrentRebalanceRoutingTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -36,13 +36,13 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
-public class ConcurrentRebalanceRoutingTests extends ElasticsearchTestCase {
+public class ConcurrentRebalanceRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ConcurrentRebalanceRoutingTests.class);
 
     @Test
     public void testClusterConcurrentRebalance() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.cluster_concurrent_rebalance", 3)
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -38,13 +38,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class DeadNodesAllocationTests extends ElasticsearchTestCase {
+public class DeadNodesAllocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(DeadNodesAllocationTests.class);
 
     @Test
     public void simpleDeadNodeOnStartedPrimaryShard() {
-        AllocationService allocation = new AllocationService(settingsBuilder()
+        AllocationService allocation = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());
@@ -96,7 +96,7 @@ public class DeadNodesAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void deadNodeWhileRelocatingOnToNode() {
-        AllocationService allocation = new AllocationService(settingsBuilder()
+        AllocationService allocation = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());
@@ -171,7 +171,7 @@ public class DeadNodesAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void deadNodeWhileRelocatingOnFromNode() {
-        AllocationService allocation = new AllocationService(settingsBuilder()
+        AllocationService allocation = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/DisableAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/DisableAllocationTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.DisableAllocationDec
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -39,13 +39,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class DisableAllocationTests extends ElasticsearchTestCase {
+public class DisableAllocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(DisableAllocationTests.class);
 
     @Test
     public void testClusterDisableAllocation() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, true)
                 .put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)
                 .build());
@@ -75,7 +75,7 @@ public class DisableAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void testClusterDisableReplicaAllocation() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.disable_replica_allocation", true)
                 .build());
 
@@ -109,7 +109,7 @@ public class DisableAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void testIndexDisableAllocation() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .build());
 
         MetaData metaData = MetaData.builder()

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ElectReplicaAsPrimaryDuringRelocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ElectReplicaAsPrimaryDuringRelocationTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -40,13 +40,13 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class ElectReplicaAsPrimaryDuringRelocationTests extends ElasticsearchTestCase {
+public class ElectReplicaAsPrimaryDuringRelocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ElectReplicaAsPrimaryDuringRelocationTests.class);
 
     @Test
     public void testElectReplicaAsPrimaryDuringRelocation() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -38,13 +38,13 @@ import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTest
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
-public class FailedNodeRoutingTests extends ElasticsearchTestCase {
+public class FailedNodeRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(FailedNodeRoutingTests.class);
 
     @Test
     public void simpleFailedNodeTest() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))
@@ -104,7 +104,7 @@ public class FailedNodeRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void simpleFailedNodeTestNoReassign() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -42,13 +42,13 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public class FailedShardsRoutingTests extends ElasticsearchTestCase {
+public class FailedShardsRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(FailedShardsRoutingTests.class);
 
     @Test
     public void testFailedShardPrimaryRelocatingToAndFrom() {
-        AllocationService allocation = new AllocationService(settingsBuilder()
+        AllocationService allocation = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());
@@ -137,7 +137,7 @@ public class FailedShardsRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void failPrimaryStartedCheckReplicaElected() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());
@@ -219,7 +219,7 @@ public class FailedShardsRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void firstAllocationFailureSingleNode() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());
@@ -276,7 +276,7 @@ public class FailedShardsRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void firstAllocationFailureTwoNodes() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());
@@ -334,7 +334,7 @@ public class FailedShardsRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void rebalanceFailure() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/FilterRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/FilterRoutingTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -42,13 +42,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class FilterRoutingTests extends ElasticsearchTestCase {
+public class FilterRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(FilterRoutingTests.class);
 
     @Test
     public void testClusterFilters() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.include.tag1", "value1,value2")
                 .put("cluster.routing.allocation.exclude.tag1", "value3,value4")
                 .build());
@@ -94,7 +94,7 @@ public class FilterRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testIndexFilters() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .build());
 
         logger.info("Building initial routing table");

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -40,13 +40,13 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  *
  */
-public class IndexBalanceTests extends ElasticsearchTestCase {
+public class IndexBalanceTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(IndexBalanceTests.class);
 
     @Test
     public void testBalanceAllNodesStarted() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -177,7 +177,7 @@ public class IndexBalanceTests extends ElasticsearchTestCase {
 
     @Test
     public void testBalanceIncrementallyStartNodes() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -340,7 +340,7 @@ public class IndexBalanceTests extends ElasticsearchTestCase {
 
     @Test
     public void testBalanceAllNodesStartedAddIndex() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/PreferLocalPrimariesToRelocatingPrimariesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/PreferLocalPrimariesToRelocatingPrimariesTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.MutableShardRouting;
 import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class PreferLocalPrimariesToRelocatingPrimariesTests extends ElasticsearchTestCase {
+public class PreferLocalPrimariesToRelocatingPrimariesTests extends ElasticsearchAllocationTestCase {
     @Test
     public void testPreferLocalPrimaryAllocationOverFiltered() {
         int concurrentRecoveries = randomIntBetween(1, 10);
@@ -45,7 +45,7 @@ public class PreferLocalPrimariesToRelocatingPrimariesTests extends Elasticsearc
         int totalNumberOfShards = numberOfShards * 2;
 
         logger.info("create an allocation with [{}] initial primary recoveries and [{}] concurrent recoveries", primaryRecoveries, concurrentRecoveries);
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", concurrentRecoveries)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", primaryRecoveries)
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/PreferPrimaryAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/PreferPrimaryAllocationTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -36,14 +36,14 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class PreferPrimaryAllocationTests extends ElasticsearchTestCase {
+public class PreferPrimaryAllocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(PreferPrimaryAllocationTests.class);
 
     @Test
     public void testPreferPrimaryAllocationOverReplicas() {
         logger.info("create an allocation with 1 initial recoveries");
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 1)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 1)
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/PrimaryElectionRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/PrimaryElectionRoutingTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -40,13 +40,13 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  *
  */
-public class PrimaryElectionRoutingTests extends ElasticsearchTestCase {
+public class PrimaryElectionRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(PrimaryElectionRoutingTests.class);
 
     @Test
     public void testBackupElectionToPrimaryWhenPrimaryCanBeAllocatedToAnotherNode() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 
@@ -97,7 +97,7 @@ public class PrimaryElectionRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testRemovingInitializingReplicasIfPrimariesFails() {
-        AllocationService allocation = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService allocation = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/PrimaryNotRelocatedWhileBeingRecoveredTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/PrimaryNotRelocatedWhileBeingRecoveredTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -39,14 +39,14 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class PrimaryNotRelocatedWhileBeingRecoveredTests extends ElasticsearchTestCase {
+public class PrimaryNotRelocatedWhileBeingRecoveredTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(PrimaryNotRelocatedWhileBeingRecoveredTests.class);
 
 
     @Test
     public void testPrimaryNotRelocatedWhileBeingRecoveredFrom() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/RandomAllocationDeciderTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/RandomAllocationDeciderTests.java
@@ -35,7 +35,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -48,7 +48,7 @@ import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTest
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
-public class RandomAllocationDeciderTests extends ElasticsearchTestCase {
+public class RandomAllocationDeciderTests extends ElasticsearchAllocationTestCase {
 
     /* This test will make random allocation decision on a growing and shrinking
      * cluster leading to a random distribution of the shards. After a certain

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -40,13 +40,13 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  *
  */
-public class RebalanceAfterActiveTests extends ElasticsearchTestCase {
+public class RebalanceAfterActiveTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(RebalanceAfterActiveTests.class);
 
     @Test
     public void testRebalanceOnlyAfterAllShardsAreActive() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.cluster_concurrent_rebalance", -1)

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ReplicaAllocatedAfterPrimaryTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ReplicaAllocatedAfterPrimaryTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -40,13 +40,13 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  *
  */
-public class ReplicaAllocatedAfterPrimaryTests extends ElasticsearchTestCase {
+public class ReplicaAllocatedAfterPrimaryTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ReplicaAllocatedAfterPrimaryTests.class);
 
     @Test
     public void testBackupIsAllocatedAfterPrimary() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocationTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.cluster.routing.MutableShardRouting;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Ignore;
 
 import java.util.List;
@@ -36,7 +36,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 
 @Ignore("Not a test")
-public class RoutingAllocationTests extends ElasticsearchTestCase {
+public class RoutingAllocationTests extends ElasticsearchAllocationTestCase {
 
     public static DiscoveryNode newNode(String nodeId) {
         return new DiscoveryNode(nodeId, DummyTransportAddress.INSTANCE, Version.CURRENT);

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesIntegrityTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -41,13 +41,13 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class RoutingNodesIntegrityTests extends ElasticsearchTestCase {
+public class RoutingNodesIntegrityTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(IndexBalanceTests.class);
 
     @Test
     public void testBalanceAllNodesStarted() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -120,7 +120,7 @@ public class RoutingNodesIntegrityTests extends ElasticsearchTestCase {
 
     @Test
     public void testBalanceIncrementallyStartNodes() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
@@ -213,7 +213,7 @@ public class RoutingNodesIntegrityTests extends ElasticsearchTestCase {
 
     @Test
     public void testBalanceAllNodesStartedAddIndex() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 1)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 3)
                 .put("cluster.routing.allocation.allow_rebalance", "always")

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationD
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
@@ -23,14 +23,14 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class SameShardRoutingTests extends ElasticsearchTestCase {
+public class SameShardRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(SameShardRoutingTests.class);
 
     @Test
     @TestLogging("cluster.routing.allocation:TRACE")
     public void sameHost() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put(SameShardAllocationDecider.SAME_HOST_SETTING, true).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put(SameShardAllocationDecider.SAME_HOST_SETTING, true).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test").numberOfShards(2).numberOfReplicas(1))

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardVersioningTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardVersioningTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -36,13 +36,13 @@ import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTest
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
-public class ShardVersioningTests extends ElasticsearchTestCase {
+public class ShardVersioningTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ShardVersioningTests.class);
 
     @Test
     public void simple() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.allow_rebalance", ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()).build());
 
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test1").numberOfShards(1).numberOfReplicas(1))

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsLimitAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsLimitAllocationTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocatio
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -42,13 +42,13 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class ShardsLimitAllocationTests extends ElasticsearchTestCase {
+public class ShardsLimitAllocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ShardsLimitAllocationTests.class);
 
     @Test
     public void indexLevelShardsLimitAllocate() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 
@@ -91,7 +91,7 @@ public class ShardsLimitAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void indexLevelShardsLimitRemain() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.cluster_concurrent_rebalance", -1)

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardNoReplicasRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardNoReplicasRoutingTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import java.util.List;
@@ -44,13 +44,13 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public class SingleShardNoReplicasRoutingTests extends ElasticsearchTestCase {
+public class SingleShardNoReplicasRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(SingleShardNoReplicasRoutingTests.class);
 
     @Test
     public void testSingleIndexStartedShard() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 
@@ -152,7 +152,7 @@ public class SingleShardNoReplicasRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testSingleIndexShardFailed() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 
@@ -202,7 +202,7 @@ public class SingleShardNoReplicasRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testMultiIndexEvenDistribution() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.cluster_concurrent_rebalance", -1)
@@ -315,7 +315,7 @@ public class SingleShardNoReplicasRoutingTests extends ElasticsearchTestCase {
 
     @Test
     public void testMultiIndexUnevenNodes() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.cluster_concurrent_rebalance", -1)

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardOneReplicaRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardOneReplicaRoutingTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -39,13 +39,13 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  *
  */
-public class SingleShardOneReplicaRoutingTests extends ElasticsearchTestCase {
+public class SingleShardOneReplicaRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(SingleShardOneReplicaRoutingTests.class);
 
     @Test
     public void testSingleIndexFirstStartPrimaryThenBackups() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/TenShardsOneReplicaRoutingTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/TenShardsOneReplicaRoutingTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -38,13 +38,13 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public class TenShardsOneReplicaRoutingTests extends ElasticsearchTestCase {
+public class TenShardsOneReplicaRoutingTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(TenShardsOneReplicaRoutingTests.class);
 
     @Test
     public void testSingleIndexFirstStartPrimaryThenBackups() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -37,13 +37,13 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class ThrottlingAllocationTests extends ElasticsearchTestCase {
+public class ThrottlingAllocationTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(ThrottlingAllocationTests.class);
 
     @Test
     public void testPrimaryRecoveryThrottling() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.node_concurrent_recoveries", 3)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 3)
                 .build());
@@ -104,7 +104,7 @@ public class ThrottlingAllocationTests extends ElasticsearchTestCase {
 
     @Test
     public void testReplicaAndPrimaryRecoveryThrottling() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 3)
                 .put("cluster.routing.allocation.node_initial_primaries_recoveries", 3)
                 .build());

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
@@ -58,7 +58,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
         logger.info("Start all the primary shards");
         RoutingNodes routingNodes = clusterState.routingNodes();
         prevRoutingTable = routingTable;
-        routingTable = strategy.applyStartedShards(clusterState, routingNodes.node("node1").shardsWithState(INITIALIZING)).routingTable();
+        routingTable = strategy.applyStartedShards(clusterState, routingNodes.shardsWithState(INITIALIZING)).routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
         logger.info("Start all the replica shards");
@@ -66,16 +66,19 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
         prevRoutingTable = routingTable;
         routingTable = strategy.applyStartedShards(clusterState, routingNodes.shardsWithState(INITIALIZING)).routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
-
+        final String nodeHoldingPrimary = routingTable.index("test").shard(0).primaryShard().currentNodeId();
+        final String nodeHoldingReplica = routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId();
+        assertThat(nodeHoldingPrimary, not(equalTo(nodeHoldingReplica)));
         assertThat(prevRoutingTable != routingTable, equalTo(true));
         assertThat(routingTable.index("test").shards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).shards().size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).primaryShard().state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo("node1"));
+        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo(nodeHoldingPrimary));
         assertThat(routingTable.index("test").shard(0).replicaShards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(0).state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo("node2"));
+        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo(nodeHoldingReplica));
+
 
         logger.info("add another replica");
         routingNodes = clusterState.routingNodes();
@@ -90,10 +93,10 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
         assertThat(routingTable.index("test").shards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(3));
         assertThat(routingTable.index("test").shard(0).primaryShard().state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo("node1"));
+        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo(nodeHoldingPrimary));
         assertThat(routingTable.index("test").shard(0).replicaShards().size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(0).state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo("node2"));
+        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo(nodeHoldingReplica));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(1).state(), equalTo(UNASSIGNED));
 
         logger.info("Add another node and start the added replica");
@@ -106,10 +109,10 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
         assertThat(routingTable.index("test").shards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(3));
         assertThat(routingTable.index("test").shard(0).primaryShard().state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo("node1"));
+        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo(nodeHoldingPrimary));
         assertThat(routingTable.index("test").shard(0).replicaShards().size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(0).state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo("node2"));
+        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo(nodeHoldingReplica));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(1).state(), equalTo(INITIALIZING));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(1).currentNodeId(), equalTo("node3"));
 
@@ -122,10 +125,10 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
         assertThat(routingTable.index("test").shards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(3));
         assertThat(routingTable.index("test").shard(0).primaryShard().state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo("node1"));
+        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo(nodeHoldingPrimary));
         assertThat(routingTable.index("test").shard(0).replicaShards().size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(0).state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo("node2"));
+        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), equalTo(nodeHoldingReplica));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(1).state(), equalTo(STARTED));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(1).currentNodeId(), equalTo("node3"));
 
@@ -142,10 +145,10 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
         assertThat(routingTable.index("test").shards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).size(), equalTo(2));
         assertThat(routingTable.index("test").shard(0).primaryShard().state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo("node1"));
+        assertThat(routingTable.index("test").shard(0).primaryShard().currentNodeId(), equalTo(nodeHoldingPrimary));
         assertThat(routingTable.index("test").shard(0).replicaShards().size(), equalTo(1));
         assertThat(routingTable.index("test").shard(0).replicaShards().get(0).state(), equalTo(STARTED));
-        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), anyOf(equalTo("node2"), equalTo("node3")));
+        assertThat(routingTable.index("test").shard(0).replicaShards().get(0).currentNodeId(), anyOf(equalTo(nodeHoldingReplica), equalTo("node3")));
 
         logger.info("do a reroute, should remain the same");
         prevRoutingTable = routingTable;

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/UpdateNumberOfReplicasTests.java
@@ -8,7 +8,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
@@ -19,13 +19,13 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public class UpdateNumberOfReplicasTests extends ElasticsearchTestCase {
+public class UpdateNumberOfReplicasTests extends ElasticsearchAllocationTestCase {
 
     private final ESLogger logger = Loggers.getLogger(UpdateNumberOfReplicasTests.class);
 
     @Test
     public void testUpdateNumberOfReplicas() {
-        AllocationService strategy = new AllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
+        AllocationService strategy = createAllocationService(settingsBuilder().put("cluster.routing.allocation.concurrent_recoveries", 10).build());
 
         logger.info("Building initial routing table");
 

--- a/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocators;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,7 +46,7 @@ import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTest
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
-public class DiskThresholdDeciderTests extends ElasticsearchTestCase {
+public class DiskThresholdDeciderTests extends ElasticsearchAllocationTestCase {
 
     @Test
     public void diskThresholdTest() {

--- a/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.transport.DummyTransportAddress;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class ClusterSerializationTests extends ElasticsearchTestCase {
+public class ClusterSerializationTests extends ElasticsearchAllocationTestCase {
 
     @Test
     public void testClusterStateSerialization() throws Exception {
@@ -54,7 +54,7 @@ public class ClusterSerializationTests extends ElasticsearchTestCase {
 
         ClusterState clusterState = ClusterState.builder().nodes(nodes).metaData(metaData).routingTable(routingTable).build();
 
-        AllocationService strategy = new AllocationService();
+        AllocationService strategy = createAllocationService();
         clusterState = ClusterState.builder(clusterState).routingTable(strategy.reroute(clusterState).routingTable()).build();
 
         ClusterState serializedClusterState = ClusterState.Builder.fromBytes(ClusterState.Builder.toBytes(clusterState), newNode("node1"));
@@ -77,7 +77,7 @@ public class ClusterSerializationTests extends ElasticsearchTestCase {
 
         ClusterState clusterState = ClusterState.builder().nodes(nodes).metaData(metaData).routingTable(routingTable).build();
 
-        AllocationService strategy = new AllocationService();
+        AllocationService strategy = createAllocationService();
         RoutingTable source = strategy.reroute(clusterState).routingTable();
 
         BytesStreamOutput outStream = new BytesStreamOutput();

--- a/src/test/java/org/elasticsearch/cluster/serialization/ClusterStateToStringTests.java
+++ b/src/test/java/org/elasticsearch/cluster/serialization/ClusterStateToStringTests.java
@@ -10,7 +10,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.transport.DummyTransportAddress;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.containsString;
 /**
  *
  */
-public class ClusterStateToStringTests extends ElasticsearchTestCase {
+public class ClusterStateToStringTests extends ElasticsearchAllocationTestCase {
     @Test
     public void testClusterStateSerialization() throws Exception {
         MetaData metaData = MetaData.builder()
@@ -34,7 +34,7 @@ public class ClusterStateToStringTests extends ElasticsearchTestCase {
 
         ClusterState clusterState = ClusterState.builder().nodes(nodes).metaData(metaData).routingTable(routingTable).build();
 
-        AllocationService strategy = new AllocationService();
+        AllocationService strategy = createAllocationService();
         clusterState = ClusterState.builder(clusterState).routingTable(strategy.reroute(clusterState).routingTable()).build();
 
         String clusterStateString = clusterState.toString();

--- a/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
+++ b/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.cluster.routing.operation.hash.djb.DjbHashFunction;
 import org.elasticsearch.cluster.routing.operation.plain.PlainOperationRouting;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchAllocationTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -40,7 +40,7 @@ import static org.elasticsearch.cluster.routing.allocation.RoutingAllocationTest
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.*;
 
-public class RoutingIteratorTests extends ElasticsearchTestCase {
+public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
 
     @Test
     public void testEmptyIterator() {
@@ -248,7 +248,7 @@ public class RoutingIteratorTests extends ElasticsearchTestCase {
 
     @Test
     public void testAttributePreferenceRouting() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .put("cluster.routing.allocation.allow_rebalance", "always")
                 .put("cluster.routing.allocation.awareness.attributes", "rack_id,zone")
@@ -299,7 +299,7 @@ public class RoutingIteratorTests extends ElasticsearchTestCase {
 
     @Test
     public void testShardsAndPreferNodeRouting() {
-        AllocationService strategy = new AllocationService(settingsBuilder()
+        AllocationService strategy = createAllocationService(settingsBuilder()
                 .put("cluster.routing.allocation.concurrent_recoveries", 10)
                 .build());
 

--- a/src/test/java/org/elasticsearch/test/ElasticsearchAllocationTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchAllocationTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test;
+
+import com.google.common.collect.ImmutableSet;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocators;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecidersModule;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.settings.NodeSettingsService;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ */
+public class ElasticsearchAllocationTestCase extends ElasticsearchTestCase {
+
+    public static AllocationService createAllocationService() {
+        return createAllocationService(ImmutableSettings.Builder.EMPTY_SETTINGS);
+    }
+
+    public static AllocationService createAllocationService(Settings settings) {
+        return createAllocationService(settings, getRandom())    ;
+    }
+
+    public static AllocationService createAllocationService(Settings settings, Random random) {
+        return new AllocationService(settings,
+                randomAllocationDeciders(settings, new NodeSettingsService(ImmutableSettings.Builder.EMPTY_SETTINGS), random),
+                new ShardsAllocators(settings), ClusterInfoService.EMPTY);
+    }
+
+    public static AllocationDeciders randomAllocationDeciders(Settings settings, NodeSettingsService nodeSettingsService, Random random) {
+        final ImmutableSet<Class<? extends AllocationDecider>> defaultAllocationDeciders = AllocationDecidersModule.DEFAULT_ALLOCATION_DECIDERS;
+        final List<AllocationDecider> list = new ArrayList<AllocationDecider>();
+        for (Class<? extends AllocationDecider> deciderClass : defaultAllocationDeciders) {
+            try {
+                try {
+                    Constructor<? extends AllocationDecider> constructor = deciderClass.getConstructor(Settings.class, NodeSettingsService.class);
+                    list.add(constructor.newInstance(settings, nodeSettingsService));
+                } catch (NoSuchMethodException e) {
+                    Constructor<? extends AllocationDecider> constructor = null;
+                    constructor = deciderClass.getConstructor(Settings.class);
+                    list.add(constructor.newInstance(settings));
+                }
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        assertThat(list.size(), equalTo(defaultAllocationDeciders.size()));
+        for (AllocationDecider d : list) {
+            assertThat(defaultAllocationDeciders.contains(d.getClass()), is(true));
+        }
+        Collections.shuffle(list, random);
+        return new AllocationDeciders(settings, list.toArray(new AllocationDecider[0]));
+
+    }
+}


### PR DESCRIPTION
When we allocate unassigned shards we can terminate early for some
shards like if we already tried to allocate a replica we don't need
to try the same replica if the first one got rejected. We also
can check if certain nodes can't allocate any primaries or shrads
at all and take those nodes out of the picture for the current round
since it will not change in the current round.
