### PR TITLE
A new generic timeout handler and changes to existing search classes to use it

### DIFF
--- a/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -74,6 +74,39 @@ public final class ExceptionsHelper {
         }
         return result;
     }
+    
+  
+    
+    /**
+     * Determines if a given exception has a particular type of exception
+     * as a cause.
+     * @param e The exception received
+     * @param exType The type of exception that is being looked for as a cause
+     * @return true if the exception or any of the nested exceptions revealed by 
+     * getCause() are of the given exType.
+     */
+    public static boolean wasCausedBy(Throwable e, Class<? extends Throwable> exType) {
+        if (exType == null) {
+            return false;
+        }
+        if (exType.isInstance(e)) {
+            return true;
+        }
+        Throwable cause = e.getCause();
+        if (cause == e) {
+            return false;
+        }
+        while (cause != null) {
+            if (exType.isInstance(cause)) {
+                return true;
+            }
+            if (cause.getCause() == cause) {
+                break;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }    
 
     public static String detailedMessage(Throwable t) {
         return detailedMessage(t, false, 0);
@@ -184,4 +217,31 @@ public final class ExceptionsHelper {
                         )
                     );
     }
+
+    /**
+     * Extracts ElasticsearchException causes from non-serializable exceptions e.g.
+     * those produced by script.
+     * @param e The exception received
+     * @return null or the top-most exception revealed by 
+     * getCause() which is of the type ElasticsearchException
+     */
+    public static ElasticsearchException extractElasticsearchCause(Throwable e) {
+        if (e instanceof ElasticsearchException) {
+            return (ElasticsearchException) e;
+        }
+        Throwable cause = e.getCause();
+        if (cause == e) {
+            return null;
+        }
+        while (cause != null) {
+            if (cause instanceof ElasticsearchException) {
+                return (ElasticsearchException) cause;
+            }
+            if (cause.getCause() == cause) {
+                break;
+            }
+            cause = cause.getCause();
+        }
+        return null;
+    }    
 }

