### PR TITLE
Expose min/max open file descriptors in Cluster Stats API

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -110,7 +110,11 @@ Will return, for example:
          "cpu": {
             "percent": 3
          },
-         "avg_open_file_descriptors": 218
+         "open_file_descriptors": {
+            "min": 200,
+            "max": 346,
+            "avg": 273
+         }
       },
       "jvm": {
          "max_uptime": "24s",

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -397,6 +397,8 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
         int count;
         int cpuPercent;
         long totalOpenFileDescriptors;
+        long minOpenFileDescriptors = Integer.MAX_VALUE;
+        long maxOpenFileDescriptors = Integer.MIN_VALUE;
 
         public void addNodeStats(NodeStats nodeStats) {
             if (nodeStats.getProcess() == null) {
@@ -407,7 +409,10 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
                 // with no sigar, this may not be available
                 cpuPercent += nodeStats.getProcess().cpu().getPercent();
             }
-            totalOpenFileDescriptors += nodeStats.getProcess().openFileDescriptors();
+            long fd = nodeStats.getProcess().openFileDescriptors();
+            totalOpenFileDescriptors += fd;
+            minOpenFileDescriptors = Math.min(minOpenFileDescriptors, fd);
+            maxOpenFileDescriptors = Math.max(maxOpenFileDescriptors, fd);
         }
 
         /**
@@ -422,6 +427,20 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
                 return -1;
             }
             return totalOpenFileDescriptors / count;
+        }
+
+        public long getMaxOpenFileDescriptors() {
+            if (count == 0) {
+                return -1;
+            }
+            return maxOpenFileDescriptors;
+        }
+
+        public long getMinOpenFileDescriptors() {
+            if (count == 0) {
+                return -1;
+            }
+            return minOpenFileDescriptors;
         }
 
         @Override
@@ -447,13 +466,22 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
         static final class Fields {
             static final XContentBuilderString CPU = new XContentBuilderString("cpu");
             static final XContentBuilderString PERCENT = new XContentBuilderString("percent");
-            static final XContentBuilderString AVG_OPEN_FD = new XContentBuilderString("avg_open_file_descriptors");
+            static final XContentBuilderString OPEN_FILE_DESCRIPTORS = new XContentBuilderString("open_file_descriptors");
+            static final XContentBuilderString MIN = new XContentBuilderString("min");
+            static final XContentBuilderString MAX = new XContentBuilderString("max");
+            static final XContentBuilderString AVG = new XContentBuilderString("avg");
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject(Fields.CPU).field(Fields.PERCENT, cpuPercent).endObject();
-            builder.field(Fields.AVG_OPEN_FD, getAvgOpenFileDescriptors());
+            if (count > 0) {
+                builder.startObject(Fields.OPEN_FILE_DESCRIPTORS);
+                builder.field(Fields.MIN, getMinOpenFileDescriptors());
+                builder.field(Fields.MAX, getMaxOpenFileDescriptors());
+                builder.field(Fields.AVG, getAvgOpenFileDescriptors());
+                builder.endObject();
+            }
             return builder;
         }
     }

--- a/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsTests.java
@@ -136,5 +136,9 @@ public class ClusterStatsTests extends ElasticsearchIntegrationTest {
         assertThat(response.nodesStats.getVersions().contains(Version.CURRENT), Matchers.equalTo(true));
         assertThat(response.nodesStats.getPlugins().size(), Matchers.greaterThanOrEqualTo(0));
 
+        assertThat(response.nodesStats.getProcess().getAvgOpenFileDescriptors(), Matchers.greaterThan(0L));
+        assertThat(response.nodesStats.getProcess().getMinOpenFileDescriptors(), Matchers.greaterThan(0L));
+        assertThat(response.nodesStats.getProcess().getMaxOpenFileDescriptors(), Matchers.greaterThan(0L));
+
     }
 }


### PR DESCRIPTION
Also changes the response format of that section to:

```
 "open_file_descriptors": {
      "min": 200,
      "max": 346,
       "avg": 273
 }
```

Closes 4681
