### PR TITLE
remove default `_all` for `type` and `index` if these are missing in RES...

### DIFF
--- a/rest-api-spec/api/exists.json
+++ b/rest-api-spec/api/exists.json
@@ -18,8 +18,7 @@
         },
         "type": {
           "type" : "string",
-          "required" : false,
-          "default" : "_all",
+          "required" : true,
           "description" : "The type of the document (use `_all` to fetch the first document matching the ID across all types)"
         }
       },

--- a/rest-api-spec/api/get.json
+++ b/rest-api-spec/api/get.json
@@ -18,8 +18,7 @@
         },
         "type": {
           "type" : "string",
-          "required" : false,
-          "default" : "_all",
+          "required" : true,
           "description" : "The type of the document (use `_all` to fetch the first document matching the ID across all types)"
         }
       },

--- a/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/api/get_source.json
@@ -18,8 +18,7 @@
         },
         "type": {
           "type" : "string",
-          "required" : false,
-          "default"  : "_all",
+          "required" : true,
           "description" : "The type of the document; use `_all` to fetch the first document matching the ID across all types"
         }
       },

--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -8,7 +8,6 @@
       "parts": {
         "index": {
          "type" : "list",
-         "default" : "_all",
          "description" : "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
         },
         "type": {

--- a/rest-api-spec/test/exists/70_defaults.yaml
+++ b/rest-api-spec/test/exists/70_defaults.yaml
@@ -11,6 +11,7 @@
   - do:
       exists:
         index: test_1
+        type: _all
         id:    1
 
   - is_true: ''

--- a/rest-api-spec/test/get/10_basic.yaml
+++ b/rest-api-spec/test/get/10_basic.yaml
@@ -22,6 +22,7 @@
   - do:
       get:
         index: test_1
+        type: _all
         id:    中文
 
   - match: { _index:   test_1 }

--- a/rest-api-spec/test/get/15_default_values.yaml
+++ b/rest-api-spec/test/get/15_default_values.yaml
@@ -11,6 +11,7 @@
   - do:
       get:
         index: test_1
+        type: _all
         id:    1
 
   - match: { _index:   test_1 }

--- a/rest-api-spec/test/get_source/10_basic.yaml
+++ b/rest-api-spec/test/get_source/10_basic.yaml
@@ -18,6 +18,7 @@
   - do:
       get_source:
         index: test_1
+        type: _all
         id:    1
 
   - match: { '':  { foo: bar } }

--- a/rest-api-spec/test/get_source/15_default_values.yaml
+++ b/rest-api-spec/test/get_source/15_default_values.yaml
@@ -10,6 +10,7 @@
   - do:
       get_source:
         index: test_1
+        type: _all
         id:    1
 
   - match: { '':  { foo: bar } }

--- a/rest-api-spec/test/search/20_default_values.yaml
+++ b/rest-api-spec/test/search/20_default_values.yaml
@@ -26,7 +26,8 @@
 
   - do:
       search:
-        type:   test
+        index: _all
+        type:  test
         body:
           query:
             match:

--- a/src/test/java/org/elasticsearch/test/rest/spec/RestApi.java
+++ b/src/test/java/org/elasticsearch/test/rest/spec/RestApi.java
@@ -36,8 +36,6 @@ import java.util.regex.Pattern;
  */
 public class RestApi {
 
-    private static final String ALL = "_all";
-
     private final String name;
     private List<String> methods = Lists.newArrayList();
     private List<String> paths = Lists.newArrayList();
@@ -123,18 +121,23 @@ public class RestApi {
         RestPath matchingRestPath = findMatchingRestPath(pathParams.keySet());
         String path = matchingRestPath.path;
         for (Map.Entry<String, String> paramEntry : matchingRestPath.params.entrySet()) {
-            //replace path placeholders with actual values
+            // replace path placeholders with actual values
             String value = pathParams.get(paramEntry.getValue());
             if (value == null) {
-                //there might be additional placeholder to replace, not available as input params
-                //it can only be {index} or {type} to be replaced with _all
-                if (paramEntry.getValue().equals("index") || paramEntry.getValue().equals("type")) {
-                    value = ALL;
-                } else {
-                    throw new IllegalArgumentException("path [" + path + "] contains placeholders that weren't replaced with proper values");
-                }
+                // if a value is missing, we got the wrong path or the test was
+                // specified incorrectly
+                // TODO: Figure out if it is possible that two paths accept same
+                // number of parameters but are called differently so that
+                // really wrong path is returned. Maybe we should return all
+                // paths that have the required number of parameters and then
+                // check which one also has the correct ones?
+                // TODO: What if more than one path exists? for example: PUT
+                // index/type/_mapping vs. PUT index/_maping/type? Should we
+                // randomize?
+                throw new IllegalArgumentException("parameter [" + paramEntry.getValue() + "] missing");
+            } else {
+                path = path.replace(paramEntry.getKey(), value);
             }
-            path = path.replace(paramEntry.getKey(), value);
         }
         return path;
     }

--- a/src/test/java/org/elasticsearch/test/rest/spec/RestApi.java
+++ b/src/test/java/org/elasticsearch/test/rest/spec/RestApi.java
@@ -126,11 +126,6 @@ public class RestApi {
             if (value == null) {
                 // if a value is missing, we got the wrong path or the test was
                 // specified incorrectly
-                // TODO: Figure out if it is possible that two paths accept same
-                // number of parameters but are called differently so that
-                // really wrong path is returned. Maybe we should return all
-                // paths that have the required number of parameters and then
-                // check which one also has the correct ones?
                 // TODO: What if more than one path exists? for example: PUT
                 // index/type/_mapping vs. PUT index/_maping/type? Should we
                 // randomize?


### PR DESCRIPTION
...T tests

If a type or path is missing in the REST test yaml file, it is
automatically replaced with _all. This makes it hard to test changes
in the api, for example adding the possibility to leave the index
blank in addition to _all and \* in the uri.

closes #4657
