### PR TITLE
Close Directory / Store once all resources have been released

### DIFF
--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -24,3 +24,11 @@ org.apache.lucene.util.RamUsageEstimator#sizeOf(java.lang.Object) @ This can be 
 org.apache.lucene.index.IndexReader#decRef()
 org.apache.lucene.index.IndexReader#incRef()
 org.apache.lucene.index.IndexReader#tryIncRef()
+
+@defaultMessage Only use wait / notify when really needed try to use concurrency primitives, latches or callbacks instead. 
+java.lang.Object#wait()
+java.lang.Object#wait(long)
+java.lang.Object#wait(long,int)
+java.lang.Object#notify()
+java.lang.Object#notifyAll()
+

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -63,6 +63,12 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
 
     void addFailedEngineListener(FailedEngineListener listener);
 
+    void onAllResourcesClosed(OnAllResourcesClosedCallback listener);
+
+    interface OnAllResourcesClosedCallback {
+        void callback();
+    }
+
     /**
      * Starts the Engine.
      * <p/>

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -37,6 +37,8 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Preconditions;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.HashedBytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.SegmentReaderUtils;
@@ -134,6 +136,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     // will not really happen, and then the commitUserData and the new translog will not be reflected
     private volatile boolean flushNeeded = false;
     private final AtomicInteger flushing = new AtomicInteger();
+    private final AtomicInteger resourceCounter = new AtomicInteger(1);
     private final Lock flushLock = new ReentrantLock();
 
     private final RecoveryCounter onGoingRecoveries = new RecoveryCounter();
@@ -153,6 +156,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     private Throwable failedEngine = null;
     private final Object failedEngineMutex = new Object();
     private final CopyOnWriteArrayList<FailedEngineListener> failedEngineListeners = new CopyOnWriteArrayList<FailedEngineListener>();
+    private volatile OnAllResourcesClosedCallback allResourcesClosed;
 
     private final AtomicLong translogIdGenerator = new AtomicLong();
 
@@ -237,6 +241,40 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     @Override
     public void addFailedEngineListener(FailedEngineListener listener) {
         failedEngineListeners.add(listener);
+    }
+
+    @Override
+    public void onAllResourcesClosed(OnAllResourcesClosedCallback listener) {
+        assert closed;
+        final int count = resourceCounter.incrementAndGet();
+        if (count == 1) {
+            // were already on count 0 so only notify the added listener
+            resourceCounter.decrementAndGet();
+            logger.info("RELEASED DIRECT");
+            listener.callback();;
+        } else {
+            allResourcesClosed = listener;
+            logger.info("ADDED count: [{}]",  count);
+            decrementResourceCounter();
+        }
+    }
+
+    private void decrementResourceCounter() {
+        assert resourceCounter.get() > 0;
+        if (resourceCounter.decrementAndGet() == 0) {
+            if (allResourcesClosed != null) {
+                logger.info("RELEASED");
+                allResourcesClosed.callback();
+            }
+        } else {
+            logger.info("NOT RELEASED but count was [{}]", resourceCounter.get());
+        }
+    }
+
+
+    private void incrementResourceCounter() {
+        ensureOpen();
+        resourceCounter.incrementAndGet();
     }
 
     @Override
@@ -345,14 +383,14 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             try {
                 docIdAndVersion = Versions.loadDocIdAndVersion(searcher.reader(), get.uid());
             } catch (Throwable e) {
-                searcher.release();
+                Releasables.releaseWhileHandlingException(searcher);
                 //TODO: A better exception goes here
                 throw new EngineException(shardId(), "Couldn't resolve version", e);
             }
 
             if (get.version() != Versions.MATCH_ANY && docIdAndVersion != null) {
                 if (get.versionType().isVersionConflict(docIdAndVersion.version, get.version())) {
-                    searcher.release();
+                    Releasables.release(searcher);
                     Uid uid = Uid.createUid(get.uid().text());
                     throw new VersionConflictEngineException(shardId, uid.type(), uid.id(), docIdAndVersion.version, get.version());
                 }
@@ -362,7 +400,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 // don't release the searcher on this path, it is the responsability of the caller to call GetResult.release
                 return new GetResult(searcher, docIdAndVersion);
             } else {
-                searcher.release();
+                Releasables.release(searcher);
                 return GetResult.NOT_EXISTS;
             }
 
@@ -688,7 +726,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             IndexSearcher searcher = manager.acquire();
             return newSearcher(source, searcher, manager);
         } catch (Throwable ex) {
-            logger.error("failed to acquire searcher, source {}", ex, source);
+            logger.error("failed to startRecovery searcher, source {}", ex, source);
             throw new EngineException(shardId, ex.getMessage());
         }
     }
@@ -1007,25 +1045,22 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     @Override
     public <T> T snapshot(SnapshotHandler<T> snapshotHandler) throws EngineException {
         SnapshotIndexCommit snapshotIndexCommit = null;
-        Translog.Snapshot traslogSnapshot = null;
+        Translog.Snapshot translogSnapshot = null;
         rwl.readLock().lock();
         try {
             snapshotIndexCommit = deletionPolicy.snapshot();
-            traslogSnapshot = translog.snapshot();
+            translogSnapshot = translog.snapshot();
         } catch (Throwable e) {
-            if (snapshotIndexCommit != null) {
-                snapshotIndexCommit.release();
-            }
+            Releasables.releaseWhileHandlingException(snapshotIndexCommit);
             throw new SnapshotFailedEngineException(shardId, e);
         } finally {
             rwl.readLock().unlock();
         }
 
         try {
-            return snapshotHandler.snapshot(snapshotIndexCommit, traslogSnapshot);
+            return snapshotHandler.snapshot(snapshotIndexCommit, translogSnapshot);
         } finally {
-            snapshotIndexCommit.release();
-            traslogSnapshot.release();
+            Releasables.release(snapshotIndexCommit, translogSnapshot);
         }
     }
 
@@ -1052,7 +1087,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             if (closed) {
                 throw new EngineClosedException(shardId);
             }
-            onGoingRecoveries.increment();
+            onGoingRecoveries.startRecovery();
         } finally {
             rwl.writeLock().unlock();
         }
@@ -1061,15 +1096,14 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             phase1Snapshot = deletionPolicy.snapshot();
         } catch (Throwable e) {
-            onGoingRecoveries.decrement();
+            Releasables.releaseWhileHandlingException(onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 1, "Snapshot failed", e);
         }
 
         try {
             recoveryHandler.phase1(phase1Snapshot);
         } catch (Throwable e) {
-            onGoingRecoveries.decrement();
-            phase1Snapshot.release();
+            Releasables.releaseWhileHandlingException(onGoingRecoveries, phase1Snapshot);
             if (closed) {
                 e = new EngineClosedException(shardId, e);
             }
@@ -1080,8 +1114,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             phase2Snapshot = translog.snapshot();
         } catch (Throwable e) {
-            onGoingRecoveries.decrement();
-            phase1Snapshot.release();
+            Releasables.releaseWhileHandlingException(onGoingRecoveries, phase1Snapshot);
             if (closed) {
                 e = new EngineClosedException(shardId, e);
             }
@@ -1091,9 +1124,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             recoveryHandler.phase2(phase2Snapshot);
         } catch (Throwable e) {
-            onGoingRecoveries.decrement();
-            phase1Snapshot.release();
-            phase2Snapshot.release();
+            Releasables.releaseWhileHandlingException(onGoingRecoveries, phase1Snapshot, phase2Snapshot);
             if (closed) {
                 e = new EngineClosedException(shardId, e);
             }
@@ -1102,19 +1133,17 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
         rwl.writeLock().lock();
         Translog.Snapshot phase3Snapshot = null;
+        boolean success = false;
         try {
             phase3Snapshot = translog.snapshot(phase2Snapshot);
             recoveryHandler.phase3(phase3Snapshot);
+            success = true;
         } catch (Throwable e) {
             throw new RecoveryEngineException(shardId, 3, "Execution failed", e);
         } finally {
-            onGoingRecoveries.decrement();
+            Releasables.release(success, onGoingRecoveries);
             rwl.writeLock().unlock();
-            phase1Snapshot.release();
-            phase2Snapshot.release();
-            if (phase3Snapshot != null) {
-                phase3Snapshot.release();
-            }
+            Releasables.release(success, phase1Snapshot, phase2Snapshot, phase3Snapshot);
         }
     }
 
@@ -1229,22 +1258,26 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
     @Override
     public void close() throws ElasticsearchException {
+        final boolean wasClosed = closed;
         rwl.writeLock().lock();
         try {
             innerClose();
         } finally {
             rwl.writeLock().unlock();
-        }
-        try {
-            // wait for recoveries to join and close all resources / IO streams
-            int ongoingRecoveries = onGoingRecoveries.awaitNoRecoveries(5000);
-            if (ongoingRecoveries > 0) {
-                logger.debug("Waiting for ongoing recoveries timed out on close currently ongoing disoveries: [{}]", ongoingRecoveries);
+            if (!wasClosed) {
+                decrementResourceCounter();
             }
-        } catch (InterruptedException e) {
-            // ignore & restore interrupt
-            Thread.currentThread().interrupt();
         }
+//        try {
+//            // wait for recoveries to join and close all resources / IO streams
+//            int ongoingRecoveries = onGoingRecoveries.awaitNoRecoveries(5000);
+//            if (ongoingRecoveries > 0) {
+//                logger.debug("Waiting for ongoing recoveries timed out on close currently ongoing disoveries: [{}]", ongoingRecoveries);
+//            }
+//        } catch (InterruptedException e) {
+//            // ignore & restore interrupt
+//            Thread.currentThread().interrupt();
+//        }
 
     }
 
@@ -1511,6 +1544,8 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                  * underlying store / directory and we call into the
                  * IndexWriter to free up pending files. */
                 return false;
