### PR TITLE
Remove redundant version checks in transport serialisation

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.cluster.reroute;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
@@ -111,7 +110,7 @@ public class ClusterRerouteRequest extends AcknowledgedRequest<ClusterRerouteReq
         super.readFrom(in);
         commands = AllocationCommands.readFrom(in);
         dryRun = in.readBoolean();
-        readTimeout(in, Version.V_0_90_6);
+        readTimeout(in);
     }
 
     @Override
@@ -119,6 +118,6 @@ public class ClusterRerouteRequest extends AcknowledgedRequest<ClusterRerouteReq
         super.writeTo(out);
         AllocationCommands.writeTo(commands, out);
         out.writeBoolean(dryRun);
-        writeTimeout(out, Version.V_0_90_6);
+        writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.cluster.settings;
 
 import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -150,7 +149,7 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         super.readFrom(in);
         transientSettings = readSettingsFromStream(in);
         persistentSettings = readSettingsFromStream(in);
-        readTimeout(in, Version.V_0_90_6);
+        readTimeout(in);
     }
 
     @Override
@@ -158,6 +157,6 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         super.writeTo(out);
         writeSettingsToStream(transientSettings, out);
         writeSettingsToStream(persistentSettings, out);
-        writeTimeout(out, Version.V_0_90_6);
+        writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.cluster.stats;
 
 import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -152,11 +151,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
         idCache = IdCacheStats.readIdCacheStats(in);
         completion = CompletionStats.readCompletionStats(in);
         segments = SegmentsStats.readSegmentsStats(in);
-        if (in.getVersion().after(Version.V_1_0_0_RC1)) {
-            peroclate = PercolateStats.readPercolateStats(in);
-        } else {
-            peroclate = new PercolateStats();
-        }
+        peroclate = PercolateStats.readPercolateStats(in);
     }
 
     @Override
@@ -170,9 +165,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
         idCache.writeTo(out);
         completion.writeTo(out);
         segments.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_1_0_0_RC1)) {
-            peroclate.writeTo(out);
-        }
+        peroclate.writeTo(out);
     }
 
     public static ClusterStatsIndices readIndicesStats(StreamInput in) throws IOException {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
@@ -50,7 +50,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
     private IdCacheStats idCache;
     private CompletionStats completion;
     private SegmentsStats segments;
-    private PercolateStats peroclate;
+    private PercolateStats percolate;
 
     private ClusterStatsIndices() {
     }
@@ -65,7 +65,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
         this.idCache = new IdCacheStats();
         this.completion = new CompletionStats();
         this.segments = new SegmentsStats();
-        this.peroclate = new PercolateStats();
+        this.percolate = new PercolateStats();
 
         for (ClusterStatsNodeResponse r : nodeResponses) {
             for (org.elasticsearch.action.admin.indices.stats.ShardStats shardStats : r.shardsStats()) {
@@ -89,7 +89,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
                 idCache.add(shardCommonStats.idCache);
                 completion.add(shardCommonStats.completion);
                 segments.add(shardCommonStats.segments);
-                peroclate.add(shardCommonStats.percolate);
+                percolate.add(shardCommonStats.percolate);
             }
         }
 
@@ -137,7 +137,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
     }
 
     public PercolateStats getPercolate() {
-        return peroclate;
+        return percolate;
     }
 
     @Override
@@ -151,7 +151,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
         idCache = IdCacheStats.readIdCacheStats(in);
         completion = CompletionStats.readCompletionStats(in);
         segments = SegmentsStats.readSegmentsStats(in);
-        peroclate = PercolateStats.readPercolateStats(in);
+        percolate = PercolateStats.readPercolateStats(in);
     }
 
     @Override
@@ -165,7 +165,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
         idCache.writeTo(out);
         completion.writeTo(out);
         segments.writeTo(out);
-        peroclate.writeTo(out);
+        percolate.writeTo(out);
     }
 
     public static ClusterStatsIndices readIndicesStats(StreamInput in) throws IOException {
@@ -189,7 +189,7 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
         idCache.toXContent(builder, params);
         completion.toXContent(builder, params);
         segments.toXContent(builder, params);
-        peroclate.toXContent(builder, params);
+        percolate.toXContent(builder, params);
         return builder;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -452,10 +452,8 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             count = in.readVInt();
             cpuPercent = in.readVInt();
             totalOpenFileDescriptors = in.readVLong();
-            if (in.getVersion().onOrAfter(Version.V_0_90_10)) {
-                minOpenFileDescriptors = in.readLong();
-                maxOpenFileDescriptors = in.readLong();
-            }
+            minOpenFileDescriptors = in.readLong();
+            maxOpenFileDescriptors = in.readLong();
         }
 
         @Override
