### PR TITLE
Remove `omit_term_freq_and_positions` for new indices

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -99,14 +99,17 @@ public interface Mapper extends ToXContent {
 
             private final ImmutableMap<String, TypeParser> typeParsers;
 
+            private final Version indexVersionCreated;
+
             public ParserContext(PostingsFormatService postingsFormatService, DocValuesFormatService docValuesFormatService,
                                  AnalysisService analysisService, SimilarityLookupService similarityLookupService,
-                                 ImmutableMap<String, TypeParser> typeParsers) {
+                                 ImmutableMap<String, TypeParser> typeParsers, Version indexVersionCreated) {
                 this.postingsFormatService = postingsFormatService;
                 this.docValuesFormatService = docValuesFormatService;
                 this.analysisService = analysisService;
                 this.similarityLookupService = similarityLookupService;
                 this.typeParsers = typeParsers;
+                this.indexVersionCreated = indexVersionCreated;
             }
 
             public AnalysisService analysisService() {
@@ -127,6 +130,10 @@ public interface Mapper extends ToXContent {
 
             public TypeParser typeParser(String type) {
                 return typeParsers.get(Strings.toUnderscoreCase(type));
+            }
+
+            public Version indexVersionCreated() {
+                return indexVersionCreated;
             }
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper.core;
 
 import org.apache.lucene.index.FieldInfo.IndexOptions;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
@@ -198,8 +199,12 @@ public class TypeParsers {
                     }
                 }
             } else if (propName.equals("omit_term_freq_and_positions")) {
+                final IndexOptions op = nodeBooleanValue(propNode) ? IndexOptions.DOCS_ONLY : IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
+                if (parserContext.indexVersionCreated().onOrAfter(Version.V_1_0_0)) {
+                    throw new ElasticsearchParseException("'omit_term_freq_and_positions' is not supported anymore - use ['index_options' : '" + op.name() + "']  instead");
+                }
                 // deprecated option for BW compat
-                builder.indexOptions(nodeBooleanValue(propNode) ? IndexOptions.DOCS_ONLY : IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+                builder.indexOptions(op);
             } else if (propName.equals("index_options")) {
                 builder.indexOptions(nodeIndexOptionValue(propNode));
             } else if (propName.equals("analyzer")) {

--- a/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/count/query/SimpleQueryTests.java
@@ -131,25 +131,6 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    public void testOmitTermFreqsAndPositions() throws Exception {
-        // backwards compat test!
-        assertAcked(prepareCreate("test")
-                .addMapping("type1", "field1", "type=string,omit_term_freq_and_positions=true")
-                .setSettings(SETTING_NUMBER_OF_SHARDS, 1));
-
-        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("field1", "quick brown fox", "field2", "quick brown fox"),
-                client().prepareIndex("test", "type1", "2").setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox"));
-
-        CountResponse countResponse = client().prepareCount().setQuery(QueryBuilders.matchQuery("field2", "quick brown").type(Type.PHRASE).slop(0)).get();
-        assertHitCount(countResponse, 1l);
-        try {
-            client().prepareCount().setQuery(QueryBuilders.matchQuery("field1", "quick brown").type(Type.PHRASE).slop(0)).get();
-        } catch (SearchPhaseExecutionException e) {
-            assertTrue(e.getMessage().endsWith("IllegalStateException[field \"field1\" was indexed without position data; cannot run PhraseQuery (term=quick)]; }"));
-        }
-    }
-
-    @Test
     public void queryStringAnalyzedWildcard() throws Exception {
         assertAcked(prepareCreate("test").setSettings(SETTING_NUMBER_OF_SHARDS, 1));
 

--- a/src/test/java/org/elasticsearch/index/mapper/MapperTestUtils.java
+++ b/src/test/java/org/elasticsearch/index/mapper/MapperTestUtils.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -39,17 +41,24 @@ import org.elasticsearch.indices.analysis.IndicesAnalysisModule;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 import org.elasticsearch.indices.fielddata.breaker.DummyCircuitBreakerService;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
+
 /**
  *
  */
 public class MapperTestUtils {
 
     public static DocumentMapperParser newParser() {
-        return new DocumentMapperParser(new Index("test"), newAnalysisService(), new PostingsFormatService(new Index("test")),
+        Settings indexSettings = ImmutableSettings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        return new DocumentMapperParser(new Index("test"), indexSettings, newAnalysisService(), new PostingsFormatService(new Index("test")),
                 new DocValuesFormatService(new Index("test")), newSimilarityLookupService());
     }
 
     public static DocumentMapperParser newParser(Settings indexSettings) {
+        ImmutableSettings.Builder indexSettingsBuilder  = ImmutableSettings.builder().put(indexSettings);
+        if (indexSettingsBuilder.get(SETTING_VERSION_CREATED) == null) {
+            indexSettingsBuilder.put(SETTING_VERSION_CREATED, Version.CURRENT);
+        }
         return new DocumentMapperParser(new Index("test"), indexSettings, newAnalysisService(indexSettings), new PostingsFormatService(new Index("test")),
                 new DocValuesFormatService(new Index("test")), newSimilarityLookupService());
     }
@@ -59,7 +68,11 @@ public class MapperTestUtils {
     }
 
     public static MapperService newMapperService(Index index, Settings indexSettings) {
-        return new MapperService(index, indexSettings, new Environment(), newAnalysisService(), new IndexFieldDataService(index, new DummyCircuitBreakerService()),
+        ImmutableSettings.Builder indexSettingsBuilder  = ImmutableSettings.builder().put(indexSettings);
+        if (indexSettingsBuilder.get(SETTING_VERSION_CREATED) == null) {
+            indexSettingsBuilder.put(SETTING_VERSION_CREATED, Version.CURRENT);
+        }
+        return new MapperService(index, indexSettingsBuilder.build(), new Environment(), newAnalysisService(), new IndexFieldDataService(index, new DummyCircuitBreakerService()),
                 new PostingsFormatService(index), new DocValuesFormatService(index), newSimilarityLookupService());
     }
 


### PR DESCRIPTION
`omit_term_freq_and_positions` was deprecated in `0.20` and
is not documented anymore. We should reject indices that are
created with this option in the future.

Closes #4722
