### PR TITLE
Add support for 'disable primary shard nodes option' in datacenter crossing case

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 ElasticSearch
-Copyright 2009-2014 ElasticSearch and Shay Banon
+Copyright 2009-2011 ElasticSearch and Shay Banon
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3,3 +3,4 @@ Copyright 2009-2014 ElasticSearch and Shay Banon
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
+test

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3,4 +3,3 @@ Copyright 2009-2014 ElasticSearch and Shay Banon
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
-test

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -39,6 +39,10 @@
 #
 # node.name: "Franz Kafka"
 
+#  node.zone: "west"
+#  cluster.routing.allocation.disable.primary.groups.zone.values: west
+#  cluster.routing.allocation.disable.primary.attributes: zone
+
 # Every node can be configured to allow or deny being eligible as the master,
 # and to allow or deny to store the data.
 #

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -22,7 +22,10 @@ package org.elasticsearch.cluster.routing;
 import com.carrotsearch.hppc.ObjectIntOpenHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.base.Predicate;
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -267,6 +270,32 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             }
         }
         return null;
+    }
+    
+    /**
+     * 
+     * if existed disable primary node,shoud go through this methed 
+     * 
+     * @param shard
+     * @param disablePrimaryNodeIDMap
+     * @return
+     */
+    public MutableShardRouting activeReplicaWithDisablePrimaryNode(ShardRouting shard, Map<String, Boolean> disablePrimaryNodeIDMap) {
+        if (null == disablePrimaryNodeIDMap) {
+            return activeReplica(shard);
+        }
+        MutableShardRouting disablePrimaryNodeShardRouting = null;
+        for (MutableShardRouting shardRouting : assignedShards(shard.shardId())) {
+            if (!shardRouting.primary() && shardRouting.active()) {
+                if (null == disablePrimaryNodeIDMap.get(shardRouting.currentNodeId())) {
+                    return shardRouting;
+                } else {
+                    disablePrimaryNodeShardRouting = shardRouting;
+                }
+
+            }
+        }
+        return disablePrimaryNodeShardRouting;
     }
 
     /**


### PR DESCRIPTION
Sometimes we need to do write request in one datacenter for low latency and another datacenter we just provide read operateion.
On the other hand ,we just have one elasticsearch cluster because of we want to use elastisearch self replication strategy.
Because of these reasons, we want to specify primary shard nodes . 
For example ,we want some nodes  in west would not be assigned primary shards and the nodes in east assigned all primary shards.
Please ignore the "NOTICE.txt" changes. 
