### PR TITLE
third party license extractor

### DIFF
--- a/dev-tools/extract_party_license.rb
+++ b/dev-tools/extract_party_license.rb
@@ -31,12 +31,12 @@ def all_installed_gems
    all
 end
 
-all_installed_gems.select {|y| y.gem_dir.include?('vendor') }.each do |x|
+all_installed_gems.select {|y| y.gem_dir.include?('vendor') }.sort {|v, u| v.name  <=> u.name }.each do |x|
   puts '='*80 #seperator
   if(x.license) #ah gem has license information
-    puts "%s,%s,%s"%[x.name, x.version, x.license] 
+    puts "%s,%s,%s,%s,%s"%[x.name, x.version, x.license, x.homepage, x.email] 
   else
-    puts "%s,%s"%[x.name, x.version]
+    puts "%s,%s,%s,%s"%[x.name, x.version, x.homepage, x.email]
     license_file =  Dir.glob(File.join(x.gem_dir,'LICENSE*')).first #see if there is a license file
     if(license_file)
       file = File.open(license_file, 'r')

--- a/dev-tools/extract_party_license.rb
+++ b/dev-tools/extract_party_license.rb
@@ -1,0 +1,54 @@
+#!/bin/env ruby
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance  with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on 
+# an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License
+#
+# The script extract license information out of logstash project
+# First it will use license information out of gem object.  
+# If that is not available, it will try to print out the license file
+#
+require 'rubygems' 
+require 'bundler/setup'
+require 'yaml'
+
+# get all local installed gems
+def all_installed_gems
+   Gem::Specification.all = nil    
+   all = Gem::Specification 
+   Gem::Specification.reset
+   all
+end
+
+all_installed_gems.select {|y| y.gem_dir.include?('vendor') }.each do |x|
+  puts '='*80 #seperator
+  if(x.license) #ah gem has license information
+    puts "%s,%s,%s"%[x.name, x.version, x.license] 
+  else
+    puts "%s,%s"%[x.name, x.version]
+    license_file =  Dir.glob(File.join(x.gem_dir,'LICENSE*')).first #see if there is a license file
+    if(license_file)
+      file = File.open(license_file, 'r')
+      data = file.read
+      file.close
+      puts data
+    else
+      #no license file.. try to print some gem information
+      puts 'No License File'
+      puts x.gem_dir
+      puts x.files.join("\n")
+    end
+  end
+end
+


### PR DESCRIPTION
extract dependency license information.

the script currently is limited to extract information out of logstash project.

example of the output
# 
# i18n,0.6.9,MIT
# multi_json,1.8.2,MIT
# activesupport,3.2.16,MIT
# addressable,2.3.5,Apache License 2.0
# atomic,1.1.14,Apache-2.0

extlib,0.9.16
Copyright (c) 2010 Dan Kubb

Permission is hereby granted, free of charge, to any person obtaining
a copy of this software and associated documentation files (the
"Software"), to deal in the Software without restriction, including
without limitation the rights to use, copy, modify, merge, publish,
distribute, sublicense, and/or sell copies of the Software, and to
permit persons to whom the Software is furnished to do so, subject to
the following conditions:

The above copyright notice and this permission notice shall be
included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

---

---

Some portions of blank.rb and mash.rb are verbatim copies of software
licensed under the MIT license. That license is included below:

Copyright (c) 2005-2008 David Heinemeier Hansson

Permission is hereby granted, free of charge, to any person obtaining
a copy of this software and associated documentation files (the
"Software"), to deal in the Software without restriction, including
without limitation the rights to use, copy, modify, merge, publish,
distribute, sublicense, and/or sell copies of the Software, and to
permit persons to whom the Software is furnished to do so, subject to
the following conditions:

The above copyright notice and this permission notice shall be
included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
