### PR TITLE
Changed get index settings api to use new internal get index settings api instead of relying on the cluster state api.

### DIFF
--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -7,3 +7,42 @@ The get settings API allows to retrieve settings of index/indices:
 --------------------------------------------------
 $ curl -XGET 'http://localhost:9200/twitter/_settings'
 --------------------------------------------------
+
+[float]
+=== Multiple Indices and Types
+
+The get settings API can be used to get settings for more than one index
+with a single call. General usage of the API follows the
+following syntax: `host:port/{index}/_settings` where
+`{index}` can stand for comma-separated list of index names and aliases. To
+get settings for all indices you can use `_all` for `{index}`.
+Wildcard expressions are also supported. The following are some examples:
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/twitter,kimchy/_settings'
+
+curl -XGET 'http://localhost:9200/_all/_settings'
+
+curl -XGET 'http://localhost:9200/2013-*/_settings'
+--------------------------------------------------
+
+[float]
+=== Prefix option
+
+There is also support for a `prefix` query string option
+that allows to include only settings matches the specified prefix.
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'http://localhost:9200/my-index/_settings?prefix=index.'
+
+curl -XGET 'http://localhost:9200/_all/_settings?prefix=index.routing.allocation.'
+
+curl -XGET 'http://localhost:9200/2013-*/_settings?prefix=index.merge.'
+--------------------------------------------------
+
+The first example returns all index settings the start with `index.` in the index `my-index`,
+the second example gets all index settings that start with `index.routing.allocation.` for
+all indices, lastly the third example returns all index settings that start with `index.merge.`
+in indices that start with `2013-`.

