### PR TITLE
Allowed empty index parameter in open/close index api

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -50,7 +50,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> {
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (indices == null || indices.length == 0) {
+        if (indices == null) {
             validationException = addValidationError("index is missing", validationException);
         }
         return validationException;

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -50,7 +50,7 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> {
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (indices == null || indices.length == 0) {
+        if (indices == null) {
             validationException = addValidationError("index is missing", validationException);
         }
         return validationException;

--- a/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexTests.java
@@ -177,22 +177,25 @@ public class OpenCloseIndexTests extends ElasticsearchIntegrationTest {
         assertIndexIsOpened("test1", "test2", "test3");
     }
 
-    @Test(expected = ActionRequestValidationException.class)
-    public void testCloseNoIndex() {
+    @Test
+    public void testCloseOpenNoIndex() {
         Client client = client();
-        client.admin().indices().prepareClose().execute().actionGet();
+        createIndex("test1", "test2", "test3");
+        ensureGreen();
+
+        CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose().execute().actionGet();
+        assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsClosed("test1", "test2", "test3");
+
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen().execute().actionGet();
+        assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
+        assertIndexIsOpened("test1", "test2", "test3");
     }
 
     @Test(expected = ActionRequestValidationException.class)
     public void testCloseNullIndex() {
         Client client = client();
         client.admin().indices().prepareClose(null).execute().actionGet();
-    }
-
-    @Test(expected = ActionRequestValidationException.class)
-    public void testOpenNoIndex() {
-        Client client = client();
-        client.admin().indices().prepareOpen().execute().actionGet();
     }
 
     @Test(expected = ActionRequestValidationException.class)


### PR DESCRIPTION
Similarly to what happens with delete index api, curl -XPOST localhost:9200/_open opens now all indices & curl -XPOST localhost:9200/_close closes now all indices.

Closes #4627