+            } finally {
+                decrementResourceCounter();
             }
         }
     }
@@ -1599,9 +1634,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                     }
                 } finally {
                     // no need to release the fullSearcher, nothing really is done...
-                    if (currentSearcher != null) {
-                        currentSearcher.release();
-                    }
+                    Releasables.release(currentSearcher);
                     if (newSearcher != null && closeNewSearcher) {
                         IOUtils.closeWhileHandlingException(newSearcher.getIndexReader()); // ignore
                     }
@@ -1611,31 +1644,28 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         }
     }
 
-    private static final class RecoveryCounter {
-        private volatile int ongoingRecoveries = 0;
+    private final class RecoveryCounter implements Releasable {
+        private final AtomicInteger onGoingRecoveries = new AtomicInteger();
 
-        synchronized void increment() {
-            ongoingRecoveries++;
+        public void startRecovery() {
+            incrementResourceCounter();
+            onGoingRecoveries.incrementAndGet();
         }
 
-        synchronized void decrement() {
-            ongoingRecoveries--;
-            if (ongoingRecoveries == 0) {
-                notifyAll(); // notify waiting threads - we only wait on ongoingRecoveries == 0
-            }
-            assert ongoingRecoveries >= 0 : "ongoingRecoveries must be >= 0 but was: " + ongoingRecoveries;
+        public int get() {
+            return onGoingRecoveries.get();
         }
 
-        int get() {
-            // volatile read - no sync needed
-            return ongoingRecoveries;
+        public void endRecovery() throws ElasticsearchException {
+            decrementResourceCounter();
+            onGoingRecoveries.decrementAndGet();
+            assert onGoingRecoveries.get() >= 0 : "ongoingRecoveries must be >= 0 but was: " + onGoingRecoveries.get();
         }
 
-        synchronized int awaitNoRecoveries(long timeout) throws InterruptedException {
-            if (ongoingRecoveries > 0) { // no loop here - we either time out or we are done!
-                wait(timeout);
-            }
-            return ongoingRecoveries;
+        @Override
+        public boolean release() throws ElasticsearchException {
+            endRecovery();
+            return true;
         }
     }
 }

--- a/src/test/java/org/elasticsearch/test/store/MockDirectoryHelper.java
+++ b/src/test/java/org/elasticsearch/test/store/MockDirectoryHelper.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.store.ram.RamDirectoryService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -49,10 +50,10 @@ public class MockDirectoryHelper {
     public static final String CHECK_INDEX_ON_CLOSE = "index.store.mock.check_index_on_close";
     public static final String RANDOM_PREVENT_DOUBLE_WRITE = "index.store.mock.random.prevent_double_write";
     public static final String RANDOM_NO_DELETE_OPEN_FILE = "index.store.mock.random.no_delete_open_file";
-    public static final String RANDOM_FAIL_ON_CLOSE= "index.store.mock.random.fail_on_close";
 
     public static final Set<ElasticsearchMockDirectoryWrapper> wrappers = ConcurrentCollections.newConcurrentSet();
-    
+
+
     private final Random random;
     private final double randomIOExceptionRate;
     private final double randomIOExceptionRateOnOpen;
@@ -63,7 +64,6 @@ public class MockDirectoryHelper {
     private final boolean preventDoubleWrite;
     private final boolean noDeleteOpenFile;
     private final ESLogger logger;
-    private final boolean failOnClose;
 
     public MockDirectoryHelper(ShardId shardId, Settings indexSettings, ESLogger logger) {
         final long seed = indexSettings.getAsLong(ElasticsearchIntegrationTest.INDEX_SEED_SETTING, 0l);
@@ -74,8 +74,7 @@ public class MockDirectoryHelper {
         noDeleteOpenFile = indexSettings.getAsBoolean(RANDOM_NO_DELETE_OPEN_FILE, random.nextBoolean()); // true is default in MDW
         random.nextInt(shardId.getId() + 1); // some randomness per shard
         throttle = Throttling.valueOf(indexSettings.get(RANDOM_THROTTLE, random.nextDouble() < 0.1 ? "SOMETIMES" : "NEVER"));
-        checkIndexOnClose = indexSettings.getAsBoolean(CHECK_INDEX_ON_CLOSE, false);// we can't do this by default since it might close the index input that we still read from in a pending fetch phase.
-        failOnClose = indexSettings.getAsBoolean(RANDOM_FAIL_ON_CLOSE, false);
+        checkIndexOnClose = indexSettings.getAsBoolean(CHECK_INDEX_ON_CLOSE, random.nextDouble() < 0.1);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Using MockDirWrapper with seed [{}] throttle: [{}] checkIndexOnClose: [{}]", SeedUtils.formatSeed(seed),
@@ -87,7 +86,7 @@ public class MockDirectoryHelper {
     }
 
     public Directory wrap(Directory dir) {
-        final ElasticsearchMockDirectoryWrapper w = new ElasticsearchMockDirectoryWrapper(random, dir, logger, failOnClose);
+        final ElasticsearchMockDirectoryWrapper w = new ElasticsearchMockDirectoryWrapper(random, dir, logger);
         w.setRandomIOExceptionRate(randomIOExceptionRate);
         w.setRandomIOExceptionRateOnOpen(randomIOExceptionRateOnOpen);
         w.setThrottling(throttle);
@@ -128,31 +127,30 @@ public class MockDirectoryHelper {
     public static final class ElasticsearchMockDirectoryWrapper extends MockDirectoryWrapper {
 
         private final ESLogger logger;
-        private final boolean failOnClose;
+        private RuntimeException closeException;
 
-        public ElasticsearchMockDirectoryWrapper(Random random, Directory delegate, ESLogger logger, boolean failOnClose) {
+        public ElasticsearchMockDirectoryWrapper(Random random, Directory delegate, ESLogger logger) {
             super(random, delegate);
             this.logger = logger;
-            this.failOnClose = failOnClose;
         }
 
         @Override
-        public  void close() throws IOException {
+        public synchronized void close() throws IOException {
             try {
                 super.close();
             } catch (RuntimeException ex) {
-                if (failOnClose) {
-                    throw ex;
-                }
-                // we catch the exception on close to properly close shards even if there are open files
-                // the test framework will call closeWithRuntimeException after the test exits to fail
-                // on unclosed files.
                 logger.debug("MockDirectoryWrapper#close() threw exception", ex);
+                closeException = ex;
+                throw ex;
             }
         }
 
-        public void closeWithRuntimeException() throws IOException {
-            super.close(); // force fail if open files etc. called in tear down of ElasticsearchIntegrationTest
+        public synchronized boolean successfullyClosed() {
+            return closeException == null && !isOpen();
+        }
+
+        public synchronized RuntimeException closeException() {
+            return closeException;
         }
     }
 }


### PR DESCRIPTION
Currently we close the store and therefor the underlying directory
when the engine / shard is closed ie. during relocation etc. We also
just close it while there are still searches going on and/or we are
recovering from it. The recoveries might fail which is ok but searches
etc. will be working like pending fetch phases.

The contract of the Directory doesn't prevent to read from a stream
that was already opened before the Directory was closed but from a
system boundary perspective and from lifecycles that we test it seems
to be the right thing to do to wait until all resources are released.

Additionally it will also help to make sure everything is closed
properly before directories are closed itself.

The code needs some work though but I wanted to get it out there for discussion
