### PR TITLE
Made APIs consistently accept a query in the request body's `query` field

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.admin.indices.refresh.TransportRefreshAction;
 import org.elasticsearch.action.deletebyquery.DeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.TransportDeleteByQueryAction;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterService;
@@ -102,7 +103,9 @@ public class TransportDeleteMappingAction extends TransportMasterNodeOperationAc
         flushAction.execute(Requests.flushRequest(request.indices()), new ActionListener<FlushResponse>() {
             @Override
             public void onResponse(FlushResponse flushResponse) {
-                deleteByQueryAction.execute(Requests.deleteByQueryRequest(request.indices()).query(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.typeFilter(request.type()))), new ActionListener<DeleteByQueryResponse>() {
+                QuerySourceBuilder querySourceBuilder = new QuerySourceBuilder()
+                        .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.typeFilter(request.type())));
+                deleteByQueryAction.execute(Requests.deleteByQueryRequest(request.indices()).source(querySourceBuilder), new ActionListener<DeleteByQueryResponse>() {
                     @Override
                     public void onResponse(DeleteByQueryResponse deleteByQueryResponse) {
                         refreshAction.execute(Requests.refreshRequest(request.indices()), new ActionListener<RefreshResponse>() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  */
 class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
 
-    private BytesReference querySource;
+    private BytesReference source;
     private String[] types = Strings.EMPTY_ARRAY;
     private boolean explain;
     private long nowInMillis;
@@ -48,15 +48,15 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
 
     public ShardValidateQueryRequest(String index, int shardId, @Nullable String[] filteringAliases, ValidateQueryRequest request) {
         super(index, shardId, request);
-        this.querySource = request.querySource();
+        this.source = request.source();
         this.types = request.types();
         this.explain = request.explain();
         this.filteringAliases = filteringAliases;
         this.nowInMillis = request.nowInMillis;
     }
 
-    public BytesReference querySource() {
-        return querySource;
+    public BytesReference source() {
+        return source;
     }
 
     public String[] types() {
@@ -78,7 +78,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        querySource = in.readBytesReference();
+        source = in.readBytesReference();
 
         int typesSize = in.readVInt();
         if (typesSize > 0) {
@@ -107,7 +107,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBytesReference(querySource);
+        out.writeBytesReference(source);
 
         out.writeVInt(types.length);
         for (String type : types) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -174,7 +174,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
         boolean valid;
         String explanation = null;
         String error = null;
-        if (request.querySource().length() == 0) {
+        if (request.source().length() == 0) {
             valid = true;
         } else {
             SearchContext.setCurrent(new DefaultSearchContext(0,
@@ -182,7 +182,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
                     null, indexShard.acquireSearcher("validate_query"), indexService, indexShard,
                     scriptService, cacheRecycler));
             try {
-                ParsedQuery parsedQuery = queryParserService.parse(request.querySource());
+                ParsedQuery parsedQuery = queryParserService.parseQuery(request.source());
                 valid = true;
                 if (request.explain()) {
                     explanation = parsedQuery.query().toString();

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.validate.query;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
@@ -30,6 +31,8 @@ import org.elasticsearch.index.query.QueryBuilder;
  *
  */
 public class ValidateQueryRequestBuilder extends BroadcastOperationRequestBuilder<ValidateQueryRequest, ValidateQueryResponse, ValidateQueryRequestBuilder> {
+
+    private QuerySourceBuilder sourceBuilder;
 
     public ValidateQueryRequestBuilder(IndicesAdminClient client) {
         super((InternalIndicesAdminClient) client, new ValidateQueryRequest());
@@ -49,37 +52,37 @@ public class ValidateQueryRequestBuilder extends BroadcastOperationRequestBuilde
      * @see org.elasticsearch.index.query.QueryBuilders
      */
     public ValidateQueryRequestBuilder setQuery(QueryBuilder queryBuilder) {
-        request.query(queryBuilder);
+        sourceBuilder().setQuery(queryBuilder);
         return this;
     }
 
     /**
-     * The query source to validate.
+     * The source to validate.
      *
      * @see org.elasticsearch.index.query.QueryBuilders
      */
-    public ValidateQueryRequestBuilder setQuery(BytesReference querySource) {
-        request.query(querySource, false);
+    public ValidateQueryRequestBuilder setSource(BytesReference source) {
+        request().source(source, false);
         return this;
     }
 
     /**
-     * The query source to validate.
+     * The source to validate.
      *
      * @see org.elasticsearch.index.query.QueryBuilders
      */
-    public ValidateQueryRequestBuilder setQuery(BytesReference querySource, boolean unsafe) {
-        request.query(querySource, unsafe);
+    public ValidateQueryRequestBuilder setSource(BytesReference source, boolean unsafe) {
+        request().source(source, unsafe);
         return this;
     }
 
     /**
-     * The query source to validate.
+     * The source to validate.
      *
      * @see org.elasticsearch.index.query.QueryBuilders
      */
-    public ValidateQueryRequestBuilder setQuery(byte[] querySource) {
-        request.query(querySource);
+    public ValidateQueryRequestBuilder setSource(byte[] source) {
+        request.source(source);
         return this;
     }
 
@@ -95,6 +98,17 @@ public class ValidateQueryRequestBuilder extends BroadcastOperationRequestBuilde
 
     @Override
     protected void doExecute(ActionListener<ValidateQueryResponse> listener) {
+        if (sourceBuilder != null) {
+            request.source(sourceBuilder);
+        }
+
         ((IndicesAdminClient) client).validateQuery(request, listener);
+    }
+
+    private QuerySourceBuilder sourceBuilder() {
+        if (sourceBuilder == null) {
+            sourceBuilder = new QuerySourceBuilder();
+        }
+        return sourceBuilder;
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/CountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.count;
 
 import org.elasticsearch.ElasticSearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
@@ -33,7 +34,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,8 +43,8 @@ import java.util.Map;
  * A request to count the number of documents matching a specific query. Best created with
  * {@link org.elasticsearch.client.Requests#countRequest(String...)}.
  * <p/>
- * <p>The request requires the query source to be set either using {@link #query(org.elasticsearch.index.query.QueryBuilder)},
- * or {@link #query(byte[])}.
+ * <p>The request requires the query source to be set either using {@link #source(QuerySourceBuilder)},
+ * or {@link #source(byte[])}.
  *
  * @see CountResponse
  * @see org.elasticsearch.client.Client#count(CountRequest)
@@ -64,8 +64,8 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
     @Nullable
     private String preference;
 
-    private BytesReference querySource;
-    private boolean querySourceUnsafe;
+    private BytesReference source;
+    private boolean sourceUnsafe;
 
     private String[] types = Strings.EMPTY_ARRAY;
 
@@ -90,9 +90,9 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
 
     @Override
     protected void beforeStart() {
-        if (querySourceUnsafe) {
-            querySource = querySource.copyBytesArray();
-            querySourceUnsafe = false;
+        if (sourceUnsafe) {
+            source = source.copyBytesArray();
+            sourceUnsafe = false;
         }
     }
 
@@ -113,69 +113,67 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    BytesReference querySource() {
-        return querySource;
+    BytesReference source() {
+        return source;
     }
 
     /**
-     * The query source to execute.
-     *
-     * @see org.elasticsearch.index.query.QueryBuilders
+     * The source to execute.
      */
-    public CountRequest query(QueryBuilder queryBuilder) {
-        this.querySource = queryBuilder.buildAsBytes();
-        this.querySourceUnsafe = false;
+    public CountRequest source(QuerySourceBuilder sourceBuilder) {
+        this.source = sourceBuilder.buildAsBytes(contentType);
+        this.sourceUnsafe = false;
         return this;
     }
 
     /**
-     * The query source to execute in the form of a map.
+     * The source to execute in the form of a map.
      */
-    public CountRequest query(Map querySource) {
+    public CountRequest source(Map querySource) {
         try {
             XContentBuilder builder = XContentFactory.contentBuilder(contentType);
             builder.map(querySource);
-            return query(builder);
+            return source(builder);
         } catch (IOException e) {
             throw new ElasticSearchGenerationException("Failed to generate [" + querySource + "]", e);
         }
     }
 
-    public CountRequest query(XContentBuilder builder) {
-        this.querySource = builder.bytes();
-        this.querySourceUnsafe = false;
+    public CountRequest source(XContentBuilder builder) {
+        this.source = builder.bytes();
+        this.sourceUnsafe = false;
         return this;
     }
 
     /**
-     * The query source to execute. It is preferable to use either {@link #query(byte[])}
-     * or {@link #query(org.elasticsearch.index.query.QueryBuilder)}.
+     * The source to execute. It is preferable to use either {@link #source(byte[])}
+     * or {@link #source(QuerySourceBuilder)}.
      */
-    public CountRequest query(String querySource) {
-        this.querySource = new BytesArray(querySource);
-        this.querySourceUnsafe = false;
+    public CountRequest source(String querySource) {
+        this.source = new BytesArray(querySource);
+        this.sourceUnsafe = false;
         return this;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public CountRequest query(byte[] querySource) {
-        return query(querySource, 0, querySource.length, false);
+    public CountRequest source(byte[] querySource) {
+        return source(querySource, 0, querySource.length, false);
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public CountRequest query(byte[] querySource, int offset, int length, boolean unsafe) {
-        return query(new BytesArray(querySource, offset, length), unsafe);
+    public CountRequest source(byte[] querySource, int offset, int length, boolean unsafe) {
+        return source(new BytesArray(querySource, offset, length), unsafe);
     }
 
-    public CountRequest query(BytesReference querySource, boolean unsafe) {
-        this.querySource = querySource;
-        this.querySourceUnsafe = unsafe;
+    public CountRequest source(BytesReference querySource, boolean unsafe) {
+        this.source = querySource;
+        this.sourceUnsafe = unsafe;
         return this;
     }
 
@@ -232,8 +230,8 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
         minScore = in.readFloat();
         routing = in.readOptionalString();
         preference = in.readOptionalString();
-        querySourceUnsafe = false;
-        querySource = in.readBytesReference();
+        sourceUnsafe = false;
+        source = in.readBytesReference();
         types = in.readStringArray();
     }
 
@@ -243,7 +241,7 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
         out.writeFloat(minScore);
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);
-        out.writeBytesReference(querySource);
+        out.writeBytesReference(source);
         out.writeStringArray(types);
     }
 
@@ -251,10 +249,10 @@ public class CountRequest extends BroadcastOperationRequest<CountRequest> {
     public String toString() {
         String sSource = "_na_";
         try {
-            sSource = XContentHelper.convertToJson(querySource, false);
+            sSource = XContentHelper.convertToJson(source, false);
         } catch (Exception e) {
             // ignore
         }
-        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", querySource[" + sSource + "]";
+        return "[" + Arrays.toString(indices) + "]" + Arrays.toString(types) + ", source[" + sSource + "]";
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/CountRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/count/CountRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.count;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.internal.InternalClient;
@@ -30,6 +31,8 @@ import org.elasticsearch.index.query.QueryBuilder;
  * A count action request builder.
  */
 public class CountRequestBuilder extends BroadcastOperationRequestBuilder<CountRequest, CountResponse, CountRequestBuilder> {
+
+    private QuerySourceBuilder sourceBuilder;
 
     public CountRequestBuilder(Client client) {
         super((InternalClient) client, new CountRequest());
@@ -85,42 +88,47 @@ public class CountRequestBuilder extends BroadcastOperationRequestBuilder<CountR
      * @see org.elasticsearch.index.query.QueryBuilders
      */
     public CountRequestBuilder setQuery(QueryBuilder queryBuilder) {
-        request.query(queryBuilder);
+        sourceBuilder().setQuery(queryBuilder);
+        return this;
+    }
+
+    /**
+     * The source to execute.
+     */
+    public CountRequestBuilder setSource(BytesReference source) {
+        request().source(source, false);
+        return this;
+    }
+
+    /**
+     * The source to execute.
+     */
+    public CountRequestBuilder setSource(BytesReference source, boolean unsafe) {
+        request().source(source, unsafe);
         return this;
     }
 
     /**
      * The query source to execute.
-     *
-     * @see org.elasticsearch.index.query.QueryBuilders
      */
-    public CountRequestBuilder setQuery(BytesReference querySource) {
-        request.query(querySource, false);
-        return this;
-    }
-
-    /**
-     * The query source to execute.
-     *
-     * @see org.elasticsearch.index.query.QueryBuilders
-     */
-    public CountRequestBuilder setQuery(BytesReference querySource, boolean unsafe) {
-        request.query(querySource, unsafe);
-        return this;
-    }
-
-    /**
-     * The query source to execute.
-     *
-     * @see org.elasticsearch.index.query.QueryBuilders
-     */
-    public CountRequestBuilder setQuery(byte[] querySource) {
-        request.query(querySource);
+    public CountRequestBuilder setSource(byte[] querySource) {
+        request.source(querySource);
         return this;
     }
 
     @Override
     protected void doExecute(ActionListener<CountResponse> listener) {
+        if (sourceBuilder != null) {
+            request.source(sourceBuilder);
+        }
+
         ((InternalClient) client).count(request, listener);
+    }
+
+    private QuerySourceBuilder sourceBuilder() {
+        if (sourceBuilder == null) {
+            sourceBuilder = new QuerySourceBuilder();
+        }
+        return sourceBuilder;
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
@@ -52,7 +52,7 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
     public ShardCountRequest(String index, int shardId, @Nullable String[] filteringAliases, CountRequest request) {
         super(index, shardId, request);
         this.minScore = request.minScore();
-        this.querySource = request.querySource();
+        this.querySource = request.source();
         this.types = request.types();
         this.filteringAliases = filteringAliases;
         this.nowInMillis = request.nowInMillis;

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -172,11 +172,11 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
             if (request.minScore() != -1) {
                 context.minimumScore(request.minScore());
             }
-            BytesReference querySource = request.querySource();
-            if (querySource != null && querySource.length() > 0) {
+            BytesReference source = request.querySource();
+            if (source != null && source.length() > 0) {
                 try {
                     QueryParseContext.setTypes(request.types());
-                    context.parsedQuery(indexService.queryParserService().parse(querySource));
+                    context.parsedQuery(indexService.queryParserService().parseQuery(source));
                 } finally {
                     QueryParseContext.removeTypes();
                 }

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.deletebyquery;
 import com.google.common.base.Charsets;
 import org.elasticsearch.ElasticSearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.replication.IndicesReplicationOperationRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Nullable;
@@ -34,7 +35,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -46,8 +46,8 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * A request to delete all documents that matching a specific query. Best created with
  * {@link org.elasticsearch.client.Requests#deleteByQueryRequest(String...)}.
  * <p/>
- * <p>The request requires the query source to be set either using {@link #query(org.elasticsearch.index.query.QueryBuilder)},
- * or {@link #query(byte[])}.
+ * <p>The request requires the source to be set either using {@link #source(QuerySourceBuilder)},
+ * or {@link #source(byte[])}.
  *
  * @see DeleteByQueryResponse
  * @see org.elasticsearch.client.Requests#deleteByQueryRequest(String...)
@@ -57,8 +57,8 @@ public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<Del
 
     private static final XContentType contentType = Requests.CONTENT_TYPE;
 
-    private BytesReference querySource;
-    private boolean querySourceUnsafe;
+    private BytesReference source;
+    private boolean sourceUnsafe;
 
     private String[] types = Strings.EMPTY_ARRAY;
     @Nullable
@@ -78,81 +78,79 @@ public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<Del
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = super.validate();
-        if (querySource == null) {
-            validationException = addValidationError("query is missing", validationException);
+        if (source == null) {
+            validationException = addValidationError("source is missing", validationException);
         }
         return validationException;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    BytesReference querySource() {
-        if (querySourceUnsafe) {
-            querySource = querySource.copyBytesArray();
+    BytesReference source() {
+        if (sourceUnsafe) {
+            source = source.copyBytesArray();
         }
-        return querySource;
+        return source;
     }
 
     /**
-     * The query source to execute.
-     *
-     * @see org.elasticsearch.index.query.QueryBuilders
+     * The source to execute.
      */
-    public DeleteByQueryRequest query(QueryBuilder queryBuilder) {
-        this.querySource = queryBuilder.buildAsBytes();
-        this.querySourceUnsafe = false;
+    public DeleteByQueryRequest source(QuerySourceBuilder sourceBuilder) {
+        this.source = sourceBuilder.buildAsBytes(contentType);
+        this.sourceUnsafe = false;
         return this;
     }
 
     /**
-     * The query source to execute. It is preferable to use either {@link #query(byte[])}
-     * or {@link #query(org.elasticsearch.index.query.QueryBuilder)}.
+     * The source to execute. It is preferable to use either {@link #source(byte[])}
+     * or {@link #source(QuerySourceBuilder)}.
      */
-    public DeleteByQueryRequest query(String querySource) {
-        this.querySource = new BytesArray(querySource.getBytes(Charsets.UTF_8));
-        this.querySourceUnsafe = false;
+    public DeleteByQueryRequest source(String query) {
+        this.source = new BytesArray(query.getBytes(Charsets.UTF_8));
+        this.sourceUnsafe = false;
         return this;
     }
 
     /**
-     * The query source to execute in the form of a map.
+     * The source to execute in the form of a map.
      */
-    public DeleteByQueryRequest query(Map querySource) {
+    public DeleteByQueryRequest source(Map source) {
         try {
             XContentBuilder builder = XContentFactory.contentBuilder(contentType);
-            builder.map(querySource);
-            return query(builder);
+            builder.map(source);
+            return source(builder);
         } catch (IOException e) {
-            throw new ElasticSearchGenerationException("Failed to generate [" + querySource + "]", e);
+            throw new ElasticSearchGenerationException("Failed to generate [" + source + "]", e);
         }
     }
 
-    public DeleteByQueryRequest query(XContentBuilder builder) {
-        this.querySource = builder.bytes();
-        this.querySourceUnsafe = false;
+    public DeleteByQueryRequest source(XContentBuilder builder) {
+        this.source = builder.bytes();
+        this.sourceUnsafe = false;
         return this;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public DeleteByQueryRequest query(byte[] querySource) {
-        return query(querySource, 0, querySource.length, false);
+    public DeleteByQueryRequest source(byte[] source) {
+        return source(source, 0, source.length, false);
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public DeleteByQueryRequest query(byte[] querySource, int offset, int length, boolean unsafe) {
-        this.querySource = new BytesArray(querySource, offset, length);
-        this.querySourceUnsafe = unsafe;
+    public DeleteByQueryRequest source(byte[] source, int offset, int length, boolean unsafe) {
+        this.source = new BytesArray(source, offset, length);
+        this.sourceUnsafe = unsafe;
         return this;
     }
 
-    public DeleteByQueryRequest query(BytesReference source, boolean unsafe) {
-        this.querySource = source;
-        this.querySourceUnsafe = unsafe;
+    public DeleteByQueryRequest source(BytesReference source, boolean unsafe) {
+        this.source = source;
+        this.sourceUnsafe = unsafe;
         return this;
     }
 
@@ -196,15 +194,15 @@ public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<Del
 
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        querySourceUnsafe = false;
-        querySource = in.readBytesReference();
+        sourceUnsafe = false;
+        source = in.readBytesReference();
         routing = in.readOptionalString();
         types = in.readStringArray();
     }
 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBytesReference(querySource);
+        out.writeBytesReference(source);
         out.writeOptionalString(routing);
         out.writeStringArray(types);
     }
@@ -213,10 +211,10 @@ public class DeleteByQueryRequest extends IndicesReplicationOperationRequest<Del
     public String toString() {
         String sSource = "_na_";
         try {
-            sSource = XContentHelper.convertToJson(querySource, false);
+            sSource = XContentHelper.convertToJson(source, false);
         } catch (Exception e) {
             // ignore
         }
-        return "[" + Arrays.toString(indices) + "][" + Arrays.toString(types) + "], querySource[" + sSource + "]";
+        return "[" + Arrays.toString(indices) + "][" + Arrays.toString(types) + "], source[" + sSource + "]";
     }
 }

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequestBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.deletebyquery;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.WriteConsistencyLevel;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.replication.IndicesReplicationOperationRequestBuilder;
 import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.client.Client;
@@ -35,6 +36,8 @@ import java.util.Map;
  *
  */
 public class DeleteByQueryRequestBuilder extends IndicesReplicationOperationRequestBuilder<DeleteByQueryRequest, DeleteByQueryResponse, DeleteByQueryRequestBuilder> {
+
+    private QuerySourceBuilder sourceBuilder;
 
     public DeleteByQueryRequestBuilder(Client client) {
         super((InternalClient) client, new DeleteByQueryRequest());
@@ -66,69 +69,69 @@ public class DeleteByQueryRequestBuilder extends IndicesReplicationOperationRequ
 
 
     /**
-     * The query source to execute.
+     * The query to delete documents for.
      *
      * @see org.elasticsearch.index.query.QueryBuilders
      */
     public DeleteByQueryRequestBuilder setQuery(QueryBuilder queryBuilder) {
-        request.query(queryBuilder);
+        sourceBuilder().setQuery(queryBuilder);
         return this;
     }
 
     /**
-     * The query source to execute. It is preferable to use either {@link #setQuery(byte[])}
-     * or {@link #setQuery(org.elasticsearch.index.query.QueryBuilder)}.
+     * The source to execute. It is preferable to use either {@link #setSource(byte[])}
+     * or {@link #setQuery(QueryBuilder)}.
      */
-    public DeleteByQueryRequestBuilder setQuery(String querySource) {
-        request.query(querySource);
+    public DeleteByQueryRequestBuilder setSource(String source) {
+        request().source(source);
         return this;
     }
 
     /**
-     * The query source to execute in the form of a map.
+     * The source to execute in the form of a map.
      */
-    public DeleteByQueryRequestBuilder setQuery(Map<String, Object> querySource) {
-        request.query(querySource);
+    public DeleteByQueryRequestBuilder setSource(Map<String, Object> source) {
+        request().source(source);
         return this;
     }
 
     /**
-     * The query source to execute in the form of a builder.
+     * The source to execute in the form of a builder.
      */
-    public DeleteByQueryRequestBuilder setQuery(XContentBuilder builder) {
-        request.query(builder);
+    public DeleteByQueryRequestBuilder setSource(XContentBuilder builder) {
+        request().source(builder);
         return this;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public DeleteByQueryRequestBuilder setQuery(byte[] querySource) {
-        request.query(querySource);
+    public DeleteByQueryRequestBuilder setSource(byte[] source) {
+        request().source(source);
         return this;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public DeleteByQueryRequestBuilder setQuery(BytesReference querySource) {
-        request.query(querySource, false);
+    public DeleteByQueryRequestBuilder setSource(BytesReference source) {
+        request().source(source, false);
         return this;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public DeleteByQueryRequestBuilder setQuery(BytesReference querySource, boolean unsafe) {
-        request.query(querySource, unsafe);
+    public DeleteByQueryRequestBuilder setSource(BytesReference source, boolean unsafe) {
+        request().source(source, unsafe);
         return this;
     }
 
     /**
-     * The query source to execute.
+     * The source to execute.
      */
-    public DeleteByQueryRequestBuilder setQuery(byte[] querySource, int offset, int length, boolean unsafe) {
-        request.query(querySource, offset, length, unsafe);
+    public DeleteByQueryRequestBuilder setSource(byte[] source, int offset, int length, boolean unsafe) {
+        request().source(source, offset, length, unsafe);
         return this;
     }
 
@@ -155,6 +158,17 @@ public class DeleteByQueryRequestBuilder extends IndicesReplicationOperationRequ
 
     @Override
     protected void doExecute(ActionListener<DeleteByQueryResponse> listener) {
+        if (sourceBuilder != null) {
+            request.source(sourceBuilder);
+        }
+
         ((Client) client).deleteByQuery(request, listener);
+    }
+
+    private QuerySourceBuilder sourceBuilder() {
+        if (sourceBuilder == null) {
+            sourceBuilder = new QuerySourceBuilder();
+        }
+        return sourceBuilder;
     }
 }

--- a/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryRequest.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<IndexDeleteByQueryRequest> {
 
-    private BytesReference querySource;
+    private BytesReference source;
     private String[] types = Strings.EMPTY_ARRAY;
     @Nullable
     private Set<String> routing;
@@ -49,7 +49,7 @@ public class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<
     IndexDeleteByQueryRequest(DeleteByQueryRequest request, String index, @Nullable Set<String> routing, @Nullable String[] filteringAliases) {
         this.index = index;
         this.timeout = request.timeout();
-        this.querySource = request.querySource();
+        this.source = request.source();
         this.types = request.types();
         this.replicationType = request.replicationType();
         this.consistencyLevel = request.consistencyLevel();
@@ -60,15 +60,15 @@ public class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<
     IndexDeleteByQueryRequest() {
     }
 
-    BytesReference querySource() {
-        return querySource;
+    BytesReference source() {
+        return source;
     }
 
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = super.validate();
-        if (querySource == null) {
-            validationException = addValidationError("querySource is missing", validationException);
+        if (source == null) {
+            validationException = addValidationError("source is missing", validationException);
         }
         return validationException;
     }
@@ -92,7 +92,7 @@ public class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<
 
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        querySource = in.readBytesReference();
+        source = in.readBytesReference();
         int typesSize = in.readVInt();
         if (typesSize > 0) {
             types = new String[typesSize];
@@ -118,7 +118,7 @@ public class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<
 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBytesReference(querySource);
+        out.writeBytesReference(source);
         out.writeVInt(types.length);
         for (String type : types) {
             out.writeString(type);

--- a/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<ShardDeleteByQueryRequest> {
 
     private int shardId;
-    private BytesReference querySource;
+    private BytesReference source;
     private String[] types = Strings.EMPTY_ARRAY;
     @Nullable
     private Set<String> routing;
@@ -51,7 +51,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
     ShardDeleteByQueryRequest(IndexDeleteByQueryRequest request, int shardId) {
         super(request);
         this.index = request.index();
-        this.querySource = request.querySource();
+        this.source = request.source();
         this.types = request.types();
         this.shardId = shardId;
         replicationType(request.replicationType());
@@ -67,8 +67,8 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = super.validate();
-        if (querySource == null) {
-            addValidationError("querySource is missing", validationException);
+        if (source == null) {
+            addValidationError("source is missing", validationException);
         }
         return validationException;
     }
@@ -77,8 +77,8 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
         return this.shardId;
     }
 
-    BytesReference querySource() {
-        return querySource;
+    BytesReference source() {
+        return source;
     }
 
     public String[] types() {
@@ -96,7 +96,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        querySource = in.readBytesReference();
+        source = in.readBytesReference();
         shardId = in.readVInt();
         types = in.readStringArray();
         int routingSize = in.readVInt();
@@ -118,7 +118,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBytesReference(querySource);
+        out.writeBytesReference(source);
         out.writeVInt(shardId);
         out.writeStringArray(types);
         if (routing != null) {
@@ -143,7 +143,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
     public String toString() {
         String sSource = "_na_";
         try {
-            sSource = XContentHelper.convertToJson(querySource, false);
+            sSource = XContentHelper.convertToJson(source, false);
         } catch (Exception e) {
             // ignore
         }

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -111,7 +111,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
         SearchContext.setCurrent(new DefaultSearchContext(0, new ShardSearchRequest().types(request.types()), null,
                 indexShard.acquireSearcher("delete_by_query"), indexService, indexShard, scriptService, cacheRecycler));
         try {
-            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.querySource(), request.filteringAliases(), request.types())
+            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.source(), request.filteringAliases(), request.types())
                     .origin(Engine.Operation.Origin.PRIMARY);
             SearchContext.current().parsedQuery(new ParsedQuery(deleteByQuery.query(), ImmutableMap.<String, Filter>of()));
             indexShard.deleteByQuery(deleteByQuery);
@@ -133,7 +133,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
         SearchContext.setCurrent(new DefaultSearchContext(0, new ShardSearchRequest().types(request.types()), null,
                 indexShard.acquireSearcher("delete_by_query", IndexShard.Mode.WRITE), indexService, indexShard, scriptService, cacheRecycler));
         try {
-            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.querySource(), request.filteringAliases(), request.types())
+            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.source(), request.filteringAliases(), request.types())
                     .origin(Engine.Operation.Origin.REPLICA);
             SearchContext.current().parsedQuery(new ParsedQuery(deleteByQuery.query(), ImmutableMap.<String, Filter>of()));
             indexShard.deleteByQuery(deleteByQuery);

--- a/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.explain;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
@@ -114,7 +115,7 @@ public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> 
         return sourceUnsafe;
     }
 
-    public ExplainRequest source(ExplainSourceBuilder sourceBuilder) {
+    public ExplainRequest source(QuerySourceBuilder sourceBuilder) {
         this.source = sourceBuilder.buildAsBytes(contentType);
         this.sourceUnsafe = false;
         return this;

--- a/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.explain;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.internal.InternalClient;
@@ -34,7 +35,7 @@ import org.elasticsearch.search.fetch.source.FetchSourceContext;
  */
 public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<ExplainRequest, ExplainResponse, ExplainRequestBuilder> {
 
-    private ExplainSourceBuilder sourceBuilder;
+    private QuerySourceBuilder sourceBuilder;
 
     ExplainRequestBuilder(Client client) {
         super((InternalClient) client, new ExplainRequest());
@@ -183,9 +184,9 @@ public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<Ex
         ((Client) client).explain(request, listener);
     }
 
-    private ExplainSourceBuilder sourceBuilder() {
+    private QuerySourceBuilder sourceBuilder() {
         if (sourceBuilder == null) {
-            sourceBuilder = new ExplainSourceBuilder();
+            sourceBuilder = new QuerySourceBuilder();
         }
         return sourceBuilder;
     }

--- a/src/main/java/org/elasticsearch/action/support/QuerySourceBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/QuerySourceBuilder.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.explain;
+package org.elasticsearch.action.support;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -29,18 +29,18 @@ import org.elasticsearch.search.builder.SearchSourceBuilderException;
 
 import java.io.IOException;
 
-public class ExplainSourceBuilder implements ToXContent {
+public class QuerySourceBuilder implements ToXContent {
 
     private QueryBuilder queryBuilder;
 
     private BytesReference queryBinary;
 
-    public ExplainSourceBuilder setQuery(QueryBuilder query) {
+    public QuerySourceBuilder setQuery(QueryBuilder query) {
         this.queryBuilder = query;
         return this;
     }
 
-    public ExplainSourceBuilder setQuery(BytesReference queryBinary) {
+    public QuerySourceBuilder setQuery(BytesReference queryBinary) {
         this.queryBinary = queryBinary;
         return this;
     }

--- a/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
@@ -134,7 +134,7 @@ public interface IndexShard extends IndexShardComponent {
 
     void delete(Engine.Delete delete) throws ElasticSearchException;
 
-    Engine.DeleteByQuery prepareDeleteByQuery(BytesReference querySource, @Nullable String[] filteringAliases, String... types) throws ElasticSearchException;
+    Engine.DeleteByQuery prepareDeleteByQuery(BytesReference source, @Nullable String[] filteringAliases, String... types) throws ElasticSearchException;
 
     void deleteByQuery(Engine.DeleteByQuery deleteByQuery) throws ElasticSearchException;
 

--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -433,17 +433,17 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
     }
 
     @Override
-    public Engine.DeleteByQuery prepareDeleteByQuery(BytesReference querySource, @Nullable String[] filteringAliases, String... types) throws ElasticSearchException {
+    public Engine.DeleteByQuery prepareDeleteByQuery(BytesReference source, @Nullable String[] filteringAliases, String... types) throws ElasticSearchException {
         long startTime = System.nanoTime();
         if (types == null) {
             types = Strings.EMPTY_ARRAY;
         }
-        Query query = queryParserService.parse(querySource).query();
+        Query query = queryParserService.parseQuery(source).query();
         query = filterQueryIfNeeded(query, types);
 
         Filter aliasFilter = indexAliasesService.aliasFilter(filteringAliases);
         Filter parentFilter = mapperService.hasNested() ? indexCache.filter().cache(NonNestedDocsFilter.INSTANCE) : null;
-        return new Engine.DeleteByQuery(query, querySource, filteringAliases, aliasFilter, parentFilter, types).startTime(startTime);
+        return new Engine.DeleteByQuery(query, source, filteringAliases, aliasFilter, parentFilter, types).startTime(startTime);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -24,10 +24,10 @@ import org.elasticsearch.action.admin.indices.validate.query.QueryExplanation;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.action.support.IgnoreIndices;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -74,15 +74,15 @@ public class RestValidateQueryAction extends BaseRestHandler {
             }
             validateQueryRequest.operationThreading(operationThreading);
             if (request.hasContent()) {
-                validateQueryRequest.query(request.content(), request.contentUnsafe());
+                validateQueryRequest.source(request.content(), request.contentUnsafe());
             } else {
                 String source = request.param("source");
                 if (source != null) {
-                    validateQueryRequest.query(source);
+                    validateQueryRequest.source(source);
                 } else {
-                    BytesReference querySource = RestActions.parseQuerySource(request);
-                    if (querySource != null) {
-                        validateQueryRequest.query(querySource, false);
+                    QuerySourceBuilder querySourceBuilder = RestActions.parseQuerySource(request);
+                    if (querySourceBuilder != null) {
+                        validateQueryRequest.source(querySourceBuilder);
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -22,15 +22,18 @@ package org.elasticsearch.rest.action.cat;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.count.CountRequest;
 import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
-import org.elasticsearch.common.table.TimestampedTable;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.common.table.TimestampedTable;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.XContentThrowableRestResponse;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestTable;
 
@@ -61,11 +64,11 @@ public class RestCountAction extends AbstractCatAction {
 
         String source = request.param("source");
         if (source != null) {
-            countRequest.query(source);
+            countRequest.source(source);
         } else {
-            BytesReference querySource = RestActions.parseQuerySource(request);
-            if (querySource != null) {
-                countRequest.query(querySource, false);
+            QuerySourceBuilder querySourceBuilder = RestActions.parseQuerySource(request);
+            if (querySourceBuilder != null) {
+                countRequest.source(querySourceBuilder);
             }
         }
 

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -23,10 +23,10 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.count.CountRequest;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.support.IgnoreIndices;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -73,15 +73,15 @@ public class RestCountAction extends BaseRestHandler {
             }
             countRequest.operationThreading(operationThreading);
             if (request.hasContent()) {
-                countRequest.query(request.content(), request.contentUnsafe());
+                countRequest.source(request.content(), request.contentUnsafe());
             } else {
                 String source = request.param("source");
                 if (source != null) {
-                    countRequest.query(source);
+                    countRequest.source(source);
                 } else {
-                    BytesReference querySource = RestActions.parseQuerySource(request);
-                    if (querySource != null) {
-                        countRequest.query(querySource, false);
+                    QuerySourceBuilder querySourceBuilder = RestActions.parseQuerySource(request);
+                    if (querySourceBuilder != null) {
+                        countRequest.source(querySourceBuilder);
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -26,10 +26,10 @@ import org.elasticsearch.action.deletebyquery.DeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.IndexDeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.ShardDeleteByQueryRequest;
 import org.elasticsearch.action.support.IgnoreIndices;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -60,14 +60,16 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
         deleteByQueryRequest.listenerThreaded(false);
         try {
             if (request.hasContent()) {
-                deleteByQueryRequest.query(request.content(), request.contentUnsafe());
+                deleteByQueryRequest.source(request.content(), request.contentUnsafe());
             } else {
                 String source = request.param("source");
                 if (source != null) {
-                    deleteByQueryRequest.query(source);
+                    deleteByQueryRequest.source(source);
                 } else {
-                    BytesReference bytes = RestActions.parseQuerySource(request);
-                    deleteByQueryRequest.query(bytes, false);
+                    QuerySourceBuilder querySourceBuilder = RestActions.parseQuerySource(request);
+                    if (querySourceBuilder != null) {
+                        deleteByQueryRequest.source(querySourceBuilder);
+                    }
                 }
             }
             deleteByQueryRequest.types(Strings.splitStringByCommaToArray(request.param("type")));

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -24,9 +24,8 @@ import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.explain.ExplainRequest;
 import org.elasticsearch.action.explain.ExplainResponse;
-import org.elasticsearch.action.explain.ExplainSourceBuilder;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
@@ -89,9 +88,9 @@ public class RestExplainAction extends BaseRestHandler {
                 }
             }
 
-            ExplainSourceBuilder explainSourceBuilder = new ExplainSourceBuilder();
-            explainSourceBuilder.setQuery(queryStringBuilder);
-            explainRequest.source(explainSourceBuilder);
+            QuerySourceBuilder querySourceBuilder = new QuerySourceBuilder();
+            querySourceBuilder.setQuery(queryStringBuilder);
+            explainRequest.source(querySourceBuilder);
         }
 
         String sField = request.param("fields");

--- a/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestActions.java
@@ -21,8 +21,8 @@ package org.elasticsearch.rest.action.support;
 
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -81,7 +81,7 @@ public class RestActions {
         builder.endObject();
     }
 
-    public static BytesReference parseQuerySource(RestRequest request) {
+    public static QuerySourceBuilder parseQuerySource(RestRequest request) {
         String queryString = request.param("q");
         if (queryString == null) {
             return null;
@@ -99,6 +99,6 @@ public class RestActions {
                 throw new ElasticSearchIllegalArgumentException("Unsupported defaultOperator [" + defaultOperator + "], can either be [OR] or [AND]");
             }
         }
-        return queryBuilder.buildAsBytes();
+        return new QuerySourceBuilder().setQuery(queryBuilder);
     }
 }

--- a/src/test/java/org/elasticsearch/ElasticSearchExceptionTests.java
+++ b/src/test/java/org/elasticsearch/ElasticSearchExceptionTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ElasticSearchExceptionTests extends ElasticsearchTestCase {

--- a/src/test/java/org/elasticsearch/broadcast/BroadcastActionsTests.java
+++ b/src/test/java/org/elasticsearch/broadcast/BroadcastActionsTests.java
@@ -61,7 +61,9 @@ public class BroadcastActionsTests extends ElasticsearchIntegrationTest {
         // check count
         for (int i = 0; i < 5; i++) {
             // test successful
-            CountResponse countResponse = client().count(countRequest("test").query(termQuery("_type", "type1")).operationThreading(BroadcastOperationThreading.NO_THREADS)).actionGet();
+            CountResponse countResponse = client().prepareCount("test")
+                    .setQuery(termQuery("_type", "type1"))
+                    .setOperationThreading(BroadcastOperationThreading.NO_THREADS).get();
             assertThat(countResponse.getCount(), equalTo(2l));
             assertThat(countResponse.getTotalShards(), equalTo(5));
             assertThat(countResponse.getSuccessfulShards(), equalTo(5));
@@ -69,7 +71,9 @@ public class BroadcastActionsTests extends ElasticsearchIntegrationTest {
         }
 
         for (int i = 0; i < 5; i++) {
-            CountResponse countResponse = client().count(countRequest("test").query(termQuery("_type", "type1")).operationThreading(BroadcastOperationThreading.SINGLE_THREAD)).actionGet();
+            CountResponse countResponse = client().prepareCount("test")
+                    .setQuery(termQuery("_type", "type1"))
+                    .setOperationThreading(BroadcastOperationThreading.SINGLE_THREAD).get();
             assertThat(countResponse.getCount(), equalTo(2l));
             assertThat(countResponse.getTotalShards(), equalTo(5));
             assertThat(countResponse.getSuccessfulShards(), equalTo(5));
@@ -77,7 +81,9 @@ public class BroadcastActionsTests extends ElasticsearchIntegrationTest {
         }
 
         for (int i = 0; i < 5; i++) {
-            CountResponse countResponse = client().count(countRequest("test").query(termQuery("_type", "type1")).operationThreading(BroadcastOperationThreading.THREAD_PER_SHARD)).actionGet();
+            CountResponse countResponse = client().prepareCount("test")
+                    .setQuery(termQuery("_type", "type1"))
+                    .setOperationThreading(BroadcastOperationThreading.THREAD_PER_SHARD).get();
             assertThat(countResponse.getCount(), equalTo(2l));
             assertThat(countResponse.getTotalShards(), equalTo(5));
             assertThat(countResponse.getSuccessfulShards(), equalTo(5));
@@ -86,7 +92,7 @@ public class BroadcastActionsTests extends ElasticsearchIntegrationTest {
 
         for (int i = 0; i < 5; i++) {
             // test failed (simply query that can't be parsed)
-            CountResponse countResponse = client().count(countRequest("test").query("{ term : { _type : \"type1 } }".getBytes(Charsets.UTF_8))).actionGet();
+            CountResponse countResponse = client().count(countRequest("test").source("{ term : { _type : \"type1 } }".getBytes(Charsets.UTF_8))).actionGet();
 
             assertThat(countResponse.getCount(), equalTo(0l));
             assertThat(countResponse.getTotalShards(), equalTo(5));

--- a/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
@@ -51,7 +51,7 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
 
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1_1", "field2", "value2_1").setRefresh(true).get();
 
-        CountResponse countResponse = client().prepareCount().setQuery(new BytesArray("{ \"term\" : { \"field1\" : \"value1_1\" }}").array()).get();
+        CountResponse countResponse = client().prepareCount().setSource(new BytesArray("{ \"query\" : { \"term\" : { \"field1\" : \"value1_1\" }}}").array()).get();
         assertHitCount(countResponse, 1l);
     }
 
@@ -103,7 +103,7 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         countResponse = client().prepareCount().setQuery(QueryBuilders.commonTerms("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("4")).get();
         assertHitCount(countResponse, 1l);
 
-        countResponse = client().prepareCount().setQuery(new BytesArray("{ \"common\" : { \"field1\" : { \"query\" : \"the lazy fox brown\", \"cutoff_frequency\" : 1, \"minimum_should_match\" : { \"high_freq\" : 4 } } } }").array()).get();
+        countResponse = client().prepareCount().setSource(new BytesArray("{ \"query\" : { \"common\" : { \"field1\" : { \"query\" : \"the lazy fox brown\", \"cutoff_frequency\" : 1, \"minimum_should_match\" : { \"high_freq\" : 4 } } } } }").array()).get();
         assertHitCount(countResponse, 1l);
 
         // Default

--- a/src/test/java/org/elasticsearch/document/DocumentActionsTests.java
+++ b/src/test/java/org/elasticsearch/document/DocumentActionsTests.java
@@ -168,18 +168,23 @@ public class DocumentActionsTests extends ElasticsearchIntegrationTest {
             assertThat(countResponse.getSuccessfulShards(), equalTo(5));
             assertThat(countResponse.getFailedShards(), equalTo(0));
 
-            countResponse = client().count(countRequest("test").query(termQuery("_type", "type1")).operationThreading(BroadcastOperationThreading.SINGLE_THREAD)).actionGet();
+            countResponse = client().prepareCount("test")
+                    .setQuery(termQuery("_type", "type1"))
+                    .setOperationThreading(BroadcastOperationThreading.SINGLE_THREAD)
+                    .get();
             assertThat(countResponse.getCount(), equalTo(2l));
             assertThat(countResponse.getSuccessfulShards(), equalTo(5));
             assertThat(countResponse.getFailedShards(), equalTo(0));
 
-            countResponse = client().count(countRequest("test").query(termQuery("_type", "type1")).operationThreading(BroadcastOperationThreading.THREAD_PER_SHARD)).actionGet();
+            countResponse = client().prepareCount("test")
+                    .setQuery(termQuery("_type", "type1"))
+                    .setOperationThreading(BroadcastOperationThreading.THREAD_PER_SHARD).get();
             assertThat(countResponse.getCount(), equalTo(2l));
             assertThat(countResponse.getSuccessfulShards(), equalTo(5));
             assertThat(countResponse.getFailedShards(), equalTo(0));
 
             // test failed (simply query that can't be parsed)
-            countResponse = client().count(countRequest("test").query("{ term : { _type : \"type1 } }".getBytes(Charsets.UTF_8))).actionGet();
+            countResponse = client().count(countRequest("test").source("{ term : { _type : \"type1 } }".getBytes(Charsets.UTF_8))).actionGet();
 
             assertThat(countResponse.getCount(), equalTo(0l));
             assertThat(countResponse.getSuccessfulShards(), equalTo(0));

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -62,7 +62,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().prepareRefresh().execute().actionGet();
 
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery("foo".getBytes(Charsets.UTF_8)).execute().actionGet().isValid(), equalTo(false));
+        assertThat(client().admin().indices().prepareValidateQuery("test").setSource("foo".getBytes(Charsets.UTF_8)).execute().actionGet().isValid(), equalTo(false));
         assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("_id:1")).execute().actionGet().isValid(), equalTo(true));
         assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("_i:d:1")).execute().actionGet().isValid(), equalTo(false));
 
@@ -101,7 +101,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
         ValidateQueryResponse response;
         response = client().admin().indices().prepareValidateQuery("test")
-                .setQuery("foo".getBytes(Charsets.UTF_8))
+                .setSource("foo".getBytes(Charsets.UTF_8))
                 .setExplain(true)
                 .execute().actionGet();
         assertThat(response.isValid(), equalTo(false));
@@ -207,7 +207,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
         
         for (Client client : cluster()) {
             ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
-                    .setQuery("foo".getBytes(Charsets.UTF_8))
+                    .setSource("foo".getBytes(Charsets.UTF_8))
                     .setExplain(true)
                     .execute().actionGet();
             assertThat(response.isValid(), equalTo(false));


### PR DESCRIPTION
The following APIs now accept the query in a top level `query` field like:
- delete_by_query
- validate_query
- count

These APIs used to accept the query directly in the request body which was inconsistent with the search and explain APIs. For this reason this is a breaking change.

Count api note: It still has its own piece if code and isn't a shortcut for /_search?search_type=count (so no facets, aggs etc.) The count api code is fine tuned for simple counting and I think it should stay that way. 

Relates to #4074
