### PR TITLE
Fix RandomExceptionCircuitBreakerTests

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
@@ -58,6 +58,11 @@ public class NodesStatsRequestBuilder extends NodesOperationRequestBuilder<Nodes
         return this;
     }
 
+    public NodesStatsRequestBuilder setBreaker(boolean breaker) {
+        request.breaker(breaker);
+        return this;
+    }
+
     /**
      * Should the node indices stats be returned.
      */

--- a/src/main/java/org/elasticsearch/common/lucene/SegmentReaderUtils.java
+++ b/src/main/java/org/elasticsearch/common/lucene/SegmentReaderUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.lucene;
+
+import org.apache.lucene.index.AtomicReader;
+import org.apache.lucene.index.FilterAtomicReader;
+import org.apache.lucene.index.SegmentReader;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.Nullable;
+
+import java.lang.reflect.Field;
+
+public class SegmentReaderUtils {
+
+    private static final Field FILTER_ATOMIC_READER_IN;
+
+    static {
+        Field in = null;
+        try { // and another one bites the dust...
+            in = FilterAtomicReader.class.getDeclaredField("in");
+            in.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            assert false : "Failed to get field: " + e.getMessage();
+        }
+        FILTER_ATOMIC_READER_IN = in;
+
+    }
+
+    /**
+     * Tries to extract a segment reader from the given index reader.
+     * If no SegmentReader can be extracted an {@link org.elasticsearch.ElasticsearchIllegalStateException} is thrown.
+     */
+    @Nullable
+    public static SegmentReader segmentReader(AtomicReader reader) {
+        return internalSegmentReader(reader, true);
+    }
+
+    /**
+     * Tries to extract a segment reader from the given index reader and returns it, otherwise <code>null</code>
+     * is returned
+     */
+    @Nullable
+    public static SegmentReader segmentReaderOrNull(AtomicReader reader) {
+        return internalSegmentReader(reader, false);
+    }
+
+    public static boolean registerCoreListener(AtomicReader reader, SegmentReader.CoreClosedListener listener) {
+        SegmentReader segReader = SegmentReaderUtils.segmentReaderOrNull(reader);
+        if (segReader != null) {
+            segReader.addCoreClosedListener(listener);
+            return true;
+        }
+        return false;
+    }
+
+    private static SegmentReader internalSegmentReader(AtomicReader reader, boolean fail) {
+        if (reader == null) {
+            return null;
+        }
+        if (reader instanceof SegmentReader) {
+            return (SegmentReader) reader;
+        } else if (reader instanceof FilterAtomicReader) {
+            final FilterAtomicReader fReader = (FilterAtomicReader) reader;
+            try {
+                return FILTER_ATOMIC_READER_IN == null ? null :
+                        segmentReader((AtomicReader) FILTER_ATOMIC_READER_IN.get(fReader));
+            } catch (IllegalAccessException e) {
+            }
+        }
+        if (fail) {
+            // hard fail - we can't get a SegmentReader
+            throw new ElasticsearchIllegalStateException("Can not extract segment reader from given index reader [" + reader + "]");
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/id/simple/SimpleIdCache.java
@@ -120,7 +120,7 @@ public class SimpleIdCache extends AbstractIndexComponent implements IdCache, Se
 
                 // do the refresh
                 Map<Object, Map<String, TypeBuilder>> builders = new HashMap<Object, Map<String, TypeBuilder>>();
-                Map<Object, IndexReader> cacheToReader = new HashMap<Object, IndexReader>();
+                Map<Object, AtomicReader> cacheToReader = new HashMap<Object, AtomicReader>();
 
                 // first, go over and load all the id->doc map for all types
                 for (AtomicReaderContext context : atomicReaderContexts) {
@@ -237,7 +237,7 @@ public class SimpleIdCache extends AbstractIndexComponent implements IdCache, Se
                                 typeBuilderEntry.getValue().parentIdsValues.toArray(new HashedBytesArray[typeBuilderEntry.getValue().parentIdsValues.size()]),
                                 typeBuilderEntry.getValue().parentIdsOrdinals));
                     }
-                    IndexReader indexReader = cacheToReader.get(readerKey);
+                    AtomicReader indexReader = cacheToReader.get(readerKey);
                     SimpleIdReaderCache readerCache = new SimpleIdReaderCache(types.immutableMap(), ShardUtils.extractShardId(indexReader));
                     idReaders.put(readerKey, readerCache);
                     onCached(readerCache);

--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataCache.java
@@ -26,6 +26,7 @@ import com.google.common.cache.RemovalNotification;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.SegmentReader;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lucene.SegmentReaderUtils;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.ShardId;
@@ -100,10 +101,7 @@ public interface IndexFieldDataCache {
             return (FD) cache.get(key, new Callable<AtomicFieldData>() {
                 @Override
                 public AtomicFieldData call() throws Exception {
-                    if (context.reader() instanceof SegmentReader) {
-                        ((SegmentReader) context.reader()).addCoreClosedListener(FieldBased.this);
-                    }
-
+                    SegmentReaderUtils.registerCoreListener(context.reader(), FieldBased.this);
                     AtomicFieldData fieldData = indexFieldData.loadDirect(context);
                     key.sizeInBytes = fieldData.getMemorySizeInBytes();
 

--- a/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.SegmentReader;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.SegmentReaderUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -134,9 +135,7 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
             return (FD) cache.get(key, new Callable<AtomicFieldData>() {
                 @Override
                 public AtomicFieldData call() throws Exception {
-                    if (context.reader() instanceof SegmentReader) {
-                        ((SegmentReader) context.reader()).addCoreClosedListener(IndexFieldCache.this);
-                    }
+                    SegmentReaderUtils.registerCoreListener(context.reader(), IndexFieldCache.this);
                     AtomicFieldData fieldData = indexFieldData.loadDirect(context);
 
                     if (indexService != null) {

--- a/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
@@ -286,7 +286,10 @@ public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTes
                         }
                         break;
                 }
+            }
 
+            public boolean wrapTerms(String field) {
+                return true;
             }
         }
 

--- a/src/test/java/org/elasticsearch/test/engine/ThrowingAtomicReaderWrapper.java
+++ b/src/test/java/org/elasticsearch/test/engine/ThrowingAtomicReaderWrapper.java
@@ -59,6 +59,13 @@ public class ThrowingAtomicReaderWrapper extends FilterAtomicReader {
          * Maybe throws an exception ;)
          */
         public void maybeThrow(Flags flag) throws IOException;
+
+        /**
+         * If this method returns true the {@link Terms} instance for the given field
+         * is wrapped with Thrower support otherwise no exception will be thrown for
+         * the current {@link Terms} instance or any other instance obtained from it.
+         */
+        public boolean wrapTerms(String field);
     }
 
     public ThrowingAtomicReaderWrapper(AtomicReader in, Thrower thrower) {
@@ -95,8 +102,11 @@ public class ThrowingAtomicReaderWrapper extends FilterAtomicReader {
         @Override
         public Terms terms(String field) throws IOException {
             Terms terms = super.terms(field);
-            thrower.maybeThrow(Flags.Terms);
-            return terms == null ? null : new ThrowingTerms(terms, thrower);
+            if (thrower.wrapTerms(field)) {
+                thrower.maybeThrow(Flags.Terms);
+                return terms == null ? null : new ThrowingTerms(terms, thrower);
+            }
+            return terms;
         }
     }
 


### PR DESCRIPTION
RandomExceptionCircuitBreakerTests never actually installed
the FilteredAtomicReader that should throw random exceptions
when field data is loaded. There were also bug in the way field data invalidates caches when a testing FilteredAtomicReader was used.
