### PR TITLE
Eager norms loading options.

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -55,6 +55,13 @@ more characters. An example mapping can be:
                 "store" : true,
                 "index" : "analyzed",
                 "null_value" : "na"
+            },
+            "user" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "norms" : {
+                    "enabled" : false
+                }
             }
         }
     }
@@ -65,7 +72,10 @@ The above mapping defines a `string` `message` property/field within the
 `tweet` type. The field is stored in the index (so it can later be
 retrieved using selective loading when searching), and it gets analyzed
 (broken down into searchable terms). If the message has a `null` value,
-then the value that will be stored is `na`.
+then the value that will be stored is `na`. There is also a `string` `user`
+which is indexed as-is (not broken down into tokens) and has norms
+disabled (so that matching this field is a binary decision, no match is
+better than another one).
 
 The following table lists all the attributes that can be used with the
 `string` type:
@@ -97,9 +107,13 @@ searchable at all (as an individual field; it may still be included in
 `null_value` as the field value. Defaults to not adding the field at
 all.
 
-|`omit_norms` |Boolean value if norms should be omitted or not. Defaults
-to `false` for `analyzed` fields, and to `true` for `not_analyzed`
-fields.
+|`norms.enabled` |Boolean value if norms should be enabled or not. Defaults
+to `true` for `analyzed` fields, and to `false` for `not_analyzed` fields.
+
+|`norms.loading` |Describes how norms should be loaded, possible values are
+`eager` and `lazy` (default). It is possible to change the default value to
+eager for all fields by configuring the index setting `index.norms.loading`
+to `eager`.
 
 |`index_options` | Allows to set the indexing
 options, possible values are `docs` (only doc numbers are indexed),

--- a/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.xcontent.support;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.TimeValue;
@@ -382,5 +383,13 @@ public class XContentMapValues {
             return TimeValue.timeValueMillis(((Number) node).longValue());
         }
         return TimeValue.parseTimeValue(node.toString(), null);
+    }
+
+    public static Map<String, Object> nodeMapValue(Object node, String desc) {
+        if (node instanceof Map) {
+            return (Map<String, Object>) node;
+        } else {
+            throw new ElasticSearchParseException(desc + " should be a hash but was of type: " + node.getClass());
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FieldDataType.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FieldDataType.java
@@ -21,19 +21,13 @@ package org.elasticsearch.index.fielddata;
 
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.FieldMapper.Loading;
 
 /**
  */
 public class FieldDataType {
 
-    private static final String LOADING_KEY = "loading";
-    private static final String EAGER_LOADING_VALUE = "eager";
-    private static final String LAZY_LOADING_VALUE = "lazy";
 
-    public static enum Loading {
-        LAZY, EAGER;
-    }
 
     public static final String FORMAT_KEY = "format";
     public static final String DOC_VALUES_FORMAT_VALUE = "doc_values";
@@ -55,14 +49,8 @@ public class FieldDataType {
         this.type = type;
         this.typeFormat = "index.fielddata.type." + type + "." + FORMAT_KEY;
         this.settings = settings;
-        final String loading = settings.get(LOADING_KEY);
-        if (loading == null || loading.equals(LAZY_LOADING_VALUE)) {
-            this.loading = Loading.LAZY;
-        } else if (loading.equals(EAGER_LOADING_VALUE)) {
-            this.loading = Loading.EAGER;
-        } else {
-            throw new MapperParsingException("Unknown [" + LOADING_KEY + "] value: [" + loading + "]");
-        }
+        final String loading = settings.get(Loading.KEY);
+        this.loading = Loading.parse(loading, Loading.LAZY);
     }
 
     public String getType() {

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -144,9 +144,9 @@ public interface FieldMapper<T> extends Mapper {
         public static Loading parse(String loading, Loading defaultValue) {
             if (Strings.isNullOrEmpty(loading)) {
                 return defaultValue;
-            } else if (EAGER_VALUE.equals(loading)) {
+            } else if (EAGER_VALUE.equalsIgnoreCase(loading)) {
                 return EAGER;
-            } else if (LAZY_VALUE.equals(loading)) {
+            } else if (LAZY_VALUE.equalsIgnoreCase(loading)) {
                 return LAZY;
             } else {
                 throw new MapperParsingException("Unknown [" + KEY + "] value: [" + loading + "]");

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import com.google.common.base.Strings;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
@@ -122,6 +123,38 @@ public interface FieldMapper<T> extends Mapper {
         }
     }
 
+    public static enum Loading {
+        LAZY {
+            @Override
+            public String toString() {
+                return LAZY_VALUE;
+            }
+        },
+        EAGER {
+            @Override
+            public String toString() {
+                return EAGER_VALUE;
+            }
+        };
+
+        public static final String KEY = "loading";
+        public static final String EAGER_VALUE = "eager";
+        public static final String LAZY_VALUE = "lazy";
+
+        public static Loading parse(String loading, Loading defaultValue) {
+            if (Strings.isNullOrEmpty(loading)) {
+                return defaultValue;
+            } else if (EAGER_VALUE.equals(loading)) {
+                return EAGER;
+            } else if (LAZY_VALUE.equals(loading)) {
+                return LAZY;
+            } else {
+                throw new MapperParsingException("Unknown [" + KEY + "] value: [" + loading + "]");
+            }
+        }
+
+    }
+
     Names names();
 
     FieldType fieldType();
@@ -214,4 +247,6 @@ public interface FieldMapper<T> extends Mapper {
     boolean isSortable();
 
     boolean hasDocValues();
+
+    Loading normsLoading(Loading defaultLoading);
 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -91,6 +91,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         protected PostingsFormatProvider postingsProvider;
         protected DocValuesFormatProvider docValuesProvider;
         protected SimilarityProvider similarity;
+        protected Loading normsLoading;
         @Nullable
         protected Settings fieldDataSettings;
 
@@ -189,6 +190,11 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             return builder;
         }
 
+        public T normsLoading(Loading normsLoading) {
+            this.normsLoading = normsLoading;
+            return builder;
+        }
+
         public T fieldDataSettings(Settings settings) {
             this.fieldDataSettings = settings;
             return builder;
@@ -223,14 +229,14 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
     protected PostingsFormatProvider postingsFormat;
     protected DocValuesFormatProvider docValuesFormat;
     protected final SimilarityProvider similarity;
-
+    protected Loading normsLoading;
     protected Settings customFieldDataSettings;
     protected FieldDataType fieldDataType;
 
     protected AbstractFieldMapper(Names names, float boost, FieldType fieldType, NamedAnalyzer indexAnalyzer,
                                   NamedAnalyzer searchAnalyzer, PostingsFormatProvider postingsFormat,
                                   DocValuesFormatProvider docValuesFormat, SimilarityProvider similarity,
-                                  @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                                  Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         this.names = names;
         this.boost = boost;
         this.fieldType = fieldType;
@@ -256,6 +262,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         this.postingsFormat = postingsFormat;
         this.docValuesFormat = docValuesFormat;
         this.similarity = similarity;
+        this.normsLoading = normsLoading;
 
         this.customFieldDataSettings = fieldDataSettings;
         if (fieldDataSettings == null) {
@@ -536,6 +543,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         if (!mergeContext.mergeFlags().simulate()) {
             // apply changeable values
             this.boost = fieldMergeWith.boost;
+            this.normsLoading = fieldMergeWith.normsLoading;
             if (fieldMergeWith.postingsFormat != null) {
                 this.postingsFormat = fieldMergeWith.postingsFormat;
             }
@@ -596,8 +604,15 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         if (includeDefaults || fieldType.storeTermVectors() != defaultFieldType.storeTermVectors()) {
             builder.field("term_vector", termVectorOptionsToString(fieldType));
         }
-        if (includeDefaults || fieldType.omitNorms() != defaultFieldType.omitNorms()) {
-            builder.field("omit_norms", fieldType.omitNorms());
+        if (includeDefaults || fieldType.omitNorms() != defaultFieldType.omitNorms() || normsLoading != null) {
+            builder.startObject("norms");
+            if (includeDefaults || fieldType.omitNorms() != defaultFieldType.omitNorms()) {
+                builder.field("enabled", !fieldType.omitNorms());
+            }
+            if (normsLoading != null) {
+                builder.field(Loading.KEY, normsLoading);
+            }
+            builder.endObject();
         }
         if (includeDefaults || fieldType.indexOptions() != defaultFieldType.indexOptions()) {
             builder.field("index_options", indexOptionToString(fieldType.indexOptions()));
@@ -736,6 +751,11 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
 
     public boolean hasDocValues() {
         return docValues;
+    }
+
+    @Override
+    public Loading normsLoading(Loading defaultLoading) {
+        return normsLoading == null ? defaultLoading : normsLoading;
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -121,7 +121,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
 
     protected BinaryFieldMapper(Names names, FieldType fieldType, Boolean compress, long compressThreshold,
                                 PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider) {
-        super(names, 1.0f, fieldType, null, null, postingsProvider, docValuesProvider, null, null, null);
+        super(names, 1.0f, fieldType, null, null, postingsProvider, docValuesProvider, null, null, null, null);
         this.compress = compress;
         this.compressThreshold = compressThreshold;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -99,7 +99,7 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
 
         @Override
         public BooleanFieldMapper build(BuilderContext context) {
-            return new BooleanFieldMapper(buildNames(context), boost, fieldType, nullValue, postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+            return new BooleanFieldMapper(buildNames(context), boost, fieldType, nullValue, postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
         }
     }
 
@@ -122,9 +122,9 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
     private Boolean nullValue;
 
     protected BooleanFieldMapper(Names names, float boost, FieldType fieldType, Boolean nullValue, PostingsFormatProvider postingsProvider,
-                                 DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, @Nullable Settings fieldDataSettings,
-                                 Settings indexSettings) {
-        super(names, boost, fieldType, Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                                 DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, Loading normsLoading,
+                                 @Nullable Settings fieldDataSettings, Settings indexSettings) {
+        super(names, boost, fieldType, Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -92,7 +92,7 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             ByteFieldMapper fieldMapper = new ByteFieldMapper(buildNames(context),
                     precisionStep, boost, fieldType, nullValue, ignoreMalformed(context),
-                    postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+                    postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -120,12 +120,12 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
 
     protected ByteFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                               Byte nullValue, Explicit<Boolean> ignoreMalformed, PostingsFormatProvider postingsProvider,
-                              DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
+                              DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, Loading normsLoading,
                               @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType,
                 ignoreMalformed, new NamedAnalyzer("_byte/" + precisionStep, new NumericIntegerAnalyzer(precisionStep)),
                 new NamedAnalyzer("_byte/max", new NumericIntegerAnalyzer(Integer.MAX_VALUE)), postingsProvider,
-                docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -195,7 +195,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
 
     public CompletionFieldMapper(Names names, NamedAnalyzer indexAnalyzer, NamedAnalyzer searchAnalyzer, PostingsFormatProvider postingsProvider, SimilarityProvider similarity, boolean payloads,
                                  boolean preserveSeparators, boolean preservePositionIncrements, int maxInputLength) {
-        super(names, 1.0f, Defaults.FIELD_TYPE, indexAnalyzer, searchAnalyzer, postingsProvider, null, similarity, null, null);
+        super(names, 1.0f, Defaults.FIELD_TYPE, indexAnalyzer, searchAnalyzer, postingsProvider, null, similarity, null, null, null);
         analyzingSuggestLookupProvider = new AnalyzingCompletionLookupProvider(preserveSeparators, false, preservePositionIncrements, payloads);
         this.completionPostingsFormatProvider = new CompletionPostingsFormatProvider("completion", postingsProvider, analyzingSuggestLookupProvider);
         this.preserveSeparators = preserveSeparators;

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -129,7 +129,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
             }
             DateFieldMapper fieldMapper = new DateFieldMapper(buildNames(context), dateTimeFormatter,
                     precisionStep, boost, fieldType, nullValue, timeUnit, roundCeil, ignoreMalformed(context),
-                    postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+                    postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -203,11 +203,11 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
     protected DateFieldMapper(Names names, FormatDateTimeFormatter dateTimeFormatter, int precisionStep, float boost, FieldType fieldType,
                               String nullValue, TimeUnit timeUnit, boolean roundCeil, Explicit<Boolean> ignoreMalformed,
                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
-                              @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                              Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, ignoreMalformed, new NamedAnalyzer("_date/" + precisionStep,
                 new NumericDateAnalyzer(precisionStep, dateTimeFormatter.parser())),
                 new NamedAnalyzer("_date/max", new NumericDateAnalyzer(Integer.MAX_VALUE, dateTimeFormatter.parser())),
-                postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.dateTimeFormatter = dateTimeFormatter;
         this.nullValue = nullValue;
         this.timeUnit = timeUnit;

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -95,7 +95,7 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             DoubleFieldMapper fieldMapper = new DoubleFieldMapper(buildNames(context),
                     precisionStep, boost, fieldType, nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider,
-                    similarity, fieldDataSettings, context.indexSettings());
+                    similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -125,10 +125,10 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
     protected DoubleFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                                 Double nullValue, Explicit<Boolean> ignoreMalformed,
                                 PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                                SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                                SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, ignoreMalformed,
                 NumericDoubleAnalyzer.buildNamedAnalyzer(precisionStep), NumericDoubleAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
-                postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -96,7 +96,7 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             FloatFieldMapper fieldMapper = new FloatFieldMapper(buildNames(context),
                     precisionStep, boost, fieldType, nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider,
-                    similarity, fieldDataSettings, context.indexSettings());
+                    similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -125,10 +125,10 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
     protected FloatFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                                Float nullValue, Explicit<Boolean> ignoreMalformed,
                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                               SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                               SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, ignoreMalformed,
                 NumericFloatAnalyzer.buildNamedAnalyzer(precisionStep), NumericFloatAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
-                postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -91,7 +91,7 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
         public IntegerFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             IntegerFieldMapper fieldMapper = new IntegerFieldMapper(buildNames(context), precisionStep, boost, fieldType,
-                    nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+                    nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -120,10 +120,11 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
     protected IntegerFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                                  Integer nullValue, Explicit<Boolean> ignoreMalformed,
                                  PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                                 SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                                 SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings,
+                                 Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, ignoreMalformed,
                 NumericIntegerAnalyzer.buildNamedAnalyzer(precisionStep), NumericIntegerAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
-                postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -91,7 +91,7 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
         public LongFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             LongFieldMapper fieldMapper = new LongFieldMapper(buildNames(context), precisionStep, boost, fieldType, nullValue,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -120,10 +120,10 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
     protected LongFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                               Long nullValue, Explicit<Boolean> ignoreMalformed,
                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                              SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                              SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, ignoreMalformed,
                 NumericLongAnalyzer.buildNamedAnalyzer(precisionStep), NumericLongAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
-                postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -147,9 +147,9 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
                                 Explicit<Boolean> ignoreMalformed, NamedAnalyzer indexAnalyzer,
                                 NamedAnalyzer searchAnalyzer, PostingsFormatProvider postingsProvider,
                                 DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
-                                @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                                Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         // LUCENE 4 UPGRADE: Since we can't do anything before the super call, we have to push the boost check down to subclasses
-        super(names, boost, fieldType, indexAnalyzer, searchAnalyzer, postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+        super(names, boost, fieldType, indexAnalyzer, searchAnalyzer, postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         if (precisionStep <= 0 || precisionStep >= maxPrecisionStep()) {
             this.precisionStep = Integer.MAX_VALUE;
         } else {

--- a/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -92,7 +92,7 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
         public ShortFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             ShortFieldMapper fieldMapper = new ShortFieldMapper(buildNames(context), precisionStep, boost, fieldType, nullValue,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -121,10 +121,10 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
     protected ShortFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                                Short nullValue, Explicit<Boolean> ignoreMalformed,
                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                               SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                               SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, ignoreMalformed, new NamedAnalyzer("_short/" + precisionStep,
                 new NumericIntegerAnalyzer(precisionStep)), new NamedAnalyzer("_short/max", new NumericIntegerAnalyzer(Integer.MAX_VALUE)),
-                postingsProvider, docValuesProvider, similarity, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
         this.nullValueAsString = nullValue == null ? null : nullValue.toString();
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -135,7 +135,7 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
             }
             StringFieldMapper fieldMapper = new StringFieldMapper(buildNames(context),
                     boost, fieldType, nullValue, indexAnalyzer, searchAnalyzer, searchQuotedAnalyzer,
-                    positionOffsetGap, ignoreAbove, postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+                    positionOffsetGap, ignoreAbove, postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -192,8 +192,9 @@ public class StringFieldMapper extends AbstractFieldMapper<String> implements Al
                                 String nullValue, NamedAnalyzer indexAnalyzer, NamedAnalyzer searchAnalyzer,
                                 NamedAnalyzer searchQuotedAnalyzer, int positionOffsetGap, int ignoreAbove,
                                 PostingsFormatProvider postingsFormat, DocValuesFormatProvider docValuesFormat,
-                                SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(names, boost, fieldType, indexAnalyzer, searchAnalyzer, postingsFormat, docValuesFormat, similarity, fieldDataSettings, indexSettings);
+                                SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings,
+                                Settings indexSettings) {
+        super(names, boost, fieldType, indexAnalyzer, searchAnalyzer, postingsFormat, docValuesFormat, similarity, normsLoading, fieldDataSettings, indexSettings);
         if (fieldType.tokenized() && fieldType.indexed() && hasDocValues()) {
             throw new MapperParsingException("Field [" + names.fullName() + "] cannot be analyzed and have doc values");
         }

--- a/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -79,7 +79,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
         public TokenCountFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             TokenCountFieldMapper fieldMapper = new TokenCountFieldMapper(buildNames(context), precisionStep, boost, fieldType, nullValue,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings(),
+                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(),
                     analyzer);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -116,9 +116,9 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
 
     protected TokenCountFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Integer nullValue,
             Explicit<Boolean> ignoreMalformed, PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-            SimilarityProvider similarity, Settings fieldDataSettings, Settings indexSettings, NamedAnalyzer analyzer) {
+            SimilarityProvider similarity, Loading normsLoading, Settings fieldDataSettings, Settings indexSettings, NamedAnalyzer analyzer) {
         super(names, precisionStep, boost, fieldType, nullValue, ignoreMalformed, postingsProvider, docValuesProvider, similarity,
-                fieldDataSettings, indexSettings);
+                normsLoading, fieldDataSettings, indexSettings);
         this.analyzer = analyzer;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.FieldMapper.Loading;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 
@@ -66,8 +67,8 @@ public class TypeParsers {
 
     public static void parseField(AbstractFieldMapper.Builder builder, String name, Map<String, Object> fieldNode, Mapper.TypeParser.ParserContext parserContext) {
         for (Map.Entry<String, Object> entry : fieldNode.entrySet()) {
-            String propName = Strings.toUnderscoreCase(entry.getKey());
-            Object propNode = entry.getValue();
+            final String propName = Strings.toUnderscoreCase(entry.getKey());
+            final Object propNode = entry.getValue();
             if (propName.equals("index_name")) {
                 builder.indexName(propNode.toString());
             } else if (propName.equals("store")) {
@@ -90,6 +91,17 @@ public class TypeParsers {
                 builder.storeTermVectorPayloads(nodeBooleanValue(propNode));
             } else if (propName.equals("omit_norms")) {
                 builder.omitNorms(nodeBooleanValue(propNode));
+            } else if (propName.equals("norms")) {
+                final Map<String, Object> properties = nodeMapValue(propNode, "norms");
+                for (Map.Entry<String, Object> entry2 : properties.entrySet()) {
+                    final String propName2 = Strings.toUnderscoreCase(entry2.getKey());
+                    final Object propNode2 = entry2.getValue();
+                    if (propName2.equals("enabled")) {
+                        builder.omitNorms(!nodeBooleanValue(propNode2));
+                    } else if (propName2.equals(Loading.KEY)) {
+                        builder.normsLoading(Loading.parse(nodeStringValue(propNode2, null), null));
+                    }
+                }
             } else if (propName.equals("omit_term_freq_and_positions")) {
                 // deprecated option for BW compat
                 builder.indexOptions(nodeBooleanValue(propNode) ? IndexOptions.DOCS_ONLY : IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
@@ -125,12 +137,7 @@ public class TypeParsers {
             } else if (propName.equals("similarity")) {
                 builder.similarity(parserContext.similarityLookupService().similarity(propNode.toString()));
             } else if (propName.equals("fielddata")) {
-                final Settings settings;
-                if (propNode instanceof Map){
-                    settings = ImmutableSettings.builder().put(SettingsLoader.Helper.loadNestedFromMap((Map<String, Object>)propNode)).build();
-                } else {
-                    throw new ElasticSearchParseException("fielddata should be a hash but was of type: " + propNode.getClass());
-                }
+                final Settings settings = ImmutableSettings.builder().put(SettingsLoader.Helper.loadNestedFromMap(nodeMapValue(propNode, "fielddata"))).build();
                 builder.fieldDataSettings(settings);
             }
         }

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -396,7 +396,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
             DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper, StringFieldMapper geohashMapper,
             boolean validateLon, boolean validateLat,
             boolean normalizeLon, boolean normalizeLat) {
-        super(names, 1f, fieldType, null, indexAnalyzer, postingsFormat, docValuesFormat, similarity, fieldDataSettings, indexSettings);
+        super(names, 1f, fieldType, null, indexAnalyzer, postingsFormat, docValuesFormat, similarity, null, fieldDataSettings, indexSettings);
         this.pathType = pathType;
         this.enableLatLon = enableLatLon;
         this.enableGeoHash = enableGeoHash || enableGeohashPrefix; // implicitly enable geohashes if geohash_prefix is set

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -196,7 +196,7 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
 
     public GeoShapeFieldMapper(FieldMapper.Names names, SpatialPrefixTree tree, String defaultStrategyName, double distanceErrorPct,
                                FieldType fieldType, PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider) {
-        super(names, 1, fieldType, null, null, postingsProvider, docValuesProvider, null, null, null);
+        super(names, 1, fieldType, null, null, postingsProvider, docValuesProvider, null, null, null, null);
         this.recursiveStrategy = new RecursivePrefixTreeStrategy(tree, names.indexName());
         this.recursiveStrategy.setDistErrPct(distanceErrorPct);
         this.termStrategy = new TermQueryPrefixTreeStrategy(tree, names.indexName());

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -106,7 +106,7 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
             fieldType.setIndexed(true);
             fieldType.setTokenized(true);
 
-            return new AllFieldMapper(name, fieldType, indexAnalyzer, searchAnalyzer, enabled, autoBoost, postingsProvider, docValuesProvider, similarity, fieldDataSettings, context.indexSettings());
+            return new AllFieldMapper(name, fieldType, indexAnalyzer, searchAnalyzer, enabled, autoBoost, postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
         }
     }
 
@@ -138,15 +138,15 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
     private volatile boolean autoBoost;
 
     public AllFieldMapper() {
-        this(Defaults.NAME, new FieldType(Defaults.FIELD_TYPE), null, null, Defaults.ENABLED, false, null, null, null, null, ImmutableSettings.EMPTY);
+        this(Defaults.NAME, new FieldType(Defaults.FIELD_TYPE), null, null, Defaults.ENABLED, false, null, null, null, null, null, ImmutableSettings.EMPTY);
     }
 
     protected AllFieldMapper(String name, FieldType fieldType, NamedAnalyzer indexAnalyzer, NamedAnalyzer searchAnalyzer,
                              boolean enabled, boolean autoBoost, PostingsFormatProvider postingsProvider,
-                             DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, @Nullable Settings fieldDataSettings,
-                             Settings indexSettings) {
+                             DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, Loading normsLoading,
+                             @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, name, name, name), 1.0f, fieldType, indexAnalyzer, searchAnalyzer, postingsProvider, docValuesProvider,
-                similarity, fieldDataSettings, indexSettings);
+                similarity, normsLoading, fieldDataSettings, indexSettings);
         this.enabled = enabled;
         this.autoBoost = autoBoost;
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -126,7 +126,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, indexName, indexName, name), precisionStep, boost, fieldType, Defaults.IGNORE_MALFORMED,
                 NumericFloatAnalyzer.buildNamedAnalyzer(precisionStep), NumericFloatAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
-                postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -135,7 +135,7 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
                             PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                             @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, indexName, indexName, name), boost, fieldType, Lucene.KEYWORD_ANALYZER,
-                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.path = path;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -120,7 +120,7 @@ public class IndexFieldMapper extends AbstractFieldMapper<String> implements Int
     public IndexFieldMapper(String name, String indexName, float boost, FieldType fieldType, EnabledAttributeMapper enabledState,
                             PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, indexName, indexName, name), boost, fieldType, Lucene.KEYWORD_ANALYZER,
-                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.enabledState = enabledState;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -127,14 +127,14 @@ public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements Inter
 
     protected ParentFieldMapper(String name, String indexName, String type, PostingsFormatProvider postingsFormat, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, indexName, indexName, name), Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE),
-                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, postingsFormat, null, null, fieldDataSettings, indexSettings);
+                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, postingsFormat, null, null, null, fieldDataSettings, indexSettings);
         this.type = type;
         this.typeAsBytes = new BytesRef(type);
     }
 
     public ParentFieldMapper() {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE),
-                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, null, null, null, null, null);
+                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, null, null, null, null, null, null);
         type = null;
         typeAsBytes = null;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -126,7 +126,7 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
     protected RoutingFieldMapper(FieldType fieldType, boolean required, String path, PostingsFormatProvider postingsProvider,
                                  DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), 1.0f, fieldType, Lucene.KEYWORD_ANALYZER,
-                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.required = required;
         this.path = path;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -102,7 +102,7 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
     public SizeFieldMapper(EnabledAttributeMapper enabled, FieldType fieldType, PostingsFormatProvider postingsProvider,
                            DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME), Defaults.PRECISION_STEP, Defaults.BOOST, fieldType, Defaults.NULL_VALUE,
-                Defaults.IGNORE_MALFORMED, postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                Defaults.IGNORE_MALFORMED, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.enabledState = enabled;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -196,7 +196,7 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
     protected SourceFieldMapper(String name, boolean enabled, String format, Boolean compress, long compressThreshold,
                                 String[] includes, String[] excludes) {
         super(new Names(name, name, name, name), Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE),
-                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, null, null, null, null, null); // Only stored.
+                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, null, null, null, null, null, null); // Only stored.
         this.enabled = enabled;
         this.compress = compress;
         this.compressThreshold = compressThreshold;

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -127,7 +127,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
                              @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), Defaults.PRECISION_STEP,
                 Defaults.BOOST, fieldType, Defaults.NULL_VALUE, ignoreMalformed,
-                postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.enabledState = enabled;
         this.defaultTTL = defaultTTL;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -105,7 +105,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
                 roundCeil =  settings.getAsBoolean("index.mapping.date.round_ceil", settings.getAsBoolean("index.mapping.date.parse_upper_inclusive", Defaults.ROUND_CEIL));
             }
             return new TimestampFieldMapper(fieldType, enabledState, path, dateTimeFormatter, roundCeil,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, fieldDataSettings, context.indexSettings());
+                    ignoreMalformed(context), postingsProvider, docValuesProvider, normsLoading, fieldDataSettings, context.indexSettings());
         }
     }
 
@@ -137,18 +137,18 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
 
     public TimestampFieldMapper() {
         this(new FieldType(Defaults.FIELD_TYPE), Defaults.ENABLED, Defaults.PATH, Defaults.DATE_TIME_FORMATTER,
-                Defaults.ROUND_CEIL, Defaults.IGNORE_MALFORMED, null, null, null, ImmutableSettings.EMPTY);
+                Defaults.ROUND_CEIL, Defaults.IGNORE_MALFORMED, null, null, null, null, ImmutableSettings.EMPTY);
     }
 
     protected TimestampFieldMapper(FieldType fieldType, EnabledAttributeMapper enabledState, String path,
                                    FormatDateTimeFormatter dateTimeFormatter, boolean roundCeil,
                                    Explicit<Boolean> ignoreMalformed, PostingsFormatProvider postingsProvider,
-                                   DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings,
-                                   Settings indexSettings) {
+                                   DocValuesFormatProvider docValuesProvider, Loading normsLoading,
+                                   @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), dateTimeFormatter,
                 Defaults.PRECISION_STEP, Defaults.BOOST, fieldType,
                 Defaults.NULL_VALUE, TimeUnit.MILLISECONDS /*always milliseconds*/,
-                roundCeil, ignoreMalformed, postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                roundCeil, ignoreMalformed, postingsProvider, docValuesProvider, null, normsLoading, fieldDataSettings, indexSettings);
         this.enabledState = enabledState;
         this.path = path;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -109,7 +109,7 @@ public class TypeFieldMapper extends AbstractFieldMapper<String> implements Inte
     public TypeFieldMapper(String name, String indexName, float boost, FieldType fieldType, PostingsFormatProvider postingsProvider,
                            DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, indexName, indexName, name), boost, fieldType, Lucene.KEYWORD_ANALYZER,
-                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, fieldDataSettings, indexSettings);
+                Lucene.KEYWORD_ANALYZER, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -109,7 +109,7 @@ public class UidFieldMapper extends AbstractFieldMapper<Uid> implements Internal
 
     protected UidFieldMapper(String name, String indexName, PostingsFormatProvider postingsFormat, DocValuesFormatProvider docValuesFormat, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(name, indexName, indexName, name), Defaults.BOOST, new FieldType(Defaults.FIELD_TYPE),
-                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, postingsFormat, docValuesFormat, null, fieldDataSettings, indexSettings);
+                Lucene.KEYWORD_ANALYZER, Lucene.KEYWORD_ANALYZER, postingsFormat, docValuesFormat, null, null, fieldDataSettings, indexSettings);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -99,7 +99,7 @@ public class VersionFieldMapper extends AbstractFieldMapper<Long> implements Int
     }
 
     VersionFieldMapper(DocValuesFormatProvider docValuesFormat) {
-        super(new Names(NAME, NAME, NAME, NAME), Defaults.BOOST, Defaults.FIELD_TYPE, null, null, null, docValuesFormat, null, null, ImmutableSettings.EMPTY);
+        super(new Names(NAME, NAME, NAME, NAME), Defaults.BOOST, Defaults.FIELD_TYPE, null, null, null, docValuesFormat, null, null, null, ImmutableSettings.EMPTY);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -122,7 +122,7 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             IpFieldMapper fieldMapper = new IpFieldMapper(buildNames(context),
                     precisionStep, boost, fieldType, nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider, similarity,
-                    fieldDataSettings, context.indexSettings());
+                    normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -149,11 +149,11 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
     protected IpFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType,
                             String nullValue, Explicit<Boolean> ignoreMalformed,
                             PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                            SimilarityProvider similarity, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                            SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType,
                 ignoreMalformed, new NamedAnalyzer("_ip/" + precisionStep, new NumericIpAnalyzer(precisionStep)),
                 new NamedAnalyzer("_ip/max", new NumericIpAnalyzer(Integer.MAX_VALUE)), postingsProvider, docValuesProvider,
-                similarity, fieldDataSettings, indexSettings);
+                similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
     }
 

--- a/src/main/java/org/elasticsearch/indices/warmer/IndicesWarmer.java
+++ b/src/main/java/org/elasticsearch/indices/warmer/IndicesWarmer.java
@@ -25,9 +25,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.Collection;
-import java.util.concurrent.Future;
-
 /**
  */
 public interface IndicesWarmer {
@@ -38,8 +35,20 @@ public interface IndicesWarmer {
             return ThreadPool.Names.WARMER;
         }
 
+        /** A handle on the execution of  warm-up action. */
+        public static interface TerminationHandle {
+
+            public static TerminationHandle NO_WAIT = new TerminationHandle() {
+                @Override
+                public void awaitTermination() {}
+            };
+
+            /** Wait until execution of the warm-up action completes. */
+            void awaitTermination() throws InterruptedException;
+        }
+
         /** Queue tasks to warm-up the given segments and return handles that allow to wait for termination of the execution of those tasks. */
-        public abstract Collection<Future<?>> warm(IndexShard indexShard, IndexMetaData indexMetaData, WarmerContext context, ThreadPool threadPool);
+        public abstract TerminationHandle warm(IndexShard indexShard, IndexMetaData indexMetaData, WarmerContext context, ThreadPool threadPool);
     }
 
     public static class WarmerContext {

--- a/src/main/java/org/elasticsearch/indices/warmer/IndicesWarmer.java
+++ b/src/main/java/org/elasticsearch/indices/warmer/IndicesWarmer.java
@@ -25,6 +25,9 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.Collection;
+import java.util.concurrent.Future;
+
 /**
  */
 public interface IndicesWarmer {
@@ -35,7 +38,8 @@ public interface IndicesWarmer {
             return ThreadPool.Names.WARMER;
         }
 
-        public abstract void warm(IndexShard indexShard, IndexMetaData indexMetaData, WarmerContext context, ThreadPool threadPool);
+        /** Queue tasks to warm-up the given segments and return handles that allow to wait for termination of the execution of those tasks. */
+        public abstract Collection<Future<?>> warm(IndexShard indexShard, IndexMetaData indexMetaData, WarmerContext context, ThreadPool threadPool);
     }
 
     public static class WarmerContext {

--- a/src/main/java/org/elasticsearch/indices/warmer/InternalIndicesWarmer.java
+++ b/src/main/java/org/elasticsearch/indices/warmer/InternalIndicesWarmer.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.indices.warmer;
 
+import com.google.common.collect.Lists;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -30,7 +31,10 @@ import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -86,8 +90,23 @@ public class InternalIndicesWarmer extends AbstractComponent implements IndicesW
         }
         indexShard.warmerService().onPreWarm();
         long time = System.nanoTime();
+        final List<Future<?>> futures = Lists.newArrayList();
+        // get a handle on pending tasks
         for (final Listener listener : listeners) {
-            listener.warm(indexShard, indexMetaData, context, threadPool);
+            futures.addAll(listener.warm(indexShard, indexMetaData, context, threadPool));
+        }
+        // wait for termination
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Warming has been interrupted", e);
+                break;
+            } catch (ExecutionException e) {
+                // warmers are supposed not to throw exceptions
+                logger.warn("Warmer threw an exception", e);
+            }
         }
         long took = System.nanoTime() - time;
         indexShard.warmerService().onPostWarm(took);

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -194,12 +194,12 @@ public class ThreadPool extends AbstractComponent {
         return new ThreadPoolStats(stats);
     }
 
-    public Executor generic() {
+    public ExecutorService generic() {
         return executor(Names.GENERIC);
     }
 
-    public Executor executor(String name) {
-        Executor executor = executors.get(name).executor;
+    public ExecutorService executor(String name) {
+        ExecutorService executor = executors.get(name).executor;
         if (executor == null) {
             throw new ElasticSearchIllegalArgumentException("No executor found for [" + name + "]");
         }
@@ -303,7 +303,7 @@ public class ThreadPool extends AbstractComponent {
             } else {
                 logger.debug("creating thread_pool [{}], type [{}], keep_alive [{}]", name, type, keepAlive);
             }
-            Executor executor = EsExecutors.newCached(keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
+            ExecutorService executor = EsExecutors.newCached(keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
             return new ExecutorHolder(executor, new Info(name, type, -1, -1, keepAlive, null));
         } else if ("fixed".equals(type)) {
             int defaultSize = defaultSettings.getAsInt("size", EsExecutors.boundedNumberOfProcessors(settings));
@@ -332,7 +332,7 @@ public class ThreadPool extends AbstractComponent {
             int size = settings.getAsInt("size", defaultSize);
             SizeValue queueSize = settings.getAsSize("capacity", settings.getAsSize("queue", settings.getAsSize("queue_size", defaultQueueSize)));
             logger.debug("creating thread_pool [{}], type [{}], size [{}], queue_size [{}]", name, type, size, queueSize);
-            Executor executor = EsExecutors.newFixed(size, queueSize == null ? -1 : (int) queueSize.singles(), threadFactory);
+            ExecutorService executor = EsExecutors.newFixed(size, queueSize == null ? -1 : (int) queueSize.singles(), threadFactory);
             return new ExecutorHolder(executor, new Info(name, type, size, size, null, queueSize));
         } else if ("scaling".equals(type)) {
             TimeValue defaultKeepAlive = defaultSettings.getAsTime("keep_alive", timeValueMinutes(5));
@@ -376,7 +376,7 @@ public class ThreadPool extends AbstractComponent {
             } else {
                 logger.debug("creating thread_pool [{}], type [{}], min [{}], size [{}], keep_alive [{}]", name, type, min, size, keepAlive);
             }
-            Executor executor = EsExecutors.newScaling(min, size, keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
+            ExecutorService executor = EsExecutors.newScaling(min, size, keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
             return new ExecutorHolder(executor, new Info(name, type, min, size, keepAlive, null));
         }
         throw new ElasticSearchIllegalArgumentException("No type found [" + type + "], for [" + name + "]");
@@ -523,10 +523,10 @@ public class ThreadPool extends AbstractComponent {
     }
 
     static class ExecutorHolder {
-        public final Executor executor;
+        public final ExecutorService executor;
         public final Info info;
 
-        ExecutorHolder(Executor executor, Info info) {
+        ExecutorHolder(ExecutorService executor, Info info) {
             this.executor = executor;
             this.info = info;
         }

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -194,12 +194,12 @@ public class ThreadPool extends AbstractComponent {
         return new ThreadPoolStats(stats);
     }
 
-    public ExecutorService generic() {
+    public Executor generic() {
         return executor(Names.GENERIC);
     }
 
-    public ExecutorService executor(String name) {
-        ExecutorService executor = executors.get(name).executor;
+    public Executor executor(String name) {
+        Executor executor = executors.get(name).executor;
         if (executor == null) {
             throw new ElasticSearchIllegalArgumentException("No executor found for [" + name + "]");
         }
@@ -303,7 +303,7 @@ public class ThreadPool extends AbstractComponent {
             } else {
                 logger.debug("creating thread_pool [{}], type [{}], keep_alive [{}]", name, type, keepAlive);
             }
-            ExecutorService executor = EsExecutors.newCached(keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
+            Executor executor = EsExecutors.newCached(keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
             return new ExecutorHolder(executor, new Info(name, type, -1, -1, keepAlive, null));
         } else if ("fixed".equals(type)) {
             int defaultSize = defaultSettings.getAsInt("size", EsExecutors.boundedNumberOfProcessors(settings));
@@ -332,7 +332,7 @@ public class ThreadPool extends AbstractComponent {
             int size = settings.getAsInt("size", defaultSize);
             SizeValue queueSize = settings.getAsSize("capacity", settings.getAsSize("queue", settings.getAsSize("queue_size", defaultQueueSize)));
             logger.debug("creating thread_pool [{}], type [{}], size [{}], queue_size [{}]", name, type, size, queueSize);
-            ExecutorService executor = EsExecutors.newFixed(size, queueSize == null ? -1 : (int) queueSize.singles(), threadFactory);
+            Executor executor = EsExecutors.newFixed(size, queueSize == null ? -1 : (int) queueSize.singles(), threadFactory);
             return new ExecutorHolder(executor, new Info(name, type, size, size, null, queueSize));
         } else if ("scaling".equals(type)) {
             TimeValue defaultKeepAlive = defaultSettings.getAsTime("keep_alive", timeValueMinutes(5));
@@ -376,7 +376,7 @@ public class ThreadPool extends AbstractComponent {
             } else {
                 logger.debug("creating thread_pool [{}], type [{}], min [{}], size [{}], keep_alive [{}]", name, type, min, size, keepAlive);
             }
-            ExecutorService executor = EsExecutors.newScaling(min, size, keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
+            Executor executor = EsExecutors.newScaling(min, size, keepAlive.millis(), TimeUnit.MILLISECONDS, threadFactory);
             return new ExecutorHolder(executor, new Info(name, type, min, size, keepAlive, null));
         }
         throw new ElasticSearchIllegalArgumentException("No type found [" + type + "], for [" + name + "]");
@@ -523,10 +523,10 @@ public class ThreadPool extends AbstractComponent {
     }
 
     static class ExecutorHolder {
-        public final ExecutorService executor;
+        public final Executor executor;
         public final Info info;
 
-        ExecutorHolder(ExecutorService executor, Info info) {
+        ExecutorHolder(Executor executor, Info info) {
             this.executor = executor;
             this.info = info;
         }

--- a/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CustomBoostMappingTests extends ElasticsearchTestCase {
@@ -35,13 +34,13 @@ public class CustomBoostMappingTests extends ElasticsearchTestCase {
     public void testCustomBoostValues() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
                 .startObject("s_field").field("type", "string").endObject()
-                .startObject("l_field").field("type", "long").field("omit_norms", false).endObject()
-                .startObject("i_field").field("type", "integer").field("omit_norms", false).endObject()
-                .startObject("sh_field").field("type", "short").field("omit_norms", false).endObject()
-                .startObject("b_field").field("type", "byte").field("omit_norms", false).endObject()
-                .startObject("d_field").field("type", "double").field("omit_norms", false).endObject()
-                .startObject("f_field").field("type", "float").field("omit_norms", false).endObject()
-                .startObject("date_field").field("type", "date").field("omit_norms", false).endObject()
+                .startObject("l_field").field("type", "long").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("i_field").field("type", "integer").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("sh_field").field("type", "short").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("b_field").field("type", "byte").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("d_field").field("type", "double").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("f_field").field("type", "float").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("date_field").field("type", "date").startObject("norms").field("enabled", true).endObject().endObject()
                 .endObject().endObject().endObject().string();
 
         DocumentMapper mapper = MapperTestUtils.newParser().parse(mapping);

--- a/src/test/java/org/elasticsearch/index/mapper/boost/FieldLevelBoostTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/boost/FieldLevelBoostTests.java
@@ -39,13 +39,13 @@ public class FieldLevelBoostTests extends ElasticsearchTestCase {
     public void testFieldLevelBoost() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("person").startObject("properties")
                 .startObject("str_field").field("type", "string").endObject()
-                .startObject("int_field").field("type", "integer").field("omit_norms", false).endObject()
-                .startObject("byte_field").field("type", "byte").field("omit_norms", false).endObject()
-                .startObject("date_field").field("type", "date").field("omit_norms", false).endObject()
-                .startObject("double_field").field("type", "double").field("omit_norms", false).endObject()
-                .startObject("float_field").field("type", "float").field("omit_norms", false).endObject()
-                .startObject("long_field").field("type", "long").field("omit_norms", false).endObject()
-                .startObject("short_field").field("type", "short").field("omit_norms", false).endObject()
+                .startObject("int_field").field("type", "integer").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("byte_field").field("type", "byte").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("date_field").field("type", "date").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("double_field").field("type", "double").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("float_field").field("type", "float").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("long_field").field("type", "long").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("short_field").field("type", "short").startObject("norms").field("enabled", true).endObject().endObject()
                 .string();
 
         DocumentMapper docMapper = MapperTestUtils.newParser().parse(mapping);
@@ -90,13 +90,13 @@ public class FieldLevelBoostTests extends ElasticsearchTestCase {
     public void testInvalidFieldLevelBoost() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("person").startObject("properties")
                 .startObject("str_field").field("type", "string").endObject()
-                .startObject("int_field").field("type", "integer").field("omit_norms", false).endObject()
-                .startObject("byte_field").field("type", "byte").field("omit_norms", false).endObject()
-                .startObject("date_field").field("type", "date").field("omit_norms", false).endObject()
-                .startObject("double_field").field("type", "double").field("omit_norms", false).endObject()
-                .startObject("float_field").field("type", "float").field("omit_norms", false).endObject()
-                .startObject("long_field").field("type", "long").field("omit_norms", false).endObject()
-                .startObject("short_field").field("type", "short").field("omit_norms", false).endObject()
+                .startObject("int_field").field("type", "integer").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("byte_field").field("type", "byte").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("date_field").field("type", "date").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("double_field").field("type", "double").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("float_field").field("type", "float").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("long_field").field("type", "long").startObject("norms").field("enabled", true).endObject().endObject()
+                .startObject("short_field").field("type", "short").startObject("norms").field("enabled", true).endObject().endObject()
                 .string();
 
         DocumentMapper docMapper = MapperTestUtils.newParser().parse(mapping);

--- a/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -120,7 +120,7 @@ public class SimpleStringMappingTests extends ElasticsearchTestCase {
         // now test it explicitly set
 
         mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "string").field("index", "not_analyzed").field("omit_norms", false).field("index_options", "freqs").endObject().endObject()
+                .startObject("properties").startObject("field").field("type", "string").field("index", "not_analyzed").startObject("norms").field("enabled", true).endObject().field("index_options", "freqs").endObject().endObject()
                 .endObject().endObject().string();
 
         defaultMapper = MapperTestUtils.newParser().parse(mapping);
@@ -137,6 +137,22 @@ public class SimpleStringMappingTests extends ElasticsearchTestCase {
         assertThat(doc.rootDoc().getField("field").fieldType().storeTermVectorOffsets(), equalTo(false));
         assertThat(doc.rootDoc().getField("field").fieldType().storeTermVectorPositions(), equalTo(false));
         assertThat(doc.rootDoc().getField("field").fieldType().storeTermVectorPayloads(), equalTo(false));
+
+        // also test the deprecated omit_norms
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "string").field("index", "not_analyzed").field("omit_norms", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        defaultMapper = MapperTestUtils.newParser().parse(mapping);
+
+        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "1234")
+                .endObject()
+                .bytes());
+
+        assertThat(doc.rootDoc().getField("field").fieldType().omitNorms(), equalTo(false));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerTests.java
@@ -21,21 +21,32 @@ package org.elasticsearch.indices.warmer;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableList;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.segments.IndexSegments;
+import org.elasticsearch.action.admin.indices.segments.IndexShardSegments;
+import org.elasticsearch.action.admin.indices.segments.IndicesSegmentResponse;
+import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse;
 import org.elasticsearch.action.admin.indices.warmer.get.GetWarmersResponse;
 import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerResponse;
+import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.engine.Segment;
+import org.elasticsearch.index.mapper.FieldMapper.Loading;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.warmer.IndexWarmerMissingException;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.*;
 
 /**
  */
@@ -224,4 +235,89 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
         IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats("test").clear().setWarmer(true).execute().actionGet();
         return indicesStatsResponse.getIndex("test").getPrimaries().warmer.total();
     }
+
+    private long getSegmentsMemoryUsage(String idx) {
+        IndicesSegmentResponse response = client().admin().indices().segments(Requests.indicesSegmentsRequest("idx")).actionGet();
+        IndexSegments indicesSegments = response.getIndices().get(idx);
+        long total = 0;
+        for (IndexShardSegments indexShardSegments : indicesSegments) {
+            for (ShardSegments shardSegments : indexShardSegments) {
+                for (Segment segment : shardSegments) {
+                    System.out.println("+=" + segment.memoryInBytes + " " + indexShardSegments.getShardId() + " " + shardSegments.getIndex());
+                    total += segment.memoryInBytes;
+                }
+            }
+        }
+        return total;
+    }
+
+    private enum LoadingMethod {
+        LAZY {
+            @Override
+            void createIndex(String indexName, String type, String fieldName) {
+                client().admin().indices().prepareCreate(indexName).setSettings(ImmutableSettings.builder().put(SINGLE_SHARD_NO_REPLICA).put(SearchService.NORMS_LOADING_KEY, Loading.LAZY_VALUE)).execute().actionGet();
+            }
+        },
+        EAGER {
+            @Override
+            void createIndex(String indexName, String type, String fieldName) {
+                client().admin().indices().prepareCreate(indexName).setSettings(ImmutableSettings.builder().put(SINGLE_SHARD_NO_REPLICA).put(SearchService.NORMS_LOADING_KEY, Loading.EAGER_VALUE)).execute().actionGet();
+            }
+            @Override
+            boolean isLazy() {
+                return false;
+            }
+        },
+        EAGER_PER_FIELD {
+            @Override
+            void createIndex(String indexName, String type, String fieldName) throws Exception {
+                client().admin().indices().prepareCreate(indexName).setSettings(ImmutableSettings.builder().put(SINGLE_SHARD_NO_REPLICA).put(SearchService.NORMS_LOADING_KEY, Loading.LAZY_VALUE)).addMapping(type, JsonXContent.contentBuilder()
+                        .startObject(type)
+                            .startObject("properties")
+                                .startObject(fieldName)
+                                    .field("type", "string")
+                                    .startObject("norms")
+                                        .field("loading", Loading.EAGER_VALUE)
+                                    .endObject()
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                        ).execute().actionGet();
+            }
+            @Override
+            boolean isLazy() {
+                return false;
+            }
+        };
+        private static Settings SINGLE_SHARD_NO_REPLICA = ImmutableSettings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build();
+        abstract void createIndex(String indexName, String type, String fieldName) throws Exception;
+        boolean isLazy() {
+            return true;
+        }
+    }
+
+    static {
+        assert Version.CURRENT.luceneVersion == org.apache.lucene.util.Version.LUCENE_46 :
+                "remove me when LUCENE-5373 is fixed";
+    }
+
+    @Ignore("enable me when LUCENE-5373 is fixed, see assertion above")
+    public void testEagerLoading() throws Exception {
+        for (LoadingMethod method : LoadingMethod.values()) {
+            System.out.println("METHOD " + method);
+            method.createIndex("idx", "t", "foo");
+            client().prepareIndex("idx", "t", "1").setSource("foo", "bar").setRefresh(true).execute().actionGet();
+            long memoryUsage0 = getSegmentsMemoryUsage("idx");
+            // queries load norms if they were not loaded before
+            client().prepareSearch("idx").setQuery(QueryBuilders.matchQuery("foo", "bar")).execute().actionGet();
+            long memoryUsage1 = getSegmentsMemoryUsage("idx");
+            if (method.isLazy()) {
+                assertThat(memoryUsage1, greaterThan(memoryUsage0));
+            } else {
+                assertThat(memoryUsage1, equalTo(memoryUsage0));
+            }
+            wipeIndices("idx");
+        }
+    }
+
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -49,10 +49,12 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FieldMapper.Loading;
 import org.elasticsearch.index.merge.policy.*;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -266,7 +268,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             .setTemplate("*")
             .setOrder(0)
             .setSettings(setRandomMergePolicy(getRandom(), ImmutableSettings.builder()
-                    .put(INDEX_SEED_SETTING, getRandom().nextLong())))
+                    .put(INDEX_SEED_SETTING, randomLong()))
+                    .put(SearchService.NORMS_LOADING_KEY, randomFrom(Arrays.asList(Loading.EAGER, Loading.LAZY))))
                     .execute().actionGet();
         }
     }


### PR DESCRIPTION
Norms can be eagerly loaded on a per-field basis by setting `norms.loading` to
`eager` instead of the default `lazy`, very similarly to fielddata:

```
"my_string_field" : {
  "type": "string",
  "norms": {
    "enabled": true
    "loading": "eager"
  }
}
```

In case this behavior should be applied to all fields, it is possible to change
the default value by setting `index.norms.loading` to `eager`.

There is no such option for terms as #4079 suggested because all terms
implementations in Lucene load the terms dictionary eagerly.

Close #4079
