### PR TITLE
Added stopwords: _none_ to the docs #329

### DIFF
--- a/docs/reference/analysis/analyzers.asciidoc
+++ b/docs/reference/analysis/analyzers.asciidoc
@@ -49,14 +49,6 @@ index :
         stopwords : [test1, test2, test3]
 --------------------------------------------------
 
-[[analyzers-stopwords]]
-=== Stopwords
-
-The `stopwords` parameter can be used to provide a custom set of stopwords. As
-certain analyzers use a default list of stopwords while others don't, please
-check out the individual analyzer sections. In case you want the analyzer to
-use no stopwords at all, simply provide `stopwords: _none_`
-
 Below is a list of the built in analyzers.
 
 include::analyzers/standard-analyzer.asciidoc[]

--- a/docs/reference/analysis/analyzers.asciidoc
+++ b/docs/reference/analysis/analyzers.asciidoc
@@ -49,6 +49,14 @@ index :
         stopwords : [test1, test2, test3]
 --------------------------------------------------
 
+[[analyzers-stopwords]]
+=== Stopwords
+
+The `stopwords` parameter can be used to provide a custom set of stopwords. As
+certain analyzers use a default list of stopwords while others don't, please
+check out the individual analyzer sections. In case you want the analyzer to
+use no stopwords at all, simply provide `stopwords: _none_`
+
 Below is a list of the built in analyzers.
 
 include::analyzers/standard-analyzer.asciidoc[]

--- a/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
@@ -11,7 +11,8 @@ following types are supported: `arabic`, `armenian`, `basque`,
 
 All analyzers support setting custom `stopwords` either internally in
 the config, or by using an external stopwords file by setting
-`stopwords_path`.
+`stopwords_path`. Check <<analysis-stop-analyzer,Stop Analyzer>> for
+more details.
 
 The following analyzers support setting custom `stem_exclusion` list:
 `arabic`, `armenian`, `basque`, `brazilian`, `bulgarian`, `catalan`,

--- a/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
@@ -15,7 +15,8 @@ type:
 |`flags` |The regular expression flags.
 |`stopwords` |A list of stopwords to initialize the stop filter with.
 Defaults to an 'empty' stopword list coming[1.0.0.RC1, Previously 
-defaulted to the English stopwords list]
+defaulted to the English stopwords list]. Check
+<<analysis-stop-analyzer,Stop Analyzer>> for more details.
 |===================================================================
 
 *IMPORTANT*: The regular expression should match the *token separators*,

--- a/docs/reference/analysis/analyzers/snowball-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/snowball-analyzer.asciidoc
@@ -41,8 +41,9 @@ filter>> and defaults to `English`. Note that not all the language
 analyzers have a default set of stopwords provided.
 
 The `stopwords` parameter can be used to provide stopwords for the
-languages that has no defaults, or to simply replace the default set
-with your custom list. A default set of stopwords for many of these
+languages that have no defaults, or to simply replace the default set
+with your custom list. Check <<analysis-stop-analyzer,Stop Analyzer>>
+for more details. A default set of stopwords for many of these
 languages is available from for instance
 https://github.com/apache/lucene-solr/tree/trunk/lucene/analysis/common/src/resources/org/apache/lucene/analysis/[here]
 and

--- a/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
@@ -19,7 +19,8 @@ type:
 |Setting |Description
 |`stopwords` |A list of stopwords to initialize the stop filter with.
 Defaults to an 'empty' stopword list added[1.0.0.Beta1, Previously 
-defaulted to the English stopwords list]
+defaulted to the English stopwords list]. Check
+<<analysis-stop-analyzer,Stop Analyzer>> for more details.
 |`max_token_length` |The maximum token length. If a token is seen that
 exceeds this length then it is discarded. Defaults to `255`.
 |=======================================================================

--- a/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
@@ -17,7 +17,7 @@ type:
 [cols="<,<",options="header",]
 |=======================================================================
 |Setting |Description
-|`stopwords` |A list of stopword to initialize the stop filter with.
+|`stopwords` |A list of stopwords to initialize the stop filter with.
 Defaults to an 'empty' stopword list added[1.0.0.Beta1, Previously 
 defaulted to the English stopwords list]
 |`max_token_length` |The maximum token length. If a token is seen that

--- a/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
@@ -14,8 +14,9 @@ The following are settings that can be set for a `stop` analyzer type:
 |Setting |Description
 |`stopwords` |A list of stopwords to initialize the stop filter with.
 Defaults to the english stop words.
-
 |`stopwords_path` |A path (either relative to `config` location, or
 absolute) to a stopwords file configuration.
 |=======================================================================
+
+Use `stopwords: _none_` to explicitly specify an 'empty' stopword list.
 

--- a/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
@@ -12,7 +12,7 @@ The following are settings that can be set for a `stop` analyzer type:
 [cols="<,<",options="header",]
 |=======================================================================
 |Setting |Description
-|`stopwords` |A list of stopword to initialize the stop filter with.
+|`stopwords` |A list of stopwords to initialize the stop filter with.
 Defaults to the english stop words.
 
 |`stopwords_path` |A path (either relative to `config` location, or


### PR DESCRIPTION
I'm missing `stopwords: _none_` in the docs, as well as a `stopwords: ...` section within the pattern analyzer docs.
