### PR TITLE
Made single shards APIs fail if routing is configured to be required in the mapping

### DIFF
--- a/src/main/java/org/elasticsearch/action/RoutingMissingException.java
+++ b/src/main/java/org/elasticsearch/action/RoutingMissingException.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.rest.RestStatus;
 
 /**
  *
@@ -49,5 +50,10 @@ public class RoutingMissingException extends ElasticSearchException {
 
     public String id() {
         return id;
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
     }
 }

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
@@ -95,6 +96,11 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
         String concreteIndex = state.metaData().concreteIndex(request.index());
         request.filteringAlias(state.metaData().filteringAliases(concreteIndex, request.index()));
         request.index(state.metaData().concreteIndex(request.index()));
+
+        // Fail fast on the node that received the request.
+        if (request.routing() == null && state.getMetaData().routingRequired(request.index(), request.type())) {
+            throw new RoutingMissingException(request.index(), request.type(), request.id());
+        }
     }
 
     protected ExplainResponse shardOperation(ExplainRequest request, int shardId) throws ElasticSearchException {

--- a/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -68,6 +68,10 @@ public class TransportMultiGetAction extends TransportAction<MultiGetRequest, Mu
                 responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(), "[" + item.index() + "] missing")));
                 continue;
             }
+            if (item.routing() == null && clusterState.getMetaData().routingRequired(item.index(), item.type())) {
+                responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(), "routing is required, but hasn't been specified")));
+                continue;
+            }
 
             item.routing(clusterState.metaData().resolveIndexRouting(item.routing(), item.index()));
             item.index(clusterState.metaData().concreteIndex(item.index()));

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -90,6 +90,14 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
     }
 
     /**
+     * Sets the type of document to get the term vector for.
+     */
+    public TermVectorRequest type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
      * Returns the type of document to get the term vector for.
      */
     public String type() {
@@ -106,8 +114,9 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
     /**
      * Sets the id of document the term vector is requested for.
      */
-    public void id(String id) {
+    public TermVectorRequest id(String id) {
         this.id = id;
+        return this;
     }
 
     /**
@@ -117,8 +126,9 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         return routing;
     }
 
-    public void routing(String routing) {
+    public TermVectorRequest routing(String routing) {
         this.routing = routing;
+        return this;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
@@ -71,6 +71,11 @@ public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVe
                         termVectorRequest.type(), termVectorRequest.id(), "[" + termVectorRequest.index() + "] missing")));
                 continue;
             }
+            if (termVectorRequest.routing() == null && clusterState.getMetaData().routingRequired(termVectorRequest.index(), termVectorRequest.type())) {
+                responses.set(i, new MultiTermVectorsItemResponse(null, new MultiTermVectorsResponse.Failure(termVectorRequest.index(),
+                        termVectorRequest.type(), termVectorRequest.id(), "routing is required, but hasn't been specified")));
+                continue;
+            }
             termVectorRequest.index(clusterState.metaData().concreteIndex(termVectorRequest.index()));
             ShardId shardId = clusterService
                     .operationRouting()

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.termvector;
 
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -80,6 +81,11 @@ public class TransportSingleShardTermVectorAction extends TransportShardSingleOp
         // update the routing (request#index here is possibly an alias)
         request.routing(state.metaData().resolveIndexRouting(request.routing(), request.index()));
         request.index(state.metaData().concreteIndex(request.index()));
+
+        // Fail fast on the node that received the request.
+        if (request.routing() == null && state.getMetaData().routingRequired(request.index(), request.type())) {
+            throw new RoutingMissingException(request.index(), request.type(), request.id());
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -931,6 +931,22 @@ public class MetaData implements Iterable<IndexMetaData> {
         return false;
     }
 
+    /**
+     * @param concreteIndex The concrete index to check if routing is required
+     * @param type          The type to check if routing is required
+     * @return Whether routing is required according to the mapping for the specified index and type
+     */
+    public boolean routingRequired(String concreteIndex, String type) {
+        IndexMetaData indexMetaData = indices.get(concreteIndex);
+        if (indexMetaData != null) {
+            MappingMetaData mappingMetaData = indexMetaData.getMappings().get(type);
+            if (mappingMetaData != null) {
+                return mappingMetaData.routing().required();
+            }
+        }
+        return false;
+    }
+
     @Override
     public UnmodifiableIterator<IndexMetaData> iterator() {
         return indices.valuesIt();

--- a/src/test/java/org/elasticsearch/mget/SimpleMgetTests.java
+++ b/src/test/java/org/elasticsearch/mget/SimpleMgetTests.java
@@ -93,8 +93,9 @@ public class SimpleMgetTests extends ElasticsearchIntegrationTest {
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(false));
         assertThat(mgetResponse.getResponses()[0].getResponse().isExists(), is(true));
 
-        assertThat(mgetResponse.getResponses()[1].isFailed(), is(false));
-        assertThat(mgetResponse.getResponses()[1].getResponse().isExists(), is(false));
+        assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
+        assertThat(mgetResponse.getResponses()[1].getResponse(), nullValue());
+        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/elasticsearch/routing/AliasRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/AliasRoutingTests.java
@@ -355,7 +355,12 @@ public class AliasRoutingTests extends ElasticsearchIntegrationTest {
         logger.info("--> deleting with no routing, should broadcast the delete since _routing is required");
         client().prepareDelete("test", "type1", "1").setRefresh(true).execute().actionGet();
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(false));
+            try {
+                client().prepareGet("test", "type1", "1").get();
+                assert false;
+            } catch (RoutingMissingException e) {
+                assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+            }
             assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
         }
 

--- a/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
@@ -21,17 +21,26 @@ package org.elasticsearch.routing;
 
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.RoutingMissingException;
+import org.elasticsearch.action.explain.ExplainResponse;
+import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.get.MultiGetResponse;
+import org.elasticsearch.action.termvector.MultiTermVectorsResponse;
+import org.elasticsearch.action.termvector.TermVectorRequest;
+import org.elasticsearch.action.termvector.TermVectorResponse;
+import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  *
@@ -173,7 +182,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
-        logger.info("--> verifying get with no routing, should not find anything");
+        logger.info("--> verifying get with no routing, should fail");
 
         logger.info("--> indexing with id [1], with no routing, should fail");
         try {
@@ -191,7 +200,13 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         logger.info("--> deleting with no routing, should broadcast the delete since _routing is required");
         client().prepareDelete("test", "type1", "1").setRefresh(true).execute().actionGet();
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(false));
+            try {
+                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                assert false;
+            } catch (RoutingMissingException e) {
+                assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+                assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+            }
             assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
         }
 
@@ -203,7 +218,13 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         client().prepareBulk().add(Requests.deleteRequest("test").type("type1").id("1")).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(false));
+            try {
+                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                assert false;
+            } catch (RoutingMissingException e) {
+                assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+                assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+            }
             assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
         }
     }