@@ -463,10 +461,8 @@ public class ClusterStatsNodes implements ToXContent, Streamable {
             out.writeVInt(count);
             out.writeVInt(cpuPercent);
             out.writeVLong(totalOpenFileDescriptors);
-            if (out.getVersion().onOrAfter(Version.V_0_90_10)) {
-                out.writeLong(minOpenFileDescriptors);
-                out.writeLong(maxOpenFileDescriptors);
-            }
+            out.writeLong(minOpenFileDescriptors);
+            out.writeLong(maxOpenFileDescriptors);
         }
 
         public static ProcessStats readStats(StreamInput in) throws IOException {

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -87,9 +86,6 @@ public class FlushRequest extends BroadcastOperationRequest<FlushRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrBefore(Version.V_0_90_3)) {
-            out.writeBoolean(false); // refresh flag
-        }
         out.writeBoolean(full);
         out.writeBoolean(force);
     }
@@ -97,9 +93,6 @@ public class FlushRequest extends BroadcastOperationRequest<FlushRequest> {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().onOrBefore(Version.V_0_90_3)) {
-            in.readBoolean(); // refresh flag
-        }
         full = in.readBoolean();
         force = in.readBoolean();
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -54,9 +53,6 @@ class ShardFlushRequest extends BroadcastShardOperationRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().onOrBefore(Version.V_0_90_3)) {
-            in.readBoolean(); // refresh flag
-        }
         full = in.readBoolean();
         force = in.readBoolean();
     }
@@ -64,9 +60,6 @@ class ShardFlushRequest extends BroadcastShardOperationRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrBefore(Version.V_0_90_3)) {
-            out.writeBoolean(false); // refresh flag
-        }
         out.writeBoolean(full);
         out.writeBoolean(force);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.mapping.delete;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
@@ -127,7 +126,7 @@ public class DeleteMappingRequest extends AcknowledgedRequest<DeleteMappingReque
         indices = in.readStringArray();
         indicesOptions =  IndicesOptions.readIndicesOptions(in);
         types = in.readStringArray();
-        readTimeout(in, Version.V_0_90_6);
+        readTimeout(in);
     }
 
     @Override
@@ -136,6 +135,6 @@ public class DeleteMappingRequest extends AcknowledgedRequest<DeleteMappingReque
         out.writeStringArrayNullable(indices);
         indicesOptions.writeIndicesOptions(out);
         out.writeStringArrayNullable(types);
-        writeTimeout(out, Version.V_0_90_6);
+        writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.optimize;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -137,9 +136,6 @@ public class OptimizeRequest extends BroadcastOperationRequest<OptimizeRequest> 
         maxNumSegments = in.readInt();
         onlyExpungeDeletes = in.readBoolean();
         flush = in.readBoolean();