--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -154,6 +154,7 @@ public class IndexMetaData {
 
     public static final String SETTING_NUMBER_OF_SHARDS = "index.number_of_shards";
     public static final String SETTING_NUMBER_OF_REPLICAS = "index.number_of_replicas";
+    public static final String SETTING_THOROUGH_TIMEOUT_CHECKS = "index.thorough_timeout_checks";
     public static final String SETTING_AUTO_EXPAND_REPLICAS = "index.auto_expand_replicas";
     public static final String SETTING_READ_ONLY = "index.blocks.read_only";
     public static final String SETTING_BLOCKS_READ = "index.blocks.read";

--- a/src/main/java/org/elasticsearch/common/util/concurrent/ActivityTimeMonitor.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/ActivityTimeMonitor.java
@@ -44,6 +44,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  */
 public class ActivityTimeMonitor implements Delayed {
 
+    public static final String TIMEOUT_MONITOR_THREADNAME = "ActivityTimeoutMonitor";
+    
     public enum ActivityStatus {
         INACTIVE, ACTIVE, OVERRUNNING
     }
@@ -149,7 +151,6 @@ public class ActivityTimeMonitor implements Delayed {
 
     static {
         timeoutMonitorThread = new TimeoutMonitorThread();
-        timeoutMonitorThread.setDaemon(true);
         timeoutMonitorThread.start();
     }
 
@@ -229,6 +230,11 @@ public class ActivityTimeMonitor implements Delayed {
     private static final class TimeoutMonitorThread extends Thread {
         // A queue of Thread statuses sorted by their scheduled timeout time.
         DelayQueue<ActivityTimeMonitor> inboundMessageQueue = new DelayQueue<ActivityTimeMonitor>();
+        
+        TimeoutMonitorThread(){
+            super(TIMEOUT_MONITOR_THREADNAME);
+            setDaemon(true);
+        }
 
         @Override
         public void run() {
@@ -238,7 +244,7 @@ public class ActivityTimeMonitor implements Delayed {
                     // timeout then set the volatile boolean indicating an error
                     inboundMessageQueue.take().moveToOverrun();
                 } catch (InterruptedException e1) {
-                    // Need to keep on trucking
+                    // Need to keep on trucking 
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/common/util/concurrent/ActivityTimeMonitor.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/ActivityTimeMonitor.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * Utility class which efficiently monitors time-limited activities. When
+ * start() is called on an ActivityTimeMonitor with a maximum length of time,
+ * the status will automatically be updated to OVERRUNNING after the allotted
+ * time has expired. If a call is made to checkForTimeout() when the status is
+ * OVERRUNING this object will throw a {@link ActivityTimedOutException} Calling
+ * stop() will reset the monitor status to inactive. It is only permitted
+ * to call start() when inactive so in order to establish a new deadline for an active
+ * activity you will need to call stop() first then cal start() with the new deadline. 
+ * When start() is called the ActivityTimeMonitor is bound to the current thread via
+ * a ThreadLocal and calling getCurrentThreadMonitor() will return the instance
+ * associated with the current thread.
+ * 
+ * A background thread is used to handle all instances and set the OVERRUNING status
+ * at the appropriate points
+ */
+public class ActivityTimeMonitor implements Delayed {
+
+    public enum ActivityStatus {
+        INACTIVE, ACTIVE, OVERRUNNING
+    }
+    private final AtomicReferenceFieldUpdater<ActivityTimeMonitor, ActivityStatus>  STATUS_UPDATER = AtomicReferenceFieldUpdater.newUpdater(ActivityTimeMonitor.class, ActivityStatus.class, "status");
+    private volatile ActivityStatus status = ActivityStatus.INACTIVE;
+    private long scheduledTimeoutInMilliseconds = Long.MIN_VALUE;
+    private final Thread associatedThread;
+
+    private ActivityTimeMonitor() {
+        associatedThread = Thread.currentThread();
+    }
+
+    public boolean moveToInactive() {
+        do {
+            ActivityStatus s = status;
+            switch (s) {
+                case INACTIVE:
+                    return false;
+                case OVERRUNNING:
+                case ACTIVE:
+                    if (STATUS_UPDATER.compareAndSet(this, s, ActivityStatus.INACTIVE)) {
+                        return true;
+                    }
+                default:
+                    assert false;
+            }
+        } while (true);
+    }
+
+    public void moveToActive() {
+        do {
+            ActivityStatus s = status;
+            switch (s) {
+                case ACTIVE:
+                    throw new ElasticsearchIllegalArgumentException("Can't move to active - already active");
+                case OVERRUNNING:
+                    assert false;
+                case INACTIVE:
+                    if (STATUS_UPDATER.compareAndSet(this, s, ActivityStatus.ACTIVE)) {
+                        return;
+                    }
+                default:
+                    assert false;
+            }
+        } while (true);
+    }
+
+    public void moveToOverrun() {
+        do {
+        ActivityStatus s = status;
+            switch (s) {
+                case OVERRUNNING:
+                    assert false;
+                case INACTIVE:
+                    return;
+                case ACTIVE:
+                    if (STATUS_UPDATER.compareAndSet(this, s, ActivityStatus.OVERRUNNING)) {
+                        return;
+                    }
+                default:
+                    assert false;
+            }
+        } while (true);
+    }
+
+    public ActivityStatus getStatus() {
+        return status;
+    }
+
+    public void start(long maxTime) {
+        assert status == ActivityStatus.INACTIVE;
+        this.scheduledTimeoutInMilliseconds = System.currentTimeMillis() + maxTime;
+        moveToActive();
+        timeoutMonitorThread.add(this);
+        timeoutStateTL.set(this);
+    }
+
+    public void stop() {
+        if (moveToInactive()) {
+            // need to remove the old timeout status from the monitor thread -
+            // this will also set status to INACTIVE
+            timeoutMonitorThread.remove(this);
+        }
+    }
+
+    public void checkForTimeout() {
+        assert assertThread();
+        if (status == ActivityStatus.OVERRUNNING) {
+            throw new ActivityTimedOutException("Timed out thread " + Thread.currentThread().getName(), getDelay(TimeUnit.MILLISECONDS));
+        }
+
+    }
+
+    private boolean assertThread() {
+        assert associatedThread == Thread.currentThread() : "ActivityTimeMonitor is not threadsafe - can't be shared across threads";
+        return true;
+    }
+
+    // an internal thread that monitors timeout activity
+    private static final TimeoutMonitorThread timeoutMonitorThread;
+    // Thread-Local holding the current timeout state associated with threads 
+    private static final ThreadLocal<ActivityTimeMonitor> timeoutStateTL = new ThreadLocal<ActivityTimeMonitor>();
+
+    static {
+        timeoutMonitorThread = new TimeoutMonitorThread();
+        timeoutMonitorThread.setDaemon(true);
+        timeoutMonitorThread.start();
+    }
+
+    /**
+     * 
+     * @return the number of timed activities currently being monitored
+     */
+    public static int getCurrentNumActivities() {
+        return timeoutMonitorThread.inboundMessageQueue.size();
+    }
+
+    /**
+     * Get the timeout status information for the current thread
+     * 
+     * @return null or the current ActivityTimeMonitor for the current thread
+     */
+    public static ActivityTimeMonitor getCurrentThreadMonitor() {
+        return timeoutStateTL.get();
+    }
+    
+    /**
+     * Get the timeout status information for the current thread or create if it does not exist
+     * 
+     * @return the current thread's ActivityTimeMonitor
+     */
+    public static ActivityTimeMonitor getOrCreateCurrentThreadMonitor() {
+
+        ActivityTimeMonitor result = timeoutStateTL.get();
+        if(result==null){
+            result=new ActivityTimeMonitor();
+            timeoutStateTL.set(result);
+        }
+        assert result.assertThread();
+        return result;
+    }    
+
+    @Override
+    public int compareTo(Delayed o) {
+        ActivityTimeMonitor other = (ActivityTimeMonitor) o;
+        return (int) (scheduledTimeoutInMilliseconds - other.scheduledTimeoutInMilliseconds);
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        long now = System.currentTimeMillis();
+        return unit.convert(scheduledTimeoutInMilliseconds - now, TimeUnit.MILLISECONDS);
+    }
+    
+    /**
+     * Helper method to start a new activity
+     * @param maxTimeInMilliseconds the maximum length of time allowed for an activity
+     * @return the existing monitor for the current thread or, a new one if none existed before
+     */
+    public static ActivityTimeMonitor startActivity(long maxTimeInMilliseconds) {
+        ActivityTimeMonitor result = getCurrentThreadMonitor();
+        if (result == null) {
+            result = new ActivityTimeMonitor();
+        }
+        result.start(maxTimeInMilliseconds);
+        return result;
+    }
+
+    /**
+     * Helper method called to mark the stopping of a timed activity associated with the current thread
+     */
+    public static ActivityTimeMonitor stopActivity() {
+        ActivityTimeMonitor result = getCurrentThreadMonitor();
+        if (result != null) {
+            result.stop();
+        }
+        return result;
+    }
+    
+
+    // A background thread used to set the timed-out status for threads when
+    // they occur
+    private static final class TimeoutMonitorThread extends Thread {
+        // A queue of Thread statuses sorted by their scheduled timeout time.
+        DelayQueue<ActivityTimeMonitor> inboundMessageQueue = new DelayQueue<ActivityTimeMonitor>();
+
+        @Override
+        public void run() {
+            while (true) {
+                try {
+                    // Block until the first ActivityTimeMonitor has reached its
+                    // timeout then set the volatile boolean indicating an error
+                    inboundMessageQueue.take().moveToOverrun();
+                } catch (InterruptedException e1) {
+                    // Need to keep on trucking
+                }
+            }
+        }
+
+        void remove(ActivityTimeMonitor state) {
+            assert state.getStatus() == ActivityStatus.INACTIVE;
+            inboundMessageQueue.remove(state);
+        }
+
+        void add(ActivityTimeMonitor state) {
+            assert state.getStatus() == ActivityStatus.ACTIVE;
+            if (state.scheduledTimeoutInMilliseconds <= System.currentTimeMillis()) {
+                state.moveToOverrun();
+            } else {
+                inboundMessageQueue.add(state);
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/org/elasticsearch/common/util/concurrent/ActivityTimedOutException.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/ActivityTimedOutException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.ElasticsearchException;
+
+public class ActivityTimedOutException extends ElasticsearchException
+{
+
+        private long overrunMilliseconds;
+
+        public ActivityTimedOutException(String msg, long overrun)
+        {
+                super(msg);
+                this.overrunMilliseconds=overrun;
+        }
+
+        public long getOverrunMilliseconds()
+        {
+                return overrunMilliseconds;
+        }
+
+}

--- a/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -241,7 +241,10 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
                 if (logger.isTraceEnabled()) {
                     logger.trace("exception running Groovy script", e);
                 }
-                throw new GroovyScriptExecutionException(ExceptionsHelper.detailedMessage(e));
+                // Cause needs to be discovered by peeling away layers of non-serializable classes introduced by 
+                // dynamic Groovy classes - was getting an "unrecognised class" error on the reducer node when deserializing
+                // unknown "cause" exceptions.
+                throw new GroovyScriptExecutionException(ExceptionsHelper.detailedMessage(e), ExceptionsHelper.extractElasticsearchCause(e));
             }
         }
 

--- a/src/test/java/org/elasticsearch/common/util/concurrent/ActivityTimeMonitorTest.java
+++ b/src/test/java/org/elasticsearch/common/util/concurrent/ActivityTimeMonitorTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+/**
+ * Tests that multi-threaded activities with various timeout settings can 
+ * run simultaneously and still trigger timely and appropriate timeout errors.
+ */
+public class ActivityTimeMonitorTest extends ElasticsearchTestCase{
+    
+    public static final int MAXIMUM_TIMING_DISCREPANCY_MS = 50;
+    
+    
+    @Test
+    public void testSingleTimeout() throws InterruptedException {
+        checkTimeoutsFireCorrectly(new TimedActivity(500, 100, 6));
+    }
+    
+    @Test
+    public void testSingleNoTimeout() throws InterruptedException {
+
+        checkTimeoutsFireCorrectly(new TimedActivity(500, 10, 5));
+    }
+    
+    @Test
+    public void testOneLongNoTimeoutOneShortTimeout() throws InterruptedException {
+
+        TimedActivity goodLong = new TimedActivity(500, 10, 5);
+        TimedActivity shortBad = new TimedActivity(100, 50, 5);
+        checkTimeoutsFireCorrectly(goodLong,shortBad);
+    }
+    @Test
+    public void testOneLongNoTimeoutManyShortTimeout() throws InterruptedException {
+
+        ArrayList<TimedActivity> activities = new ArrayList<TimedActivity>();
+        TimedActivity goodLong = new TimedActivity(500, 10, 5);
+        int numShorts = 10;
+        activities.add(goodLong);
+        for (int i = 0; i < numShorts; i++) {
+            activities.add(new TimedActivity(100, 50, 5));
+        }
+        checkTimeoutsFireCorrectly((TimedActivity[]) activities.toArray(new TimedActivity[activities.size()]));
+    }
+    @Test
+    public void testOneLongTimeoutManyShortNoTimeout() throws InterruptedException {
+        ArrayList<TimedActivity> activities = new ArrayList<TimedActivity>();
+        TimedActivity goodLong = new TimedActivity(500, 5, 120);
+        int numShorts = 10;
+        activities.add(goodLong);
+        for (int i = 0; i < numShorts; i++) {
+            activities.add(new TimedActivity(100, 5, 5));
+        }
+        checkTimeoutsFireCorrectly((TimedActivity[]) activities.toArray(new TimedActivity[activities.size()]));
+    }
+    
+
+    @Test 
+    public void testTimerReset() throws InterruptedException {
+        ActivityTimeMonitor atm = ActivityTimeMonitor.getOrCreateCurrentThreadMonitor();
+        atm.start(500);
+        Thread.sleep(100);
+        atm.checkForTimeout();
+        atm.stop();
+        atm.start(1000); // extend the time allotted to this thread
+        Thread.sleep(500);
+        atm.checkForTimeout();
+        atm.stop();
+    }
+    
+    @Test
+    public void testRandomThreads() throws InterruptedException {
+        // Tests for a mix of threads - some of which are expected to timeout
+        // while others not
+        int numThreads = 100;
+        int maxTimeToTake = 2000;
+        int maxNumChecks = 50;
+        int minTimeBetweenChecks = 5;
+        int maxTimeBetweenChecks = 50;
+
+        ArrayList<TimedActivity> activities = new ArrayList<TimedActivity>(numThreads);
+        for (int i = 0; i < numThreads; i++) {
+            int maxTime = (int) (Math.random() * maxTimeToTake);
+            int numChecks = 1 + (int) (Math.random() * maxNumChecks);
+            int timeBetweenChecks = minTimeBetweenChecks + (int) (Math.random() * maxTimeBetweenChecks);
+            activities.add(new TimedActivity(maxTime, timeBetweenChecks, numChecks));
+        }
+        checkTimeoutsFireCorrectly((TimedActivity[]) activities.toArray(new TimedActivity[activities.size()]));
+        int numTimeouts = 0;
+        for (TimedActivity timedActivity : activities) {
+            if (timedActivity.didTimeout) {
+                numTimeouts++;
+            }
+        }
+        assertTrue("Invalid test parameters - failed to produce a timeout condition", numTimeouts > 0);
+        assertEquals("All activities should be completed", 0, ActivityTimeMonitor.getCurrentNumActivities());
+    }    
+    
+    public void checkTimeoutsFireCorrectly(TimedActivity... activities ) throws InterruptedException{
+        Thread threads[] = new Thread[activities.length];
+        for (int i = 0; i < activities.length; i++) {
+            threads[i] = new Thread(activities[i]);
+        }
+        for (int i = 0; i < threads.length; i++) {
+            threads[i].start();
+        }
+        for (int i = 0; i < threads.length; i++) {
+            threads[i].join();
+        }
+        for (int i = 0; i < activities.length; i++) {
+            activities[i].checkAssertions();
+        }
+    }
+    
+    
+    static class TimedActivity implements Runnable{
+        int maxTimePermitted;
+        int checkForTimeoutEvery;
+        int numberOfChecks;
+        boolean didTimeout = false;
+        private long timeTaken;
+
+        public TimedActivity(int maxTimePermitted, int checkForTimeoutEvery, int numberOfChecks) {
+            super();
+            this.maxTimePermitted = maxTimePermitted;
+            this.checkForTimeoutEvery = checkForTimeoutEvery;
+            this.numberOfChecks = numberOfChecks;
+        }
+
+        @Override
+        public void run() {
+            long start = System.currentTimeMillis();
+            ActivityTimeMonitor.getOrCreateCurrentThreadMonitor().start(maxTimePermitted);
+            try {
+                try {
+                    for (int i = 0; i < numberOfChecks; i++) {
+                        Thread.sleep(checkForTimeoutEvery);
+                        ActivityTimeMonitor.getOrCreateCurrentThreadMonitor().checkForTimeout();
+                    }
+                } catch (ActivityTimedOutException e) {
+                    didTimeout = true;
+                } catch (InterruptedException e) {
+                    throw new RuntimeException();
+                }
+            } finally {
+                ActivityTimeMonitor.getOrCreateCurrentThreadMonitor().stop();
+                timeTaken = System.currentTimeMillis() - start;
+            }
+
+        }
+
+        public void checkAssertions() {
+            boolean timeoutExpected = timeTaken >= maxTimePermitted;
+            long overrun = timeTaken - maxTimePermitted;
+            if ((timeoutExpected) && (!didTimeout)) {
+                if (overrun <= MAXIMUM_TIMING_DISCREPANCY_MS) {
+                    // allow for minor timing discrepancies (<10ms) in heavily
+                    // multi-threaded tests
+                    // where a thread that overruns marginally escapes the
+                    // scheduled overrun
+                    // detection logic.
+                    return;
+                }
+            }
+            assertEquals("Took " + timeTaken + " but timeout set to " + maxTimePermitted, timeoutExpected, didTimeout);
+            boolean wasTooSlowReportingOverrun = overrun > (checkForTimeoutEvery + MAXIMUM_TIMING_DISCREPANCY_MS);
+            assertFalse("Too slow reporting timeout - overrun of " + overrun + " with check every " + checkForTimeoutEvery,
+                    wasTooSlowReportingOverrun);
+
+        }
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -473,7 +473,7 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
                     client().prepareSearch().setQuery(matchQuery("field1", "quick brown").type(MatchQueryBuilder.Type.PHRASE).slop(0)).get();
                     fail("SearchPhaseExecutionException should have been thrown");
                 } catch (SearchPhaseExecutionException e) {
-                    assertTrue(e.getMessage().endsWith("IllegalStateException[field \"field1\" was indexed without position data; cannot run PhraseQuery (term=quick)]; }"));
+                    assertTrue(e.getMessage().contains("IllegalStateException[field \"field1\" was indexed without position data; cannot run PhraseQuery (term=quick)]"));
                 }
                 cluster().wipeIndices("test");
             } catch (MapperParsingException ex) {

--- a/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
+++ b/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
@@ -19,22 +19,40 @@
 
 package org.elasticsearch.search.timeout;
 
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.FilterBuilders.scriptFilter;
-import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
 @ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
 public class SearchTimeoutTests extends ElasticsearchIntegrationTest {
+
+    
+    //Timings in this test rely on having 2 shards
+    @Override
+    protected int minimumNumberOfShards() {
+        return 2;
+    }
+
+    //Timings in this test rely on having 2 shards
+    @Override
+    protected int maximumNumberOfShards() {
+        return 2;
+    }
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
@@ -51,4 +69,91 @@ public class SearchTimeoutTests extends ElasticsearchIntegrationTest {
                 .execute().actionGet();
         assertThat(searchResponse.isTimedOut(), equalTo(true));
     }
+    
+    @Test
+    public void timedFileAccessTests() throws Exception {
+        createIndex("test");
+
+        //Create an index with documents that have test fields that hold delay times required to simulate 
+        // processing the documents' content during a search
+        int []delays={0,0,0,0,0,10,10,10,10,10,100,100,100,100,100,1000,1000};
+        for (int i = 0; i < delays.length; i++) {
+            client().prepareIndex("test", "type", Integer.toString(i))
+                .setSource("delay", delays[i]).execute().actionGet();
+        }
+        client().admin().indices().prepareRefresh().execute().actionGet();
+       
+        //Run a series of searches on docs with different processing delays between doc retrieves 
+        // and expected search timeouts
+        assertThat(runTimeRestrictedSearch(0,10,1000).isTimedOut(),equalTo(false));
+        assertThat(runTimeRestrictedSearch(10,10,1000).isTimedOut(),equalTo(false));
+        assertThat(runTimeRestrictedSearch(100,100,200).isTimedOut(),equalTo(true));
+        
+        //Test partial results
+        //One shard should take <250 ms but the other shard should take >250ms
+        SearchResponse longResponse = runTimeRestrictedSearch(100,100,250);
+        assertThat(longResponse.isTimedOut(),equalTo(true));
+        SearchHits hits = longResponse.getHits();
+        assertTrue("Must have some hits", hits.getTotalHits()>0);
+        for (SearchHit searchHit : hits) {
+            Integer delayField = (Integer) searchHit.getSource().get("delay");
+            
+            assertNotNull(delayField);
+            int delay=delayField.intValue();
+            //Must have only retrieved docs before the search timeout threshold 
+            assertThat(delay, Matchers.lessThan(500));
+        }
+    }    
+    @Test
+    public void timedAggScriptTests() throws Exception {
+        createIndex("test");
+        
+        // Create an index with documents that have test fields that hold delay times required to simulate 
+        // processing the documents' content during a search
+        int []delays={50,50,1000,50,50,2000,10,10};
+        for (int i = 0; i < delays.length; i++) {
+            client().prepareIndex("test", "type", Integer.toString(i))
+                .setSource("delay", delays[i]).execute().actionGet();
+        }
+        client().admin().indices().prepareRefresh().execute().actionGet();
+        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("10m").execute().actionGet();
+        
+        //One shard should run 50+50+10ms delay and another 50+1000+50+10ms
+        SearchResponse oneShardTimedoutResponse = runTimeRestrictedAgg(500, 0, 1000);            
+        assertThat(oneShardTimedoutResponse.isTimedOut(),equalTo(true));
+        Aggregations aggs = oneShardTimedoutResponse.getAggregations();
+        assertNotNull(aggs);
+        //One shard should run 50+50+1000+10 delays and another 50+50 + 2000+10 - both > 500ms timeout
+        SearchResponse bothShardsTimedoutResponse = runTimeRestrictedAgg(500, 0, 2000);            
+        assertThat(bothShardsTimedoutResponse.isTimedOut(),equalTo(true));
+        aggs = bothShardsTimedoutResponse.getAggregations();
+        assertNull(aggs);        
+    }
+
+    private SearchResponse runTimeRestrictedAgg(int overallTimeout, int fromDelay, int toDelay) {
+        SearchResponse searchResponse = client().prepareSearch("test")
+                .setTimeout(overallTimeout+"ms")
+                .setQuery(rangeQuery("delay").from(fromDelay).to(toDelay))
+                //Use _source field in script to force slow evaluations that involve disk access
+                .addAggregation(new TermsBuilder("delayAgg").script("Integer delay=_source.delay;"
+                        + "Thread.sleep(delay);"
+                        //If needed, explicit checking of timeouts rather than relying on implicit checks on file accesses..
+//                        + "org.elasticsearch.common.util.concurrent.ActivityTimeMonitor.getCurrentThreadMonitor().checkForTimeout();"
+                        + "return delay"))
+                .execute().actionGet();
+        return searchResponse;
+    }    
+    
+    private SearchResponse runTimeRestrictedSearch(int fromDelay, int toDelay, int overallTimeout){
+        SearchResponse searchResponse = client().prepareSearch("test")
+                .setTimeout(overallTimeout+"ms")
+               .setQuery(filteredQuery(rangeQuery("delay").from(fromDelay).to(toDelay),
+                        //Use _source field in script to force slow evaluations that involve disk access
+                        scriptFilter("Integer delay=_source.delay;"                              
+                                + "Thread.sleep(delay);"
+                                + "return true;")))
+                .execute().actionGet();    
+        return searchResponse;
+    }
+    
 }

--- a/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
+++ b/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.timeout;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
@@ -32,6 +33,8 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.index.query.FilterBuilders.scriptFilter;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,17 +44,20 @@ import static org.hamcrest.Matchers.equalTo;
 @ElasticsearchIntegrationTest.ClusterScope(scope=ElasticsearchIntegrationTest.Scope.SUITE)
 public class SearchTimeoutTests extends ElasticsearchIntegrationTest {
 
-    
-    //Timings in this test rely on having 2 shards
-    @Override
-    protected int minimumNumberOfShards() {
-        return 2;
-    }
 
-    //Timings in this test rely on having 2 shards
     @Override
-    protected int maximumNumberOfShards() {
-        return 2;
+    public Settings indexSettings() {
+        ImmutableSettings.Builder builder = ImmutableSettings.builder();
+        //Timings in this test rely on having 2 shards
+        builder.put(SETTING_NUMBER_OF_SHARDS, 2).build();
+        builder.put(IndexMetaData.SETTING_THOROUGH_TIMEOUT_CHECKS, true).build();
+        if (randomizeNumberOfShardsAndReplicas()) {            
+            int numberOfReplicas = numberOfReplicas();
+            if (numberOfReplicas >= 0) {
+                builder.put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
+            }
+        }
+        return builder.build();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/ElasticsearchThreadFilter.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchThreadFilter.java
@@ -21,7 +21,7 @@ package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.ThreadFilter;
 import org.elasticsearch.common.network.MulticastChannel;
-import org.elasticsearch.test.hamcrest.RegexMatcher;
+import org.elasticsearch.common.util.concurrent.ActivityTimeMonitor;
 import org.elasticsearch.tribe.TribeTests;
 
 import java.util.regex.Pattern;
@@ -49,7 +49,8 @@ public final class ElasticsearchThreadFilter implements ThreadFilter {
 
         if (threadName.contains("[" + MulticastChannel.SHARED_CHANNEL_NAME + "]")
                 || threadName.contains("[" + ElasticsearchSingleNodeTest.nodeName() + "]")
-                || threadName.contains("Keep-Alive-Timer")) {
+                || threadName.contains("Keep-Alive-Timer")
+                || threadName.contains(ActivityTimeMonitor.TIMEOUT_MONITOR_THREADNAME)) {
             return true;
         }
         return nodePrefix.matcher(t.getName()).find();

--- a/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
@@ -26,16 +26,16 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.network.MulticastChannel;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ActivityTimeMonitor;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.*;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import org.elasticsearch.test.ElasticsearchSingleNodeTest;
-import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.elasticsearch.test.hamcrest.RegexMatcher;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.tribe.TribeTests;
@@ -52,7 +52,6 @@ import java.util.regex.Pattern;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
@@ -114,7 +113,8 @@ public class SimpleThreadPoolTests extends ElasticsearchIntegrationTest {
             // or the ones that are occasionally come up from ElasticsearchSingleNodeTest
             if (threadName.contains("[" + MulticastChannel.SHARED_CHANNEL_NAME + "]")
                     || threadName.contains("[" + ElasticsearchSingleNodeTest.nodeName() + "]")
-                    || threadName.contains("Keep-Alive-Timer")) {
+                    || threadName.contains("Keep-Alive-Timer")
+                    || threadName.contains(ActivityTimeMonitor.TIMEOUT_MONITOR_THREADNAME)) {
                 continue;
             }
             String nodePrefix = "(" + Pattern.quote(InternalTestCluster.TRANSPORT_CLIENT_PREFIX) + ")?(" +


### PR DESCRIPTION
A more effective approach to time-limiting activities such as search requests. Special runtime exceptions can now short-cut the execution of long-running calls to Lucene classes and are caught and reported back, not as a fatal error but using the existing “timedOut” flag in results.

Phases like the FetchPhase can now exit early and so also have a timed-out status. The SearchPhaseController does its best to assemble whatever hits, aggregations and facets have been produced within the provided time limits rather than returning nothing and throwing an error.

ActivityTimeMonitor is the new central class for efficiently monitoring all forms of thread overrun in a JVM.
The SearchContext setup is modified to register the start and end of query tasks with ActivityTimeMonitor.
Store.java is modified to add timeout checks (via calls to ATM) in the low-level file access routines by using a delegating wrapper for Lucene's IndexInput and IndexInputSlicer.
ContextIndexSearcher is modified to catch and unwrap ActivityTimedOutExceptions that can now come out of the Lucene calls and report them as timeouts along with any partial results.
FetchPhase is similarly modified to deal with the possibility of timeout errors.
