### PR TITLE
Use `recycler` prefix for CacheRecycler settings

### DIFF
--- a/src/main/java/org/elasticsearch/cache/recycler/CacheRecycler.java
+++ b/src/main/java/org/elasticsearch/cache/recycler/CacheRecycler.java
@@ -24,12 +24,20 @@ import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.recycler.*;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.Locale;
 
 @SuppressWarnings("unchecked")
 public class CacheRecycler extends AbstractComponent {
+    private static final String SETTINGS_PREFIX = ImmutableSettings.getSettingPrefix(CacheRecycler.class);
+    private static final String TYPE = "type";
+    private static final String LIMIT = "limit";
+    private static final String SMART_SIZE = "smart_size";
+    public static final String TYPE_SETTINGS = SETTINGS_PREFIX + TYPE;
+    public static final String LIMIT_SETTINGS = SETTINGS_PREFIX + LIMIT;
+    public static final String SMART_SIZE_SETTINGS = SETTINGS_PREFIX + SMART_SIZE;
 
     public final Recycler<ObjectObjectOpenHashMap> hashMap;
     public final Recycler<ObjectOpenHashSet> hashSet;
@@ -62,9 +70,10 @@ public class CacheRecycler extends AbstractComponent {
     @Inject
     public CacheRecycler(Settings settings) {
         super(settings);
-        String type = settings.get("type", Type.SOFT_THREAD_LOCAL.name());
-        int limit = settings.getAsInt("limit", 10);
-        int smartSize = settings.getAsInt("smart_size", 1024);
+        Settings componentSettings = settings.getComponentSettings(CacheRecycler.class);
+        String type = componentSettings.get(TYPE, Type.SOFT_THREAD_LOCAL.name());
+        int limit = componentSettings.getAsInt(LIMIT, 10);
+        int smartSize = componentSettings.getAsInt(SMART_SIZE, 1024);
 
         hashMap = build(type, limit, smartSize, new Recycler.C<ObjectObjectOpenHashMap>() {
             @Override

--- a/src/main/java/org/elasticsearch/cache/recycler/CacheRecycler.java
+++ b/src/main/java/org/elasticsearch/cache/recycler/CacheRecycler.java
@@ -70,7 +70,6 @@ public class CacheRecycler extends AbstractComponent {
     @Inject
     public CacheRecycler(Settings settings) {
         super(settings);
-        Settings componentSettings = settings.getComponentSettings(CacheRecycler.class);
         String type = componentSettings.get(TYPE, Type.SOFT_THREAD_LOCAL.name());
         int limit = componentSettings.getAsInt(LIMIT, 10);
         int smartSize = componentSettings.getAsInt(SMART_SIZE, 1024);

--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -83,22 +83,28 @@ public class ImmutableSettings implements Settings {
 
     @Override
     public Settings getComponentSettings(Class component) {
-        if (component.getName().startsWith("org.elasticsearch")) {
-            return getComponentSettings("org.elasticsearch", component);
-        }
-        // not starting with org.elasticsearch, just remove the first package part (probably org/net/com)
-        return getComponentSettings(component.getName().substring(0, component.getName().indexOf('.')), component);
+        return getByPrefix(getSettingPrefix(component));
     }
 
     @Override
     public Settings getComponentSettings(String prefix, Class component) {
+        return getByPrefix(getSettingPrefix(prefix, component));
+    }
+    public static String getSettingPrefix(Class component) {
+        if (component.getName().startsWith("org.elasticsearch")) {
+            return getSettingPrefix("org.elasticsearch", component);
+        }
+        // not starting with org.elasticsearch, just remove the first package part (probably org/net/com)
+        return getSettingPrefix(component.getName().substring(0, component.getName().indexOf('.')), component);
+    }
+
+    public static String getSettingPrefix(String prefix, Class component) {
         String type = component.getName();
         if (!type.startsWith(prefix)) {
             throw new SettingsException("Component [" + type + "] does not start with prefix [" + prefix + "]");
         }
         String settingPrefix = type.substring(prefix.length() + 1); // 1 for the '.'
-        settingPrefix = settingPrefix.substring(0, settingPrefix.length() - component.getSimpleName().length()); // remove the simple class name (keep the dot)
-        return getByPrefix(settingPrefix);
+        return settingPrefix.substring(0, settingPrefix.length() - component.getSimpleName().length()); // remove the simple class name (keep the dot)
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -215,7 +215,15 @@ public final class TestCluster implements Iterable<Client> {
         } else {
             builder.put(Transport.TransportSettings.TRANSPORT_TCP_COMPRESS, rarely(random));
         }
-        builder.put("type", RandomPicks.randomFrom(random, CacheRecycler.Type.values()));
+        if (random.nextBoolean()) {
+            builder.put(CacheRecycler.TYPE_SETTINGS, RandomPicks.randomFrom(random, CacheRecycler.Type.values()));
+            builder.put(CacheRecycler.LIMIT_SETTINGS, 1 + random.nextInt(25));
+            if (random.nextBoolean()) {
+                builder.put(CacheRecycler.SMART_SIZE_SETTINGS, random.nextInt(2048));
+            } else {
+                builder.put(CacheRecycler.SMART_SIZE_SETTINGS, 0);
+            }
+        }
         return builder.build();
     }
 


### PR DESCRIPTION
Currently the cache recycler uses top level settings for it's
configuration. We should prefix them with a `recycler` to make sure
we don't have any confilicts.
