### PR TITLE
Make PUT consistent for `_mapping`, `_alias` and `_warmer`

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -153,17 +153,22 @@ curl -XGET 'http://localhost:9200/alias2/_search?q=user:kimchy&routing=2,3'
 
 [float]
 [[alias-adding]]
-=== Add a single index alias
+=== Add a single alias
 
-There is also an api to add a single index alias, with options: 
+An alias can also be added with the endpoint
+
+`PUT /{index}/_alias/{name}`
+
+
+where
 
 [horizontal]
-`index`::   The index to alias refers to. This is a required option. 
-`alias`::   The name of the alias. This is a required option. 
+`index`::   The index to alias refers to. Can be any of `blank | * | _all | glob pattern | name1, name2, …` 
+`name`::   The name of the alias. This is a required option. 
 `routing`:: An optional routing that can be associated with an alias. 
 `filter`::  An optional filter that can be associated with an alias.
 
-The rest endpoint is: `/{index}/_alias/{alias}`.
+You can also use the plural `_aliases`.
 
 [float]
 ==== Examples:
@@ -191,16 +196,18 @@ curl -XPUT 'localhost:9200/users/_alias/user_12' -d '{
 
 [float]
 [[deleting]]
-=== Delete a single index alias
+=== Delete aliases
 
-Th API to delete a single index alias, has options: 
+
+The rest endpoint is: `/{index}/_alias/{name}`
+
+where
 
 [horizontal]
-`index`:: The index the alias is in, the needs to be deleted. This is
-          a required option. 
-`alias`:: The name of the alias to delete. This is a required option.
+`index`::  `* | _all | glob pattern | name1, name2, …` 
+`name`::  `* | _all | glob pattern | name1, name2, …` 
 
-The rest endpoint is: `/{index}/_alias/{alias}`. Example:
+Alternatively you can use the plural `_aliases`. Example:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/indices/delete-mapping.asciidoc
+++ b/docs/reference/indices/delete-mapping.asciidoc
@@ -1,8 +1,25 @@
 [[indices-delete-mapping]]
 == Delete Mapping
 
-Allow to delete a mapping (type) along with its data. The REST endpoint
-is `/{index}/{type}` with `DELETE` method.
+Allow to delete a mapping (type) along with its data. The REST endpoints are
+
+[source,js]
+--------------------------------------------------
+
+[DELETE] /{index}/{type}        
+    
+[DELETE] /{index}/{type}/_mapping      
+
+[DELETE] /{index}/_mapping/{type}  
+
+--------------------------------------------------
+
+where
+
+[horizontal]
+
+`index`::  `* | _all | glob pattern | name1, name2, …` 
+`type`::  `* | _all | glob pattern | name1, name2, …` 
 
 Note, most times, it make more sense to reindex the data into a fresh
 index compared to delete large chunks of it.

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -59,3 +59,25 @@ $ curl -XPUT 'http://localhost:9200/kimchy,elasticsearch/tweet/_mapping' -d '
 }
 '
 --------------------------------------------------
+
+All options:
+
+[source,js]
+--------------------------------------------------
+
+PUT /{index}/_mapping/{type}        
+         
+
+--------------------------------------------------
+    
+
+where
+
+[horizontal]
+`{index}`:: `blank | * | _all | glob pattern | name1, name2, …`
+    
+`{type}`:: Name of the type to add. Must be the name of the type defined in the body.
+
+
+Instead of `_mapping` you can also use the plural `_mappings`.
+The uri `PUT /{index}/{type}/_mapping` is still supported for backwardscompatibility.  

--- a/docs/reference/indices/warmers.asciidoc
+++ b/docs/reference/indices/warmers.asciidoc
@@ -112,25 +112,55 @@ curl -XPUT localhost:9200/test/type1/_warmer/warmer_1 -d '{
 }'
 --------------------------------------------------
 
-[float]
-[[removing]]
-=== Delete Warmer
-
-Removing a warmer can be done against an index (or alias / indices)
-based on its name. The provided name can be a simple wildcard expression
-or omitted to remove all warmers. Some samples:
+All options:
 
 [source,js]
 --------------------------------------------------
-# delete warmer named warmer_1 on test index
-curl -XDELETE localhost:9200/test/_warmer/warmer_1 
 
-# delete all warmers that start with warm on test index
-curl -XDELETE localhost:9200/test/_warmer/warm* 
+PUT _warmer/{warmer_name}        
 
-# delete all warmers for test index
-curl -XDELETE localhost:9200/test/_warmer/
+PUT /{index}/_warmer/{warmer_name}  
+    
+PUT /{index}/{type}/_warmer/{warmer_name}        
+
 --------------------------------------------------
+    
+
+where
+
+[horizontal]
+`{index}`:: `* | _all | glob pattern | name1, name2, …`
+    
+`{type}`:: `* | _all | glob pattern | name1, name2, …`
+
+Instead of `_warmer` you can also use the plural `_warmers`.
+
+
+
+[float]
+[[removing]]
+=== Delete Warmers
+
+Warmers can be deleted using the following endpoint:
+
+
+
+[source,js]
+--------------------------------------------------
+
+[DELETE] /{index}/_warmer/{name}  
+          
+--------------------------------------------------
+    
+
+where
+
+[horizontal]
+`{index}`:: `* | _all | glob pattern | name1, name2, …`
+    
+`{name}`:: `* | _all | glob pattern | name1, name2, …`
+
+Instead of `_warmer` you can also use the plural `_warmers`.
 
 [float]
 [[warmer-retrieving]]

