### PR TITLE
Fixed open/close index api when using wildcard only

### DIFF
--- a/rest-api-spec/test/indices.open/20_multiple_indices.yaml
+++ b/rest-api-spec/test/indices.open/20_multiple_indices.yaml
@@ -1,0 +1,82 @@
+setup:
+  - do:
+      indices.create:
+        index: test_index1
+  - do:
+      indices.create:
+        index: test_index2
+  - do:
+      indices.create:
+        index: test_index3
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"All indices":
+  - do:
+      indices.close:
+        index: _all
+
+  - do:
+      catch: forbidden
+      search:
+        index: test_index2
+
+  - do:
+      indices.open:
+        index: _all
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      search:
+        index: test_index2
+
+---
+"Trailing wildcard":
+  - do:
+      indices.close:
+        index: test_*
+
+  - do:
+      catch: forbidden
+      search:
+        index: test_index2
+
+  - do:
+      indices.open:
+        index: test_*
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      search:
+        index: test_index2
+
+---
+"Only wildcard":
+  - do:
+      indices.close:
+        index: '*'
+
+  - do:
+      catch: forbidden
+      search:
+        index: test_index3
+
+  - do:
+      indices.open:
+        index: '*'
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      search:
+        index: test_index3

--- a/src/main/java/org/elasticsearch/common/path/PathTrie.java
+++ b/src/main/java/org/elasticsearch/common/path/PathTrie.java
@@ -157,23 +157,20 @@ public class PathTrie<T> {
 
             String token = path[index];
             TrieNode<T> node = children.get(token);
-            boolean usedWildcard = false;
+            boolean usedWildcard;
             if (node == null) {
                 node = children.get(wildcard);
                 if (node == null) {
                     return null;
-                } else {
-                    usedWildcard = true;
-                    if (params != null && node.isNamedWildcard()) {
-                        put(params, node.namedWildcard(), token);
-                    }
                 }
+                usedWildcard = true;
+            } else {
+                usedWildcard = token.equals(wildcard);
             }
 
+            put(params, node, token);
+
             if (index == (path.length - 1)) {
-                if (params != null && node.isNamedWildcard()) {
-                    put(params, node.namedWildcard(), token);
-                }
                 return node.value;
             }
 
@@ -181,9 +178,7 @@ public class PathTrie<T> {
             if (res == null && !usedWildcard) {
                 node = children.get(wildcard);
                 if (node != null) {
-                    if (params != null && node.isNamedWildcard()) {
-                        put(params, node.namedWildcard(), token);
-                    }
+                    put(params, node, token);
                     res = node.retrieve(path, index + 1, params);
                 }
             }
@@ -191,8 +186,10 @@ public class PathTrie<T> {
             return res;
         }
 
-        private void put(Map<String, String> params, String key, String value) {
-            params.put(key, decoder.decode(value));
+        private void put(Map<String, String> params, TrieNode<T> node, String value) {
+            if (params != null && node.isNamedWildcard()) {
+                params.put(node.namedWildcard(), decoder.decode(value));
+            }
         }
     }
 

--- a/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
+++ b/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -113,11 +112,32 @@ public class PathTrieTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testEndWithNamedWildcardAndLookupWithWildcard() {
+    public void testNamedWildcardAndLookupWithWildcard() {
         PathTrie<String> trie = new PathTrie<String>();
         trie.insert("x/{test}", "test1");
+        trie.insert("{test}/a", "test2");
+        trie.insert("/{test}", "test3");
+        trie.insert("/{test}/_endpoint", "test4");
+        trie.insert("/*/{test}/_endpoint", "test5");
+
         Map<String, String> params = newHashMap();
         assertThat(trie.retrieve("/x/*", params), equalTo("test1"));
+        assertThat(params.get("test"), equalTo("*"));
+
+        params = newHashMap();
+        assertThat(trie.retrieve("/b/a", params), equalTo("test2"));
+        assertThat(params.get("test"), equalTo("b"));
+
+        params = newHashMap();
+        assertThat(trie.retrieve("/*", params), equalTo("test3"));
+        assertThat(params.get("test"), equalTo("*"));
+
+        params = newHashMap();
+        assertThat(trie.retrieve("/*/_endpoint", params), equalTo("test4"));
+        assertThat(params.get("test"), equalTo("*"));
+
+        params = newHashMap();
+        assertThat(trie.retrieve("a/*/_endpoint", params), equalTo("test5"));
         assertThat(params.get("test"), equalTo("*"));
     }
 }


### PR DESCRIPTION
Named wildcards were not always properly replaced with proper values by PathTrie.
Delete index (`curl -XDELETE localhost:9200/*`) worked anyway as the named wildcard is the last path element. 
When the named wildcard wasn't the last path element (e.g. `curl -XPOST localhost:29200/*/_close`), the variable didn't get replaced with the current '*' value, but with the empty string, which lead to an error as empty index is not allowed by open/close index.

Closes #4564
