### PR TITLE
Add the ability to retrieve fields from field data using `fielddata_fields`

### DIFF
--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -31,7 +31,7 @@ And here is a sample response:
             {
                 "_index" : "twitter",
                 "_type" : "tweet",
-                "_id" : "1", 
+                "_id" : "1",
                 "_source" : {
                     "user" : "kimchy",
                     "postDate" : "2009-11-15T14:12:12",
@@ -87,6 +87,8 @@ include::request/fields.asciidoc[]
 
 include::request/script-fields.asciidoc[]
 
+include::request/fielddata-fields.asciidoc[]
+
 include::request/post-filter.asciidoc[]
 
 include::request/highlighting.asciidoc[]
@@ -108,4 +110,3 @@ include::request/index-boost.asciidoc[]
 include::request/min-score.asciidoc[]
 
 include::request/named-queries-and-filters.asciidoc[]
-

--- a/docs/reference/search/request/fielddata-fields.asciidoc
+++ b/docs/reference/search/request/fielddata-fields.asciidoc
@@ -1,0 +1,21 @@
+[[search-request-fielddata-fields]]
+=== Field Data Fields
+
+Allows to return the field data representiation of a field for each hit, for
+example:
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {
+        ...
+    },
+    "fielddata_fields" : ["test1", "test2"]
+}
+--------------------------------------------------
+
+Field data fields can work on fields that are not stored.
+
+It's important to understand that using the `fielddata_fields` parameter will
+cause the terms for that field to be loaded to memory (cached), which will
+result in more memory consumption.

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -418,6 +418,17 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Adds a field data based field to load and return. The field does not have to be stored,
+     * but its recommended to use non analyzed or numeric fields.
+     *
+     * @param name The field to get from the field data cache
+     */
+    public SearchRequestBuilder addFieldDataField(String name) {
+        sourceBuilder().fieldDataField(name);
+        return this;
+    }
+
+    /**
      * Adds a script based field to load and return. The field does not have to be stored,
      * but its recommended to use non analyzed or numeric fields.
      *

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -61,6 +61,7 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.facet.SearchContextFacets;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.partial.PartialFieldsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -404,6 +405,16 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public void rescore(RescoreSearchContext rescore) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasFieldDataFields() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FieldDataFieldsContext fieldDataFields() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -24,8 +24,6 @@ import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.inject.SpawnModules;
 import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
-import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.fielddata.breaker.InternalCircuitBreakerService;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.aggregations.AggregationModule;
 import org.elasticsearch.search.controller.SearchPhaseController;
@@ -33,6 +31,7 @@ import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.facet.FacetModule;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
 import org.elasticsearch.search.fetch.partial.PartialFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
@@ -62,6 +61,7 @@ public class SearchModule extends AbstractModule implements SpawnModules {
 
         bind(FetchPhase.class).asEagerSingleton();
         bind(ExplainFetchSubPhase.class).asEagerSingleton();
+        bind(FieldDataFieldsFetchSubPhase.class).asEagerSingleton();
         bind(ScriptFieldsFetchSubPhase.class).asEagerSingleton();
         bind(PartialFieldsFetchSubPhase.class).asEagerSingleton();
         bind(FetchSourceSubPhase.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -98,6 +98,7 @@ public class SearchSourceBuilder implements ToXContent {
     private long timeoutInMillis = -1;
 
     private List<String> fieldNames;
+    private List<String> fieldDataFields;
     private List<ScriptField> scriptFields;
     private List<PartialField> partialFields;
     private FetchSourceContext fetchSourceContext;
@@ -569,6 +570,17 @@ public class SearchSourceBuilder implements ToXContent {
     }
 
     /**
+     * Adds a field to load from the field data cache and return as part of the search request.
+     */
+    public SearchSourceBuilder fieldDataField(String name) {
+        if (fieldDataFields == null) {
+            fieldDataFields = new ArrayList<String>();
+        }
+        fieldDataFields.add(name);
+        return this;
+    }
+
+    /**
      * Adds a script field under the given name with the provided script.
      *
      * @param name   The name of the field
@@ -760,6 +772,14 @@ public class SearchSourceBuilder implements ToXContent {
                 }
                 builder.endArray();
             }
+        }
+
+        if (fieldDataFields != null) {
+            builder.startArray("fielddata_fields");
+            for (String fieldName : fieldDataFields) {
+                builder.value(fieldName);
+            }
+            builder.endArray();
         }
 
         if (partialFields != null) {

--- a/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchPhase;
 import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
 import org.elasticsearch.search.fetch.partial.PartialFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
@@ -61,9 +62,9 @@ public class FetchPhase implements SearchPhase {
     @Inject
     public FetchPhase(HighlightPhase highlightPhase, ScriptFieldsFetchSubPhase scriptFieldsPhase, PartialFieldsFetchSubPhase partialFieldsPhase,
                       MatchedQueriesFetchSubPhase matchedQueriesPhase, ExplainFetchSubPhase explainPhase, VersionFetchSubPhase versionPhase,
-                      FetchSourceSubPhase fetchSourceSubPhase) {
+                      FetchSourceSubPhase fetchSourceSubPhase, FieldDataFieldsFetchSubPhase fieldDataFieldsFetchSubPhase) {
         this.fetchSubPhases = new FetchSubPhase[]{scriptFieldsPhase, partialFieldsPhase, matchedQueriesPhase, explainPhase, highlightPhase,
-                fetchSourceSubPhase, versionPhase};
+                fetchSourceSubPhase, versionPhase, fieldDataFieldsFetchSubPhase};
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsContext.java
+++ b/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsContext.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.fielddata;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * All the required context to pull a field from the field data cache.
+ */
+public class FieldDataFieldsContext {
+
+    public static class FieldDataField {
+        private final String name;
+
+        public FieldDataField(String name) {
+            this.name = name;
+        }
+
+        public String name() {
+            return name;
+        }
+    }
+
+    private List<FieldDataField> fields = Lists.newArrayList();
+
+    public FieldDataFieldsContext() {
+    }
+
+    public void add(FieldDataField field) {
+        this.fields.add(field);
+    }
+
+    public List<FieldDataField> fields() {
+        return this.fields;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.fielddata;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHitField;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Query sub phase which pulls data from field data (using the cache if
+ * available, building it if not).
+ *
+ * Specifying {@code "fielddata_fields": ["field1", "field2"]}
+ */
+public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
+
+    @Inject
+    public FieldDataFieldsFetchSubPhase() {
+    }
+
+    @Override
+    public Map<String, ? extends SearchParseElement> parseElements() {
+        ImmutableMap.Builder<String, SearchParseElement> parseElements = ImmutableMap.builder();
+        parseElements.put("fielddata_fields", new FieldDataFieldsParseElement())
+                .put("fielddataFields", new FieldDataFieldsParseElement());
+        return parseElements.build();
+    }
+
+    @Override
+    public boolean hitsExecutionNeeded(SearchContext context) {
+        return false;
+    }
+
+    @Override
+    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) throws ElasticsearchException {
+    }
+
+    @Override
+    public boolean hitExecutionNeeded(SearchContext context) {
+        return context.hasFieldDataFields();
+    }
+
+    @Override
+    public void hitExecute(SearchContext context, HitContext hitContext) throws ElasticsearchException {
+        for (FieldDataFieldsContext.FieldDataField field : context.fieldDataFields().fields()) {
+            if (hitContext.hit().fieldsOrNull() == null) {
+                hitContext.hit().fields(new HashMap<String, SearchHitField>(2));
+            }
+            SearchHitField hitField = hitContext.hit().fields().get(field.name());
+            if (hitField == null) {
+                hitField = new InternalSearchHitField(field.name(), new ArrayList<Object>(2));
+                hitContext.hit().fields().put(field.name(), hitField);
+            }
+            FieldMapper mapper = context.mapperService().smartNameFieldMapper(field.name());
+            if (mapper != null) {
+                AtomicFieldData data = context.fieldData().getForField(mapper).load(hitContext.readerContext());
+                ScriptDocValues values = data.getScriptValues();
+                values.setNextDocId(hitContext.docId());
+                hitField.values().addAll(values.getValues());
+            }
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
@@ -7,7 +7,7 @@
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -17,36 +17,30 @@
  * under the License.
  */
 
-package org.elasticsearch.search.fetch;
+package org.elasticsearch.search.fetch.fielddata;
 
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.SearchParseElement;
-import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 /**
+ * Parses field name values from the {@code fielddata_fields} parameter in a
+ * search request.
  *
+ * <pre>
+ * {
+ *   "query": {...},
+ *   "fielddata_fields" : ["field1", "field2"]
+ * }
+ * </pre>
  */
-public class FieldsParseElement implements SearchParseElement {
-
+public class FieldDataFieldsParseElement implements SearchParseElement {
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
-        XContentParser.Token token = parser.currentToken();
-        if (token == XContentParser.Token.START_ARRAY) {
-            boolean added = false;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                String name = parser.text();
-                added = true;
-                context.fieldNames().add(name);
-            }
-            if (!added) {
-                context.emptyFieldNames();
-            }
-        } else if (token == XContentParser.Token.VALUE_STRING) {
-            String name = parser.text();
-            context.fieldNames().add(name);
-
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            String fieldName = parser.text();
+            context.fieldDataFields().add(new FieldDataFieldsContext.FieldDataField(fieldName));
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -58,6 +58,7 @@ import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.facet.SearchContextFacets;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.partial.PartialFieldsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -122,6 +123,7 @@ public class DefaultSearchContext extends SearchContext {
     private boolean version = false; // by default, we don't return versions
 
     private List<String> fieldNames;
+    private FieldDataFieldsContext fieldDataFields;
     private ScriptFieldsContext scriptFields;
     private PartialFieldsContext partialFields;
     private FetchSourceContext fetchSourceContext;
@@ -346,6 +348,17 @@ public class DefaultSearchContext extends SearchContext {
 
     public void rescore(RescoreSearchContext rescore) {
         this.rescore = rescore;
+    }
+
+    public boolean hasFieldDataFields() {
+        return fieldDataFields != null;
+    }
+
+    public FieldDataFieldsContext fieldDataFields() {
+        if (fieldDataFields == null) {
+            fieldDataFields = new FieldDataFieldsContext();
+        }
+        return this.fieldDataFields;
     }
 
     public boolean hasScriptFields() {

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.facet.SearchContextFacets;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.partial.PartialFieldsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -138,6 +139,10 @@ public abstract class SearchContext implements Releasable {
     public abstract RescoreSearchContext rescore();
 
     public abstract void rescore(RescoreSearchContext rescore);
+
+    public abstract boolean hasFieldDataFields();
+
+    public abstract FieldDataFieldsContext fieldDataFields();
 
     public abstract boolean hasScriptFields();
 

--- a/src/test/java/org/elasticsearch/document/DocumentActionsTests.java
+++ b/src/test/java/org/elasticsearch/document/DocumentActionsTests.java
@@ -107,11 +107,11 @@ public class DocumentActionsTests extends ElasticsearchIntegrationTest {
 
         logger.info("Get [type1/1] with script");
         for (int i = 0; i < 5; i++) {
-            getResult = client().prepareGet("test", "type1", "1").setFields("_source.type1.name").execute().actionGet();
+            getResult = client().prepareGet("test", "type1", "1").setFields("type1.name").execute().actionGet();
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
             assertThat(getResult.isExists(), equalTo(true));
             assertThat(getResult.getSourceAsBytes(), nullValue());
-            assertThat(getResult.getField("_source.type1.name").getValues().get(0).toString(), equalTo("test"));
+            assertThat(getResult.getField("type1.name").getValues().get(0).toString(), equalTo("test"));
         }
 
         logger.info("Get [type1/2] (should be empty)");

--- a/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
+++ b/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
@@ -151,15 +151,14 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
 
         response = client().prepareExplain("test", "test", "1")
                 .setQuery(QueryBuilders.matchAllQuery())
-                .setFields("_source.obj1")
+                .setFields("obj1.field1", "obj1.field2")
                 .execute().actionGet();
         assertNotNull(response);
         assertTrue(response.isMatch());
-        assertThat(response.getGetResult().getFields().size(), equalTo(1));
-        Map<String, String> fields = (Map<String, String>) response.getGetResult().field("_source.obj1").getValue();
-        assertThat(fields.size(), equalTo(2));
-        assertThat(fields.get("field1"), equalTo("value1"));
-        assertThat(fields.get("field2"), equalTo("value2"));
+        String v1 = (String) response.getGetResult().field("obj1.field1").getValue();
+        String v2 = (String) response.getGetResult().field("obj1.field2").getValue();
+        assertThat(v1, equalTo("value1"));
+        assertThat(v2, equalTo("value2"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.facet.SearchContextFacets;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.partial.PartialFieldsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -210,6 +211,16 @@ class TestSearchContext extends SearchContext {
 
     @Override
     public void rescore(RescoreSearchContext rescore) {
+    }
+
+    @Override
+    public boolean hasFieldDataFields() {
+        return false;
+    }
+
+    @Override
+    public FieldDataFieldsContext fieldDataFields() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Adds a new FetchSubPhase, FieldDataFieldsFetchSubPhase, which loads the
field data cache for a field and returns an array of values for the
field.

Also removes a `doc['<field>']` workaround no longer needed in field
name resolving.

Closes #4492
