### PR TITLE
Added `action.destructive_requires_name` that controls whether wildcard expressions are allowed for destructive operations.

### DIFF
--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -8,10 +8,12 @@ The delete index API allows to delete an existing index.
 $ curl -XDELETE 'http://localhost:9200/twitter/'
 --------------------------------------------------
 
-The above example deletes an index called `twitter`.
+The above example deletes an index called `twitter`. Specifying an index,
+alias or wildcard expression is required.
 
 The delete index API can also be applied to more than one index, or on
-`_all` indices (be careful!). All indices will also be deleted when no
-specific index is provided. In order to disable allowing to delete all
-indices, set `action.disable_delete_all_indices` setting in the config
-to `true`.
+all indices (be careful!) by using `_all` or `*` as index.
+
+In order to disable allowing to delete indices via wildcards or `_all`,
+set `action.destructive_requires_name` setting in the config to `true`.
+This setting can also be changed via the cluster update settings api.

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -23,6 +23,7 @@ disabled using the `ignore_unavailable=true` parameter.
 
 All indices can be opened or closed at once using `_all` as the index name
 or specifying patterns that identify them all (e.g. `*`).
-Closing all indices can be disabled by setting the `action.disable_close_all_indices`
-flag in the config file to `true`.
 
+Identifying indices via wildcards or `_all` can be disabled by setting the
+`action.destructive_requires_name` flag in the config file to `true`.
+This setting can also be changed via the cluster update settings api.

--- a/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/api/indices.delete.json
@@ -8,7 +8,7 @@
       "parts": {
         "index": {
           "type" : "list",
-          "description" : "A comma-separated list of indices to delete; use `_all` or empty string to delete all indices"
+          "description" : "A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices"
         }
       },
       "params": {

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -68,7 +68,7 @@ public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRe
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (indices == null) {
+        if (indices == null || indices.length == 0) {
             validationException = addValidationError("index / indices is missing", validationException);
         }
         return validationException;
@@ -114,10 +114,7 @@ public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRe
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        indices = new String[in.readVInt()];
-        for (int i = 0; i < indices.length; i++) {
-            indices[i] = in.readString();
-        }
+        indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         timeout = readTimeValue(in);
     }
@@ -125,14 +122,7 @@ public class DeleteIndexRequest extends MasterNodeOperationRequest<DeleteIndexRe
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (indices == null) {
-            out.writeVInt(0);
-        } else {
-            out.writeVInt(indices.length);
-            for (String index : indices) {
-                out.writeString(index);
-            }
-        }
+        out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
         timeout.writeTo(out);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -39,18 +39,17 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Open index action
  */
-public class TransportOpenIndexAction extends TransportMasterNodeOperationAction<OpenIndexRequest, OpenIndexResponse> implements NodeSettingsService.Listener {
+public class TransportOpenIndexAction extends TransportMasterNodeOperationAction<OpenIndexRequest, OpenIndexResponse> {
 
     private final MetaDataIndexStateService indexStateService;
-    private volatile boolean destructiveRequiresName;
+    private final DestructiveOperations destructiveOperations;
 
     @Inject
     public TransportOpenIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService) {
         super(settings, transportService, clusterService, threadPool);
         this.indexStateService = indexStateService;
-        this.destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, false);
-        nodeSettingsService.addListener(this);
+        this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
 
     @Override
@@ -76,7 +75,7 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
 
     @Override
     protected void doExecute(OpenIndexRequest request, ActionListener<OpenIndexResponse> listener) {
-        DestructiveOperations.failDestructive(request.indices(), destructiveRequiresName);
+        destructiveOperations.failDestructive(request.indices());
         super.doExecute(request, listener);
     }
 
@@ -105,14 +104,5 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
                 listener.onFailure(t);
             }
         });