@@ -229,9 +250,15 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         }
 
 
-        logger.info("--> verifying get with no routing, should not find anything");
+        logger.info("--> verifying get with no routing, should fail");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(false));
+            try {
+                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                assert false;
+            } catch (RoutingMissingException e) {
+                assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+                assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+            }
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
@@ -253,9 +280,15 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
                 client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", "0")).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
-        logger.info("--> verifying get with no routing, should not find anything");
+        logger.info("--> verifying get with no routing, should fail");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(false));
+            try {
+                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                assert false;
+            } catch (RoutingMissingException e) {
+                assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+                assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+            }
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
@@ -277,13 +310,131 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", 0).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
-        logger.info("--> verifying get with no routing, should not find anything");
+        logger.info("--> verifying get with no routing, should fail");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(false));
+            try {
+                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                assert false;
+            } catch (RoutingMissingException e) {
+                assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+                assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+            }
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
         }
+    }
+
+    @Test
+    public void testRequiredRoutingMapping_variousAPIs() throws Exception {
+        client().admin().indices().prepareCreate("test")
+                .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_routing").field("required", true).endObject().endObject().endObject())
+                .execute().actionGet();
+        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+
+        logger.info("--> indexing with id [1], and routing [0]");
+        client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").get();
+        logger.info("--> indexing with id [2], and routing [0]");
+        client().prepareIndex("test", "type1", "2").setRouting("0").setSource("field", "value2").setRefresh(true).get();
+
+        logger.info("--> verifying get with id [1] with routing [0], should succeed");
+        assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
+
+        logger.info("--> verifying get with id [1], with no routing, should fail");
+        try {
+            client().prepareGet("test", "type1", "1").get();
+            assert false;
+        } catch (RoutingMissingException e) {
+            assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+        }
+
+        logger.info("--> verifying explain with id [2], with routing [0], should succeed");
+        ExplainResponse explainResponse = client().prepareExplain("test", "type1", "2")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .setRouting("0").get();
+        assertThat(explainResponse.isExists(), equalTo(true));
+        assertThat(explainResponse.isMatch(), equalTo(true));
+
+        logger.info("--> verifying explain with id [2], with no routing, should fail");
+        try {
+            client().prepareExplain("test", "type1", "2")
+                    .setQuery(QueryBuilders.matchAllQuery()).get();
+            assert false;
+        } catch (RoutingMissingException e) {
+            assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[2]"));
+        }
+
+        logger.info("--> verifying term vector with id [1], with routing [0], should succeed");
+        TermVectorResponse termVectorResponse = client().prepareTermVector("test", "type1", "1").setRouting("0").get();
+        assertThat(termVectorResponse.isExists(), equalTo(true));
+        assertThat(termVectorResponse.getId(), equalTo("1"));
+
+        try {
+            client().prepareTermVector("test", "type1", "1").get();
+            assert false;
+        } catch (RoutingMissingException e) {
+            assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+        }
+
+        UpdateResponse updateResponse = client().prepareUpdate("test", "type1", "1").setRouting("0")
+                .setDoc("field1", "value1").get();
+        assertThat(updateResponse.getId(), equalTo("1"));
+        assertThat(updateResponse.getVersion(), equalTo(2l));
+
+        try {
+            client().prepareUpdate("test", "type1", "1").setDoc("field1", "value1").get();
+            assert false;
+        } catch (RoutingMissingException e) {
+            assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+        }
+
+        logger.info("--> verifying mget with ids [1,2], with routing [0], should succeed");
+        MultiGetResponse multiGetResponse = client().prepareMultiGet()
+                .add(new MultiGetRequest.Item("test", "type1", "1").routing("0"))
+                .add(new MultiGetRequest.Item("test", "type1", "2").routing("0")).get();
+        assertThat(multiGetResponse.getResponses().length, equalTo(2));
+        assertThat(multiGetResponse.getResponses()[0].isFailed(), equalTo(false));
+        assertThat(multiGetResponse.getResponses()[0].getResponse().getId(), equalTo("1"));
+        assertThat(multiGetResponse.getResponses()[1].isFailed(), equalTo(false));
+        assertThat(multiGetResponse.getResponses()[1].getResponse().getId(), equalTo("2"));
+
+        logger.info("--> verifying mget with ids [1,2], with no routing, should fail");
+        multiGetResponse = client().prepareMultiGet()
+                .add(new MultiGetRequest.Item("test", "type1", "1"))
+                .add(new MultiGetRequest.Item("test", "type1", "2")).get();
+        assertThat(multiGetResponse.getResponses().length, equalTo(2));
+        assertThat(multiGetResponse.getResponses()[0].isFailed(), equalTo(true));
+        assertThat(multiGetResponse.getResponses()[0].getFailure().getId(), equalTo("1"));
+        assertThat(multiGetResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(multiGetResponse.getResponses()[1].isFailed(), equalTo(true));
+        assertThat(multiGetResponse.getResponses()[1].getFailure().getId(), equalTo("2"));
+        assertThat(multiGetResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+
+        MultiTermVectorsResponse multiTermVectorsResponse = client().prepareMultiTermVectors()
+                .add(new TermVectorRequest("test", "type1", "1").routing("0"))
+                .add(new TermVectorRequest("test", "type1", "2").routing("0")).get();
+        assertThat(multiTermVectorsResponse.getResponses().length, equalTo(2));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getId(), equalTo("1"));
+        assertThat(multiTermVectorsResponse.getResponses()[0].isFailed(), equalTo(false));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getResponse().getId(), equalTo("1"));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getResponse().isExists(), equalTo(true));
+        assertThat(multiTermVectorsResponse.getResponses()[1].getId(), equalTo("2"));
+        assertThat(multiTermVectorsResponse.getResponses()[1].isFailed(), equalTo(false));
+        assertThat(multiTermVectorsResponse.getResponses()[1].getResponse().getId(), equalTo("2"));
+        assertThat(multiTermVectorsResponse.getResponses()[1].getResponse().isExists(), equalTo(true));
+
+        multiTermVectorsResponse = client().prepareMultiTermVectors()
+                .add(new TermVectorRequest("test", "type1", "1"))
+                .add(new TermVectorRequest("test", "type1", "2")).get();
+        assertThat(multiTermVectorsResponse.getResponses().length, equalTo(2));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getId(), equalTo("1"));
+        assertThat(multiTermVectorsResponse.getResponses()[0].isFailed(), equalTo(true));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getResponse(), nullValue());
+        assertThat(multiTermVectorsResponse.getResponses()[1].getId(), equalTo("2"));
+        assertThat(multiTermVectorsResponse.getResponses()[1].isFailed(), equalTo(true));
+        assertThat(multiTermVectorsResponse.getResponses()[1].getResponse(),nullValue());
+        assertThat(multiTermVectorsResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
     }
 }


### PR DESCRIPTION
This change make single shard requests fail when no routing is specified and routing has been configured to be required in the mapping. This change affects the following APIs: get, mget, explain, termvector, multi term vector and exists.

Relates to #4506
