### PR TITLE
Use FHV's phraseLimit

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -526,3 +526,15 @@ to
     }
 --------------------------------------------------
 ===================================================================
+
+added[0.90.10]
+[[matched-fields]]
+==== Phrase Limit
+The `fast-vector-highlighter` has a `phrase_limit` parameter that prevents
+it from analyzing too many phrases and eating tons of memory.  It defaults
+to 256 so only the first 256 matching phrases in the document scored
+considered.  You can raise the limit with the `phrase_limit` parameter but
+keep in mind that scoring more phrases consumes more time and memory.
+
+If using `matched_fields` keep in mind that `phrase_limit` phrases per
+matched field are considered.

--- a/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
@@ -138,6 +138,7 @@ public class FastVectorHighlighter implements Highlighter {
                 CustomFieldQuery.highlightFilters.set(field.highlightFilter());
                 cache.mappers.put(mapper, entry);
             }
+            cache.fvh.setPhraseLimit(field.phraseLimit());
 
             String[] fragments;
 

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
@@ -58,6 +58,8 @@ public class HighlightBuilder implements ToXContent {
 
     private Integer noMatchSize;
 
+    private Integer phraseLimit;
+
     private Map<String, Object> options;
 
     private Boolean forceSource;
@@ -228,6 +230,16 @@ public class HighlightBuilder implements ToXContent {
     }
 
     /**
+     * Sets the maximum number of phrases the fvh will consider if the field doesn't also define phraseLimit.
+     * @param phraseLimit maximum number of phrases the fvh will consider
+     * @return this for chaining
+     */
+    public HighlightBuilder phraseLimit(Integer phraseLimit) {
+        this.phraseLimit = phraseLimit;
+        return this;
+    }
+
+    /**
      * Allows to set custom options for custom highlighters.
      */
     public HighlightBuilder options(Map<String, Object> options) {
@@ -275,6 +287,9 @@ public class HighlightBuilder implements ToXContent {
         }
         if (noMatchSize != null) {
             builder.field("no_match_size", noMatchSize);
+        }
+        if (phraseLimit != null) {
+            builder.field("phrase_limit", phraseLimit);
         }
         if (options != null && options.size() > 0) {
             builder.field("options", options);
@@ -331,6 +346,9 @@ public class HighlightBuilder implements ToXContent {
                 if (field.matchedFields != null) {
                     builder.field("matched_fields", field.matchedFields);
                 }
+                if (field.phraseLimit != null) {
+                    builder.field("phrase_limit", field.phraseLimit);
+                }
                 if (field.options != null && field.options.size() > 0) {
                     builder.field("options", field.options);
                 }
@@ -364,6 +382,7 @@ public class HighlightBuilder implements ToXContent {
         QueryBuilder highlightQuery;
         Integer noMatchSize;
         String[] matchedFields;
+        Integer phraseLimit;
         Map<String, Object> options;
         Boolean forceSource;
 
@@ -496,6 +515,17 @@ public class HighlightBuilder implements ToXContent {
             this.matchedFields = matchedFields;
             return this;
         }
+
+        /**
+         * Sets the maximum number of phrases the fvh will consider.
+         * @param phraseLimit maximum number of phrases the fvh will consider
+         * @return this for chaining
+         */
+        public Field phraseLimit(Integer phraseLimit) {
+            this.phraseLimit = phraseLimit;
+            return this;
+        }
+
 
         /**
          * Forces the highlighting to highlight this field based on the source even if this field is stored separately.

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -86,6 +86,7 @@ public class HighlighterParseElement implements SearchParseElement {
         Map<String, Object> globalOptions = null;
         Query globalHighlightQuery = null;
         int globalNoMatchSize = 0;
+        int globalPhraseLimit = 256;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -139,6 +140,8 @@ public class HighlighterParseElement implements SearchParseElement {
                     globalNoMatchSize = parser.intValue();
                 } else if ("force_source".equals(topLevelFieldName) || "forceSource".equals(topLevelFieldName)) {
                     globalForceSource = parser.booleanValue();
+                } else if ("phrase_limit".equals(topLevelFieldName) || "phraseLimit".equals(topLevelFieldName)) {
+                    globalPhraseLimit = parser.intValue();
                 }
             } else if (token == XContentParser.Token.START_OBJECT && "options".equals(topLevelFieldName)) {
                 globalOptions = parser.map();
@@ -204,6 +207,8 @@ public class HighlighterParseElement implements SearchParseElement {
                                         field.noMatchSize(parser.intValue());
                                     } else if ("force_source".equals(fieldName) || "forceSource".equals(fieldName)) {
                                         field.forceSource(parser.booleanValue());
+                                    } else if ("phrase_limit".equals(fieldName) || "phraseLimit".equals(fieldName)) {
+                                        field.phraseLimit(parser.intValue());
                                     }
                                 } else if (token == XContentParser.Token.START_OBJECT) {
                                     if ("highlight_query".equals(fieldName) || "highlightQuery".equals(fieldName)) {
@@ -274,6 +279,9 @@ public class HighlighterParseElement implements SearchParseElement {
             }
             if (field.forceSource() == null) {
                 field.forceSource(globalForceSource);
+            }
+            if (field.phraseLimit() == -1) {
+                field.phraseLimit(globalPhraseLimit);
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -80,6 +80,8 @@ public class SearchContextHighlight {
 
         private Map<String, Object> options;
 
+        private int phraseLimit = -1;
+
         public Field(String field) {
             this.field = field;
         }
@@ -214,6 +216,14 @@ public class SearchContextHighlight {
 
         public void noMatchSize(int noMatchSize) {
             this.noMatchSize = noMatchSize;
+        }
+
+        public int phraseLimit() {
+            return phraseLimit;
+        }
+
+        public void phraseLimit(int phraseLimit) {
+            this.phraseLimit = phraseLimit;
         }
 
         public Set<String> matchedFields() {


### PR DESCRIPTION
This prevents poisoning the FVH with documents that contain TONS of matches
which take tons of memory and time to highlight.

Closes #4645
