### PR TITLE
ClusterHealthResponse.validationFailures now maps to RoutingTableValidation.allFailures()

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -71,7 +71,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
     public ClusterHealthResponse(String clusterName, String[] concreteIndices, ClusterState clusterState) {
         this.clusterName = clusterName;
         RoutingTableValidation validation = clusterState.routingTable().validate(clusterState.metaData());
-        validationFailures = validation.failures();
+        validationFailures = validation.allFailures();
         numberOfNodes = clusterState.nodes().size();
         numberOfDataNodes = clusterState.nodes().dataNodes().size();
 

--- a/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -199,9 +199,12 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         IndexMetaData indexMetaData = IndexMetaData.builder("test").numberOfShards(2).numberOfReplicas(2).build();
         ShardCounter counter = new ShardCounter();
         IndexRoutingTable indexRoutingTable = genIndexRoutingTable(indexMetaData, counter);
+
+        // generate other meta data settings to cause errors.
         indexMetaData = IndexMetaData.builder("test").numberOfShards(2).numberOfReplicas(3).build();
 
         ClusterIndexHealth indexHealth = new ClusterIndexHealth(indexMetaData, indexRoutingTable);
+        // one failure per shard
         assertThat(indexHealth.getValidationFailures(), Matchers.hasSize(2));
 
         RoutingTable.Builder routingTable = RoutingTable.builder();
@@ -210,7 +213,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder().metaData(metaData).routingTable(routingTable).build();
         ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null), clusterState);
-        // currently we have no cluster level validation failures as index validation issues are reported per index.
-        assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));
+
+        assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(2));
     }
 }


### PR DESCRIPTION
The ClusterHealthResponse.validationFailures is currently wired to RoutingTable.failures , which contains cluster level validation errors. That means that the list doesn't contain any index level validation failure, if exists. Since we by default return only the top level information (`level=cluster`), this important information is hidden to the rest layer. This PR adds the index validation failures to this list.  The Java API always return index level information but one needs to check it for every index, which means this change is imho good here as well.
