### PR TITLE
Allow 'omit_norms'  on the '_all' field

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -261,7 +261,8 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
 
         if (!includeDefaults && enabled == Defaults.ENABLED && fieldType.stored() == Defaults.FIELD_TYPE.stored() &&
                 fieldType.storeTermVectors() == Defaults.FIELD_TYPE.storeTermVectors() &&
-                indexAnalyzer == null && searchAnalyzer == null && customFieldDataSettings == null) {
+                indexAnalyzer == null && searchAnalyzer == null && customFieldDataSettings == null
+                && fieldType.omitNorms() == Defaults.FIELD_TYPE.omitNorms()) {
             return builder;
         }
         builder.startObject(CONTENT_TYPE);
@@ -285,6 +286,9 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
         }
         if (includeDefaults || fieldType.storeTermVectorPayloads() != Defaults.FIELD_TYPE.storeTermVectorPayloads()) {
             builder.field("store_term_vector_payloads", fieldType.storeTermVectorPayloads());
+        }
+        if (includeDefaults || fieldType.omitNorms() != Defaults.FIELD_TYPE.omitNorms()) {
+            builder.field("omit_norms", fieldType.omitNorms());
         }
 
 

--- a/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -56,6 +56,7 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
         assertThat(allEntries.fields().contains("name.last"), equalTo(true));
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
         FieldMapper mapper = docMapper.mappers().smartNameFieldMapper("_all");
+        assertThat(field.fieldType().omitNorms(), equalTo(true));
         assertThat(mapper.queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(AllTermQuery.class));
     }
 
@@ -72,6 +73,7 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
         assertThat(allEntries.fields().contains("name.last"), equalTo(true));
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
         FieldMapper mapper = docMapper.mappers().smartNameFieldMapper("_all");
+        assertThat(field.fieldType().omitNorms(), equalTo(false));
         assertThat(mapper.queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(TermQuery.class));
     }
 
@@ -88,6 +90,7 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
         assertThat(allEntries.fields().contains("name.last"), equalTo(true));
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
         FieldMapper mapper = docMapper.mappers().smartNameFieldMapper("_all");
+        assertThat(field.fieldType().omitNorms(), equalTo(false));
         assertThat(mapper.queryStringTermQuery(new Term("_all", "foobar")), Matchers.instanceOf(TermQuery.class));
 
     }
@@ -109,6 +112,7 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
         assertThat(allEntries.fields().contains("address.last.location"), equalTo(true));
         assertThat(allEntries.fields().contains("name.last"), equalTo(true));
         assertThat(allEntries.fields().contains("simple1"), equalTo(true));
+        assertThat(field.fieldType().omitNorms(), equalTo(false));
     }
 
     @Test
@@ -125,6 +129,7 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
 
         String text = field.stringValue();
         assertThat(text, equalTo(allEntries.buildText()));
+        assertThat(field.fieldType().omitNorms(), equalTo(false));
     }
 
     @Test
@@ -145,5 +150,6 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
 
         String text = field.stringValue();
         assertThat(text, equalTo(allEntries.buildText()));
+        assertThat(field.fieldType().omitNorms(), equalTo(false));
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/all/mapping.json
+++ b/src/test/java/org/elasticsearch/index/mapper/all/mapping.json
@@ -1,7 +1,8 @@
 {
     "person":{
         "_all":{
-            "enabled":true
+            "enabled":true,
+            "omit_norms":true
         },
         "properties":{
             "name":{

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -58,6 +58,37 @@ import static org.hamcrest.Matchers.*;
 
 public class SimpleQueryTests extends ElasticsearchIntegrationTest {
 
+    @Test
+    public void testOmitNormsOnAll() throws ExecutionException, InterruptedException, IOException {
+        assertAcked(client().admin().indices().prepareCreate("test")
+                .addMapping("type1", jsonBuilder().startObject().startObject("type1")
+                        .startObject("_all").field("omit_norms", true).endObject()
+                        .endObject().endObject()));
+        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox jumps"),
+                client().prepareIndex("test", "type1", "2").setSource("field1", "quick brown"),
+                client().prepareIndex("test", "type1", "3").setSource("field1", "quick"));
+
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("_all", "quick")).get(), 3l);
+        SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("_all", "quick")).get();
+        SearchHit[] hits = searchResponse.getHits().hits();
+        assertThat(hits.length, equalTo(3));
+        assertThat(hits[0].score(), allOf(equalTo(hits[1].getScore()), equalTo(hits[2].getScore())));
+        wipeIndices("test");
+
+        assertAcked(client().admin().indices().prepareCreate("test"));
+        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox jumps"),
+                client().prepareIndex("test", "type1", "2").setSource("field1", "quick brown"),
+                client().prepareIndex("test", "type1", "3").setSource("field1", "quick"));
+
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("_all", "quick")).get(), 3l);
+        searchResponse = client().prepareSearch().setQuery(matchQuery("_all", "quick")).get();
+        hits = searchResponse.getHits().hits();
+        assertThat(hits.length, equalTo(3));
+        assertThat(hits[0].score(), allOf(greaterThan(hits[1].getScore()), greaterThan(hits[2].getScore())));
+
+    }
+
+
     @Test // see https://github.com/elasticsearch/elasticsearch/issues/3177
     public void testIssue3177() {
         assertAcked(prepareCreate("test").setSettings(settingsBuilder().put(SETTING_NUMBER_OF_SHARDS, 1)));


### PR DESCRIPTION
The '_all' field doesn't allow to omit norms. In certain scenarios
omitting the norm values makes a lot of sense to get senseable scoring.

Closes #3734