-    }
-
-    @Override
-    public void onRefreshSettings(Settings settings) {
-        boolean newValue = settings.getAsBoolean("action.destructive_requires_name", destructiveRequiresName);
-        if (destructiveRequiresName != newValue) {
-            logger.info("updating [action.operate_all_indices] from [{}] to [{}]", destructiveRequiresName, newValue);
-            this.destructiveRequiresName = newValue;
-        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.action.deletebyquery;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.replication.TransportIndicesReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -27,6 +29,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -36,12 +39,23 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  */
-public class TransportDeleteByQueryAction extends TransportIndicesReplicationOperationAction<DeleteByQueryRequest, DeleteByQueryResponse, IndexDeleteByQueryRequest, IndexDeleteByQueryResponse, ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> {
+public class TransportDeleteByQueryAction extends TransportIndicesReplicationOperationAction<DeleteByQueryRequest, DeleteByQueryResponse, IndexDeleteByQueryRequest, IndexDeleteByQueryResponse, ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> implements NodeSettingsService.Listener {
+
+    private volatile boolean destructiveRequiresName;
 
     @Inject
     public TransportDeleteByQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                        ThreadPool threadPool, TransportIndexDeleteByQueryAction indexDeleteByQueryAction) {
+                                        ThreadPool threadPool, TransportIndexDeleteByQueryAction indexDeleteByQueryAction,
+                                        NodeSettingsService nodeSettingsService) {
         super(settings, transportService, clusterService, threadPool, indexDeleteByQueryAction);
+        this.destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, false);
+        nodeSettingsService.addListener(this);
+    }
+
+    @Override
+    protected void doExecute(DeleteByQueryRequest request, ActionListener<DeleteByQueryResponse> listener) {
+        DestructiveOperations.failDestructive(request.indices(), destructiveRequiresName);
+        super.doExecute(request, listener);
     }
 
     @Override
@@ -82,7 +96,7 @@ public class TransportDeleteByQueryAction extends TransportIndicesReplicationOpe
     }
 
     @Override
-    protected ClusterBlockException checkRequestBlock(ClusterState state, DeleteByQueryRequest replicationPingRequest, String[] concreteIndices) {
+    protected ClusterBlockException checkRequestBlock(ClusterState state, DeleteByQueryRequest request, String[] concreteIndices) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.WRITE, concreteIndices);
     }
 
