### PR TITLE
Fix loading templates in config/ directory

### DIFF
--- a/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import static org.elasticsearch.cluster.metadata.AliasMetaData.newAliasMetaDataBuilder;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
@@ -89,6 +90,11 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
                         .putAlias(newAliasMetaDataBuilder("alias1").filter(ALIAS_FILTER1))
                         .putAlias(newAliasMetaDataBuilder("alias2"))
                         .putAlias(newAliasMetaDataBuilder("alias4").filter(ALIAS_FILTER2)))
+                        .put(IndexTemplateMetaData.builder("foo")
+                                .template("bar")
+                                .order(1).settings(settingsBuilder()
+                                        .put("setting1", "value1")
+                                        .put("setting2", "value2")))
                 .build();
 
         String metaDataSource = MetaData.Builder.toXContent(metaData);
@@ -172,6 +178,12 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
         assertThat(indexMetaData.aliases().get("alias3").filter(), nullValue());
         assertThat(indexMetaData.aliases().get("alias4").alias(), equalTo("alias4"));
         assertThat(indexMetaData.aliases().get("alias4").filter().string(), equalTo(ALIAS_FILTER2));
+
+        // templates
+        assertThat(parsedMetaData.templates().get("foo").name(), is("foo"));
+        assertThat(parsedMetaData.templates().get("foo").template(), is("bar"));
+        assertThat(parsedMetaData.templates().get("foo").settings().get("index.setting1"), is("value1"));
+        assertThat(parsedMetaData.templates().get("foo").settings().getByPrefix("index.").get("setting2"), is("value2"));
     }
 
     private static final String MAPPING_SOURCE1 = "{\"mapping1\":{\"text1\":{\"type\":\"string\"}}}";

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -58,7 +58,7 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
 
             File dst = new File(templatesDir, "template.json");
             // random template, one uses the 'setting.index.number_of_shards', the other 'settings.number_of_shards'
-            String template = Streams.copyToStringFromClasspath("/org/elasticsearch/indices/template/template" + randomInt(1) + ".json");
+            String template = Streams.copyToStringFromClasspath("/org/elasticsearch/indices/template/template" + randomInt(5) + ".json");
             Files.write(template, dst, Charsets.UTF_8);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/org/elasticsearch/indices/template/template3.json
+++ b/src/test/java/org/elasticsearch/indices/template/template3.json
@@ -1,0 +1,9 @@
+{
+    "mytemplate" : {
+        "template" : "foo*",
+        "settings" : {
+            "index.number_of_shards": 10,
+            "index.number_of_replicas": 0
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/template/template4.json
+++ b/src/test/java/org/elasticsearch/indices/template/template4.json
@@ -1,0 +1,9 @@
+{
+    "mytemplate" : {
+        "template" : "foo*",
+        "settings" : {
+            "number_of_shards": 10,
+            "number_of_replicas": 0
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/template/template5.json
+++ b/src/test/java/org/elasticsearch/indices/template/template5.json
@@ -1,0 +1,11 @@
+{
+    "mytemplate" : {
+        "template" : "foo*",
+        "settings" : {
+            "index" : {
+                "number_of_shards": 10,
+                "number_of_replicas": 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
The fixes introduced in #4235 and #4411 do not take into account, that a
template JSON in the config/ directory includes a template name, as opposed
when calling the Put Template API.

This PR allows to put both formats (either specifying a template name or not)
into files. However you template name/id may not be one of the template
element names like "template", "settings", "order" or "mapping".

Closes #4511