-        if (in.getVersion().onOrBefore(Version.V_0_90_3)) {
-            in.readBoolean(); // old refresh flag
-        }
     }
 
     public void writeTo(StreamOutput out) throws IOException {
@@ -148,8 +144,5 @@ public class OptimizeRequest extends BroadcastOperationRequest<OptimizeRequest> 
         out.writeInt(maxNumSegments);
         out.writeBoolean(onlyExpungeDeletes);
         out.writeBoolean(flush);
-        if (out.getVersion().onOrBefore(Version.V_0_90_3)) {
-            out.writeBoolean(false); // old refresh flag
-        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.optimize;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -70,9 +69,6 @@ class ShardOptimizeRequest extends BroadcastShardOperationRequest {
         maxNumSegments = in.readInt();
         onlyExpungeDeletes = in.readBoolean();
         flush = in.readBoolean();
-        if (in.getVersion().onOrBefore(Version.V_0_90_3)) {
-            in.readBoolean(); // old refresh flag
-        }
     }
 
     @Override
@@ -82,8 +78,5 @@ class ShardOptimizeRequest extends BroadcastShardOperationRequest {
         out.writeInt(maxNumSegments);
         out.writeBoolean(onlyExpungeDeletes);
         out.writeBoolean(flush);
-        if (out.getVersion().onOrBefore(Version.V_0_90_3)) {
-            out.writeBoolean(false); // old refresh flag
-        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
@@ -146,7 +145,7 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         settings = readSettingsFromStream(in);
-        readTimeout(in, Version.V_0_90_6);
+        readTimeout(in);
     }
 
     @Override
@@ -155,6 +154,6 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
         out.writeStringArrayNullable(indices);
         indicesOptions.writeIndicesOptions(out);
         writeSettingsToStream(settings, out);
-        writeTimeout(out, Version.V_0_90_6);
+        writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -479,19 +478,13 @@ public class CommonStats implements Streamable, ToXContent {
         if (in.readBoolean()) {
             percolate = PercolateStats.readPercolateStats(in);
         }
-        if (in.getVersion().onOrAfter(Version.V_0_90_4)) {
-            if (in.readBoolean()) {
-                completion = CompletionStats.readCompletionStats(in);
-            }
+        if (in.readBoolean()) {
+            completion = CompletionStats.readCompletionStats(in);
         }
-        if (in.getVersion().after(Version.V_0_90_6)) {
-            if (in.readBoolean()) {
-                segments = SegmentsStats.readSegmentsStats(in);
-            }
+        if (in.readBoolean()) {
+            segments = SegmentsStats.readSegmentsStats(in);
         }
-        if (in.getVersion().after(Version.V_1_0_0_Beta2)) {
-            translog = in.readOptionalStreamable(new TranslogStats());
-        }
+        translog = in.readOptionalStreamable(new TranslogStats());
     }
 
     @Override
@@ -574,25 +567,19 @@ public class CommonStats implements Streamable, ToXContent {
             out.writeBoolean(true);
             percolate.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_0_90_4)) {
-            if (completion == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                completion.writeTo(out);
-            }
+        if (completion == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            completion.writeTo(out);
         }
-        if (out.getVersion().after(Version.V_0_90_6)) {
-            if (segments == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                segments.writeTo(out);
-            }
+        if (segments == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            segments.writeTo(out);
         }
-        if (out.getVersion().after(Version.V_1_0_0_Beta2)) {
-            out.writeOptionalStreamable(translog);
-        }
+        out.writeOptionalStreamable(translog);
     }
 
     // note, requires a wrapping object

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -177,9 +176,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         out.writeStringArrayNullable(types);
         out.writeStringArrayNullable(groups);
         out.writeStringArrayNullable(fieldDataFields);
-        if (out.getVersion().onOrAfter(Version.V_0_90_4)) {
-            out.writeStringArrayNullable(completionDataFields);
-        }
+        out.writeStringArrayNullable(completionDataFields);
     }
 
     @Override
@@ -194,9 +191,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         types = in.readStringArray();
         groups = in.readStringArray();
         fieldDataFields = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_0_90_4)) {
-            completionDataFields = in.readStringArray();
-        }
+        completionDataFields = in.readStringArray();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequest.java
@@ -18,9 +18,7 @@
  */
 package org.elasticsearch.action.admin.indices.template.delete;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,7 +26,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 
 /**
  * A request to delete an index template.
@@ -67,19 +64,11 @@ public class DeleteIndexTemplateRequest extends MasterNodeOperationRequest<Delet
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         name = in.readString();
-        //timeout was ignored till 0.90.7, removed afterwards
-        if (in.getVersion().onOrBefore(Version.V_0_90_7)) {
-            readTimeValue(in);
-        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(name);
-        //timeout was ignored till 0.90.7, removed afterwards
-        if (out.getVersion().onOrBefore(Version.V_0_90_7)) {
-            AcknowledgedRequest.DEFAULT_ACK_TIMEOUT.writeTo(out);
-        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.indices.template.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.common.Strings;
@@ -76,21 +75,12 @@ public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetInde
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().onOrAfter(Version.V_0_90_4)) {
-            names = in.readStringArray();
-        } else {
-            names = new String[1];
-            names[0] = in.readString();
-        }
+        names = in.readStringArray();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_0_90_4)) {
-            out.writeStringArray(names);
-        } else {
-            out.writeString(names.length == 0 ? "*" : names[0]);
-        }
+        out.writeStringArray(names);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -21,9 +21,7 @@ package org.elasticsearch.action.admin.indices.template.put;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -45,7 +43,6 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
 import static org.elasticsearch.common.settings.ImmutableSettings.readSettingsFromStream;
 import static org.elasticsearch.common.settings.ImmutableSettings.writeSettingsToStream;
-import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 
 /**
  * A request to create an index template.
@@ -348,10 +345,6 @@ public class PutIndexTemplateRequest extends MasterNodeOperationRequest<PutIndex
         order = in.readInt();
         create = in.readBoolean();
         settings = readSettingsFromStream(in);
-        //timeout was ignored till 0.90.7, removed afterwards
-        if (in.getVersion().onOrBefore(Version.V_0_90_7)) {
-            readTimeValue(in);
-        }
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
             mappings.put(in.readString(), in.readString());
@@ -373,10 +366,6 @@ public class PutIndexTemplateRequest extends MasterNodeOperationRequest<PutIndex
         out.writeInt(order);
         out.writeBoolean(create);
         writeSettingsToStream(settings, out);
-        //timeout was ignored till 0.90.7, removed afterwards
-        if (out.getVersion().onOrBefore(Version.V_0_90_7)) {
-            AcknowledgedRequest.DEFAULT_ACK_TIMEOUT.writeTo(out);
-        }
         out.writeVInt(mappings.size());
         for (Map.Entry<String, String> entry : mappings.entrySet()) {
             out.writeString(entry.getKey());

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -96,12 +95,7 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         }
 
         explain = in.readBoolean();
-
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            nowInMillis = in.readVLong();
-        } else {
-            nowInMillis = System.currentTimeMillis();
-        }
+        nowInMillis = in.readVLong();
     }
 
     @Override
@@ -123,9 +117,6 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
         }
 
         out.writeBoolean(explain);
-
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            out.writeVLong(nowInMillis);
-        }
+        out.writeVLong(nowInMillis);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
@@ -129,7 +129,7 @@ public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest
         names = in.readStringArray();
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        readTimeout(in, Version.V_0_90_6);
+        readTimeout(in);
     }
 
     @Override
@@ -138,6 +138,6 @@ public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest
         out.writeStringArrayNullable(names);
         out.writeStringArrayNullable(indices);
         indicesOptions.writeIndicesOptions(out);
-        writeTimeout(out, Version.V_0_90_6);
+        writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.warmer.put;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -106,7 +105,7 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> {
             searchRequest = new SearchRequest();
             searchRequest.readFrom(in);
         }
-        readTimeout(in, Version.V_0_90_6);
+        readTimeout(in);
     }
 
     @Override
@@ -119,6 +118,6 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> {
             out.writeBoolean(true);
             searchRequest.writeTo(out);
         }
-        writeTimeout(out, Version.V_0_90_6);
+        writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.bulk;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.WriteConsistencyLevel;
@@ -495,9 +494,7 @@ public class BulkRequest extends ActionRequest<BulkRequest> {
             }
         }
         refresh = in.readBoolean();
-        if (in.getVersion().after(Version.V_0_90_7)) {
-            timeout = TimeValue.readTimeValue(in);
-        }
+        timeout = TimeValue.readTimeValue(in);
     }
 
     @Override
@@ -517,8 +514,6 @@ public class BulkRequest extends ActionRequest<BulkRequest> {
             request.writeTo(out);
         }
         out.writeBoolean(refresh);
-        if (out.getVersion().after(Version.V_0_90_7)) {
-            timeout.writeTo(out);
-        }
+        timeout.writeTo(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.count;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -99,11 +98,7 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
                 filteringAliases[i] = in.readString();
             }
         }
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            nowInMillis = in.readVLong();
-        } else {
-            nowInMillis = System.currentTimeMillis();
-        }
+        nowInMillis = in.readVLong();
     }
 
     @Override
@@ -125,8 +120,6 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
         } else {
             out.writeVInt(0);
         }
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            out.writeVLong(nowInMillis);
-        }
+        out.writeVLong(nowInMillis);
     }
 }

--- a/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.explain;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.QuerySourceBuilder;
@@ -199,12 +198,7 @@ public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> 
         }
 
         fetchSourceContext = FetchSourceContext.optionalReadFromStream(in);
-
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            nowInMillis = in.readVLong();
-        } else {
-            nowInMillis = System.currentTimeMillis();
-        }
+        nowInMillis = in.readVLong();
     }
 
     @Override
@@ -224,9 +218,6 @@ public class ExplainRequest extends SingleShardOperationRequest<ExplainRequest> 
         }
 
         FetchSourceContext.optionalWriteToStream(fetchSourceContext, out);
-
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            out.writeVLong(nowInMillis);
-        }
+        out.writeVLong(nowInMillis);
     }
 }

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.mlt;
 
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
@@ -592,9 +591,7 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
 
         searchSize = in.readVInt();
         searchFrom = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_0_90_1)) {
-            routing = in.readOptionalString();
-        }
+        routing = in.readOptionalString();
     }
 
     @Override
@@ -662,8 +659,6 @@ public class MoreLikeThisRequest extends ActionRequest<MoreLikeThisRequest> {
 
         out.writeVInt(searchSize);
         out.writeVInt(searchFrom);
-        if (out.getVersion().onOrAfter(Version.V_0_90_1)) {
-            out.writeOptionalString(routing);
-        }
+        out.writeOptionalString(routing);
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.support.master;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -75,31 +74,13 @@ public abstract class AcknowledgedRequest<T extends MasterNodeOperationRequest> 
      * Reads the timeout value
      */
     protected void readTimeout(StreamInput in) throws IOException {
-        readTimeout(in, null);
-    }
-
-    /**
-     * Reads the timeout value if on or after the specified min version or if the version is <code>null</code>.
-     */
-    protected void readTimeout(StreamInput in, Version minVersion) throws IOException {
-        if (minVersion == null || in.getVersion().onOrAfter(minVersion)) {
-            timeout = readTimeValue(in);
-        }
+        timeout = readTimeValue(in);
     }
 
     /**
      * writes the timeout value
      */
     protected void writeTimeout(StreamOutput out) throws IOException {
-        writeTimeout(out, null);
-    }
-
-    /**
-     * writes the timeout value if on or after the specified min version or if the version is <code>null</code>.
-     */
-    protected void writeTimeout(StreamOutput out, Version minVersion) throws IOException {
-        if (minVersion == null || out.getVersion().onOrAfter(minVersion)) {
-            timeout.writeTo(out);
-        }
+        timeout.writeTo(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.update;
 
 import com.google.common.collect.Maps;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
@@ -603,9 +602,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
             upsertRequest = new IndexRequest();
             upsertRequest.readFrom(in);
         }
-        if (in.getVersion().onOrAfter(Version.V_0_90_2)) {
-            docAsUpsert = in.readBoolean();
-        }
+        docAsUpsert = in.readBoolean();
         version = in.readLong();
         versionType = VersionType.fromValue(in.readByte());
     }
@@ -651,9 +648,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
             upsertRequest.id(id);
             upsertRequest.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_0_90_2)) {
-            out.writeBoolean(docAsUpsert);
-        }
+        out.writeBoolean(docAsUpsert);
         out.writeLong(version);
         out.writeByte(versionType.getValue());
     }