@@ -90,5 +104,14 @@ public class TransportDeleteByQueryAction extends TransportIndicesReplicationOpe
     protected IndexDeleteByQueryRequest newIndexRequestInstance(DeleteByQueryRequest request, String index, Set<String> routing) {
         String[] filteringAliases = clusterService.state().metaData().filteringAliases(index, request.indices());
         return new IndexDeleteByQueryRequest(request, index, routing, filteringAliases);
+    }
+
+    @Override
+    public void onRefreshSettings(Settings settings) {
+        boolean newValue = settings.getAsBoolean("action.destructive_requires_name", destructiveRequiresName);
+        if (destructiveRequiresName != newValue) {
+            logger.info("updating [action.operate_all_indices] from [{}] to [{}]", destructiveRequiresName, newValue);
+            this.destructiveRequiresName = newValue;
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
+++ b/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
@@ -20,23 +20,36 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.settings.NodeSettingsService;
 
 /**
- * Static helper for dealing with destructive operations and wildcards.
+ * Helper for dealing with destructive operations and wildcard usage.
  */
-public final class DestructiveOperations {
+public final class DestructiveOperations implements NodeSettingsService.Listener {
 
+    /**
+     * Setting which controls whether wildcard usage (*, prefix*, _all) is allowed.
+     */
     public static final String REQUIRES_NAME = "action.destructive_requires_name";
 
-    private DestructiveOperations() {
+    private final ESLogger logger;
+    private volatile boolean destructiveRequiresName;
+
+    // TODO: Turn into a component that be reused and wired up into all the transport actions where
+    // this helper logic is required. Note: also added the logger as argument, otherwise the same log
+    // statement is printed several times, this can removed once this becomes a component.
+    public DestructiveOperations(ESLogger logger, Settings settings, NodeSettingsService nodeSettingsService) {
+        this.logger = logger;
+        destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, false);
+        nodeSettingsService.addListener(this);
     }
 
     /**
      * Fail if there is wildcard usage in indices and the named is required for destructive operations.
-     *
-     * @param destructiveRequiresName Controls whether wildcard usage (*, prefix*, _all) is allowed
      */
-    public static void failDestructive(String[] aliasesOrIndices, boolean destructiveRequiresName) {
+    public void failDestructive(String[] aliasesOrIndices) {
         if (!destructiveRequiresName) {
             return;
         }
@@ -53,6 +66,15 @@ public final class DestructiveOperations {
                     throw new ElasticsearchIllegalArgumentException("Wildcard expressions or all indices are not allowed");
                 }
             }
+        }
+    }
+
+    @Override
+    public void onRefreshSettings(Settings settings) {
+        boolean newValue = settings.getAsBoolean("action.destructive_requires_name", destructiveRequiresName);
+        if (destructiveRequiresName != newValue) {
+            logger.info("updating [action.operate_all_indices] from [{}] to [{}]", destructiveRequiresName, newValue);
+            this.destructiveRequiresName = newValue;
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
+++ b/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+
+/**
+ * Static helper for dealing with destructive operations and wildcards.
+ */
+public final class DestructiveOperations {
+
+    public static final String REQUIRES_NAME = "action.destructive_requires_name";
+
+    private DestructiveOperations() {
+    }
+
+    /**
+     * Fail if there is wildcard usage in indices and the named is required for destructive operations.
+     *
+     * @param destructiveRequiresName Controls whether wildcard usage (*, prefix*, _all) is allowed
+     */
+    public static void failDestructive(String[] aliasesOrIndices, boolean destructiveRequiresName) {
+        if (!destructiveRequiresName) {
+            return;
+        }
+
+        if (aliasesOrIndices == null || aliasesOrIndices.length == 0) {
+            throw new ElasticsearchIllegalArgumentException("Wildcard expressions or all indices are not allowed");
+        } else if (aliasesOrIndices.length == 1) {
+            if (hasWildcardUsage(aliasesOrIndices[0])) {
+                throw new ElasticsearchIllegalArgumentException("Wildcard expressions or all indices are not allowed");
+            }
+        } else {
+            for (String aliasesOrIndex : aliasesOrIndices) {
+                if (hasWildcardUsage(aliasesOrIndex)) {
+                    throw new ElasticsearchIllegalArgumentException("Wildcard expressions or all indices are not allowed");
+                }
+            }
+        }
+    }
+
+    private static boolean hasWildcardUsage(String aliasOrIndex) {
+        return "_all".equals(aliasOrIndex) || aliasOrIndex.indexOf('*') != -1;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.settings;
 
+import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
@@ -79,6 +80,7 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(SnapshotInProgressAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED);
         clusterDynamicSettings.addDynamicSetting(InternalCircuitBreakerService.CIRCUIT_BREAKER_MAX_BYTES_SETTING, Validator.BYTES_SIZE);
         clusterDynamicSettings.addDynamicSetting(InternalCircuitBreakerService.CIRCUIT_BREAKER_OVERHEAD_SETTING, Validator.NON_NEGATIVE_DOUBLE);
+        clusterDynamicSettings.addDynamicSetting(DestructiveOperations.REQUIRES_NAME);
     }
 
     public void addDynamicSettings(String... settings) {

--- a/src/test/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIntegrationTests.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.operateAllIndices;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.support.DestructiveOperations;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST)
+public class DestructiveOperationsIntegrationTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    // One test for test performance, since cluster scope is test
+    // The cluster scope is test b/c we can't clear cluster settings.
+    public void testDestructiveOperations() throws Exception {
+        Settings settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, true)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        assertAcked(client().admin().indices().prepareCreate("index1").get());
+        assertAcked(client().admin().indices().prepareCreate("1index").get());
+
+        // Should succeed, since no wildcards
+        assertAcked(client().admin().indices().prepareDelete("1index").get());
+
+        try {
+            // should fail since index1 is the only index.
+            client().admin().indices().prepareDelete("i*").get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+
+        try {
+            client().admin().indices().prepareDelete("_all").get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, false)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        assertAcked(client().admin().indices().prepareDelete("_all").get());
+        assertThat(client().admin().indices().prepareExists("_all").get().isExists(), equalTo(false));
+
+        // end delete index:
+        // close index:
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, true)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        assertAcked(client().admin().indices().prepareCreate("index1").get());
+        assertAcked(client().admin().indices().prepareCreate("1index").get());
+
+        // Should succeed, since no wildcards
+        assertAcked(client().admin().indices().prepareClose("1index").get());
+
+        try {
+            client().admin().indices().prepareClose("_all").get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+        try {
+            assertAcked(client().admin().indices().prepareOpen("_all").get());
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {
+        }
+        try {
+            client().admin().indices().prepareClose("*").get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+        try {
+            assertAcked(client().admin().indices().prepareOpen("*").get());
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {
+        }
+
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, false)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+        assertAcked(client().admin().indices().prepareClose("_all").get());
+        assertAcked(client().admin().indices().prepareOpen("_all").get());
+
+        // end close index:
+        client().admin().indices().prepareDelete("_all").get();
+        // delete_by_query:
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, true)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        assertAcked(client().admin().indices().prepareCreate("index1").get());
+        assertAcked(client().admin().indices().prepareCreate("1index").get());
+
+        // Should succeed, since no wildcards
+        client().prepareDeleteByQuery("1index").setQuery(QueryBuilders.matchAllQuery()).get();
+
+        try {
+            client().prepareDeleteByQuery("_all").setQuery(QueryBuilders.matchAllQuery()).get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+
+        try {
+            client().prepareDeleteByQuery().setQuery(QueryBuilders.matchAllQuery()).get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, false)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        client().prepareDeleteByQuery().setQuery(QueryBuilders.matchAllQuery()).get();
+        client().prepareDeleteByQuery("_all").setQuery(QueryBuilders.matchAllQuery()).get();
+
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+        client().prepareDeleteByQuery().setQuery(QueryBuilders.matchAllQuery()).get();
+        // end delete_by_query:
+        client().admin().indices().prepareDelete("_all").get();
+        // delete mapping:
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, true)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        assertAcked(client().admin().indices().prepareCreate("index1").addMapping("1", "field1", "type=string").get());
+        assertAcked(client().admin().indices().prepareCreate("1index").addMapping("1", "field1", "type=string").get());
+
+        // Should succeed, since no wildcards
+        client().admin().indices().prepareDeleteMapping("1index").setType("1").get();
+        try {
+            client().admin().indices().prepareDeleteMapping("_all").setType("1").get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+
+        try {
+            client().admin().indices().prepareDeleteMapping().setType("1").get();
+            assert false;
+        } catch (ElasticsearchIllegalArgumentException e) {}
+
+        settings = ImmutableSettings.builder()
+                .put(DestructiveOperations.REQUIRES_NAME, false)
+                .build();
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
+
+        client().admin().indices().preparePutMapping("1index").setType("1").setSource("field1", "type=string").get();
+        client().admin().indices().prepareDeleteMapping().setType("1").get();
+        client().admin().indices().preparePutMapping("1index").setType("1").setSource("field1", "type=string").get();
+        client().admin().indices().prepareDeleteMapping("_all").setType("1").get();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -1504,7 +1504,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeletePercolatorType() throws Exception {
-        DeleteIndexResponse deleteIndexResponse = client().admin().indices().prepareDelete().execute().actionGet();
+        DeleteIndexResponse deleteIndexResponse = client().admin().indices().prepareDelete("_all").execute().actionGet();
         assertThat("Delete Index failed - not acked", deleteIndexResponse.isAcknowledged(), equalTo(true));
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
@@ -196,7 +196,7 @@ public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
         cluster().startNode(settings);
         cluster().startNode(settings);
 
-        client().admin().indices().prepareDelete().execute().actionGet();
+        client().admin().indices().prepareDelete("_all").execute().actionGet();
         ensureGreen();
 
         client().admin().indices().prepareCreate("test")
@@ -265,7 +265,7 @@ public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
         logger.info("--> Adding 3th node");
         cluster().startNode(settingsBuilder().put("node.stay", true));
 
-        client().admin().indices().prepareDelete().execute().actionGet();
+        client().admin().indices().prepareDelete("_all").execute().actionGet();
         ensureGreen();
 
         client().admin().indices().prepareCreate("test")

--- a/src/test/java/org/elasticsearch/percolator/TTLPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/TTLPercolatorTests.java
@@ -55,7 +55,7 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
     @Test
     public void testPercolatingWithTimeToLive() throws Exception {
         Client client = client();
-        client.admin().indices().prepareDelete().execute().actionGet();
+        client.admin().indices().prepareDelete("_all").execute().actionGet();
         ensureGreen();
 
         String precolatorMapping = XContentFactory.jsonBuilder().startObject().startObject(PercolatorService.TYPE_NAME)

--- a/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
@@ -610,7 +610,7 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
     public void testThatStatsAreWorking() throws Exception {
         String otherField = "testOtherField";
 
-        client().admin().indices().prepareDelete().get();
+        client().admin().indices().prepareDelete("_all").get();
         client().admin().indices().prepareCreate(INDEX)
                 .setSettings(createDefaultSettings())
                 .get();


### PR DESCRIPTION
Added `action.destructive_requires_name` that controls whether wildcard expressions and `_all` is allowed to be used for destructive operations. Also the delete index api requires always an index to be specified (either concrete index, alias or wildcard expression)

Relates to  #4549 #4481