--- a/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/api/indices.get_settings.json
@@ -12,6 +12,24 @@
         }
       },
       "params": {
+        "ignore_unavailable": {
+            "type" : "boolean",
+            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+        },
+        "allow_no_indices": {
+            "type" : "boolean",
+            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
+        "expand_wildcards": {
+            "type" : "enum",
+            "options" : ["open","closed"],
+            "default" : ["open","closed"],
+            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "prefix" : {
+           "type" : "string",
+           "description" : "The prefix all settings must have in order to be included"
+        }
       }
     },
     "body": null

--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -98,8 +98,10 @@ import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.TransportRefreshAction;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.segments.TransportIndicesSegmentsAction;
-import org.elasticsearch.action.admin.indices.settings.TransportUpdateSettingsAction;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.get.TransportGetSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
 import org.elasticsearch.action.admin.indices.stats.TransportIndicesStatsAction;
 import org.elasticsearch.action.admin.indices.status.IndicesStatusAction;
@@ -246,6 +248,7 @@ public class ActionModule extends AbstractModule {
         registerAction(GetWarmersAction.INSTANCE, TransportGetWarmersAction.class);
         registerAction(GetAliasesAction.INSTANCE, TransportGetAliasesAction.class);
         registerAction(AliasesExistAction.INSTANCE, TransportAliasesExistAction.class);
+        registerAction(GetSettingsAction.INSTANCE, TransportGetSettingsAction.class);
 
         registerAction(IndexAction.INSTANCE, TransportIndexAction.class);
         registerAction(GetAction.INSTANCE, TransportGetAction.class);

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsAction.java
@@ -17,36 +17,30 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.settings;
+package org.elasticsearch.action.admin.indices.settings.get;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.elasticsearch.action.admin.indices.IndicesAction;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.client.internal.InternalGenericClient;
 
 /**
- * A response for an update index settings action
  */
-public class UpdateSettingsResponse extends AcknowledgedResponse {
+public class GetSettingsAction extends IndicesAction<GetSettingsRequest, GetSettingsResponse, GetSettingsRequestBuilder> {
 
-    UpdateSettingsResponse() {
-    }
+    public static final GetSettingsAction INSTANCE = new GetSettingsAction();
+    public static final String NAME = "indices/settings/get";
 
-    UpdateSettingsResponse(boolean acknowledged) {
-        super(acknowledged);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        readAcknowledged(in, Version.V_0_90_6);
+    public GetSettingsAction() {
+        super(NAME);
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        writeAcknowledged(out, Version.V_0_90_6);
+    public GetSettingsRequestBuilder newRequestBuilder(IndicesAdminClient client) {
+        return new GetSettingsRequestBuilder((InternalGenericClient) client);
+    }
+
+    @Override
+    public GetSettingsResponse newResponse() {
+        return new GetSettingsResponse();
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.settings.get;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ */
+public class GetSettingsRequest extends MasterNodeOperationRequest<GetSettingsRequest> {
+
+    private String[] indices = Strings.EMPTY_ARRAY;
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
+    private String prefix;
+
+    public GetSettingsRequest indices(String... indices) {
+        this.indices = indices;
+        return this;
+    }
+
+    public GetSettingsRequest indicesOptions(IndicesOptions indicesOptions) {
+        this.indicesOptions = indicesOptions;
+        return this;
+    }
+
+    public String[] indices() {
+        return indices;
+    }
+
+    public IndicesOptions indicesOptions() {
+        return indicesOptions;
+    }
+
+    public String prefix() {
+        return prefix;
+    }
+
+    public GetSettingsRequest prefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        indices = in.readStringArray();
+        indicesOptions = IndicesOptions.readIndicesOptions(in);
+        prefix = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeStringArray(indices);
+        indicesOptions.writeIndicesOptions(out);
+        out.writeOptionalString(prefix);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.settings.get;
+
+import com.google.common.collect.ObjectArrays;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.client.internal.InternalGenericClient;
+
+/**
+ */
+public class GetSettingsRequestBuilder extends MasterNodeOperationRequestBuilder<GetSettingsRequest, GetSettingsResponse, GetSettingsRequestBuilder> {
+
+    public GetSettingsRequestBuilder(InternalGenericClient client, String... indices) {
+        super(client, new GetSettingsRequest().indices(indices));
+    }
+
+    public GetSettingsRequestBuilder setIndices(String... indices) {
+        request.indices(indices);
+        return this;
+    }
+
+    public GetSettingsRequestBuilder addIndices(String... indices) {
+        request.indices(ObjectArrays.concat(request.indices(), indices, String.class));
+        return this;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore and wildcard indices expressions.
+     *
+     * For example indices that don't exist.
+     */
+    public GetSettingsRequestBuilder setIndicesOptions(IndicesOptions options) {
+        request.indicesOptions(options);
+        return this;
+    }
+
+    public GetSettingsRequestBuilder setPrefix(String prefix) {
+        request.prefix(prefix);
+        return this;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<GetSettingsResponse> listener) {
+        ((IndicesAdminClient) client).getSettings(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.settings.get;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+
+/**
+ */
+public class GetSettingsResponse extends ActionResponse {
+
+    private ImmutableOpenMap<String, Settings> indexToSettings = ImmutableOpenMap.of();
+
+    public GetSettingsResponse(ImmutableOpenMap<String, Settings> indexToSettings) {
+        this.indexToSettings = indexToSettings;
+    }
+
+    GetSettingsResponse() {
+    }
+
+    public ImmutableOpenMap<String, Settings> getIndexToSettings() {
+        return indexToSettings;
+    }
+
+    public String getSetting(String index, String setting) {
+        Settings settings = indexToSettings.get(index);
+        if (setting != null) {
+            return settings.get(setting);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        int size = in.readVInt();
+        ImmutableOpenMap.Builder<String, Settings> builder = ImmutableOpenMap.builder();
+        for (int i = 0; i < size; i++) {
+            builder.put(in.readString(), ImmutableSettings.readSettingsFromStream(in));
+        }
+        indexToSettings = builder.build();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(indexToSettings.size());
+        for (ObjectObjectCursor<String, Settings> cursor : indexToSettings) {
+            out.writeString(cursor.key);
+            ImmutableSettings.writeSettingsToStream(cursor.value, out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.settings.get;
+
+import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Map;
+
+/**
+ */
+public class TransportGetSettingsAction extends TransportMasterNodeOperationAction<GetSettingsRequest, GetSettingsResponse> {
+
+    private final SettingsFilter settingsFilter;
+    private final ClusterService clusterService;
+
+    @Inject
+    public TransportGetSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                      ThreadPool threadPool, SettingsFilter settingsFilter) {
+        super(settings, transportService, clusterService, threadPool);
+        this.settingsFilter = settingsFilter;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    protected String transportAction() {
+        return GetSettingsAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        // Very lightweight operation
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected GetSettingsRequest newRequest() {
+        return new GetSettingsRequest();
+    }
+
+    @Override
+    protected GetSettingsResponse newResponse() {
+        return new GetSettingsResponse();
+    }
+
+    @Override
+    protected void processBeforeProcess(GetSettingsRequest request, ClusterState clusterState) {
+        request.indices(clusterState.metaData().concreteIndices(request.indices(), request.indicesOptions()));
+    }
+
+    @Override
+    protected void masterOperation(GetSettingsRequest request, ClusterState state, ActionListener<GetSettingsResponse> listener) throws ElasticSearchException {
+        ImmutableOpenMap.Builder<String, Settings> indexToSettingsBuilder = ImmutableOpenMap.builder();
+        for (String concreteIndex : request.indices()) {
+            IndexMetaData indexMetaData = state.getMetaData().index(concreteIndex);
+            if (indexMetaData == null) {
+                continue;
+            }
+
+            Settings settings = settingsFilter.filterSettings(indexMetaData.settings());
+            if (request.prefix() != null) {
+                ImmutableSettings.Builder settingsBuilder = ImmutableSettings.builder();
+                for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
+                    if (entry.getKey().startsWith(request.prefix())) {
+                        settingsBuilder.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                settings = settingsBuilder.build();
+            }
+            indexToSettingsBuilder.put(concreteIndex, settings);
+        }
+        listener.onResponse(new GetSettingsResponse(indexToSettingsBuilder.build()));
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.settings;
+package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.ActionListener;

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsAction.java
@@ -17,34 +17,29 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.settings;
+package org.elasticsearch.action.admin.indices.settings.put;
 
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.action.admin.indices.IndicesAction;
+import org.elasticsearch.client.IndicesAdminClient;
 
 /**
- * Cluster state update request that allows to update settings for some indices
  */
-public class UpdateSettingsClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<UpdateSettingsClusterStateUpdateRequest> {
+public class UpdateSettingsAction extends IndicesAction<UpdateSettingsRequest, UpdateSettingsResponse, UpdateSettingsRequestBuilder> {
 
-    private Settings settings;
+    public static final UpdateSettingsAction INSTANCE = new UpdateSettingsAction();
+    public static final String NAME = "indices/settings/update";
 
-    public UpdateSettingsClusterStateUpdateRequest() {
-
+    private UpdateSettingsAction() {
+        super(NAME);
     }
 
-    /**
-     * Returns the {@link Settings} to update
-     */
-    public Settings settings() {
-        return settings;
+    @Override
+    public UpdateSettingsResponse newResponse() {
+        return new UpdateSettingsResponse();
     }
 
-    /**
-     * Sets the {@link Settings} to update
-     */
-    public UpdateSettingsClusterStateUpdateRequest settings(Settings settings) {
-        this.settings = settings;
-        return this;
+    @Override
+    public UpdateSettingsRequestBuilder newRequestBuilder(IndicesAdminClient client) {
+        return new UpdateSettingsRequestBuilder(client);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
@@ -17,29 +17,34 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.settings;
+package org.elasticsearch.action.admin.indices.settings.put;
 
-import org.elasticsearch.action.admin.indices.IndicesAction;
-import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
+import org.elasticsearch.common.settings.Settings;
 
 /**
+ * Cluster state update request that allows to update settings for some indices
  */
-public class UpdateSettingsAction extends IndicesAction<UpdateSettingsRequest, UpdateSettingsResponse, UpdateSettingsRequestBuilder> {
+public class UpdateSettingsClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<UpdateSettingsClusterStateUpdateRequest> {
 
-    public static final UpdateSettingsAction INSTANCE = new UpdateSettingsAction();
-    public static final String NAME = "indices/settings/update";
+    private Settings settings;
 
-    private UpdateSettingsAction() {
-        super(NAME);
+    public UpdateSettingsClusterStateUpdateRequest() {
+
     }
 
-    @Override
-    public UpdateSettingsResponse newResponse() {
-        return new UpdateSettingsResponse();
+    /**
+     * Returns the {@link Settings} to update
+     */
+    public Settings settings() {
+        return settings;
     }
 
-    @Override
-    public UpdateSettingsRequestBuilder newRequestBuilder(IndicesAdminClient client) {
-        return new UpdateSettingsRequestBuilder(client);
+    /**
+     * Sets the {@link Settings} to update
+     */
+    public UpdateSettingsClusterStateUpdateRequest settings(Settings settings) {
+        this.settings = settings;
+        return this;
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.settings;
+package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.ElasticSearchGenerationException;
 import org.elasticsearch.Version;

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestBuilder.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.settings;
+package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.settings.put;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * A response for an update index settings action
+ */
+public class UpdateSettingsResponse extends AcknowledgedResponse {
+
+    UpdateSettingsResponse() {
+    }
+
+    UpdateSettingsResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readAcknowledged(in, Version.V_0_90_6);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeAcknowledged(out, Version.V_0_90_6);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
@@ -81,6 +81,9 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
 
     }
 
+    protected void processBeforeProcess(Request request, ClusterState clusterState) {
+    }
+
     @Override
     public void execute(Request request, ActionListener<Response> listener) {
         // since the callback is async, we typically can get called from within an event in the cluster service
@@ -97,6 +100,7 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
     private void innerExecute(final Request request, final ActionListener<Response> listener, final boolean retrying) {
         final ClusterState clusterState = clusterService.state();
         final DiscoveryNodes nodes = clusterState.nodes();
+        processBeforeProcess(request, clusterState);
         if (nodes.localNodeMaster() || localExecute(request)) {
             // check for block, if blocked, retry, else, execute locally
             final ClusterBlockException blockException = checkBlock(request, clusterState);

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -75,9 +75,12 @@ import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequestBuilder;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequestBuilder;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequestBuilder;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequestBuilder;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -742,4 +745,9 @@ public interface IndicesAdminClient {
 
     GetWarmersRequestBuilder prepareGetWarmers(String... indices);
 
+    void getSettings(GetSettingsRequest request, ActionListener<GetSettingsResponse> listener);
+
+    ActionFuture<GetSettingsResponse> getSettings(GetSettingsRequest request);
+
+    GetSettingsRequestBuilder prepareGetSettings(String... indices);
 }

--- a/src/main/java/org/elasticsearch/client/Requests.java
+++ b/src/main/java/org/elasticsearch/client/Requests.java
@@ -50,7 +50,7 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.optimize.OptimizeRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.status.IndicesStatusRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.count.CountRequest;

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -93,10 +93,14 @@ import org.elasticsearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequestBuilder;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsAction;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequestBuilder;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequestBuilder;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequestBuilder;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
@@ -599,5 +603,20 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
     @Override
     public void getWarmers(GetWarmersRequest request, ActionListener<GetWarmersResponse> listener) {
         execute(GetWarmersAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public GetSettingsRequestBuilder prepareGetSettings(String... indices) {
+        return new GetSettingsRequestBuilder(this, indices);
+    }
+
+    @Override
+    public ActionFuture<GetSettingsResponse> getSettings(GetSettingsRequest request) {
+        return execute(GetSettingsAction.INSTANCE, request);
+    }
+
+    @Override
+    public void getSettings(GetSettingsRequest request, ActionListener<GetSettingsResponse> listener) {
+        execute(GetSettingsAction.INSTANCE, request, listener);
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -21,7 +21,7 @@ package org.elasticsearch.cluster.metadata;
 
 import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsClusterStateUpdateRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsClusterStateUpdateRequest;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -19,20 +19,17 @@
 
 package org.elasticsearch.rest.action.admin.indices.settings;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.Requests;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
@@ -45,59 +42,41 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestGetSettingsAction extends BaseRestHandler {
 
-    private final SettingsFilter settingsFilter;
-
     @Inject
-    public RestGetSettingsAction(Settings settings, Client client, RestController controller, SettingsFilter settingsFilter) {
+    public RestGetSettingsAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
         controller.registerHandler(GET, "/_settings", this);
         controller.registerHandler(GET, "/{index}/_settings", this);
-
-        this.settingsFilter = settingsFilter;
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
+        GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
+                .indices(Strings.splitStringByCommaToArray(request.param("index")))
+                .indicesOptions(IndicesOptions.fromRequest(request, IndicesOptions.strict()))
+                .prefix(request.param("prefix"));
 
-        ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
-                .filterRoutingTable(true)
-                .filterNodes(true)
-                .filteredIndices(indices);
-        clusterStateRequest.listenerThreaded(false);
+        client.admin().indices().getSettings(getSettingsRequest, new ActionListener<GetSettingsResponse>() {
 
-        client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
-            public void onResponse(ClusterStateResponse response) {
+            public void onResponse(GetSettingsResponse getSettingsResponse) {
                 try {
-                    MetaData metaData = response.getState().metaData();
-
-                    if (metaData.indices().isEmpty() && indices.length > 0) {
-                        channel.sendResponse(new XContentThrowableRestResponse(request, new IndexMissingException(new Index(indices[0]))));
-                        return;
-                    }
-
                     boolean foundAny = false;
                     XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
                     builder.startObject();
-
-                    for (IndexMetaData indexMetaData : metaData) {
-                        builder.startObject(indexMetaData.index(), XContentBuilder.FieldCaseConversion.NONE);
-                        foundAny = true;
-                        builder.startObject("settings");
-                        Settings settings = settingsFilter.filterSettings(indexMetaData.settings());
-                        for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
+                    for (ObjectObjectCursor<String, Settings> cursor : getSettingsResponse.getIndexToSettings()) {
+                        builder.startObject(cursor.key, XContentBuilder.FieldCaseConversion.NONE);
+                        builder.startObject(Fields.SETTINGS);
+                        for (Map.Entry<String, String> entry : cursor.value.getAsMap().entrySet()) {
+                            foundAny = true;
                             builder.field(entry.getKey(), entry.getValue());
                         }
                         builder.endObject();
-
                         builder.endObject();
                     }
-
                     builder.endObject();
-
                     channel.sendResponse(new XContentRestResponse(request, foundAny ? OK : NOT_FOUND, builder));
-                } catch (Throwable e) {
+                } catch (IOException e) {
                     onFailure(e);
                 }
             }
@@ -111,5 +90,11 @@ public class RestGetSettingsAction extends BaseRestHandler {
                 }
             }
         });
+    }
+
+    static class Fields {
+
+        static final XContentBuilderString SETTINGS = new XContentBuilderString("settings");
+
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.rest.action.admin.indices.settings;
 
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;

--- a/src/test/java/org/elasticsearch/blocks/SimpleBlocksTests.java
+++ b/src/test/java/org/elasticsearch/blocks/SimpleBlocksTests.java
@@ -21,8 +21,8 @@ package org.elasticsearch.blocks;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequestBuilder;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequestBuilder;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;

--- a/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.action.admin.indices.mapping.delete.DeleteMappingRespon
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.action.admin.indices.warmer.get.GetWarmersResponse;
 import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerResponse;
 import org.elasticsearch.client.Client;

--- a/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.indices.settings;
 
 import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -36,9 +37,7 @@ public class UpdateSettingsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testOpenCloseUpdateSettings() throws Exception {
-
         createIndex("test");
-
         try {
             client().admin().indices().prepareUpdateSettings("test")
                     .setSettings(ImmutableSettings.settingsBuilder()
@@ -55,6 +54,11 @@ public class UpdateSettingsTests extends ElasticsearchIntegrationTest {
         assertThat(indexMetaData.settings().get("index.refresh_interval"), nullValue());
         assertThat(indexMetaData.settings().get("index.cache.filter.type"), nullValue());
 
+        // Now verify via dedicated get settings api:
+        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
+        assertThat(getSettingsResponse.getSetting("test", "index.refresh_interval"), nullValue());
+        assertThat(getSettingsResponse.getSetting("test", "index.cache.filter.type"), nullValue());
+
         client().admin().indices().prepareUpdateSettings("test")
                 .setSettings(ImmutableSettings.settingsBuilder()
                         .put("index.refresh_interval", -1) // this one can change
@@ -63,6 +67,9 @@ public class UpdateSettingsTests extends ElasticsearchIntegrationTest {
 
         indexMetaData = client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("test");
         assertThat(indexMetaData.settings().get("index.refresh_interval"), equalTo("-1"));
+        // Now verify via dedicated get settings api:
+        getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
+        assertThat(getSettingsResponse.getSetting("test", "index.refresh_interval"), equalTo("-1"));
 
         // now close the index, change the non dynamic setting, and see that it applies
 
@@ -82,6 +89,11 @@ public class UpdateSettingsTests extends ElasticsearchIntegrationTest {
         indexMetaData = client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("test");
         assertThat(indexMetaData.settings().get("index.refresh_interval"), equalTo("1s"));
         assertThat(indexMetaData.settings().get("index.cache.filter.type"), equalTo("none"));
+
+        // Now verify via dedicated get settings api:
+        getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
+        assertThat(getSettingsResponse.getSetting("test", "index.refresh_interval"), equalTo("1s"));
+        assertThat(getSettingsResponse.getSetting("test", "index.cache.filter.type"), equalTo("none"));
     }
 
     @Test


### PR DESCRIPTION
The new internal get index settings api is more efficient when it comes to sending the index settings from the master to the client via the node that received the initial request. Also the get index settings support now all the indices options and a new prefix option.

Relates to #4620
