### PR TITLE
Make doc lookup in geo_shape filter and query consistent with terms lookup

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterBuilder.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.index.query;
 
-import java.io.IOException;
-
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
 
 /**
  * {@link FilterBuilder} that builds a GeoShape Filter
@@ -46,7 +46,7 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
     private final String indexedShapeType;
 
     private String indexedShapeIndex;
-    private String indexedShapeFieldName;
+    private String indexedShapePath;
 
     private ShapeRelation relation = null;
     
@@ -150,13 +150,13 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
     }
 
     /**
-     * Sets the name of the field in the indexed Shape document that has the Shape itself
+     * Sets the path of the field in the indexed Shape document that has the Shape itself
      *
-     * @param indexedShapeFieldName Name of the field where the Shape itself is defined
+     * @param indexedShapePath Path of the field where the Shape itself is defined
      * @return this
      */
-    public GeoShapeFilterBuilder indexedShapeFieldName(String indexedShapeFieldName) {
-        this.indexedShapeFieldName = indexedShapeFieldName;
+    public GeoShapeFilterBuilder indexedShapePath(String indexedShapePath) {
+        this.indexedShapePath = indexedShapePath;
         return this;
     }
 
@@ -190,8 +190,8 @@ public class GeoShapeFilterBuilder extends BaseFilterBuilder {
             if (indexedShapeIndex != null) {
                 builder.field("index", indexedShapeIndex);
             }
-            if (indexedShapeFieldName != null) {
-                builder.field("shape_field_name", indexedShapeFieldName);
+            if (indexedShapePath != null) {
+                builder.field("path", indexedShapePath);
             }
             builder.endObject();
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeFilterParser.java
@@ -88,7 +88,7 @@ public class GeoShapeFilterParser implements FilterParser {
         String id = null;
         String type = null;
         String index = DEFAULTS.INDEX_NAME;
-        String shapeFieldName = DEFAULTS.SHAPE_FIELD_NAME;
+        String shapePath = DEFAULTS.SHAPE_FIELD_NAME;
 
         XContentParser.Token token;
         String currentFieldName = null;
@@ -124,8 +124,8 @@ public class GeoShapeFilterParser implements FilterParser {
                                         type = parser.text();
                                     } else if ("index".equals(currentFieldName)) {
                                         index = parser.text();
-                                    } else if ("shape_field_name".equals(currentFieldName)) {
-                                        shapeFieldName = parser.text();
+                                    } else if ("path".equals(currentFieldName)) {
+                                        shapePath = parser.text();
                                     }
                                 }
                             }
@@ -134,8 +134,8 @@ public class GeoShapeFilterParser implements FilterParser {
                             } else if (type == null) {
                                 throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided");
                             }
-                            shape = fetchService.fetch(id, type, index, shapeFieldName);
-                        } else {
+                            shape = fetchService.fetch(id, type, index, shapePath);
+                        }  else {
                             throw new QueryParsingException(parseContext.index(), "[geo_shape] filter does not support [" + currentFieldName + "]");
                         }
                     }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -42,7 +42,7 @@ public class GeoShapeQueryBuilder extends BaseQueryBuilder implements BoostableQ
     private final String indexedShapeType;
 
     private String indexedShapeIndex;
-    private String indexedShapeFieldName;
+    private String indexedShapePath;
 
     private String queryName;
 
@@ -109,13 +109,13 @@ public class GeoShapeQueryBuilder extends BaseQueryBuilder implements BoostableQ
     }
 
     /**
-     * Sets the name of the field in the indexed Shape document that has the Shape itself
+     * Sets the path of the field in the indexed Shape document that has the Shape itself
      *
-     * @param indexedShapeFieldName Name of the field where the Shape itself is defined
+     * @param indexedShapePath path of the field where the Shape itself is defined
      * @return this
      */
-    public GeoShapeQueryBuilder indexedShapeFieldName(String indexedShapeFieldName) {
-        this.indexedShapeFieldName = indexedShapeFieldName;
+    public GeoShapeQueryBuilder indexedShapePath(String indexedShapePath) {
+        this.indexedShapePath = indexedShapePath;
         return this;
     }
 
@@ -146,8 +146,8 @@ public class GeoShapeQueryBuilder extends BaseQueryBuilder implements BoostableQ
             if (indexedShapeIndex != null) {
                 builder.field("index", indexedShapeIndex);
             }
-            if (indexedShapeFieldName != null) {
-                builder.field("shape_field_name", indexedShapeFieldName);
+            if (indexedShapePath != null) {
+                builder.field("path", indexedShapePath);
             }
             builder.endObject();
         }

--- a/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -65,7 +65,7 @@ public class GeoShapeQueryParser implements QueryParser {
         String id = null;
         String type = null;
         String index = DEFAULTS.INDEX_NAME;
-        String shapeFieldName = DEFAULTS.SHAPE_FIELD_NAME;
+        String shapePath = DEFAULTS.SHAPE_FIELD_NAME;
 
         XContentParser.Token token;
         String currentFieldName = null;
@@ -102,8 +102,8 @@ public class GeoShapeQueryParser implements QueryParser {
                                         type = parser.text();
                                     } else if ("index".equals(currentFieldName)) {
                                         index = parser.text();
-                                    } else if ("shape_field_name".equals(currentFieldName)) {
-                                        shapeFieldName = parser.text();
+                                    } else if ("path".equals(currentFieldName)) {
+                                        shapePath = parser.text();
                                     }
                                 }
                             }
@@ -112,7 +112,7 @@ public class GeoShapeQueryParser implements QueryParser {
                             } else if (type == null) {
                                 throw new QueryParsingException(parseContext.index(), "Type for indexed shape not provided");
                             }
-                            shape = fetchService.fetch(id, type, index, shapeFieldName);
+                            shape = fetchService.fetch(id, type, index, shapePath);
                         } else {
                             throw new QueryParsingException(parseContext.index(), "[geo_shape] query does not support [" + currentFieldName + "]");
                         }


### PR DESCRIPTION
The `geo_shape filter and query` option in geo_shape filter and query has been replaced with the `path` option, which allows these filter and query to fetch shapes from within objects as well.

Relates to #4486
