### PR TITLE
RPMs: Add timeout to shutdown with KILL signal

### DIFF
--- a/src/rpm/init.d/elasticsearch
+++ b/src/rpm/init.d/elasticsearch
@@ -95,7 +95,7 @@ start() {
 stop() {
     echo -n $"Stopping $prog: "
     # stop it here, often "killproc $prog"
-    killproc -p $pidfile $prog
+    killproc -p $pidfile -d 20 $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile

--- a/src/rpm/systemd/elasticsearch.service
+++ b/src/rpm/systemd/elasticsearch.service
@@ -13,6 +13,8 @@ ExecStart=/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearc
 LimitNOFILE=65535
 # See MAX_LOCKED_MEMORY in sysconfig, use "infinity" when MAX_LOCKED_MEMORY=unlimited and using bootstrap.mlockall: true
 #LimitMEMLOCK=infinity
+# Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)
+TimeoutStopSec=20
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If the thread pools of an elasticsearch node cannot be shutdown
immediately, a wait of 10 seconds is added. This clashes with the
RPM scripts, as by default the init functions wait for 3 seconds
for a service to shutdown before a KILL signal is sent, resulting
in an unclean shutdown - not from an elasticsearch point of view,
but from init system point of view, as some lock files are left
around.

In order to prevent this the init script as well as the systemd
configuration now feature the same timeout than the debian package,
which is 20 seconds.

The await statement, which causes the 10 second delay can be found in
InternalNode.close()

Closes #5020
