### PR TITLE
Adds a new “coerce” flag for controlling numeric value field mappings 

### DIFF
--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -51,8 +51,16 @@ index>>.
 
 The `index.mapping.ignore_malformed` global setting can be set on the
 index level to allow to ignore malformed content globally across all
-mapping types (malformed content example is trying to index a string
+mapping types (malformed content example is trying to index a text string
 value as a numeric type).
+
+The `index.mapping.coerce` global setting can be set on the
+index level to coerce numeric content globally across all
+mapping types (The default setting is true and coercions attempted are 
+to convert strings with numbers into numeric types and also numeric values
+with fractions to any integer/short/long values minus the fraction part).
+When the permitted conversions fail in their attempts, the value is considered 
+malformed and the ignore_malformed setting dictates what will happen next.
 --
 
 include::mapping/fields.asciidoc[]

--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -230,6 +230,8 @@ defaults to `true` or to the parent `object` type setting.
 
 |`ignore_malformed` |Ignored a malformed number. Defaults to `false`.
 
+|`coerce` |Try convert strings to numbers and truncate fractions for integers. Defaults to `true`.
+
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/common/Explicit.java
+++ b/src/main/java/org/elasticsearch/common/Explicit.java
@@ -20,12 +20,24 @@
 package org.elasticsearch.common;
 
 /**
+ * Holds a value that is either:
+ * a) set implicitly e.g. through some default value
+ * b) set explicitly e.g. from a user selection
+ * 
+ * When merging conflicting configuration settings such as
+ * field mapping settings it is preferable to preserve an explicit
+ * choice rather than a choice made only made implicitly by defaults. 
+ * 
  */
 public class Explicit<T> {
 
     private final T value;
     private final boolean explicit;
-
+    /**
+     * Create a value with an indication if this was an explicit choice
+     * @param value a setting value
+     * @param explicit true if the value passed is a conscious decision, false if using some kind of default
+     */
     public Explicit(T value, boolean explicit) {
         this.value = value;
         this.explicit = explicit;
@@ -35,6 +47,10 @@ public class Explicit<T> {
         return this.value;
     }
 
+    /**
+     * 
+     * @return true if the value passed is a conscious decision, false if using some kind of default
+     */
     public boolean explicit() {
         return this.explicit;
     }

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -157,6 +157,16 @@ public interface XContentParser extends Closeable {
      */
     boolean estimatedNumberType();
 
+    short shortValue(boolean coerce) throws IOException;
+
+    int intValue(boolean coerce) throws IOException;
+
+    long longValue(boolean coerce) throws IOException;
+
+    float floatValue(boolean coerce) throws IOException;
+
+    double doubleValue(boolean coerce) throws IOException;
+    
     short shortValue() throws IOException;
 
     int intValue() throws IOException;

--- a/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -31,6 +31,39 @@ import java.util.*;
  */
 public abstract class AbstractXContentParser implements XContentParser {
 
+    //Currently this is not a setting that can be changed and is a policy 
+    // that relates to how parsing of things like "boost" are done across
+    // the whole of Elasticsearch (eg if String "1.0" is a valid float).
+    // The idea behind keeping it as a constant is that we can track
+    // references to this policy decision throughout the codebase and find
+    // and change any code that needs to apply an alternative policy.
+    public static final boolean DEFAULT_NUMBER_COEERCE_POLICY = true;
+    
+    private static void checkCoerceString(boolean coeerce, Class<? extends Number> clazz) {
+        if (!coeerce) {
+            //Need to throw type IllegalArgumentException as current catch logic in 
+            //NumberFieldMapper.parseCreateField relies on this for "malformed" value detection
+            throw new IllegalArgumentException(clazz.getSimpleName() + " value passed as String");
+        }
+    }
+
+
+    
+    // The 3rd party parsers we rely on are known to silently truncate fractions: see
+    //   http://fasterxml.github.io/jackson-core/javadoc/2.3.0/com/fasterxml/jackson/core/JsonParser.html#getShortValue()
+    // If this behaviour is flagged as undesirable and any truncation occurs
+    // then this method is called to trigger the"malformed" handling logic
+    void ensureNumberConversion(boolean coerce, long result, Class<? extends Number> clazz) throws IOException {
+        if (!coerce) {
+            double fullVal = doDoubleValue();
+            if (result != fullVal) {
+                // Need to throw type IllegalArgumentException as current catch
+                // logic in NumberFieldMapper.parseCreateField relies on this
+                // for "malformed" value detection
+                throw new IllegalArgumentException(fullVal + " cannot be converted to " + clazz.getSimpleName() + " without data loss");
+            }
+        }
+    }
 
     @Override
     public boolean isBooleanValue() throws IOException {
@@ -62,41 +95,72 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public short shortValue() throws IOException {
+        return shortValue(DEFAULT_NUMBER_COEERCE_POLICY);
+    }
+
+    @Override
+    public short shortValue(boolean coerce) throws IOException {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
+            checkCoerceString(coerce, Short.class);
             return Short.parseShort(text());
         }
-        return doShortValue();
+        short result = doShortValue();
+        ensureNumberConversion(coerce, result, Short.class);
+        return result;
     }
 
     protected abstract short doShortValue() throws IOException;
 
     @Override
     public int intValue() throws IOException {
+        return intValue(DEFAULT_NUMBER_COEERCE_POLICY);
+    }
+
+    
+    @Override
+    public int intValue(boolean coerce) throws IOException {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
+            checkCoerceString(coerce, Integer.class);
             return Integer.parseInt(text());
         }
-        return doIntValue();
+        int result = doIntValue();
+        ensureNumberConversion(coerce, result, Integer.class);
+        return result;        
     }
 
     protected abstract int doIntValue() throws IOException;
 
     @Override
     public long longValue() throws IOException {
+        return longValue(DEFAULT_NUMBER_COEERCE_POLICY);
+    }
+    
+    @Override
+    public long longValue(boolean coerce) throws IOException {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
+            checkCoerceString(coerce, Long.class);
             return Long.parseLong(text());
         }
-        return doLongValue();
+        long result = doLongValue();
+        ensureNumberConversion(coerce, result, Long.class);
+        return result;        
     }
 
     protected abstract long doLongValue() throws IOException;
 
     @Override
     public float floatValue() throws IOException {
+        return floatValue(DEFAULT_NUMBER_COEERCE_POLICY);
+    }
+    
+    @Override
+    public float floatValue(boolean coerce) throws IOException {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
+            checkCoerceString(coerce, Float.class);
             return Float.parseFloat(text());
         }
         return doFloatValue();
@@ -104,10 +168,17 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     protected abstract float doFloatValue() throws IOException;
 
+    
     @Override
     public double doubleValue() throws IOException {
+        return doubleValue(DEFAULT_NUMBER_COEERCE_POLICY);
+    }
+
+    @Override
+    public double doubleValue(boolean coerce) throws IOException {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
+            checkCoerceString(coerce, Double.class);
             return Double.parseDouble(text());
         }
         return doDoubleValue();

--- a/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -93,7 +93,8 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             ByteFieldMapper fieldMapper = new ByteFieldMapper(buildNames(context),
                     precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context),
-                    postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
+                    coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, 
+                    fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -120,11 +121,12 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
     private String nullValueAsString;
 
     protected ByteFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                              Byte nullValue, Explicit<Boolean> ignoreMalformed, PostingsFormatProvider postingsProvider,
+                              Byte nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, 
+                              PostingsFormatProvider postingsProvider,
                               DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity, Loading normsLoading,
                               @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, docValues,
-                ignoreMalformed, new NamedAnalyzer("_byte/" + precisionStep, new NumericIntegerAnalyzer(precisionStep)),
+                ignoreMalformed, coerce, new NamedAnalyzer("_byte/" + precisionStep, new NumericIntegerAnalyzer(precisionStep)),
                 new NamedAnalyzer("_byte/max", new NumericIntegerAnalyzer(Integer.MAX_VALUE)), postingsProvider,
                 docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -293,7 +295,7 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = (byte) parser.shortValue();
+                                objValue = (byte) parser.shortValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -308,7 +310,7 @@ public class ByteFieldMapper extends NumberFieldMapper<Byte> {
                 }
                 value = objValue;
             } else {
-                value = (byte) parser.shortValue();
+                value = (byte) parser.shortValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(names.fullName(), parser.text(), boost);
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -128,7 +128,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                 dateTimeFormatter = new FormatDateTimeFormatter(dateTimeFormatter.format(), dateTimeFormatter.parser(), dateTimeFormatter.printer(), locale);
             }
             DateFieldMapper fieldMapper = new DateFieldMapper(buildNames(context), dateTimeFormatter,
-                    precisionStep, boost, fieldType, docValues, nullValue, timeUnit, roundCeil, ignoreMalformed(context),
+                    precisionStep, boost, fieldType, docValues, nullValue, timeUnit, roundCeil, ignoreMalformed(context), coerce(context),
                     postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -201,10 +201,10 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
     protected final TimeUnit timeUnit;
 
     protected DateFieldMapper(Names names, FormatDateTimeFormatter dateTimeFormatter, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                              String nullValue, TimeUnit timeUnit, boolean roundCeil, Explicit<Boolean> ignoreMalformed,
+                              String nullValue, TimeUnit timeUnit, boolean roundCeil, Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce,
                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
                               Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, new NamedAnalyzer("_date/" + precisionStep,
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce, new NamedAnalyzer("_date/" + precisionStep,
                 new NumericDateAnalyzer(precisionStep, dateTimeFormatter.parser())),
                 new NamedAnalyzer("_date/max", new NumericDateAnalyzer(Integer.MAX_VALUE, dateTimeFormatter.parser())),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
@@ -392,7 +392,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
             if (token == XContentParser.Token.VALUE_NULL) {
                 dateAsString = nullValue;
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                value = parser.longValue();
+                value = parser.longValue(coerce.value());
             } else if (token == XContentParser.Token.START_OBJECT) {
                 String currentFieldName = null;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -403,7 +403,7 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                             if (token == XContentParser.Token.VALUE_NULL) {
                                 dateAsString = nullValue;
                             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                                value = parser.longValue();
+                                value = parser.longValue(coerce.value());
                             } else {
                                 dateAsString = parser.text();
                             }

--- a/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -95,8 +95,8 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
         public DoubleFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             DoubleFieldMapper fieldMapper = new DoubleFieldMapper(buildNames(context),
-                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider,
-                    similarity, normsLoading, fieldDataSettings, context.indexSettings());
+                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context), postingsProvider, 
+                    docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -124,10 +124,10 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
     private String nullValueAsString;
 
     protected DoubleFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                                Double nullValue, Explicit<Boolean> ignoreMalformed,
+                                Double nullValue, Explicit<Boolean> ignoreMalformed,  Explicit<Boolean> coerce,
                                 PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                                 SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed,
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce,
                 NumericDoubleAnalyzer.buildNamedAnalyzer(precisionStep), NumericDoubleAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -287,7 +287,7 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = parser.doubleValue();
+                                objValue = parser.doubleValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -302,7 +302,7 @@ public class DoubleFieldMapper extends NumberFieldMapper<Double> {
                 }
                 value = objValue;
             } else {
-                value = parser.doubleValue();
+                value = parser.doubleValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(names.fullName(), parser.text(), boost);
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -96,8 +96,8 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
         public FloatFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             FloatFieldMapper fieldMapper = new FloatFieldMapper(buildNames(context),
-                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider,
-                    similarity, normsLoading, fieldDataSettings, context.indexSettings());
+                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context), postingsProvider, 
+                    docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -124,10 +124,10 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
     private String nullValueAsString;
 
     protected FloatFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                               Float nullValue, Explicit<Boolean> ignoreMalformed,
+                               Float nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                                SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed,
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce,
                 NumericFloatAnalyzer.buildNamedAnalyzer(precisionStep), NumericFloatAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -293,7 +293,7 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = parser.floatValue();
+                                objValue = parser.floatValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -308,7 +308,7 @@ public class FloatFieldMapper extends NumberFieldMapper<Float> {
                 }
                 value = objValue;
             } else {
-                value = parser.floatValue();
+                value = parser.floatValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(names.fullName(), parser.text(), boost);
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -92,7 +92,7 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
         public IntegerFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             IntegerFieldMapper fieldMapper = new IntegerFieldMapper(buildNames(context), precisionStep, boost, fieldType, docValues,
-                    nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
+                    nullValue, ignoreMalformed(context), coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -119,11 +119,11 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
     private String nullValueAsString;
 
     protected IntegerFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                                 Integer nullValue, Explicit<Boolean> ignoreMalformed,
+                                 Integer nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                  PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                                  SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings,
                                  Settings indexSettings) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed,
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce,
                 NumericIntegerAnalyzer.buildNamedAnalyzer(precisionStep), NumericIntegerAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -288,7 +288,7 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = parser.intValue();
+                                objValue = parser.intValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -303,7 +303,7 @@ public class IntegerFieldMapper extends NumberFieldMapper<Integer> {
                 }
                 value = objValue;
             } else {
-                value = parser.intValue();
+                value = parser.intValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(names.fullName(), parser.text(), boost);
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -92,7 +92,7 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
         public LongFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             LongFieldMapper fieldMapper = new LongFieldMapper(buildNames(context), precisionStep, boost, fieldType, docValues, nullValue,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
+                    ignoreMalformed(context), coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -119,10 +119,10 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
     private String nullValueAsString;
 
     protected LongFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                              Long nullValue, Explicit<Boolean> ignoreMalformed,
+                              Long nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                               SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed,
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce,
                 NumericLongAnalyzer.buildNamedAnalyzer(precisionStep), NumericLongAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -277,7 +277,7 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = parser.longValue();
+                                objValue = parser.longValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -292,7 +292,7 @@ public class LongFieldMapper extends NumberFieldMapper<Long> {
                 }
                 value = objValue;
             } else {
-                value = parser.longValue();
+                value = parser.longValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(names.fullName(), parser.text(), boost);
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -77,6 +77,7 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
         }
 
         public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<Boolean>(false, false);
+        public static final Explicit<Boolean> COERCE = new Explicit<Boolean>(true, false);
     }
 
     public abstract static class Builder<T extends Builder, Y extends NumberFieldMapper> extends AbstractFieldMapper.Builder<T, Y> {
@@ -85,6 +86,8 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
 
         private Boolean ignoreMalformed;
 
+        private Boolean coerce;
+        
         public Builder(String name, FieldType fieldType) {
             super(name, fieldType);
         }
@@ -108,6 +111,22 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
             }
             return Defaults.IGNORE_MALFORMED;
         }
+        
+        public T coerce(boolean coerce) {
+            this.coerce = coerce;
+            return builder;
+        }
+
+        protected Explicit<Boolean> coerce(BuilderContext context) {
+            if (coerce != null) {
+                return new Explicit<Boolean>(coerce, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<Boolean>(context.indexSettings().getAsBoolean("index.mapping.coerce", Defaults.COERCE.value()), false);
+            }
+            return Defaults.COERCE;
+        }
+        
     }
 
     protected int precisionStep;
@@ -116,6 +135,8 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
 
     protected Explicit<Boolean> ignoreMalformed;
 
+    protected Explicit<Boolean> coerce;
+    
     private ThreadLocal<NumericTokenStream> tokenStream = new ThreadLocal<NumericTokenStream>() {
         @Override
         protected NumericTokenStream initialValue() {
@@ -145,7 +166,7 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
     };
 
     protected NumberFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                                Explicit<Boolean> ignoreMalformed, NamedAnalyzer indexAnalyzer,
+                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, NamedAnalyzer indexAnalyzer,
                                 NamedAnalyzer searchAnalyzer, PostingsFormatProvider postingsProvider,
                                 DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
                                 Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
@@ -157,6 +178,7 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
             this.precisionStep = precisionStep;
         }
         this.ignoreMalformed = ignoreMalformed;
+        this.coerce = coerce;
     }
 
     @Override
@@ -327,6 +349,9 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
             if (nfmMergeWith.ignoreMalformed.explicit()) {
                 this.ignoreMalformed = nfmMergeWith.ignoreMalformed;
             }
+            if (nfmMergeWith.coerce.explicit()) {
+                this.coerce = nfmMergeWith.coerce;
+            }
         }
     }
 
