### PR TITLE
REST cluster state API: Improved consistency

### DIFF
--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -17,32 +17,45 @@ particular node by adding `local=true` to the  query string.
 [float]
 === Response Filters
 
-It is possible to filter the cluster state response using the following
-REST parameters:
-
-`filter_nodes`::
-	Set to `true` to filter out the `nodes` part of the
-	response.
-
-`filter_routing_table`:: 
-	Set to `true` to filter out the `routing_table`
-	part of the response.
-
-`filter_metadata`::
-	Set to `true` to filter out the `metadata` part of the
-	response.
-
-`filter_blocks`::
-	Set to `true` to filter out the `blocks` part of the
-	response.
-
-`filter_indices`::
-	When not filtering metadata, a comma separated list of
-	indices to include in the response.
-
-Example follows:
+As the cluster state can grow (depending on the number of shards and indices, your mapping, templates),
+it is possible to filter the cluster state response specifying the parts in the URL.
 
 [source,js]
 --------------------------------------------------
-$ curl -XGET 'http://localhost:9200/_cluster/state?filter_nodes=true'
+$ curl -XGET 'http://localhost:9200/_cluster/state/{metrics}/{indices}'
 --------------------------------------------------
+
+`metrics` can be a comma-separated list of
+
+`nodes`::
+    Shows the `nodes` part of the response
+
+`routing_table`:: 
+    Shows the `routing_table` part of the response. If you supply a comma separated list of indices, the returned output will only contain the indices listed.
+
+`metadata`::
+    Shows the `metadata` part of the response. If you supply a comma separated list of indices, the returned output will only contain the indices listed.
+
+`blocks`::
+    Shows the `blocks` part of the response
+
+In addition the `index_templates` parameter can be specified, which returns the specified index templates only. This works only if the `metadata` is asked to be returned.
+
+A couple of example calls:
+
+[source,js]
+--------------------------------------------------
+# return only metadata and routing_table data for specified indices
+$ curl -XGET 'http://localhost:9200/_cluster/state/metadata,routing_table/foo,bar'
+
+# return everything for these two indices
+$ curl -XGET 'http://localhost:9200/_cluster/state/_all/foo,bar'
+
+# Return only blocks data
+$ curl -XGET 'http://localhost:9200/_cluster/state/blocks'
+
+# Return only metadata and a specific index_template
+# You should use the dedicated template endpoint for this
+$ curl -XGET 'http://localhost:9200/_cluster/state/metadata?index_templates=template_1'
+--------------------------------------------------
+

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -32,20 +32,12 @@ import java.io.IOException;
  */
 public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterStateRequest> {
 
-    public final static String NONE = "_na";
-
-    private boolean filterRoutingTable = false;
-
-    private boolean filterNodes = false;
-
-    private boolean filterMetaData = false;
-
-    private boolean filterBlocks = false;
-
-    private String[] filteredIndices = Strings.EMPTY_ARRAY;
-
-    private String[] filteredIndexTemplates = Strings.EMPTY_ARRAY;
-
+    private boolean routingTable = true;
+    private boolean nodes = true;
+    private boolean metaData = true;
+    private boolean blocks = true;
+    private String[] indices = Strings.EMPTY_ARRAY;
+    private String[] indexTemplates = Strings.EMPTY_ARRAY;
     private boolean local = false;
 
     public ClusterStateRequest() {
@@ -56,72 +48,77 @@ public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterState
         return null;
     }
 
-    public ClusterStateRequest filterAll() {
-        filterRoutingTable = true;
-        filterNodes = true;
-        filterMetaData = true;
-        filterBlocks = true;
-        filteredIndices = Strings.EMPTY_ARRAY;
-        filteredIndexTemplates = Strings.EMPTY_ARRAY;
+    public ClusterStateRequest all() {
+        routingTable = true;
+        nodes = true;
+        metaData = true;
+        blocks = true;
+        indices = Strings.EMPTY_ARRAY;
+        indexTemplates = Strings.EMPTY_ARRAY;
+        return this;
+    }
+    
+    public ClusterStateRequest clear() {
+        routingTable = false;
+        nodes = false;
+        metaData = false;
+        blocks = false;
+        indices = Strings.EMPTY_ARRAY;
+        indexTemplates = Strings.EMPTY_ARRAY;
         return this;
     }
 
-    public boolean filterRoutingTable() {
-        return filterRoutingTable;
+    public boolean routingTable() {
+        return routingTable;
     }
 
-    public ClusterStateRequest filterRoutingTable(boolean filterRoutingTable) {
-        this.filterRoutingTable = filterRoutingTable;
+    public ClusterStateRequest routingTable(boolean routingTable) {
+        this.routingTable = routingTable;
         return this;
     }
 
-    public boolean filterNodes() {
-        return filterNodes;
+    public boolean nodes() {
+        return nodes;
     }
 
-    public ClusterStateRequest filterNodes(boolean filterNodes) {
-        this.filterNodes = filterNodes;
+    public ClusterStateRequest nodes(boolean nodes) {
+        this.nodes = nodes;
         return this;
     }
 
-    public boolean filterMetaData() {
-        return filterMetaData;
+    public boolean metaData() {
+        return metaData;
     }
 
-    public ClusterStateRequest filterMetaData(boolean filterMetaData) {
-        this.filterMetaData = filterMetaData;
+    public ClusterStateRequest metaData(boolean metaData) {
+        this.metaData = metaData;
         return this;
     }
 
-    public boolean filterBlocks() {
-        return filterBlocks;
+    public boolean blocks() {
+        return blocks;
     }
 
-    public ClusterStateRequest filterBlocks(boolean filterBlocks) {
-        this.filterBlocks = filterBlocks;
+    public ClusterStateRequest blocks(boolean blocks) {
+        this.blocks = blocks;
         return this;
     }
 
-    public String[] filteredIndices() {
-        return filteredIndices;
+    public String[] indices() {
+        return indices;
     }
 
-    public ClusterStateRequest filterOutIndices() {
-        this.filteredIndices = new String[]{NONE};
+    public ClusterStateRequest indices(String... indices) {
+        this.indices = indices;
         return this;
     }
 
-    public ClusterStateRequest filteredIndices(String... filteredIndices) {
-        this.filteredIndices = filteredIndices;
-        return this;
+    public String[] indexTemplates() {
+        return this.indexTemplates;
     }
 
-    public String[] filteredIndexTemplates() {
-        return this.filteredIndexTemplates;
-    }
-
-    public ClusterStateRequest filteredIndexTemplates(String... filteredIndexTemplates) {
-        this.filteredIndexTemplates = filteredIndexTemplates;
+    public ClusterStateRequest indexTemplates(String... indexTemplates) {
+        this.indexTemplates = indexTemplates;
         return this;
     }
 
@@ -137,24 +134,24 @@ public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterState
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        filterRoutingTable = in.readBoolean();
-        filterNodes = in.readBoolean();
-        filterMetaData = in.readBoolean();
-        filterBlocks = in.readBoolean();
-        filteredIndices = in.readStringArray();
-        filteredIndexTemplates = in.readStringArray();
+        routingTable = in.readBoolean();
+        nodes = in.readBoolean();
+        metaData = in.readBoolean();
+        blocks = in.readBoolean();
+        indices = in.readStringArray();
+        indexTemplates = in.readStringArray();
         local = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBoolean(filterRoutingTable);
-        out.writeBoolean(filterNodes);
-        out.writeBoolean(filterMetaData);
-        out.writeBoolean(filterBlocks);
-        out.writeStringArray(filteredIndices);
-        out.writeStringArray(filteredIndexTemplates);
+        out.writeBoolean(routingTable);
+        out.writeBoolean(nodes);
+        out.writeBoolean(metaData);
+        out.writeBoolean(blocks);
+        out.writeStringArray(indices);
+        out.writeStringArray(indexTemplates);
         out.writeBoolean(local);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -34,56 +34,64 @@ public class ClusterStateRequestBuilder extends MasterNodeOperationRequestBuilde
     }
 
     /**
-     * Filters all data responses.
+     * Include all data
      */
-    public ClusterStateRequestBuilder setFilterAll() {
-        request.filterAll();
+    public ClusterStateRequestBuilder all() {
+        request.all();
         return this;
     }
 
-    public ClusterStateRequestBuilder setFilterBlocks(boolean filter) {
-        request.filterBlocks(filter);
+    /**
+     * Do not include any data
+     */
+    public ClusterStateRequestBuilder clear() {
+        request.clear();
+        return this;
+    }
+
+    public ClusterStateRequestBuilder setBlocks(boolean filter) {
+        request.blocks(filter);
         return this;
     }
 
     /**
      * Should the cluster state result include the {@link org.elasticsearch.cluster.metadata.MetaData}. Defaults
-     * to <tt>false</tt>.
+     * to <tt>true</tt>.
      */
-    public ClusterStateRequestBuilder setFilterMetaData(boolean filter) {
-        request.filterMetaData(filter);
+    public ClusterStateRequestBuilder setMetaData(boolean filter) {
+        request.metaData(filter);
         return this;
     }
 
     /**
      * Should the cluster state result include the {@link org.elasticsearch.cluster.node.DiscoveryNodes}. Defaults
-     * to <tt>false</tt>.
+     * to <tt>true</tt>.
      */
-    public ClusterStateRequestBuilder setFilterNodes(boolean filter) {
-        request.filterNodes(filter);
+    public ClusterStateRequestBuilder setNodes(boolean filter) {
+        request.nodes(filter);
         return this;
     }
 
     /**
      * Should the cluster state result include teh {@link org.elasticsearch.cluster.routing.RoutingTable}. Defaults
-     * to <tt>false</tt>.
+     * to <tt>true</tt>.
      */
-    public ClusterStateRequestBuilder setFilterRoutingTable(boolean filter) {
-        request.filterRoutingTable(filter);
+    public ClusterStateRequestBuilder setRoutingTable(boolean filter) {
+        request.routingTable(filter);
         return this;
     }
 
     /**
-     * When {@link #setFilterMetaData(boolean)} is not set, which indices to return the {@link org.elasticsearch.cluster.metadata.IndexMetaData}
+     * When {@link #setMetaData(boolean)} is set, which indices to return the {@link org.elasticsearch.cluster.metadata.IndexMetaData}
      * for. Defaults to all indices.
      */
-    public ClusterStateRequestBuilder setFilterIndices(String... indices) {
-        request.filteredIndices(indices);
+    public ClusterStateRequestBuilder setIndices(String... indices) {
+        request.indices(indices);
         return this;
     }
 
-    public ClusterStateRequestBuilder setFilterIndexTemplates(String... templates) {
-        request.filteredIndexTemplates(templates);
+    public ClusterStateRequestBuilder setIndexTemplates(String... templates) {
+        request.indexTemplates(templates);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -432,7 +432,7 @@ public class TransportClientNodesService extends AbstractComponent {
                             }
                             transportService.sendRequest(listedNode, ClusterStateAction.NAME,
                                     Requests.clusterStateRequest()
-                                            .filterAll().filterNodes(false).local(true),
+                                            .clear().nodes(true).local(true),
                                     TransportRequestOptions.options().withType(TransportRequestOptions.Type.STATE).withTimeout(pingTimeout),
                                     new BaseTransportResponseHandler<ClusterStateResponse>() {
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
@@ -47,8 +47,8 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
                 .listenerThreaded(false)
-                .filterRoutingTable(true)
-                .filterNodes(true);
+                .routingTable(false)
+                .nodes(false);
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
             public void onResponse(ClusterStateResponse response) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
@@ -57,9 +57,9 @@ public class RestGetIndicesAliasesAction extends BaseRestHandler {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
-                .filterRoutingTable(true)
-                .filterNodes(true)
-                .filteredIndices(indices);
+                .routingTable(false)
+                .nodes(false)
+                .indices(indices);
 
         clusterStateRequest.listenerThreaded(false);
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -61,9 +61,9 @@ public class RestGetSettingsAction extends BaseRestHandler {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
-                .filterRoutingTable(true)
-                .filterNodes(true)
-                .filteredIndices(indices);
+                .routingTable(false)
+                .nodes(false)
+                .indices(indices);
         clusterStateRequest.listenerThreaded(false);
 
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -64,7 +64,7 @@ public class RestAllocationAction extends AbstractCatAction {
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] nodes = Strings.splitStringByCommaToArray(request.param("nodes"));
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.filterMetaData(true);
+        clusterStateRequest.clear().routingTable(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
@@ -61,7 +62,7 @@ public class RestIndicesAction extends AbstractCatAction {
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.filteredIndices(indices);
+        clusterStateRequest.clear().indices(indices).metaData(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -50,7 +51,7 @@ public class RestMasterAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.filterMetaData(true);
+        clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
 
@@ -88,9 +89,10 @@ public class RestMasterAction extends AbstractCatAction {
 
     private Table buildTable(RestRequest request, ClusterStateResponse state) {
         Table table = getTableWithHeader(request);
-        String masterId = state.getState().nodes().masterNodeId();
-        String masterIp = ((InetSocketTransportAddress) state.getState().nodes().get(masterId).address()).address().getAddress().getHostAddress();
-        String masterName = state.getState().nodes().masterNode().name();
+        DiscoveryNodes nodes = state.getState().nodes();
+        String masterId = nodes.masterNodeId();
+        String masterIp = ((InetSocketTransportAddress) nodes.get(masterId).address()).address().getAddress().getHostAddress();
+        String masterName = nodes.masterNode().name();
 
         table.startRow();
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -61,7 +62,7 @@ public class RestNodesAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.filterMetaData(true);
+        clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
 
@@ -209,10 +210,11 @@ public class RestNodesAction extends AbstractCatAction {
     private Table buildTable(RestRequest req, ClusterStateResponse state, NodesInfoResponse nodesInfo, NodesStatsResponse nodesStats) {
         boolean fullId = req.paramAsBoolean("full_id", false);
 
-        String masterId = state.getState().nodes().masterNodeId();
+        DiscoveryNodes nodes = state.getState().nodes();
+        String masterId = nodes.masterNodeId();
         Table table = getTableWithHeader(req);
 
-        for (DiscoveryNode node : state.getState().nodes()) {
+        for (DiscoveryNode node : nodes) {
             NodeInfo info = nodesInfo.getNodesMap().get(node.id());
             NodeStats stats = nodesStats.getNodesMap().get(node.id());
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -66,7 +66,7 @@ public class RestRecoveryAction extends AbstractCatAction {
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.filterMetaData(true);
+        clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
 

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -58,7 +58,7 @@ public class RestMainAction extends BaseRestHandler {
         clusterStateRequest.listenerThreaded(false);
         clusterStateRequest.masterNodeTimeout(TimeValue.timeValueMillis(0));
         clusterStateRequest.local(true);
-        clusterStateRequest.filterAll().filterBlocks(false);
+        clusterStateRequest.clear().blocks(true);
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
             public void onResponse(ClusterStateResponse response) {

--- a/src/test/java/org/elasticsearch/cluster/BlockClusterStatsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/BlockClusterStatsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Scoped as test, because the if the test with cluster read only block fails, all other tests fail as well, as this is not cleaned up properly
+ */
+@ClusterScope(scope=Scope.TEST)
+public class BlockClusterStatsTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testBlocks() throws Exception {
+        createIndex("foo");
+        ClusterUpdateSettingsResponse updateSettingsResponse = client().admin().cluster().prepareUpdateSettings().setTransientSettings(
+                ImmutableSettings.settingsBuilder().put("cluster.blocks.read_only", true).build()).get();
+        assertThat(updateSettingsResponse.isAcknowledged(), is(true));
+        UpdateSettingsResponse indexSettingsResponse = client().admin().indices().prepareUpdateSettings("foo").setSettings(
+                ImmutableSettings.settingsBuilder().put("index.blocks.read_only", true)).get();
+        assertThat(indexSettingsResponse.isAcknowledged(), is(true));
+
+        ClusterStateResponse clusterStateResponseUnfiltered = client().admin().cluster().prepareState().clear().setBlocks(true).get();
+        assertThat(clusterStateResponseUnfiltered.getState().blocks().global(), hasSize(1));
+        assertThat(clusterStateResponseUnfiltered.getState().blocks().indices().size(), is(1));
+
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().get();
+        assertThat(clusterStateResponse.getState().blocks().global(), hasSize(0));
+        assertThat(clusterStateResponse.getState().blocks().indices().size(), is(0));
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/SimpleClusterStateTests.java
+++ b/src/test/java/org/elasticsearch/cluster/SimpleClusterStateTests.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.hamcrest.CollectionAssertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Checking simple filtering capabilites of the cluster state
+ *
+ */
+public class SimpleClusterStateTests extends ElasticsearchIntegrationTest {
+
+    @Before
+    public void indexData() throws Exception {
+        index("foo", "bar", "1", XContentFactory.jsonBuilder().startObject().field("foo", "foo").endObject());
+        index("fuu", "buu", "1", XContentFactory.jsonBuilder().startObject().field("fuu", "fuu").endObject());
+        index("baz", "baz", "1", XContentFactory.jsonBuilder().startObject().field("baz", "baz").endObject());
+        refresh();
+    }
+
+    @Test
+    public void testRoutingTable() throws Exception {
+        ClusterStateResponse clusterStateResponseUnfiltered = client().admin().cluster().prepareState().clear().setRoutingTable(true).get();
+        assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("foo"), is(true));
+        assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("fuu"), is(true));
+        assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("baz"), is(true));
+        assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("non-existent"), is(false));
+
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().get();
+        assertThat(clusterStateResponse.getState().routingTable().hasIndex("foo"), is(false));
+        assertThat(clusterStateResponse.getState().routingTable().hasIndex("fuu"), is(false));
+        assertThat(clusterStateResponse.getState().routingTable().hasIndex("baz"), is(false));
+        assertThat(clusterStateResponse.getState().routingTable().hasIndex("non-existent"), is(false));
+    }
+
+    @Test
+    public void testNodes() throws Exception {
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().setNodes(true).get();
+        assertThat(clusterStateResponse.getState().nodes().nodes().size(), is(cluster().size()));
+
+        ClusterStateResponse clusterStateResponseFiltered = client().admin().cluster().prepareState().clear().get();
+        assertThat(clusterStateResponseFiltered.getState().nodes().nodes().size(), is(0));
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        ClusterStateResponse clusterStateResponseUnfiltered = client().admin().cluster().prepareState().clear().setMetaData(true).get();
+        assertThat(clusterStateResponseUnfiltered.getState().metaData().indices().size(), is(3));
+
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().get();
+        assertThat(clusterStateResponse.getState().metaData().indices().size(), is(0));
+    }
+
+    @Test
+    public void testIndexTemplates() throws Exception {
+        client().admin().indices().preparePutTemplate("foo_template")
+                .setTemplate("te*")
+                .setOrder(0)
+                .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
+                        .startObject("field1").field("type", "string").field("store", "yes").endObject()
+                        .startObject("field2").field("type", "string").field("store", "yes").field("index", "not_analyzed").endObject()
+                        .endObject().endObject().endObject())
+                .get();
+
+        client().admin().indices().preparePutTemplate("fuu_template")
+                .setTemplate("test*")
+                .setOrder(1)
+                .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
+                        .startObject("field2").field("type", "string").field("store", "no").endObject()
+                        .endObject().endObject().endObject())
+                .get();
+
+        ClusterStateResponse clusterStateResponseUnfiltered = client().admin().cluster().prepareState().get();
+        assertThat(clusterStateResponseUnfiltered.getState().metaData().templates().size(), is(greaterThanOrEqualTo(2)));
+
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().setMetaData(true).setIndexTemplates("foo_template").get();
+        assertThat(clusterStateResponse.getState().metaData().templates().size(), is(1));
+    }
+
+    @Test
+    public void testThatFilteringByIndexWorksForMetadataAndRoutingTable() throws Exception {
+        ClusterStateResponse clusterStateResponseFiltered = client().admin().cluster().prepareState().clear()
+                .setMetaData(true).setRoutingTable(true).setIndices("foo", "fuu", "non-existent").get();
+
+        // metadata
+        assertThat(clusterStateResponseFiltered.getState().metaData().indices().size(), is(2));
+        assertThat(clusterStateResponseFiltered.getState().metaData().indices(), CollectionAssertions.hasKey("foo"));
+        assertThat(clusterStateResponseFiltered.getState().metaData().indices(), CollectionAssertions.hasKey("fuu"));
+
+        // routing table
+        assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("foo"), is(true));
+        assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("fuu"), is(true));
+        assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("baz"), is(false));
+    }
+}

--- a/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
@@ -223,7 +223,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify we have an index");
-        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().setFilterIndices("test").execute().actionGet();
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().setIndices("test").execute().actionGet();
         assertThat(clusterStateResponse.getState().metaData().hasIndex("test"), equalTo(true));
     }
 

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -84,7 +84,7 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
             createIndex(indexName);
             ensureYellow(); // ensuring yellow so the test fails faster if the template cannot be loaded
 
-            ClusterStateResponse stateResponse = client().admin().cluster().prepareState().setFilterIndices(indexName).get();
+            ClusterStateResponse stateResponse = client().admin().cluster().prepareState().setIndices(indexName).get();
             assertThat(stateResponse.getState().getMetaData().indices().get(indexName).getNumberOfShards(), is(10));
             assertThat(stateResponse.getState().getMetaData().indices().get(indexName).getNumberOfReplicas(), is(0));
         }

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -53,7 +53,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
         logger.info("--> set test persistent setting");
         String settingValue = "test-" + randomInt();
         client.admin().cluster().prepareUpdateSettings().setPersistentSettings(ImmutableSettings.settingsBuilder().put(ThreadPool.THREADPOOL_GROUP + "dummy.value", settingValue)).execute().actionGet();
-        assertThat(client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).execute().actionGet().getState()
+        assertThat(client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).execute().actionGet().getState()
                 .getMetaData().persistentSettings().get(ThreadPool.THREADPOOL_GROUP + "dummy.value"), equalTo(settingValue));
 
         logger.info("--> create repository");
@@ -69,12 +69,12 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
 
         logger.info("--> clean the test persistent setting");
         client.admin().cluster().prepareUpdateSettings().setPersistentSettings(ImmutableSettings.settingsBuilder().put(ThreadPool.THREADPOOL_GROUP + "dummy.value", "")).execute().actionGet();
-        assertThat(client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).execute().actionGet().getState()
+        assertThat(client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).execute().actionGet().getState()
                 .getMetaData().persistentSettings().get(ThreadPool.THREADPOOL_GROUP + "dummy.value"), equalTo(""));
 
         logger.info("--> restore snapshot");
         client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setRestoreGlobalState(true).setWaitForCompletion(true).execute().actionGet();
-        assertThat(client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).execute().actionGet().getState()
+        assertThat(client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).execute().actionGet().getState()
                 .getMetaData().persistentSettings().get(ThreadPool.THREADPOOL_GROUP + "dummy.value"), equalTo(settingValue));
     }
 

--- a/src/test/java/org/elasticsearch/snapshots/RepositoriesTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/RepositoriesTests.java
@@ -51,7 +51,7 @@ public class RepositoriesTests extends AbstractSnapshotTests {
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> check that repository is really there");
-        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().setFilterAll().setFilterMetaData(false).get();
+        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().clear().setMetaData(true).get();
         MetaData metaData = clusterStateResponse.getState().getMetaData();
         RepositoriesMetaData repositoriesMetaData = metaData.custom(RepositoriesMetaData.TYPE);
         assertThat(repositoriesMetaData, notNullValue());
@@ -66,7 +66,7 @@ public class RepositoriesTests extends AbstractSnapshotTests {
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> check that both repositories are in cluster state");
-        clusterStateResponse = client.admin().cluster().prepareState().setFilterAll().setFilterMetaData(false).get();
+        clusterStateResponse = client.admin().cluster().prepareState().clear().setMetaData(true).get();
         metaData = clusterStateResponse.getState().getMetaData();
         repositoriesMetaData = metaData.custom(RepositoriesMetaData.TYPE);
         assertThat(repositoriesMetaData, notNullValue());

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -174,7 +175,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("-->  delete test template");
         assertThat(client.admin().indices().prepareDeleteTemplate("test-template").get().isAcknowledged(), equalTo(true));
-        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices(Strings.EMPTY_ARRAY).get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(false));
 
         logger.info("--> restore cluster state");
@@ -183,7 +184,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
         logger.info("--> check that template is restored");
-        clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices(Strings.EMPTY_ARRAY).get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(true));
     }
 
@@ -214,7 +215,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("-->  delete test template");
         wipeTemplates("test-template");
-        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices().get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(false));
 
         logger.info("--> try restoring cluster state from snapshot without global state");
@@ -222,7 +223,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
         logger.info("--> check that template wasn't restored");
-        clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices().get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(false));
 
         logger.info("--> restore cluster state");
@@ -230,7 +231,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
         logger.info("--> check that template is restored");
-        clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices().get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(true));
 
         createIndex("test-idx");
@@ -252,7 +253,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("-->  delete test template and index ");
         wipeIndices("test-idx");
         wipeTemplates("test-template");
-        clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices().get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(false));
 
         logger.info("--> try restoring index and cluster state from snapshot without global state");
@@ -262,7 +263,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         ensureGreen();
         logger.info("--> check that template wasn't restored but index was");
-        clusterStateResponse = client.admin().cluster().prepareState().setFilterRoutingTable(true).setFilterNodes(true).setFilterIndexTemplates("test-template").setFilterIndices().get();
+        clusterStateResponse = client.admin().cluster().prepareState().setRoutingTable(false).setNodes(false).setIndexTemplates("test-template").setIndices().get();
         assertThat(clusterStateResponse.getState().getMetaData().templates().containsKey("test-template"), equalTo(false));
         assertThat(client.prepareCount("test-idx").get().getCount(), equalTo(100L));
 


### PR DESCRIPTION
Instead of specifying what kind of data should be filtered, this commit
streamlines the API to actually specify, what kind of data should be displayed.

A small feature has been added as well: If you specify an index to select on, not
only the metadata, but also the routing tables are filtered by index in order
to prevent too big cluster states to be returned.

Also the CAT apis have been changed to only return the wanted data in order to keep
network traffic as small as needed.

Tests for the cluster state API filtering have been added as well.

Note: This change breaks backwards compatibility with 0.90!

Closes #4065