--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.action.index;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
@@ -174,13 +173,9 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
             index = in.readString();
             type = in.readString();
             mappingSource = CompressedString.readCompressedString(in);
-            if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-                indexUUID = in.readString();
-            }
-            if (in.getVersion().after(Version.V_0_90_7)) {
-                order = in.readLong();
-                nodeId = in.readOptionalString();
-            }
+            indexUUID = in.readString();
+            order = in.readLong();
+            nodeId = in.readOptionalString();
         }
 
         @Override
@@ -189,13 +184,9 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
             out.writeString(index);
             out.writeString(type);
             mappingSource.writeTo(out);
-            if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-                out.writeString(indexUUID);
-            }
-            if (out.getVersion().after(Version.V_0_90_7)) {
-                out.writeLong(order);
-                out.writeOptionalString(nodeId);
-            }
+            out.writeString(indexUUID);
+            out.writeLong(order);
+            out.writeOptionalString(nodeId);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.action.index;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaDataMappingService;
@@ -126,9 +125,7 @@ public class NodeMappingRefreshAction extends AbstractComponent {
             out.writeString(index);
             out.writeStringArray(types);
             out.writeString(nodeId);
-            if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-                out.writeString(indexUUID);
-            }
+            out.writeString(indexUUID);
         }
 
         @Override
