### PR TITLE
Added no-cache infrastucture the the filter cache.

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/NoCacheFilter.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/NoCacheFilter.java
@@ -19,11 +19,61 @@
 
 package org.elasticsearch.common.lucene.search;
 
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.Bits;
+
+import java.io.IOException;
 
 /**
  * A marker interface for {@link org.apache.lucene.search.Filter} denoting the filter
  * as one that should not be cached, ever.
  */
 public abstract class NoCacheFilter extends Filter {
+
+    private static final class NoCacheFilterWrapper extends NoCacheFilter {
+        private final Filter delegate;
+        private NoCacheFilterWrapper(Filter delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+            return delegate.getDocIdSet(context, acceptDocs);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj instanceof NoCacheFilterWrapper) {
+                return delegate.equals(((NoCacheFilterWrapper)obj).delegate);
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+
+            return "no_cache(" + delegate + ")";
+        }
+
+    }
+
+    /**
+     * Wraps a filter in a NoCacheFilter or returns it if it already is a NoCacheFilter.
+     */
+    public static Filter wrap(Filter filter) {
+        if (filter instanceof NoCacheFilter) {
+            return filter;
+        }
+        return new NoCacheFilterWrapper(filter);
+    }
 }


### PR DESCRIPTION
During query parsing if a filter is encountered that extends from NoCacheFilter then the filter will not be given to the filter cache (also not wrapped in FilterCacheFilterWrapper). Also if a filter directly or indirectly wraps a NoCacheFilter then that filter will also not be cached.

This addition is useful for p/c filters, date range filters that use `NOW` in the range expressions and perhaps other filters.

Relates to #4757
