### PR TITLE
Expose `simple_query_string` flags in `flags` parameter

### DIFF
--- a/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
@@ -36,6 +36,9 @@ with default operator of `AND`, the same query is translated to
 
 |`analyzer` |The analyzer used to analyze each term of the query when
 creating composite queries.
+
+|`flags` |Flags specifying which features of the `simple_query_string` to
+enable. Defaults to `ALL`.
 |=======================================================================
 
 [float]
@@ -76,3 +79,22 @@ introduced fields included). For example:
     }
 }
 --------------------------------------------------
+
+[float]
+==== Flags
+`simple_query_string` support multiple flags to specify which parsing features
+should be enabled. It is specified as a `|`-delimited string with the
+`flags` parameter:
+
+[source,js]
+--------------------------------------------------
+{
+    "simple_query_string" : {
+        "query" : "foo | bar  & baz*",
+        "flags" : "OR|AND|PREFIX"
+    }
+}
+--------------------------------------------------
+
+The available flags are: `ALL`, `NONE`, `AND`, `OR`, `PREFIX`, `PHRASE`,
+`PRECEDENCE`, `ESCAPE`, and `WHITESPACE`.

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -35,6 +35,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
     private String analyzer;
     private Operator operator;
     private final String queryText;
+    private int flags = -1;
 
     /**
      * Operators for the default_operator
@@ -84,6 +85,22 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
         return this;
     }
 
+    /**
+     * Specify the enabled features of the SimpleQueryString.
+     */
+    public SimpleQueryStringBuilder flags(SimpleQueryStringFlag... flags) {
+        int value = 0;
+        if (flags.length == 0) {
+            value = SimpleQueryStringFlag.ALL.value;
+        } else {
+            for (SimpleQueryStringFlag flag : flags) {
+                value |= flag.value;
+            }
+        }
+        this.flags = value;
+        return this;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(SimpleQueryStringParser.NAME);
@@ -102,6 +119,10 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
                 }
             }
             builder.endArray();
+        }
+
+        if (flags != -1) {
+            builder.field("flags", flags);
         }
 
         if (analyzer != null) {

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringFlag.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringFlag.java
@@ -1,0 +1,58 @@
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.queryparser.XSimpleQueryParser;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.common.Strings;
+
+import java.util.Locale;
+
+/**
+ * Flags for the XSimpleQueryString parser
+ */
+public enum SimpleQueryStringFlag {
+    ALL(-1),
+    NONE(0),
+    AND(XSimpleQueryParser.AND_OPERATOR),
+    NOT(XSimpleQueryParser.NOT_OPERATOR),
+    OR(XSimpleQueryParser.OR_OPERATOR),
+    PREFIX(XSimpleQueryParser.PREFIX_OPERATOR),
+    PRECEDENCE(XSimpleQueryParser.PRECEDENCE_OPERATORS),
+    ESCAPE(XSimpleQueryParser.ESCAPE_OPERATOR),
+    WHITESPACE(XSimpleQueryParser.WHITESPACE_OPERATOR);
+
+    final int value;
+
+    private SimpleQueryStringFlag(int value) {
+        this.value = value;
+    }
+
+    public int value() {
+        return value;
+    }
+
+    static int resolveFlags(String flags) {
+        if (!Strings.hasLength(flags)) {
+            return ALL.value();
+        }
+        int magic = NONE.value();
+        for (String s : Strings.delimitedListToStringArray(flags, "|")) {
+            if (s.isEmpty()) {
+                continue;
+            }
+            try {
+                SimpleQueryStringFlag flag = SimpleQueryStringFlag.valueOf(s.toUpperCase(Locale.ROOT));
+                switch (flag) {
+                    case NONE:
+                        return 0;
+                    case ALL:
+                        return -1;
+                    default:
+                        magic |= flag.value();
+                }
+            } catch (IllegalArgumentException iae) {
+                throw new ElasticSearchIllegalArgumentException("Unknown " + SimpleQueryStringParser.NAME + " flag [" + s + "]");
+            }
+        }
+        return magic;
+    }
+}


### PR DESCRIPTION
This exposes the built-in flags for XSimpleQueryParser as part of the query DSL.

Fixes #4490