@@ -137,9 +134,7 @@ public class NodeMappingRefreshAction extends AbstractComponent {
             index = in.readString();
             types = in.readStringArray();
             nodeId = in.readString();
-            if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-                indexUUID = in.readString();
-            }
+            indexUUID = in.readString();
         }
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.action.shard;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -320,9 +319,7 @@ public class ShardStateAction extends AbstractComponent {
             super.readFrom(in);
             shardRouting = readShardRoutingEntry(in);
             reason = in.readString();
-            if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-                indexUUID = in.readString();
-            }
+            indexUUID = in.readString();
         }
 
         @Override
@@ -330,9 +327,7 @@ public class ShardStateAction extends AbstractComponent {
             super.writeTo(out);
             shardRouting.writeTo(out);
             out.writeString(reason);
-            if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-                out.writeString(indexUUID);
-            }
+            out.writeString(indexUUID);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -529,9 +529,7 @@ public class MappingMetaData {
             out.writeBoolean(false);
         }
         out.writeString(mappingMd.timestamp().format());
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            out.writeBoolean(mappingMd.hasParentField());
-        }
+        out.writeBoolean(mappingMd.hasParentField());
     }
 
     @Override
@@ -569,12 +567,7 @@ public class MappingMetaData {
         Routing routing = new Routing(in.readBoolean(), in.readBoolean() ? in.readString() : null);
         // timestamp
         Timestamp timestamp = new Timestamp(in.readBoolean(), in.readBoolean() ? in.readString() : null, in.readString());
-        final boolean hasParentField;
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            hasParentField = in.readBoolean();
-        } else {
-            hasParentField = true; // We assume here that the type has a parent field, which is confirm with the behaviour of <= 0.90.5
-        }
+        final boolean hasParentField = in.readBoolean();
         return new MappingMetaData(type, source, id, routing, timestamp, hasParentField);
     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1336,9 +1336,7 @@ public class MetaData implements Iterable<IndexMetaData> {
         public static MetaData readFrom(StreamInput in) throws IOException {
             Builder builder = new Builder();
             builder.version = in.readLong();
-            if (in.getVersion().after(Version.V_0_90_7)) {
-                builder.uuid = in.readString();
-            }
+            builder.uuid = in.readString();
             builder.transientSettings(readSettingsFromStream(in));
             builder.persistentSettings(readSettingsFromStream(in));
             int size = in.readVInt();
@@ -1360,9 +1358,7 @@ public class MetaData implements Iterable<IndexMetaData> {
 
         public static void writeTo(MetaData metaData, StreamOutput out) throws IOException {
             out.writeLong(metaData.version);
-            if (out.getVersion().after(Version.V_0_90_7)) {
-                out.writeString(metaData.uuid);
-            }
+            out.writeString(metaData.uuid);
             writeSettingsToStream(metaData.transientSettings(), out);
             writeSettingsToStream(metaData.persistentSettings(), out);
             out.writeVInt(metaData.indices.size());

--- a/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.engine;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -141,12 +140,8 @@ public class Segment implements Streamable {
         sizeInBytes = in.readLong();
         version = in.readOptionalString();
         compound = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_0_90_6)) {
-            mergeId = in.readOptionalString();
-        }
-        if (in.getVersion().after(Version.V_0_90_8)) {
-            memoryInBytes = in.readLong();
-        }
+        mergeId = in.readOptionalString();
+        memoryInBytes = in.readLong();
     }
 
     @Override
@@ -159,11 +154,7 @@ public class Segment implements Streamable {
         out.writeLong(sizeInBytes);
         out.writeOptionalString(version);
         out.writeOptionalBoolean(compound);
-        if (out.getVersion().onOrAfter(Version.V_0_90_6)) {
-            out.writeOptionalString(mergeId);
-        }
-        if (out.getVersion().after(Version.V_0_90_8)) {
-            out.writeLong(memoryInBytes);
-        }
+        out.writeOptionalString(mergeId);
+        out.writeLong(memoryInBytes);
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.engine;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -98,16 +97,12 @@ public class SegmentsStats implements Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         count = in.readVLong();
-        if (in.getVersion().after(Version.V_0_90_8)) {
-            memoryInBytes = in.readLong();
-        }
+        memoryInBytes = in.readLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(count);
-        if (out.getVersion().after(Version.V_0_90_8)) {
-            out.writeLong(memoryInBytes);
-        }
+        out.writeLong(memoryInBytes);
     }
 }

--- a/src/main/java/org/elasticsearch/monitor/fs/FsStats.java
+++ b/src/main/java/org/elasticsearch/monitor/fs/FsStats.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.monitor.fs;
 
 import com.google.common.collect.Iterators;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -65,11 +64,7 @@ public class FsStats implements Iterable<FsStats.Info>, Streamable, ToXContent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            if (in.getVersion().after(Version.V_0_90_7)) {
-                path = in.readOptionalString();
-            } else {
-                path = in.readString();
-            }
+            path = in.readOptionalString();
             mount = in.readOptionalString();
             dev = in.readOptionalString();
             total = in.readLong();
@@ -85,11 +80,7 @@ public class FsStats implements Iterable<FsStats.Info>, Streamable, ToXContent {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().after(Version.V_0_90_7)) {
-                out.writeOptionalString(path); // total aggregates do not have a path
-            } else {
-                out.writeString(path);
-            }
+            out.writeOptionalString(path); // total aggregates do not have a path
             out.writeOptionalString(mount);
             out.writeOptionalString(dev);
             out.writeLong(total);

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.jvm;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -357,10 +356,8 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
         }
         mem = new Mem();
         mem.readFrom(in);
