### PR TITLE
add MockPageCacheRecycler in test jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1059,6 +1059,7 @@
                         <configuration>
                             <includes>
                                 <include>org/elasticsearch/test/**/*</include>
+                                <include>org/elasticsearch/cache/recycler/MockPageCacheRecycler.class</include>
                                 <include>org/apache/lucene/util/AbstractRandomizedTest.class</include>
                                 <include>org/apache/lucene/util/AbstractRandomizedTest$*.class</include> <!-- inner classes -->
                                 <include>com/carrotsearch/randomizedtesting/StandaloneRandomizedContext.class</include>


### PR DESCRIPTION
MockPageCacheRecycler is missing in test jar which makes failing tests when using
test jar in plugins:

```
1> [2014-01-11 10:51:30,531][ERROR][test                     ] FAILURE  : testWikipediaRiver(org.elasticsearch.river.wikipedia.WikipediaRiverTest)
  1> REPRODUCE WITH  : mvn test -Dtests.seed=5DAFD4FBAE587363 -Dtests.class=org.elasticsearch.river.wikipedia.WikipediaRiverTest -Dtests.method=testWikipediaRiver -Dtests.prefix=tests -Dtests.network=true -Dfile.encoding=MacRoman -Duser.timezone=Europe/Paris -Des.logger.level=INFO -Des.node.local=true -Dtests.cluster_seed=134842C2D806FFC0
  1> Throwable:
  1> java.lang.NoClassDefFoundError: org/elasticsearch/cache/recycler/MockPageCacheRecycler
  1>     org.elasticsearch.test.cache.recycler.MockPageCacheRecyclerModule.configure(MockPageCacheRecyclerModule.java:30)
  1>     org.elasticsearch.common.inject.AbstractModule.configure(AbstractModule.java:60)
```