--- a/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/api/indices.delete_alias.json
@@ -4,7 +4,7 @@
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/_alias/{name}",
-      "paths": ["/{index}/_alias/{name}"],
+      "paths": ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
       "parts": {
         "index": {
           "type" : "string",

--- a/rest-api-spec/api/indices.delete_mapping.json
+++ b/rest-api-spec/api/indices.delete_mapping.json
@@ -4,7 +4,7 @@
     "methods": ["DELETE"],
     "url": {
       "path": "/{index}/{type}/_mapping",
-      "paths": ["/{index}/{type}/_mapping", "/{index}/{type}"],
+      "paths": ["/{index}/{type}/_mapping", "/{index}/{type}", "/{index}/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}"],
       "parts": {
         "index": {
           "type" : "list",

--- a/rest-api-spec/api/indices.delete_warmer.json
+++ b/rest-api-spec/api/indices.delete_warmer.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-warmers.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/{index}/_warmer",
-      "paths": ["/{index}/_warmer", "/{index}/_warmer/{name}", "/{index}/{type}/_warmer/{name}"],
+      "path": "/{index}/_warmer/{name}",
+      "paths": ["/{index}/_warmer", "/{index}/_warmer/{name}", "/{index}/_warmers", "/{index}/_warmers/{name}"],
       "parts": {
         "index": {
           "type" : "list",

--- a/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/api/indices.put_alias.json
@@ -1,10 +1,10 @@
 {
   "indices.put_alias": {
     "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html",
-    "methods": ["PUT"],
+    "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/_alias/{name}",
-      "paths": ["/{index}/_alias/{name}", "/_alias/{name}", "/{index}/_alias", "/_alias"],
+      "paths": ["/{index}/_alias/{name}", "/_alias/{name}", "/{index}/_aliases/{name}", "/_aliases/{name}"],
       "parts": {
         "index": {
           "type" : "string",

--- a/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/api/indices.put_mapping.json
@@ -4,11 +4,11 @@
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/{type}/_mapping",
-      "paths": ["/{index}/{type}/_mapping"],
+      "paths": ["/{index}/{type}/_mapping", "/{index}/_mapping/{type}", "/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}", "/_mappings/{type}"],
       "parts": {
         "index": {
           "type" : "list",
-          "required" : true,
+          "required" : false,
           "description" : "A comma-separated list of index names; use `_all` to perform the operation on all indices"
         },
         "type": {

--- a/rest-api-spec/api/indices.put_warmer.json
+++ b/rest-api-spec/api/indices.put_warmer.json
@@ -1,10 +1,10 @@
 {
   "indices.put_warmer": {
     "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-warmers.html",
-    "methods": ["PUT"],
+    "methods": ["PUT", "POST"],
     "url": {
       "path": "/{index}/_warmer/{name}",
-      "paths": ["/{index}/_warmer/{name}", "/{index}/{type}/_warmer/{name}"],
+      "paths": ["/_warmer/{name}", "/{index}/_warmer/{name}", "/{index}/{type}/_warmer/{name}", "/_warmers/{name}", "/{index}/_warmers/{name}", "/{index}/{type}/_warmers/{name}"],
       "parts": {
         "index": {
           "type" : "list",

--- a/rest-api-spec/test/indices.delete_alias/all_path_options.yaml
+++ b/rest-api-spec/test/indices.delete_alias/all_path_options.yaml
@@ -1,0 +1,225 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: test_index1
+
+  - do:
+      indices.create:
+        index: test_index2
+
+  - do:
+      indices.create:
+        index: foo
+
+  - do:
+      indices.put_alias:
+        name:  alias1
+        body:
+          routing: "routing value"
+  - do:
+      indices.put_alias:
+        name:  alias2
+        body:
+          routing: "routing value"
+
+---
+"check setup":
+  - do:
+      indices.get_alias:
+        name: alias1
+
+  - match: {test_index1.aliases.alias1.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias1.search_routing: "routing value"}
+  - match: {foo.aliases.alias1.search_routing: "routing value"}
+
+  - do:
+      indices.get_alias:
+        name: alias2
+
+  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias2.search_routing: "routing value"}
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+
+---
+"check delete with _all index":
+  - do:
+      indices.delete_alias:
+        index: _all
+        name: alias1
+
+  - do:
+      catch: missing
+      indices.get_alias:
+        name:  alias1
+  - do:
+      indices.get_alias:
+        name: alias2
+
+  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias2.search_routing: "routing value"}
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+
+---
+"check delete with * index":
+  - do:
+      indices.delete_alias:
+        index: "*"
+        name: alias1
+
+  - do:
+      catch: missing
+      indices.get_alias:
+        name:  alias1
+  - do:
+      indices.get_alias:
+        name: alias2
+
+  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias2.search_routing: "routing value"}
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+
+---
+"check delete with index list":
+  - do:
+      indices.delete_alias:
+        index: "test_index1,test_index2"
+        name: alias1
+
+  - do:
+      indices.get_alias:
+        name:  alias1
+
+  - match: {foo.aliases.alias1.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_alias:
+        name: alias2
+
+  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias2.search_routing: "routing value"}
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+
+---
+"check delete with prefix* index":
+  - do:
+      indices.delete_alias:
+        index: "test_*"
+        name: alias1
+
+  - do:
+      indices.get_alias:
+        name:  alias1
+
+  - match: {foo.aliases.alias1.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_alias:
+        name: alias2
+
+  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias2.search_routing: "routing value"}
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+
+
+---
+"check delete with index list and * aliases":
+  - do:
+      indices.delete_alias:
+        index: "test_index1,test_index2"
+        name: "*"
+
+  - do:
+      indices.get_alias:
+        name:  alias1
+
+  - match: {foo.aliases.alias1.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_alias:
+        name:  alias2
+
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+---
+"check delete with index list and _all aliases":
+  - do:
+      indices.delete_alias:
+        index: "test_index1,test_index2"
+        name: _all
+
+  - do:
+      indices.get_alias:
+        name:  alias1
+
+  - match: {foo.aliases.alias1.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_alias:
+        name:  alias2
+
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+---
+"check delete with index list and wildcard aliases":
+  - do:
+      indices.delete_alias:
+        index: "test_index1,test_index2"
+        name: "*1"
+
+  - do:
+      indices.get_alias:
+        name:  alias1
+
+  - match: {foo.aliases.alias1.search_routing: "routing value"}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_alias:
+        name:  alias2
+
+  - match: {test_index1.aliases.alias2.search_routing: "routing value"}
+  - match: {test_index2.aliases.alias2.search_routing: "routing value"}
+  - match: {foo.aliases.alias2.search_routing: "routing value"}
+
+---
+"check 404 on no matching alias":
+  - do:
+      catch: missing
+      indices.delete_alias:
+        index: "*"
+        name: "non_existent"
+
+  - do:
+      catch: missing
+      indices.delete_alias:
+        index: "non_existent"
+        name: "alias1"
+
+
+---
+"check delete with blank index and blank alias":
+  - do:
+      catch: param
+      indices.delete_alias:
+        name: "alias1"
+
+  - do:
+      catch: param
+      indices.delete_alias:
+        index: "test_index1"
+

--- a/rest-api-spec/test/indices.delete_mapping/all_path_options.yaml
+++ b/rest-api-spec/test/indices.delete_mapping/all_path_options.yaml
@@ -1,0 +1,286 @@
+setup:
+
+  - do:
+      indices.create:
+        index: test_index1
+        body:
+            mappings: { test_type1: { }}
+
+  - do:
+      indices.create:
+        index: test_index2
+        body:
+            mappings: { test_type2: { }}
+  - do:
+      indices.create:
+        index: foo
+        body:
+            mappings: { test_type2: {  }}
+
+---
+"delete with _all index":
+  - do:
+      indices.delete_mapping:
+        index: _all
+        type: test_type2
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_true: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_false: ''
+
+---
+"delete with * index":
+  - do:
+      indices.delete_mapping:
+        index: '*'
+        type: test_type2
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_true: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_false: ''
+
+---
+"delete with prefix* index":
+  - do:
+      indices.delete_mapping:
+        index: test*
+        type: test_type2
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_true: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_true: ''
+
+---
+"delete with list of indices":
+
+  - do:
+      indices.delete_mapping:
+        index: test_index1,test_index2
+        type: test_type2
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_true: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_true: ''
+
+---
+"delete with index list and _all type":
+  - do:
+      indices.delete_mapping:
+        index: test_index1,test_index2
+        type: _all
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_true: ''
+
+
+---
+"delete with index list and * type":
+  - do:
+      indices.delete_mapping:
+        index: test_index1,test_index2
+        type: '*'
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_true: ''
+
+
+---
+"delete with index list and prefix* type":
+  - do:
+      indices.delete_mapping:
+        index: test_index1,test_index2
+        type: '*2'
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_true: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_true: ''
+
+---
+"delete with index list and list of types":
+  - do:
+      indices.delete_mapping:
+        index: test_index1,test_index2
+        type: test_type1,test_type2
+
+  - do:
+      indices.exists_type:
+        index: test_index1
+        type: test_type1
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: test_index2
+        type: test_type2
+
+  - is_false: ''
+
+  - do:
+      indices.exists_type:
+        index: foo
+        type: test_type2
+
+  - is_true: ''
+
+---
+"check 404 on no matching type":
+  - do:
+      catch: missing
+      indices.delete_mapping:
+        index: "*"
+        type: "non_existent"
+
+  - do:
+      catch: missing
+      indices.delete_mapping:
+        index: "non_existent"
+        type: "test_type1"
+
+
+---
+"check delete with blank index and blank alias":
+  - do:
+      catch: param
+      indices.delete_alias:
+        name: "alias1"
+
+  - do:
+      catch: param
+      indices.delete_alias:
+        index: "test_index1"
+
+
+---
+"check delete with blank index and blank type":
+  - do:
+      catch: param
+      indices.delete_mapping:
+        name: "test_type1"
+
+  - do:
+      catch: param
+      indices.delete_mapping:
+        index: "test_index1"
+

--- a/rest-api-spec/test/indices.delete_warmer/all_path_options.yaml
+++ b/rest-api-spec/test/indices.delete_warmer/all_path_options.yaml
@@ -1,0 +1,214 @@
+setup:
+  - do:
+      indices.create:
+        index: test_index1
+
+  - do:
+      indices.create:
+        index: test_index2
+
+  - do:
+      indices.create:
+        index: foo
+
+  - do:
+      indices.put_warmer:
+        index: "test_index1,test_index2,foo"
+        name: test_warmer1
+        body:
+          query:
+            match_all: {}
+
+  - do:
+      indices.put_warmer:
+        index: "test_index1,test_index2,foo"
+        name: test_warmer2
+        body:
+          query:
+            match_all: {}
+
+---
+"Check setup":
+
+  - do:
+      indices.get_warmer:  { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.test_warmer1.source.query.match_all: {}}
+  - match: {test_index1.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer1.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer1.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+
+
+---
+"check delete with _all index":
+  - do:
+      indices.delete_warmer:
+        index: _all
+        name: test_warmer1
+
+  - do:
+      catch: missing
+      indices.get_warmer:  { index: _all, name: 'test_warmer1' }
+
+  - do:
+      indices.get_warmer:  { index: _all, name: 'test_warmer2' }
+
+
+  - match: {test_index1.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+
+---
+"check delete with * index":
+  - do:
+      indices.delete_warmer:
+        index: "*"
+        name: test_warmer1
+
+  - do:
+      catch: missing
+      indices.get_warmer:  { index: _all, name: 'test_warmer1' }
+
+  - do:
+      indices.get_warmer:  { index: _all, name: 'test_warmer2' }
+
+
+  - match: {test_index1.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+
+---
+"check delete with index list":
+  - do:
+      indices.delete_warmer:
+        index: "test_index1,test_index2"
+        name: test_warmer1
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer1' }
+
+  - match: {foo.warmers.test_warmer1.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer2' }
+
+  - match: {test_index1.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+
+---
+"check delete with prefix* index":
+  - do:
+      indices.delete_warmer:
+        index: "test_*"
+        name: test_warmer1
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer1' }
+
+  - match: {foo.warmers.test_warmer1.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer2' }
+
+  - match: {test_index1.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+
+
+---
+"check delete with index list and * warmers":
+  - do:
+      indices.delete_warmer:
+        index: "test_index1,test_index2"
+        name: "*"
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer1' }
+
+  - match: {foo.warmers.test_warmer1.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_warmer:  { index: _all, name: 'test_warmer2' }
+
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+---
+"check delete with index list and _all warmers":
+  - do:
+      indices.delete_warmer: 
+        index: "test_index1,test_index2"
+        name: _all
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer1' }
+
+  - match: {foo.warmers.test_warmer1.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer2' }
+
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+---
+"check delete with index list and wildcard warmers":
+  - do:
+      indices.delete_warmer:
+        index: "test_index1,test_index2"
+        name: "*1"
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer1' }
+
+  - match: {foo.warmers.test_warmer1.source.query.match_all: {}}
+  - is_false: test_index1
+  - is_false: test_index2
+
+  - do:
+      indices.get_warmer: { index: _all, name: 'test_warmer2' }
+
+  - match: {test_index1.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {test_index2.warmers.test_warmer2.source.query.match_all: {}}
+  - match: {foo.warmers.test_warmer2.source.query.match_all: {}}
+
+---
+"check 404 on no matching test_warmer":
+  - do:
+      catch: missing
+      indices.delete_warmer:
+        index: "*"
+        name: "non_existent"
+
+  - do:
+      catch: missing
+      indices.delete_warmer:
+        index: "non_existent"
+        name: "test_warmer1"
+
+
+---
+"check delete with blank index and blank test_warmer":
+  - do:
+      catch: param
+      indices.delete_warmer:
+        name: "test_warmer1"
+
+  - do:
+      catch: param
+      indices.delete_warmer:
+        index: "test_index1"
+

--- a/rest-api-spec/test/indices.put_alias/all_path_options.yaml
+++ b/rest-api-spec/test/indices.put_alias/all_path_options.yaml
@@ -1,0 +1,127 @@
+---
+setup:
+# create three indices
+
+  - do:
+      indices.create:
+        index: test_index1
+  - do:
+      indices.create:
+        index: test_index2
+  - do:
+      indices.create:
+        index: foo
+
+---
+"put alias per index":
+
+  - do:
+      indices.put_alias:
+        index: test_index1
+        name: alias
+  - do:
+      indices.put_alias:
+        index: test_index2
+        name: alias
+
+  - do:
+      indices.get_alias:
+        name: alias
+
+  - match: {test_index1.aliases.alias: {}}
+
+  - match: {test_index2.aliases.alias: {}}
+
+  - is_false: foo
+
+---
+"put alias in _all index":
+
+  - do:
+      indices.put_alias:
+        index: _all
+        name: alias
+
+  - do:
+      indices.get_alias:
+        name: alias
+
+  - match: {test_index1.aliases.alias: {}}
+  - match: {test_index2.aliases.alias: {}}
+  - match: {foo.aliases.alias: {}}
+
+---
+"put alias in * index":
+
+
+  - do:
+      indices.put_alias:
+        index: '*'
+        name: alias
+
+  - do:
+      indices.get_alias:
+        name: alias
+
+  - match: {test_index1.aliases.alias: {}}
+  - match: {test_index2.aliases.alias: {}}
+  - match: {foo.aliases.alias: {}}
+
+---
+"put alias prefix* index":
+
+
+  - do:
+      indices.put_alias:
+        index: "test_*"
+        name: alias
+
+  - do:
+      indices.get_alias:
+        name: alias
+
+  - match: {test_index1.aliases.alias: {}}
+  - match: {test_index2.aliases.alias: {}}
+  - is_false: foo
+
+---
+"put alias in list of indices":
+
+
+  - do:
+      indices.put_alias:
+        index: "test_index1,test_index2"
+        name: alias
+
+  - do:
+      indices.get_alias:
+        name: alias
+
+  - match: {test_index1.aliases.alias: {}}
+  - match: {test_index2.aliases.alias: {}}
+  - is_false: foo
+
+---
+"put alias with blank index":
+
+
+  - do:
+      indices.put_alias:
+        name: alias
+
+  - do:
+      indices.get_alias:
+        name: alias
+
+  - match: {test_index1.aliases.alias: {}}
+  - match: {test_index2.aliases.alias: {}}
+  - match: {foo.aliases.alias: {}}
+
+---
+"put alias with mising name":
+
+
+  - do:
+      catch: param
+      indices.put_alias: {}
+

--- a/rest-api-spec/test/indices.put_mapping/all_path_options.yaml
+++ b/rest-api-spec/test/indices.put_mapping/all_path_options.yaml
@@ -1,0 +1,178 @@
+setup:
+  - do:
+      indices.create:
+        index: test_index1
+  - do:
+      indices.create:
+        index: test_index2
+  - do:
+      indices.create:
+        index: foo
+
+
+---
+"put one mapping per index":
+  - do:
+      indices.put_mapping:
+        index: test_index1
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+  - do:
+      indices.put_mapping:
+        index: test_index2
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {test_index1.test_type.properties.text.type:     string}
+  - match: {test_index1.test_type.properties.text.analyzer: whitespace}
+
+  - match: {test_index2.test_type.properties.text.type:     string}
+  - match: {test_index2.test_type.properties.text.analyzer: whitespace}
+
+  - match: {foo: {}}
+
+---
+"put mapping in _all index":
+
+  - do:
+      indices.put_mapping:
+        index: _all
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {test_index1.test_type.properties.text.type:     string}
+  - match: {test_index1.test_type.properties.text.analyzer: whitespace}
+
+  - match: {test_index2.test_type.properties.text.type:     string}
+  - match: {test_index2.test_type.properties.text.analyzer: whitespace}
+
+  - match: {foo.test_type.properties.text.type:     string}
+  - match: {foo.test_type.properties.text.analyzer: whitespace}
+
+---
+"put mapping in * index":
+  - do:
+      indices.put_mapping:
+        index: "*"
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {test_index1.test_type.properties.text.type:     string}
+  - match: {test_index1.test_type.properties.text.analyzer: whitespace}
+
+  - match: {test_index2.test_type.properties.text.type:     string}
+  - match: {test_index2.test_type.properties.text.analyzer: whitespace}
+
+  - match: {foo.test_type.properties.text.type:     string}
+  - match: {foo.test_type.properties.text.analyzer: whitespace}
+
+---
+"put mapping in prefix* index":
+  - do:
+      indices.put_mapping:
+        index: "test_index*"
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {test_index1.test_type.properties.text.type:     string}
+  - match: {test_index1.test_type.properties.text.analyzer: whitespace}
+
+  - match: {test_index2.test_type.properties.text.type:     string}
+  - match: {test_index2.test_type.properties.text.analyzer: whitespace}
+
+  - match: {foo: {}}
+
+---
+"put mapping in list of indices":
+  - do:
+      indices.put_mapping:
+        index: [test_index1, test_index2]
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {test_index1.test_type.properties.text.type:     string}
+  - match: {test_index1.test_type.properties.text.analyzer: whitespace}
+
+  - match: {test_index2.test_type.properties.text.type:     string}
+  - match: {test_index2.test_type.properties.text.analyzer: whitespace}
+
+  - match: {foo: {}}
+
+---
+"put mapping with blank index":
+  - do:
+      indices.put_mapping:
+        type: test_type
+        body:
+          test_type:
+            properties:
+              text:
+                type:     string
+                analyzer: whitespace
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {test_index1.test_type.properties.text.type:     string}
+  - match: {test_index1.test_type.properties.text.analyzer: whitespace}
+
+  - match: {test_index2.test_type.properties.text.type:     string}
+  - match: {test_index2.test_type.properties.text.analyzer: whitespace}
+
+  - match: {foo.test_type.properties.text.type:     string}
+  - match: {foo.test_type.properties.text.analyzer: whitespace}
+
+---
+"put mapping with mising type":
+
+
+  - do:
+      catch: param
+      indices.put_mapping: {}
+

--- a/rest-api-spec/test/indices.put_settings/all_path_options.yaml
+++ b/rest-api-spec/test/indices.put_settings/all_path_options.yaml
@@ -1,0 +1,113 @@
+setup:
+  - do:
+      indices.create:
+        index: test_index1
+  - do:
+      indices.create:
+        index: test_index2
+  - do:
+      indices.create:
+        index: foo
+
+
+---
+"put settings per index":
+  - do:
+      indices.put_settings:
+        index: test_index1
+        body:
+          refresh_interval: 1s
+
+  - do:
+      indices.put_settings:
+        index: test_index2
+        body:
+          refresh_interval: 1s
+
+
+  - do:
+      indices.get_settings: {}
+
+  - match: {test_index1.settings.index.refresh_interval:     1s}
+  - match: {test_index2.settings.index.refresh_interval:     1s}
+  - is_false: foo.settings.index.refresh_interval
+
+---
+"put settings in _all index":
+  - do:
+      indices.put_settings:
+        index: _all
+        body:
+          refresh_interval: 1s
+
+  - do:
+      indices.get_settings: {}
+
+  - match: {test_index1.settings.index.refresh_interval:     1s}
+  - match: {test_index2.settings.index.refresh_interval:     1s}
+  - match: {foo.settings.index.refresh_interval:     1s}
+
+---
+"put settings in * index":
+  - do:
+      indices.put_settings:
+        index: '*'
+        body:
+          refresh_interval: 1s
+
+  - do:
+      indices.get_settings: {}
+
+  - match: {test_index1.settings.index.refresh_interval:     1s}
+  - match: {test_index2.settings.index.refresh_interval:     1s}
+  - match: {foo.settings.index.refresh_interval:     1s}
+
+
+---
+"put settings in prefix* index":
+  - do:
+      indices.put_settings:
+        index: 'test*'
+        body:
+          refresh_interval: 1s
+
+  - do:
+      indices.get_settings: {}
+
+  - match: {test_index1.settings.index.refresh_interval:     1s}
+  - match: {test_index2.settings.index.refresh_interval:     1s}
+  - is_false: foo.settings.index.refresh_interval
+
+---
+"put settings in list of indices":
+  - skip:
+      version: 1 - 999
+      reason:  list of indices not implemented yet
+  - do:
+      indices.put_settings:
+        index: test_index1, test_index2
+        body:
+          refresh_interval: 1s
+
+  - do:
+      indices.get_settings: {}
+
+  - match: {test_index1.settings.index.refresh_interval:     1s}
+  - match: {test_index2.settings.index.refresh_interval:     1s}
+  - is_false: foo.settings.index.refresh_interval
+
+
+---
+"put settings in blank index":
+  - do:
+      indices.put_settings:
+        body:
+          refresh_interval: 1s
+
+  - do:
+      indices.get_settings: {}
+
+  - match: {test_index1.settings.index.refresh_interval:     1s}
+  - match: {test_index2.settings.index.refresh_interval:     1s}
+  - match: {foo.settings.index.refresh_interval:     1s}
+

--- a/rest-api-spec/test/indices.put_warmer/10_basic.yaml
+++ b/rest-api-spec/test/indices.put_warmer/10_basic.yaml
@@ -32,6 +32,7 @@
   - do:
       indices.delete_warmer:
         index: test_index
+        name: test_warmer
 
   - do:
       catch: missing

--- a/rest-api-spec/test/indices.put_warmer/all_path_options.yaml
+++ b/rest-api-spec/test/indices.put_warmer/all_path_options.yaml
@@ -1,0 +1,128 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: test_index1
+  - do:
+      indices.create:
+        index: test_index2
+  - do:
+      indices.create:
+        index: foo
+
+---
+"put warmer per index":
+
+  - do:
+      indices.put_warmer:
+        index: test_index1
+        name: warmer
+        body:
+          query:
+            match_all: {}
+  - do:
+      indices.put_warmer:
+        index: test_index2
+        name: warmer
+        body:
+          query:
+            match_all: {}
+
+  - do:
+      indices.get_warmer: { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.warmer.source.query.match_all: {}}
+  - match: {test_index2.warmers.warmer.source.query.match_all: {}}
+  - is_false: foo
+
+---
+"put warmer in _all index":
+  - do:
+      indices.put_warmer:
+        index: _all
+        name: warmer
+        body:
+          query:
+            match_all: {}
+  - do:
+      indices.get_warmer: { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.warmer.source.query.match_all: {}}
+  - match: {test_index2.warmers.warmer.source.query.match_all: {}}
+  - match: {foo.warmers.warmer.source.query.match_all: {}}
+
+---
+"put warmer in * index":
+  - do:
+      indices.put_warmer:
+        index: "*"
+        name: warmer
+        body:
+          query:
+            match_all: {}
+  - do:
+      indices.get_warmer: { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.warmer.source.query.match_all: {}}
+  - match: {test_index2.warmers.warmer.source.query.match_all: {}}
+  - match: {foo.warmers.warmer.source.query.match_all: {}}
+
+---
+"put warmer prefix* index":
+  - do:
+      indices.put_warmer:
+        index: "test_index*"
+        name: warmer
+        body:
+          query:
+            match_all: {}
+  - do:
+      indices.get_warmer: { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.warmer.source.query.match_all: {}}
+  - match: {test_index2.warmers.warmer.source.query.match_all: {}}
+  - is_false: foo
+
+---
+"put warmer in list of indices":
+  - do:
+      indices.put_warmer:
+        index: [test_index1, test_index2]
+        name: warmer
+        body:
+          query:
+            match_all: {}
+  - do:
+      indices.get_warmer: { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.warmer.source.query.match_all: {}}
+  - match: {test_index2.warmers.warmer.source.query.match_all: {}}
+  - is_false: foo
+
+---
+"put warmer with blank index":
+  - do:
+      indices.put_warmer:
+        name: warmer
+        body:
+          query:
+            match_all: {}
+  - do:
+      indices.get_warmer: { index: _all, name: '*' }
+
+  - match: {test_index1.warmers.warmer.source.query.match_all: {}}
+  - match: {test_index2.warmers.warmer.source.query.match_all: {}}
+  - match: {foo.warmers.warmer.source.query.match_all: {}}
+
+---
+"put warmer with mising name":
+
+
+  - do:
+      catch: param
+      indices.put_warmer: {}
+
+
+
+

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -19,21 +19,25 @@
 
 package org.elasticsearch.action.admin.indices.alias;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.AliasAction;
+import org.elasticsearch.cluster.metadata.AliasAction.Type;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.query.FilterBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -46,115 +50,260 @@ import static org.elasticsearch.cluster.metadata.AliasAction.readAliasAction;
  */
 public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> {
 
-    private List<AliasAction> aliasActions = Lists.newArrayList();
+    private List<AliasActions> allAliasActions = Lists.newArrayList();
+    
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
 
     public IndicesAliasesRequest() {
 
     }
 
+    /*
+     * Aliases can be added by passing multiple indices to the Request and
+     * deleted by passing multiple indices and aliases. They are expanded into
+     * distinct AliasAction instances when the request is processed. This class
+     * holds the AliasAction and in addition the arrays or alias names and
+     * indices that is later used to create the final AliasAction instances.
+     */
+    public static class AliasActions {
+        private String[] indices = Strings.EMPTY_ARRAY;
+        private String[] aliases = Strings.EMPTY_ARRAY;
+        private AliasAction aliasAction;
+        
+        public AliasActions(AliasAction.Type type, String[] indices, String[] aliases) {
+            aliasAction = new AliasAction(type);
+            indices(indices);
+            aliases(aliases);
+        }
+        
+        public AliasActions(AliasAction.Type type, String index, String alias) {
+            aliasAction = new AliasAction(type);
+            indices(index);
+            aliases(alias);
+        }
+        
+        AliasActions(AliasAction.Type type, String[] index, String alias) {
+            aliasAction = new AliasAction(type);
+            indices(index);
+            aliases(alias);
+        }
+        
+        public AliasActions(AliasAction action) {
+            this.aliasAction = action;
+            indices(action.index());
+            aliases(action.alias());
+        }
+
+        public AliasActions(Type type, String index, String[] aliases) {
+            aliasAction = new AliasAction(type);
+            indices(index);
+            aliases(aliases);
+        }
+
+        public AliasActions() {
+        }
+
+        public AliasActions filter(Map<String, Object> filter) {
+            aliasAction.filter(filter);
+            return this;
+        }
+        
+        public AliasActions filter(FilterBuilder filter) {
+            aliasAction.filter(filter);
+            return this;
+        }
+
+        public Type actionType() {
+            return aliasAction.actionType();
+        }
+
+        public void routing(String routing) {
+            aliasAction.routing(routing);
+        }
+
+        public void searchRouting(String searchRouting) {
+            aliasAction.searchRouting(searchRouting);
+        }
+
+        public void indexRouting(String indexRouting) {
+            aliasAction.indexRouting(indexRouting);
+        }
+
+        public AliasActions filter(String filter) {
+            aliasAction.filter(filter);
+            return this;
+        }
+        
+        public void indices(String... indices) {
+            List<String> finalIndices = new ArrayList<String>();
+            for (String index : indices) {
+                if (index != null) {
+                    finalIndices.add(index);
+                }
+            }
+            this.indices = finalIndices.toArray(new String[finalIndices.size()]);
+        }
+        
+        public void aliases(String... aliases) {
+            this.aliases = aliases;
+        }
+        
+        public String[] aliases() {
+            return aliases;
+        }
+        
+        public String[] indices() {
+            return indices;
+        }
+
+        public AliasAction aliasAction() {
+            return aliasAction;
+        }
+
+        public String[] concreteAliases(MetaData metaData, String concreteIndex) {
+            if (aliasAction.actionType() == Type.REMOVE) {
+                //for DELETE we expand the aliases
+                String[] indexAsArray = {concreteIndex};
+                ImmutableOpenMap<String, ImmutableList<AliasMetaData>> aliasMetaData = metaData.findAliases(aliases, indexAsArray);
+                List<String> finalAliases = new ArrayList<String> ();
+                for (ObjectCursor<ImmutableList<AliasMetaData>> curAliases : aliasMetaData.values()) {
+                    for (AliasMetaData aliasMeta: curAliases.value) {
+                        finalAliases.add(aliasMeta.alias());
+                    }
+                }
+                return finalAliases.toArray(new String[finalAliases.size()]);
+            } else {
+                //for add we just return the current aliases
+                return aliases;
+            }
+        }
+        public AliasActions readFrom(StreamInput in) throws IOException {
+            indices = in.readStringArray();
+            aliases = in.readStringArray();
+            aliasAction = readAliasAction(in);
+            return this;
+        }
+        
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeStringArray(indices);
+            out.writeStringArray(aliases);
+            this.aliasAction.writeTo(out);
+        }
+    }
+
     /**
      * Adds an alias to the index.
-     *
-     * @param index The index
      * @param alias The alias
+     * @param indices The indices
      */
-    public IndicesAliasesRequest addAlias(String index, String alias) {
-        aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias));
+    public IndicesAliasesRequest addAlias(String alias, String... indices) {
+        addAliasAction(new AliasActions(AliasAction.Type.ADD, indices, alias));
+        return this;
+    }
+
+
+    public void addAliasAction(AliasActions aliasAction) {
+        allAliasActions.add(aliasAction);
+    }
+
+
+    public IndicesAliasesRequest addAliasAction(AliasAction action) {
+        addAliasAction(new AliasActions(action));
+        return this;
+    }
+    
+    /**
+     * Adds an alias to the index.
+     * @param alias  The alias
+     * @param filter The filter
+     * @param indices  The indices
+     */
+    public IndicesAliasesRequest addAlias(String alias, Map<String, Object> filter, String... indices) {
+        addAliasAction(new AliasActions(AliasAction.Type.ADD, indices, alias).filter(filter));
         return this;
     }
 
     /**
      * Adds an alias to the index.
-     *
-     * @param index  The index
-     * @param alias  The alias
-     * @param filter The filter
-     */
-    public IndicesAliasesRequest addAlias(String index, String alias, String filter) {
-        aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias, filter));
-        return this;
-    }
-
-    /**
-     * Adds an alias to the index.
-     *
-     * @param index  The index
-     * @param alias  The alias
-     * @param filter The filter
-     */
-    public IndicesAliasesRequest addAlias(String index, String alias, Map<String, Object> filter) {
-        if (filter == null || filter.isEmpty()) {
-            aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias));
-            return this;
-        }
-        try {
-            XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
-            builder.map(filter);
-            aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias, builder.string()));
-            return this;
-        } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to generate [" + filter + "]", e);
-        }
-    }
-
-    /**
-     * Adds an alias to the index.
-     *
-     * @param index         The index
      * @param alias         The alias
      * @param filterBuilder The filter
+     * @param indices         The indices
      */
-    public IndicesAliasesRequest addAlias(String index, String alias, FilterBuilder filterBuilder) {
-        if (filterBuilder == null) {
-            aliasActions.add(new AliasAction(AliasAction.Type.ADD, index, alias));
-            return this;
-        }
-        try {
-            XContentBuilder builder = XContentFactory.jsonBuilder();
-            filterBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            builder.close();
-            return addAlias(index, alias, builder.string());
-        } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to build json for alias request", e);
-        }
+    public IndicesAliasesRequest addAlias(String alias, FilterBuilder filterBuilder, String... indices) {
+        addAliasAction(new AliasActions(AliasAction.Type.ADD, indices, alias).filter(filterBuilder));
+        return this;
     }
-
+    
+    
+    /**
+     * Removes an alias to the index.
+     *
+     * @param indices The indices
+     * @param aliases The aliases
+     */
+    public IndicesAliasesRequest removeAlias(String[] indices, String... aliases) {
+        addAliasAction(new AliasActions(AliasAction.Type.REMOVE, indices, aliases));
+        return this;
+    }
+    
     /**
      * Removes an alias to the index.
      *
      * @param index The index
-     * @param alias The alias
+     * @param aliases The aliases
      */
-    public IndicesAliasesRequest removeAlias(String index, String alias) {
-        aliasActions.add(new AliasAction(AliasAction.Type.REMOVE, index, alias));
+    public IndicesAliasesRequest removeAlias(String index, String... aliases) {
+        addAliasAction(new AliasActions(AliasAction.Type.REMOVE, index, aliases));
         return this;
     }
 
-    public IndicesAliasesRequest addAliasAction(AliasAction action) {
-        aliasActions.add(action);
-        return this;
+    List<AliasActions> aliasActions() {
+        return this.allAliasActions;
     }
 
-    List<AliasAction> aliasActions() {
-        return this.aliasActions;
-    }
-
-    public List<AliasAction> getAliasActions() {
+    public List<AliasActions> getAliasActions() {
         return aliasActions();
     }
 
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (aliasActions.isEmpty()) {
+        if (allAliasActions.isEmpty()) {
             return addValidationError("Must specify at least one alias action", validationException);
         }
-        for (AliasAction aliasAction : aliasActions) {
-            if (!Strings.hasText(aliasAction.alias())) {
-                validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH) + "] requires an [alias] to be set", validationException);
+        for (AliasActions aliasAction : allAliasActions) {
+            if (aliasAction.actionType() == AliasAction.Type.ADD) {
+                if (aliasAction.aliases.length != 1) {
+                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                            + "] requires exactly one [alias] to be set", validationException);
+                }
+                if (!Strings.hasText(aliasAction.aliases[0])) {
+                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                            + "] requires an [alias] to be set", validationException);
+                }
+            } else {
+                if (aliasAction.aliases.length == 0) {
+                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                            + "]: aliases may not be empty", validationException);
+                }
+                for (String alias : aliasAction.aliases) {
+                    if (!Strings.hasText(alias)) {
+                        validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                                + "]: [alias] may not be empty string", validationException);
+                    }
+                }
+                if (CollectionUtils.isEmpty(aliasAction.indices)) {
+                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                            + "]: indices may not be empty", validationException);
+                }
             }
-            if (!Strings.hasText(aliasAction.index())) {
-                validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH) + "] requires an [index] to be set", validationException);
+            if (!CollectionUtils.isEmpty(aliasAction.indices)) {
+                for (String index : aliasAction.indices) {
+                    if (!Strings.hasText(index)) {
+                        validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                                + "]: [index] may not be empty string", validationException);
+                    }
+                }
             }
         }
         return validationException;
@@ -165,7 +314,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         super.readFrom(in);
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
-            aliasActions.add(readAliasAction(in));
+            allAliasActions.add(readAliasActions(in));
         }
         readTimeout(in);
     }
@@ -173,10 +322,20 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeVInt(aliasActions.size());
-        for (AliasAction aliasAction : aliasActions) {
+        out.writeVInt(allAliasActions.size());
+        for (AliasActions aliasAction : allAliasActions) {
             aliasAction.writeTo(out);
         }
         writeTimeout(out);
     }
+
+    public IndicesOptions indicesOptions() {
+        return indicesOptions;
+    }
+    
+    private AliasActions readAliasActions(StreamInput in) throws IOException {
+        AliasActions actions = new AliasActions();
+        return actions.readFrom(in);
+    }
+
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.alias;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
@@ -36,15 +37,26 @@ public class IndicesAliasesRequestBuilder extends AcknowledgedRequestBuilder<Ind
     public IndicesAliasesRequestBuilder(IndicesAdminClient indicesClient) {
         super((InternalIndicesAdminClient) indicesClient, new IndicesAliasesRequest());
     }
-
+    
     /**
      * Adds an alias to the index.
      *
-     * @param index The index
-     * @param alias The alias
+     * @param index         The index
+     * @param alias         The alias
      */
     public IndicesAliasesRequestBuilder addAlias(String index, String alias) {
-        request.addAlias(index, alias);
+        request.addAlias(alias, index);
+        return this;
+    }
+    
+    /**
+     * Adds an alias to the index.
+     *
+     * @param index The indices
+     * @param alias The alias
+     */
+    public IndicesAliasesRequestBuilder addAlias(String[] indices, String alias) {
+        request.addAlias(alias, indices);
         return this;
     }
 
@@ -56,46 +68,74 @@ public class IndicesAliasesRequestBuilder extends AcknowledgedRequestBuilder<Ind
      * @param filter The filter
      */
     public IndicesAliasesRequestBuilder addAlias(String index, String alias, String filter) {
-        request.addAlias(index, alias, filter);
+        AliasActions action = new AliasActions(AliasAction.Type.ADD, index, alias).filter(filter);
+        request.addAliasAction(action);
         return this;
     }
-
+    
     /**
      * Adds an alias to the index.
      *
-     * @param index  The index
+     * @param indices       The indices
+     * @param alias         The alias
+     * @param filter The filter
+     */
+    public IndicesAliasesRequestBuilder addAlias(String indices[], String alias, String filter) {
+        AliasActions action = new AliasActions(AliasAction.Type.ADD, indices, alias).filter(filter);
+        request.addAliasAction(action);
+        return this;
+    }
+   
+    /**
+     * Adds an alias to the index.
+     *
+     * @param indices  The indices
+     * @param alias  The alias
+     * @param filter The filter
+     */
+    public IndicesAliasesRequestBuilder addAlias(String[] indices, String alias, Map<String, Object> filter) {
+        request.addAlias(alias, filter, indices);
+        return this;
+    }
+    
+    /**
+     * Adds an alias to the index.
+     *
+     * @param index  The indices
      * @param alias  The alias
      * @param filter The filter
      */
     public IndicesAliasesRequestBuilder addAlias(String index, String alias, Map<String, Object> filter) {
-        request.addAlias(index, alias, filter);
+        request.addAlias(alias, filter, index);
         return this;
     }
 
     /**
      * Adds an alias to the index.
      *
-     * @param index         The index
+     * @param indices       The indices
+     * @param alias         The alias
+     * @param filterBuilder The filter
+     */
+    public IndicesAliasesRequestBuilder addAlias(String indices[], String alias, FilterBuilder filterBuilder) {
+        request.addAlias(alias, filterBuilder, indices);
+        return this;
+    }
+    
+    /**
+     * Adds an alias to the index.
+     *
+     * @param index       The index
      * @param alias         The alias
      * @param filterBuilder The filter
      */
     public IndicesAliasesRequestBuilder addAlias(String index, String alias, FilterBuilder filterBuilder) {
-        request.addAlias(index, alias, filterBuilder);
+        request.addAlias(alias, filterBuilder, index);
         return this;
     }
 
     /**
-     * Adds an alias action to the request.
-     *
-     * @param aliasAction The alias Action
-     */
-    public IndicesAliasesRequestBuilder addAliasAction(AliasAction aliasAction) {
-        request.addAliasAction(aliasAction);
-        return this;
-    }
-
-    /**
-     * Removes an alias to the index.
+     * Removes an alias from the index.
      *
      * @param index The index
      * @param alias The alias
@@ -104,9 +144,54 @@ public class IndicesAliasesRequestBuilder extends AcknowledgedRequestBuilder<Ind
         request.removeAlias(index, alias);
         return this;
     }
-
+    
+    /**
+     * Removes aliases from the index.
+     *
+     * @param indices The indices
+     * @param aliases The aliases
+     */
+    public IndicesAliasesRequestBuilder removeAlias(String[] indices, String... aliases) {
+        request.removeAlias(indices, aliases);
+        return this;
+    }
+    
+    /**
+     * Removes aliases from the index.
+     *
+     * @param index The index
+     * @param aliases The aliases
+     */
+    public IndicesAliasesRequestBuilder removeAlias(String index, String[] aliases) {
+        request.removeAlias(index, aliases);
+        return this;
+    }
+    
     @Override
     protected void doExecute(ActionListener<IndicesAliasesResponse> listener) {
         ((IndicesAdminClient) client).aliases(request, listener);
     }
+    
+    /**
+     * Adds an alias action to the request.
+     *
+     * @param aliasAction The alias action
+     */
+    public IndicesAliasesRequestBuilder addAliasAction(AliasAction aliasAction) {
+        request.addAliasAction(aliasAction);
+        return this;
+    }
+
+    /**
+     * Adds an alias action to the request.
+     *
+     * @param aliasAction The alias Action
+     */
+    public IndicesAliasesRequestBuilder addAliasAction(
+            AliasActions action) {
+        request.addAliasAction(action);
+        return this;
+    }
+
+   
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingClusterStateUpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingClusterStateUpdateRequest.java
@@ -26,7 +26,7 @@ import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
  */
 public class DeleteMappingClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<DeleteMappingClusterStateUpdateRequest> {
 
-    private String type;
+    private String[] types;
 
     DeleteMappingClusterStateUpdateRequest() {
 
@@ -35,15 +35,15 @@ public class DeleteMappingClusterStateUpdateRequest extends IndicesClusterStateU
     /**
      * Returns the type to be removed
      */
-    public String type() {
-        return type;
+    public String[] types() {
+        return types;
     }
 
     /**
      * Sets the type to be removed
      */
-    public DeleteMappingClusterStateUpdateRequest type(String type) {
-        this.type = type;
+    public DeleteMappingClusterStateUpdateRequest types(String[] types) {
+        this.types = types;
         return this;
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingRequestBuilder.java
@@ -45,8 +45,8 @@ public class DeleteMappingRequestBuilder extends AcknowledgedRequestBuilder<Dele
     /**
      * Sets the type of the mapping to remove
      */
-    public DeleteMappingRequestBuilder setType(String type) {
-        request.type(type);
+    public DeleteMappingRequestBuilder setType(String... types) {
+        request.types(types);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestBuilder.java
@@ -43,8 +43,8 @@ public class DeleteWarmerRequestBuilder extends AcknowledgedRequestBuilder<Delet
      * The name (or wildcard expression) of the index warmer to delete, or null
      * to delete all warmers.
      */
-    public DeleteWarmerRequestBuilder setName(String name) {
-        request.name(name);
+    public DeleteWarmerRequestBuilder setNames(String... names) {
+        request.names(names);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
@@ -82,7 +82,20 @@ public class AliasAction implements Streamable {
     private AliasAction() {
 
     }
-
+    
+    public AliasAction(AliasAction other) {
+        this.actionType = other.actionType;
+        this.index = other.index;
+        this.alias = other.alias;
+        this.filter = other.filter;
+        this.indexRouting = other.indexRouting;
+        this.searchRouting = other.searchRouting;
+    }
+    
+    public AliasAction(Type actionType) {
+        this.actionType = actionType;
+    }
+    
     public AliasAction(Type actionType, String index, String alias) {
         this.actionType = actionType;
         this.index = index;
@@ -99,9 +112,19 @@ public class AliasAction implements Streamable {
     public Type actionType() {
         return actionType;
     }
+    
+    public AliasAction index(String index) {
+        this.index = index;
+        return this;
+    }
 
     public String index() {
         return index;
+    }
+    
+    public AliasAction alias(String alias) {
+        this.alias = alias;
+        return this;
     }
 
     public String alias() {
@@ -181,42 +204,21 @@ public class AliasAction implements Streamable {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         actionType = Type.fromValue(in.readByte());
-        index = in.readString();
-        alias = in.readString();
-        if (in.readBoolean()) {
-            filter = in.readString();
-        }
-        if (in.readBoolean()) {
-            indexRouting = in.readString();
-        }
-        if (in.readBoolean()) {
-            searchRouting = in.readString();
-        }
+        index = in.readOptionalString();
+        alias = in.readOptionalString();
+        filter = in.readOptionalString();
+        indexRouting = in.readOptionalString();
+        searchRouting = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeByte(actionType.value());
-        out.writeString(index);
-        out.writeString(alias);
-        if (filter == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeString(filter);
-        }
-        if (indexRouting == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeString(indexRouting);
-        }
-        if (searchRouting == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeString(searchRouting);
-        }
+        out.writeOptionalString(index);
+        out.writeOptionalString(alias);
+        out.writeOptionalString(filter);
+        out.writeOptionalString(indexRouting);
+        out.writeOptionalString(searchRouting);
     }
 
     public static AliasAction newAddAliasAction(String index, String alias) {

--- a/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -187,5 +187,16 @@ public enum CollectionUtils {
         }
         return uniqueCount;
     }
+    
+    /**
+     * Checks if the given array contains any elements.
+     * 
+     * @param array The array to check
+     * 
+     * @return false if the array contains an element, true if not or the array is null.
+     */
+    public static boolean isEmpty(Object[] array) {
+        return array == null || array.length == 0;
+    }
 
 }

--- a/src/main/java/org/elasticsearch/indices/TypeMissingException.java
+++ b/src/main/java/org/elasticsearch/indices/TypeMissingException.java
@@ -23,17 +23,19 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexException;
 import org.elasticsearch.rest.RestStatus;
 
+import java.util.Arrays;
+
 /**
  *
  */
 public class TypeMissingException extends IndexException {
 
-    public TypeMissingException(Index index, String type) {
-        super(index, "type[" + type + "] missing");
+    public TypeMissingException(Index index, String... types) {
+        super(index, "type[" + Arrays.toString(types) + "] missing");
     }
 
-    public TypeMissingException(Index index, String type, String message) {
-        super(index, "type[" + type + "] missing: " + message);
+    public TypeMissingException(Index index, String[] types, String message) {
+        super(index, "type[" + Arrays.toString(types) + "] missing: " + message);
     }
 
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/AliasesMissingException.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/AliasesMissingException.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.warmer;
+package org.elasticsearch.rest.action.admin.indices.alias.delete;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.rest.RestStatus;
@@ -26,19 +26,18 @@ import java.util.Arrays;
 /**
  *
  */
-public class IndexWarmerMissingException extends ElasticsearchException {
+public class AliasesMissingException extends ElasticsearchException {
 
     private final String[] names;
 
-    public IndexWarmerMissingException(String... names) {
-        super("index_warmer [" +  Arrays.toString(names) + "] missing");
+    public AliasesMissingException(String... names) {
+        super("aliases [" +  Arrays.toString(names) + "] missing");
         this.names = names;
     }
 
     public String[] names() {
         return this.names;
     }
-
 
     @Override
     public RestStatus status() {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.rest.action.admin.indices.alias.delete;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
@@ -35,15 +36,16 @@ public class RestIndexDeleteAliasesAction extends BaseRestHandler {
     public RestIndexDeleteAliasesAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
         controller.registerHandler(DELETE, "/{index}/_alias/{name}", this);
+        controller.registerHandler(DELETE, "/{index}/_aliases/{name}", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        final String index = request.param("index");
-        String alias = request.param("name");
+        final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
+        final String[] aliases = Strings.splitStringByCommaToArray(request.param("name"));
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
         indicesAliasesRequest.timeout(request.paramAsTime("timeout", indicesAliasesRequest.timeout()));
-        indicesAliasesRequest.removeAlias(index, alias);
+        indicesAliasesRequest.removeAlias(indices, aliases);
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", indicesAliasesRequest.masterNodeTimeout()));
 
         client.admin().indices().aliases(indicesAliasesRequest, new AcknowledgedRestResponseActionListener<IndicesAliasesResponse>(request, channel, logger));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
@@ -41,13 +41,18 @@ public class RestDeleteMappingAction extends BaseRestHandler {
         super(settings, client);
         controller.registerHandler(DELETE, "/{index}/{type}/_mapping", this);
         controller.registerHandler(DELETE, "/{index}/{type}", this);
+        controller.registerHandler(DELETE, "/{index}/_mapping/{type}", this);
+        
+        //support _mappings also
+        controller.registerHandler(DELETE, "/{index}/{type}/_mappings", this);
+        controller.registerHandler(DELETE, "/{index}/_mappings/{type}", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         DeleteMappingRequest deleteMappingRequest = deleteMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteMappingRequest.listenerThreaded(false);
-        deleteMappingRequest.type(request.param("type"));
+        deleteMappingRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         deleteMappingRequest.timeout(request.paramAsTime("timeout", deleteMappingRequest.timeout()));
         deleteMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteMappingRequest.masterNodeTimeout()));
         deleteMappingRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteMappingRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -37,14 +37,30 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
  */
 public class RestPutMappingAction extends BaseRestHandler {
 
+
     @Inject
     public RestPutMappingAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
-        controller.registerHandler(PUT, "/{index}/_mapping", this);
+        controller.registerHandler(PUT, "/{index}/_mapping/", this);
         controller.registerHandler(PUT, "/{index}/{type}/_mapping", this);
+        controller.registerHandler(PUT, "/{index}/_mapping/{type}", this);
+        controller.registerHandler(PUT, "/_mapping/{type}", this);
 
-        controller.registerHandler(POST, "/{index}/_mapping", this);
+        controller.registerHandler(POST, "/{index}/_mapping/", this);
         controller.registerHandler(POST, "/{index}/{type}/_mapping", this);
+        controller.registerHandler(POST, "/{index}/_mapping/{type}", this);
+        controller.registerHandler(POST, "/_mapping/{type}", this);
+        
+        //register the same paths, but with plural form _mappings
+        controller.registerHandler(PUT, "/{index}/_mappings/", this);
+        controller.registerHandler(PUT, "/{index}/{type}/_mappings", this);
+        controller.registerHandler(PUT, "/{index}/_mappings/{type}", this);
+        controller.registerHandler(PUT, "/_mappings/{type}", this);
+
+        controller.registerHandler(POST, "/{index}/_mappings/", this);
+        controller.registerHandler(POST, "/{index}/{type}/_mappings", this);
+        controller.registerHandler(POST, "/{index}/_mappings/{type}", this);
+        controller.registerHandler(POST, "/_mappings/{type}", this);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -37,12 +37,13 @@ public class RestDeleteWarmerAction extends BaseRestHandler {
         super(settings, client);
         controller.registerHandler(DELETE, "/{index}/_warmer", this);
         controller.registerHandler(DELETE, "/{index}/_warmer/{name}", this);
-        controller.registerHandler(DELETE, "/{index}/{type}/_warmer/{name}", this);
+        controller.registerHandler(DELETE, "/{index}/_warmers", this);
+        controller.registerHandler(DELETE, "/{index}/_warmers/{name}", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        DeleteWarmerRequest deleteWarmerRequest = new DeleteWarmerRequest(request.param("name"))
+        DeleteWarmerRequest deleteWarmerRequest = new DeleteWarmerRequest(Strings.splitStringByCommaToArray(request.param("name")))
                 .indices(Strings.splitStringByCommaToArray(request.param("index")));
         deleteWarmerRequest.listenerThreaded(false);
         deleteWarmerRequest.timeout(request.paramAsTime("timeout", deleteWarmerRequest.timeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
 
+import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 /**
@@ -36,8 +37,21 @@ public class RestPutWarmerAction extends BaseRestHandler {
     @Inject
     public RestPutWarmerAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
+        controller.registerHandler(PUT, "/_warmer/{name}", this);
         controller.registerHandler(PUT, "/{index}/_warmer/{name}", this);
         controller.registerHandler(PUT, "/{index}/{type}/_warmer/{name}", this);
+        
+        controller.registerHandler(PUT, "/_warmers/{name}", this);
+        controller.registerHandler(PUT, "/{index}/_warmers/{name}", this);
+        controller.registerHandler(PUT, "/{index}/{type}/_warmers/{name}", this);
+        
+        controller.registerHandler(POST, "/_warmer/{name}", this);
+        controller.registerHandler(POST, "/{index}/_warmer/{name}", this);
+        controller.registerHandler(POST, "/{index}/{type}/_warmer/{name}", this);
+        
+        controller.registerHandler(POST, "/_warmers/{name}", this);
+        controller.registerHandler(POST, "/{index}/_warmers/{name}", this);
+        controller.registerHandler(POST, "/{index}/{type}/_warmers/{name}", this);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestTests.java
@@ -48,7 +48,7 @@ public class DeleteWarmerRequestTests extends ElasticsearchTestCase {
         DeleteWarmerRequest inRequest = new DeleteWarmerRequest();
         inRequest.readFrom(esBuffer);
 
-        assertThat(inRequest.name(), equalTo("warmer1"));
+        assertThat(inRequest.names()[0], equalTo("warmer1"));
         //timeout is default as we don't read it from the received buffer
         assertThat(inRequest.timeout().millis(), equalTo(new DeleteWarmerRequest().timeout().millis()));
 
@@ -70,7 +70,7 @@ public class DeleteWarmerRequestTests extends ElasticsearchTestCase {
         DeleteWarmerRequest inRequest = new DeleteWarmerRequest();
         inRequest.readFrom(esBuffer);
 
-        assertThat(inRequest.name(), equalTo("warmer1"));
+        assertThat(inRequest.names()[0], equalTo("warmer1"));
         //timeout is default as we don't read it from the received buffer
         assertThat(inRequest.timeout().millis(), equalTo(outRequest.timeout().millis()));
 

--- a/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -123,7 +123,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
         assertAcked(client().admin().indices().preparePutWarmer("custom_warmer")
                 .setSearchRequest(client().prepareSearch("test").setTypes("test").setQuery(QueryBuilders.matchAllQuery())));
 
-        assertAcked(client().admin().indices().prepareDeleteWarmer().setIndices("test").setName("custom_warmer"));
+        assertAcked(client().admin().indices().prepareDeleteWarmer().setIndices("test").setNames("custom_warmer"));
 
         for (Client client : clients()) {
             GetWarmersResponse getWarmersResponse = client.admin().indices().prepareGetWarmers().setLocal(true).get();

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -369,37 +369,37 @@ public class MetaDataTests extends ElasticsearchTestCase {
     @Test
     public void testIsExplicitAllIndices_null() throws Exception {
         MetaData metaData = MetaData.builder().build();
-        assertThat(metaData.isExplicitAllIndices(null), equalTo(false));
+        assertThat(metaData.isExplicitAllPattern(null), equalTo(false));
     }
 
     @Test
     public void testIsExplicitAllIndices_empty() throws Exception {
         MetaData metaData = MetaData.builder().build();
-        assertThat(metaData.isExplicitAllIndices(new String[0]), equalTo(false));
+        assertThat(metaData.isExplicitAllPattern(new String[0]), equalTo(false));
     }
 
     @Test
     public void testIsExplicitAllIndices_explicitAll() throws Exception {
         MetaData metaData = MetaData.builder().build();
-        assertThat(metaData.isExplicitAllIndices(new String[]{"_all"}), equalTo(true));
+        assertThat(metaData.isExplicitAllPattern(new String[]{"_all"}), equalTo(true));
     }
 
     @Test
     public void testIsExplicitAllIndices_explicitAllPlusOther() throws Exception {
         MetaData metaData = MetaData.builder().build();
-        assertThat(metaData.isExplicitAllIndices(new String[]{"_all", "other"}), equalTo(false));
+        assertThat(metaData.isExplicitAllPattern(new String[]{"_all", "other"}), equalTo(false));
     }
 
     @Test
     public void testIsExplicitAllIndices_normalIndexes() throws Exception {
         MetaData metaData = MetaData.builder().build();
-        assertThat(metaData.isExplicitAllIndices(new String[]{"index1", "index2", "index3"}), equalTo(false));
+        assertThat(metaData.isExplicitAllPattern(new String[]{"index1", "index2", "index3"}), equalTo(false));
     }
 
     @Test
     public void testIsExplicitAllIndices_wildcard() throws Exception {
         MetaData metaData = MetaData.builder().build();
-        assertThat(metaData.isExplicitAllIndices(new String[]{"*"}), equalTo(false));
+        assertThat(metaData.isExplicitAllPattern(new String[]{"*"}), equalTo(false));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
@@ -127,7 +127,7 @@ public class LocalGatewayIndicesWarmerTests extends ElasticsearchIntegrationTest
 
 
         logger.info("--> delete warmer warmer_1");
-        DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer().setIndices("test").setName("warmer_1").execute().actionGet();
+        DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer().setIndices("test").setNames("warmer_1").execute().actionGet();
         assertThat(deleteWarmerResponse.isAcknowledged(), equalTo(true));
 
         logger.info("--> verify warmers (delete) are registered in cluster state");

--- a/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerTests.java
@@ -175,10 +175,10 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
         createIndex("test");
 
         try {
-            client().admin().indices().prepareDeleteWarmer().setIndices("test").setName("foo").execute().actionGet(1000);
+            client().admin().indices().prepareDeleteWarmer().setIndices("test").setNames("foo").execute().actionGet(1000);
             assert false : "warmer foo should not exist";
         } catch (IndexWarmerMissingException ex) {
-            assertThat(ex.name(), equalTo("foo"));
+            assertThat(ex.names()[0], equalTo("foo"));
         }
     }
 
@@ -199,7 +199,7 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
         assertThat(entry.value.size(), equalTo(1));
         assertThat(entry.value.iterator().next().name(), equalTo("custom_warmer"));
 
-        DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer().setIndices("test").setName("custom_warmer").get();
+        DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer().setIndices("test").setNames("custom_warmer").get();
         assertThat(deleteWarmerResponse.isAcknowledged(), equalTo(true));
 
         getWarmersResponse = client().admin().indices().prepareGetWarmers("test").get();

--- a/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
@@ -93,8 +93,8 @@ public class MoreLikeThisActionTests extends ElasticsearchIntegrationTest {
                     .startObject("text").field("type", "string").endObject()
                     .endObject().endObject().endObject()));
         logger.info("Creating aliases alias release");
-        client().admin().indices().aliases(indexAliasesRequest().addAlias("test", "release", termFilter("text", "release"))).actionGet();
-        client().admin().indices().aliases(indexAliasesRequest().addAlias("test", "beta", termFilter("text", "beta"))).actionGet();
+        client().admin().indices().aliases(indexAliasesRequest().addAlias("release", termFilter("text", "release"), "test")).actionGet();
+        client().admin().indices().aliases(indexAliasesRequest().addAlias("beta", termFilter("text", "beta"), "test")).actionGet();
 
         logger.info("Running Cluster Health");
         assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));

--- a/src/test/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIntegrationTests.java
@@ -149,7 +149,8 @@ public class DestructiveOperationsIntegrationTests extends ElasticsearchIntegrat
                 .put(DestructiveOperations.REQUIRES_NAME, true)
                 .build();
         assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
-
+        
+        
         assertAcked(client().admin().indices().prepareCreate("index1").addMapping("1", "field1", "type=string").get());
         assertAcked(client().admin().indices().prepareCreate("1index").addMapping("1", "field1", "type=string").get());
 
@@ -158,20 +159,19 @@ public class DestructiveOperationsIntegrationTests extends ElasticsearchIntegrat
         try {
             client().admin().indices().prepareDeleteMapping("_all").setType("1").get();
             fail();
-        } catch (ElasticsearchIllegalArgumentException e) {}
-
+        } catch (ElasticsearchIllegalArgumentException e) {
+        }
         try {
-            client().admin().indices().prepareDeleteMapping().setType("1").get();
+            client().admin().indices().prepareDeleteMapping().setIndices("*").setType("1").get();
             fail();
-        } catch (ElasticsearchIllegalArgumentException e) {}
+        } catch (ElasticsearchIllegalArgumentException e) {
+        }
 
-        settings = ImmutableSettings.builder()
-                .put(DestructiveOperations.REQUIRES_NAME, false)
-                .build();
+        settings = ImmutableSettings.builder().put(DestructiveOperations.REQUIRES_NAME, false).build();
         assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
 
         assertAcked(client().admin().indices().preparePutMapping("1index").setType("1").setSource("field1", "type=string"));
-        assertAcked(client().admin().indices().prepareDeleteMapping().setType("1"));
+        assertAcked(client().admin().indices().prepareDeleteMapping().setIndices("*").setType("1"));
         assertAcked(client().admin().indices().preparePutMapping("1index").setType("1").setSource("field1", "type=string"));
         assertAcked(client().admin().indices().prepareDeleteMapping("_all").setType("1"));
     }


### PR DESCRIPTION
This pull request makes consistent the PUT for `_mapping`, `_alias` and `_warmer` as described in issue #4071.
### `_mapping`:

Single type can now be added with

`[PUT|POST] {index|_all|*|regex|blank}/[_mapping|_mappings]/type`

and

`[PUT|POST] {index|_all|*|regex|blank}/type/[_mapping|_mappings]`
### `_warmer`

A single warmer can now be put with

`[PUT|POST] {index|_all|*|prefix*|blank}/{type|_all|*|prefix*|blank}/[_warmer|_warmers]/warmer_name`
### `_alias`

A single alias can now be PUT with

`[PUT|POST] {index|_all|*|prefix*|blank}/[_alias|_aliases]/alias`
