### PR TITLE
improve buffered output

### DIFF
--- a/src/main/java/org/apache/lucene/store/RateLimitedFSDirectory.java
+++ b/src/main/java/org/apache/lucene/store/RateLimitedFSDirectory.java
@@ -83,7 +83,7 @@ public final class RateLimitedFSDirectory extends FilterDirectory{
         private final StoreRateLimiting.Listener rateListener;
 
         RateLimitedIndexOutput(final RateLimiter rateLimiter, final StoreRateLimiting.Listener rateListener, final IndexOutput delegate) {
-            // TODO if Lucene exposed in BufferedIndexOutput#getBufferSize, we could initialize it if the delegate is buffered
+            super(delegate instanceof BufferedIndexOutput ? ((BufferedIndexOutput) delegate).getBufferSize() : BufferedIndexOutput.DEFAULT_BUFFER_SIZE);
             if (delegate instanceof BufferedIndexOutput) {
                 bufferedDelegate = (BufferedIndexOutput) delegate;
                 this.delegate = delegate;
@@ -124,6 +124,11 @@ public final class RateLimitedFSDirectory extends FilterDirectory{
             } finally {
                 delegate.flush();
             }
+        }
+
+        @Override
+        public void setLength(long length) throws IOException {
+            delegate.setLength(length);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Directories;
-import org.elasticsearch.common.lucene.store.BufferedChecksumIndexOutput;
 import org.elasticsearch.common.lucene.store.ChecksumIndexOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;


### PR DESCRIPTION
- use the same buffer size if wrapping a buffered output
- directly call flush on the checksum wrapper