@@ -469,6 +494,9 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
 
         if (includeDefaults || ignoreMalformed.explicit()) {
             builder.field("ignore_malformed", ignoreMalformed.value());
+        }
+        if (includeDefaults || coerce.explicit()) {
+            builder.field("coerce", coerce.value());
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -93,7 +93,7 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
         public ShortFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             ShortFieldMapper fieldMapper = new ShortFieldMapper(buildNames(context), precisionStep, boost, fieldType, docValues, nullValue,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
+                    ignoreMalformed(context), coerce(context),postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
         }
@@ -120,10 +120,10 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
     private String nullValueAsString;
 
     protected ShortFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                               Short nullValue, Explicit<Boolean> ignoreMalformed,
+                               Short nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                                SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, new NamedAnalyzer("_short/" + precisionStep,
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce, new NamedAnalyzer("_short/" + precisionStep,
                 new NumericIntegerAnalyzer(precisionStep)), new NamedAnalyzer("_short/max", new NumericIntegerAnalyzer(Integer.MAX_VALUE)),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -292,7 +292,7 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
                     } else {
                         if ("value".equals(currentFieldName) || "_value".equals(currentFieldName)) {
                             if (parser.currentToken() != XContentParser.Token.VALUE_NULL) {
-                                objValue = parser.shortValue();
+                                objValue = parser.shortValue(coerce.value());
                             }
                         } else if ("boost".equals(currentFieldName) || "_boost".equals(currentFieldName)) {
                             boost = parser.floatValue();
@@ -307,7 +307,7 @@ public class ShortFieldMapper extends NumberFieldMapper<Short> {
                 }
                 value = objValue;
             } else {
-                value = parser.shortValue();
+                value = parser.shortValue(coerce.value());
                 if (context.includeInAll(includeInAll, this)) {
                     context.allEntries().addText(names.fullName(), parser.text(), boost);
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -79,7 +79,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
         public TokenCountFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             TokenCountFieldMapper fieldMapper = new TokenCountFieldMapper(buildNames(context), precisionStep, boost, fieldType, docValues, nullValue,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(),
+                    ignoreMalformed(context), coerce(context), postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, context.indexSettings(),
                     analyzer);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -115,9 +115,9 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
     private NamedAnalyzer analyzer;
 
     protected TokenCountFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues, Integer nullValue,
-            Explicit<Boolean> ignoreMalformed, PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+            Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
             SimilarityProvider similarity, Loading normsLoading, Settings fieldDataSettings, Settings indexSettings, NamedAnalyzer analyzer) {
-        super(names, precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed, postingsProvider, docValuesProvider, similarity,
+        super(names, precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed, coerce, postingsProvider, docValuesProvider, similarity,
                 normsLoading, fieldDataSettings, indexSettings);
         this.analyzer = analyzer;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -58,6 +58,8 @@ public class TypeParsers {
                 builder.precisionStep(nodeIntegerValue(propNode));
             } else if (propName.equals("ignore_malformed")) {
                 builder.ignoreMalformed(nodeBooleanValue(propNode));
+            } else if (propName.equals("coerce")) {
+                builder.coerce(nodeBooleanValue(propNode));
             } else if (propName.equals("omit_norms")) {
                 builder.omitNorms(nodeBooleanValue(propNode));
             } else if (propName.equals("similarity")) {

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -125,7 +125,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
 
     protected BoostFieldMapper(String name, String indexName, int precisionStep, float boost, FieldType fieldType, Boolean docValues, Float nullValue,
                                PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(new Names(name, indexName, indexName, name), precisionStep, boost, fieldType, docValues, Defaults.IGNORE_MALFORMED,
+        super(new Names(name, indexName, indexName, name), precisionStep, boost, fieldType, docValues, Defaults.IGNORE_MALFORMED, Defaults.COERCE,
                 NumericFloatAnalyzer.buildNamedAnalyzer(precisionStep), NumericFloatAnalyzer.buildNamedAnalyzer(Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;
@@ -273,7 +273,7 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
             }
             value = nullValue;
         } else {
-            value = context.parser().floatValue();
+            value = context.parser().floatValue(coerce.value());
         }
         return value;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -102,7 +102,7 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
     public SizeFieldMapper(EnabledAttributeMapper enabled, FieldType fieldType, PostingsFormatProvider postingsProvider,
                            DocValuesFormatProvider docValuesProvider, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME), Defaults.PRECISION_STEP, Defaults.BOOST, fieldType, null, Defaults.NULL_VALUE,
-                Defaults.IGNORE_MALFORMED, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
+                Defaults.IGNORE_MALFORMED,  Defaults.COERCE, postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.enabledState = enabled;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -89,7 +89,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
 
         @Override
         public TTLFieldMapper build(BuilderContext context) {
-            return new TTLFieldMapper(fieldType, enabledState, defaultTTL, ignoreMalformed(context), postingsProvider, docValuesProvider, fieldDataSettings, context.indexSettings());
+            return new TTLFieldMapper(fieldType, enabledState, defaultTTL, ignoreMalformed(context),coerce(context), postingsProvider, docValuesProvider, fieldDataSettings, context.indexSettings());
         }
     }
 
@@ -119,14 +119,14 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
     private long defaultTTL;
 
     public TTLFieldMapper() {
-        this(new FieldType(Defaults.TTL_FIELD_TYPE), Defaults.ENABLED_STATE, Defaults.DEFAULT, Defaults.IGNORE_MALFORMED, null, null, null, ImmutableSettings.EMPTY);
+        this(new FieldType(Defaults.TTL_FIELD_TYPE), Defaults.ENABLED_STATE, Defaults.DEFAULT, Defaults.IGNORE_MALFORMED, Defaults.COERCE, null, null, null, ImmutableSettings.EMPTY);
     }
 
     protected TTLFieldMapper(FieldType fieldType, EnabledAttributeMapper enabled, long defaultTTL, Explicit<Boolean> ignoreMalformed,
-                             PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
-                             @Nullable Settings fieldDataSettings, Settings indexSettings) {
+                Explicit<Boolean> coerce, PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), Defaults.PRECISION_STEP,
-                Defaults.BOOST, fieldType, null, Defaults.NULL_VALUE, ignoreMalformed,
+                Defaults.BOOST, fieldType, null, Defaults.NULL_VALUE, ignoreMalformed, coerce,
                 postingsProvider, docValuesProvider, null, null, fieldDataSettings, indexSettings);
         this.enabledState = enabled;
         this.defaultTTL = defaultTTL;
@@ -184,7 +184,7 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
             if (context.parser().currentToken() == XContentParser.Token.VALUE_STRING) {
                 ttl = TimeValue.parseTimeValue(context.parser().text(), null).millis();
             } else {
-                ttl = context.parser().longValue();
+                ttl = context.parser().longValue(coerce.value());
             }
             if (ttl <= 0) {
                 throw new MapperParsingException("TTL value must be > 0. Illegal value provided [" + ttl + "]");

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -105,7 +105,7 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
                 roundCeil =  settings.getAsBoolean("index.mapping.date.round_ceil", settings.getAsBoolean("index.mapping.date.parse_upper_inclusive", Defaults.ROUND_CEIL));
             }
             return new TimestampFieldMapper(fieldType, docValues, enabledState, path, dateTimeFormatter, roundCeil,
-                    ignoreMalformed(context), postingsProvider, docValuesProvider, normsLoading, fieldDataSettings, context.indexSettings());
+                    ignoreMalformed(context), coerce(context), postingsProvider, docValuesProvider, normsLoading, fieldDataSettings, context.indexSettings());
         }
     }
 
@@ -137,18 +137,18 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
 
     public TimestampFieldMapper() {
         this(new FieldType(Defaults.FIELD_TYPE), null, Defaults.ENABLED, Defaults.PATH, Defaults.DATE_TIME_FORMATTER,
-                Defaults.ROUND_CEIL, Defaults.IGNORE_MALFORMED, null, null, null, null, ImmutableSettings.EMPTY);
+                Defaults.ROUND_CEIL, Defaults.IGNORE_MALFORMED, Defaults.COERCE, null, null, null, null, ImmutableSettings.EMPTY);
     }
 
     protected TimestampFieldMapper(FieldType fieldType, Boolean docValues, EnabledAttributeMapper enabledState, String path,
                                    FormatDateTimeFormatter dateTimeFormatter, boolean roundCeil,
-                                   Explicit<Boolean> ignoreMalformed, PostingsFormatProvider postingsProvider,
+                                   Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce, PostingsFormatProvider postingsProvider,
                                    DocValuesFormatProvider docValuesProvider, Loading normsLoading,
                                    @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(new Names(Defaults.NAME, Defaults.NAME, Defaults.NAME, Defaults.NAME), dateTimeFormatter,
                 Defaults.PRECISION_STEP, Defaults.BOOST, fieldType, docValues,
                 Defaults.NULL_VALUE, TimeUnit.MILLISECONDS /*always milliseconds*/,
-                roundCeil, ignoreMalformed, postingsProvider, docValuesProvider, null, normsLoading, fieldDataSettings, indexSettings);
+                roundCeil, ignoreMalformed, coerce, postingsProvider, docValuesProvider, null, normsLoading, fieldDataSettings, indexSettings);
         this.enabledState = enabledState;
         this.path = path;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -122,7 +122,8 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
         public IpFieldMapper build(BuilderContext context) {
             fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
             IpFieldMapper fieldMapper = new IpFieldMapper(buildNames(context),
-                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), postingsProvider, docValuesProvider, similarity,
+                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context),
+                    postingsProvider, docValuesProvider, similarity,
                     normsLoading, fieldDataSettings, context.indexSettings());
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -148,11 +149,11 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
     private String nullValue;
 
     protected IpFieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
-                            String nullValue, Explicit<Boolean> ignoreMalformed,
+                            String nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                             PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
                             SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings) {
         super(names, precisionStep, boost, fieldType, docValues,
-                ignoreMalformed, new NamedAnalyzer("_ip/" + precisionStep, new NumericIpAnalyzer(precisionStep)),
+                ignoreMalformed, coerce, new NamedAnalyzer("_ip/" + precisionStep, new NumericIpAnalyzer(precisionStep)),
                 new NamedAnalyzer("_ip/max", new NumericIpAnalyzer(Integer.MAX_VALUE)), postingsProvider, docValuesProvider,
                 similarity, normsLoading, fieldDataSettings, indexSettings);
         this.nullValue = nullValue;


### PR DESCRIPTION
Defaulted to true

When set to false a new strict mode of parsing is employed which
a) does not permit numbers to be passed as JSON strings in quotes
b) rejects numbers with fractions that are passed to integer, short or long fields.

Closes #4117
