### PR TITLE
excluding all fields of an object should not remove parent.

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -160,15 +160,12 @@ public class XContentMapValues {
                 continue;
             }
 
-            boolean exactIncludeMatch; // true if the current position was specifically mentioned
-            boolean pathIsPrefixOfAnInclude; // true if potentially a sub scope can be included
+            boolean exactIncludeMatch = false; // true if the current position was specifically mentioned
+            boolean pathIsPrefixOfAnInclude = false; // true if potentially a sub scope can be included
             if (includes.length == 0) {
                 // implied match anything
                 exactIncludeMatch = true;
-                pathIsPrefixOfAnInclude = false;
             } else {
-                exactIncludeMatch = false;
-                pathIsPrefixOfAnInclude = false;
                 for (String include : includes) {
                     // check for prefix matches as well to see if we need to zero in, something like: obj1.arr1.* or *.field
                     // note, this does not work well with middle matches, like obj1.*.obj3

--- a/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -154,24 +154,21 @@ public class XContentMapValues {
             }
             sb.append(key);
             String path = sb.toString();
-            boolean excluded = false;
-            for (String exclude : excludes) {
-                if (Regex.simpleMatch(exclude, path)) {
-                    excluded = true;
-                    break;
-                }
-            }
-            if (excluded) {
+
+            if (Regex.simpleMatch(excludes, path)) {
                 sb.setLength(mark);
                 continue;
             }
-            boolean exactIncludeMatch;
+
+            boolean exactIncludeMatch; // true if the current position was specifically mentioned
+            boolean pathIsPrefixOfAnInclude; // true if potentially a sub scope can be included
             if (includes.length == 0) {
                 // implied match anything
                 exactIncludeMatch = true;
+                pathIsPrefixOfAnInclude = false;
             } else {
                 exactIncludeMatch = false;
-                boolean pathIsPrefixOfAnInclude = false;
+                pathIsPrefixOfAnInclude = false;
                 for (String include : includes) {
                     // check for prefix matches as well to see if we need to zero in, something like: obj1.arr1.* or *.field
                     // note, this does not work well with middle matches, like obj1.*.obj3
@@ -198,11 +195,12 @@ public class XContentMapValues {
                         break;
                     }
                 }
-                if (!pathIsPrefixOfAnInclude && !exactIncludeMatch) {
-                    // skip subkeys, not interesting.
-                    sb.setLength(mark);
-                    continue;
-                }
+            }
+
+            if (!(pathIsPrefixOfAnInclude || exactIncludeMatch)) {
+                // skip subkeys, not interesting.
+                sb.setLength(mark);
+                continue;
             }
 
 
@@ -210,7 +208,7 @@ public class XContentMapValues {
                 Map<String, Object> innerInto = Maps.newHashMap();
                 // if we had an exact match, we want give deeper excludes their chance
                 filter((Map<String, Object>) entry.getValue(), innerInto, exactIncludeMatch ? Strings.EMPTY_ARRAY : includes, excludes, sb);
-                if (!innerInto.isEmpty()) {
+                if (exactIncludeMatch || !innerInto.isEmpty()) {
                     into.put(entry.getKey(), innerInto);
                 }
             } else if (entry.getValue() instanceof List) {

--- a/src/test/java/org/elasticsearch/search/fields/SearchFieldsTests.java
+++ b/src/test/java/org/elasticsearch/search/fields/SearchFieldsTests.java
@@ -253,7 +253,7 @@ public class SearchFieldsTests extends ElasticsearchIntegrationTest {
 
         SearchResponse response = client().prepareSearch("test")
                 .addPartialField("partial1", "obj1.arr1.*", null)
-                .addPartialField("partial2", null, "obj1.*")
+                .addPartialField("partial2", null, "obj1")
                 .execute().actionGet();
         assertThat("Failures " + Arrays.toString(response.getShardFailures()), response.getShardFailures().length, equalTo(0));
 


### PR DESCRIPTION
When excluding '*.f1' from `{ "obj": { "f1": 1, "f2": 2 } }` XContentMapValues.filter returns `{ "obj": { "f2": 2}}`. When run on `{ "obj": { "f1" : 1 }}` we should return `{ "obj": { }}` to maintain object structure. People currently need to always check whether `obj` is there or not.

Closes #4715
Closes #4047
Related to #4491