-        if (in.getVersion().after(Version.V_0_90_9)) {
-            gcCollectors = in.readStringArray();
-            memoryPools = in.readStringArray();
-        }
+        gcCollectors = in.readStringArray();
+        memoryPools = in.readStringArray();
     }
 
     @Override
@@ -383,10 +380,8 @@ public class JvmInfo implements Streamable, Serializable, ToXContent {
             out.writeString(entry.getValue());
         }
         mem.writeTo(out);
-        if (out.getVersion().after(Version.V_0_90_9)) {
-            out.writeStringArray(gcCollectors);
-            out.writeStringArray(memoryPools);
-        }
+        out.writeStringArray(gcCollectors);
+        out.writeStringArray(memoryPools);
     }
 
     public static class Mem implements Streamable, Serializable {

--- a/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.monitor.jvm;
 
 import com.google.common.collect.Iterators;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -822,11 +821,7 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
             heapUsed = in.readVLong();
             nonHeapCommitted = in.readVLong();
             nonHeapUsed = in.readVLong();
-
-            if (in.getVersion().onOrAfter(Version.V_0_90_7)) {
-                heapMax = in.readVLong();
-            }
-
+            heapMax = in.readVLong();
             pools = new MemoryPool[in.readVInt()];
             for (int i = 0; i < pools.length; i++) {
                 pools[i] = MemoryPool.readMemoryPool(in);
@@ -839,11 +834,7 @@ public class JvmStats implements Streamable, Serializable, ToXContent {
             out.writeVLong(heapUsed);
             out.writeVLong(nonHeapCommitted);
             out.writeVLong(nonHeapUsed);
-
-            if (out.getVersion().onOrAfter(Version.V_0_90_7)) {
-                out.writeVLong(heapMax);
-            }
-
+            out.writeVLong(heapMax);
             out.writeVInt(pools.length);
             for (MemoryPool pool : pools) {
                 pool.writeTo(out);

--- a/src/main/java/org/elasticsearch/monitor/process/ProcessInfo.java
+++ b/src/main/java/org/elasticsearch/monitor/process/ProcessInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.process;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -122,9 +121,7 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
         refreshInterval = in.readLong();
         id = in.readLong();
         maxFileDescriptors = in.readLong();
-        if (in.getVersion().after(Version.V_0_90_7)) {
-            mlockall = in.readBoolean();
-        }
+        mlockall = in.readBoolean();
     }
 
     @Override
@@ -132,8 +129,6 @@ public class ProcessInfo implements Streamable, Serializable, ToXContent {
         out.writeLong(refreshInterval);
         out.writeLong(id);
         out.writeLong(maxFileDescriptors);
-        if (out.getVersion().after(Version.V_0_90_7)) {
-            out.writeBoolean(mlockall);
-        }
+        out.writeBoolean(mlockall);
     }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.suggest;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -571,18 +570,14 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                 public void readFrom(StreamInput in) throws IOException {
                     text = in.readText();
                     score = in.readFloat();
-                    if (in.getVersion().onOrAfter(Version.V_0_90_4)) {
-                        highlighted = in.readOptionalText();
-                    }
+                    highlighted = in.readOptionalText();
                 }
 
                 @Override
                 public void writeTo(StreamOutput out) throws IOException {
                     out.writeText(text);
                     out.writeFloat(score);
-                    if (out.getVersion().onOrAfter(Version.V_0_90_4)) {
-                        out.writeOptionalText(highlighted);
-                    }
+                    out.writeOptionalText(highlighted);
                 }
 
                 @Override

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.suggest.phrase;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.Text;
@@ -98,22 +97,12 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            // If the other side is older than 0.90.4 then it shouldn't be sending suggestions of this type but just in case
-            // we're going to assume that they are regular suggestions so we won't read anything.
-            if (in.getVersion().before(Version.V_0_90_4)) {
-                return;
-            }
             cutoffScore = in.readDouble();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            // If the other side of the message is older than 0.90.4 it'll interpret these suggestions as regular suggestions
-            // so we have to pretend to be one which we can do by just calling the superclass writeTo and doing nothing else
-            if (out.getVersion().before(Version.V_0_90_4)) {
-                return;
-            }
             out.writeDouble(cutoffScore);
         }
     }

--- a/src/test/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequestTests.java
@@ -33,28 +33,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class DeleteWarmerRequestTests extends ElasticsearchTestCase {
 
     @Test
-    public void testDeleteWarmerTimeoutBwComp_Pre0906Format() throws Exception {
-        DeleteWarmerRequest outRequest = new DeleteWarmerRequest("warmer1");
-        outRequest.timeout(TimeValue.timeValueMillis(1000));
-
-        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
-        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-        out.setVersion(Version.V_0_90_0);
-        outRequest.writeTo(out);
-
-        ByteArrayInputStream esInBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
-        InputStreamStreamInput esBuffer = new InputStreamStreamInput(esInBuffer);
-        esBuffer.setVersion(Version.V_0_90_0);
-        DeleteWarmerRequest inRequest = new DeleteWarmerRequest();
-        inRequest.readFrom(esBuffer);
-
-        assertThat(inRequest.names()[0], equalTo("warmer1"));
-        //timeout is default as we don't read it from the received buffer
-        assertThat(inRequest.timeout().millis(), equalTo(new DeleteWarmerRequest().timeout().millis()));
-
-    }
-
-    @Test
     public void testDeleteWarmerTimeoutBwComp_Post0906Format() throws Exception {
         DeleteWarmerRequest outRequest = new DeleteWarmerRequest("warmer1");
         outRequest.timeout(TimeValue.timeValueMillis(1000));

--- a/src/test/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequestTests.java
@@ -32,30 +32,8 @@ import java.io.ByteArrayOutputStream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 public class PutWarmerRequestTests extends ElasticsearchTestCase {
-
-    @Test
-    public void testPutWarmerTimeoutBwComp_Pre0906Format() throws Exception {
-        PutWarmerRequest outRequest = new PutWarmerRequest("warmer1");
-        outRequest.timeout(TimeValue.timeValueMillis(1000));
-
-        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
-        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
-        out.setVersion(Version.V_0_90_0);
-        outRequest.writeTo(out);
-
-        ByteArrayInputStream esInBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
-        InputStreamStreamInput esBuffer = new InputStreamStreamInput(esInBuffer);
-        esBuffer.setVersion(Version.V_0_90_0);
-        PutWarmerRequest inRequest = new PutWarmerRequest();
-        inRequest.readFrom(esBuffer);
-
-        assertThat(inRequest.name(), equalTo("warmer1"));
-        //timeout is default as we don't read it from the received buffer
-        assertThat(inRequest.timeout().millis(), equalTo(new PutWarmerRequest().timeout().millis()));
-    }
 
     @Test
     public void testPutWarmerTimeoutBwComp_Post0906Format() throws Exception {


### PR DESCRIPTION
Since 1.0 breaks transport serialisation support with 0.90.x, it doesn't make sense to do version checks in the serialisation code. This will clean up the code (writeTo() and readFrom()) and allows ES to start fresh.
