### PR TITLE
p/c filters should never cache

### DIFF
--- a/docs/reference/query-dsl/filters/has-child-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/has-child-filter.asciidoc
@@ -48,3 +48,10 @@ The `has_child` filter also accepts a filter instead of a query:
 With the current implementation, all `_id` values are loaded to memory
 (heap) in order to support fast lookups, so make sure there is enough
 memory for it.
+
+[float]
+==== Caching
+
+The `has_child` filter cannot be cached in the filter cache. The `_cache`
+and `_cache_key` options are a no-op in this filter. Also any filter that
+wraps the `has_child` filter either directly or indirectly will not be cached.

--- a/docs/reference/query-dsl/filters/has-parent-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/has-parent-filter.asciidoc
@@ -51,3 +51,10 @@ The `has_parent` filter also accepts a filter instead of a query:
 With the current implementation, all `_id` values are loaded to memory
 (heap) in order to support fast lookups, so make sure there is enough
 memory for it.
+
+[float]
+==== Caching
+
+The `has_parent` filter cannot be cached in the filter cache. The `_cache`
+and `_cache_key` options are a no-op in this filter. Also any filter that
+wraps the `has_parent` filter either directly or indirectly will not be cached.

--- a/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.search.child;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.lucene.search.NoCacheFilter;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.io.IOException;
  *
  * @elasticsearch.internal
  */
-public class CustomQueryWrappingFilter extends Filter {
+public class CustomQueryWrappingFilter extends NoCacheFilter {
 
     private final Query query;
 

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -2170,6 +2170,60 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         assertSearchHits(searchResponse, "c1");
     }
 
+    @Test
+    public void testParentChildCaching() throws Exception {
+        client().admin().indices().prepareCreate("test")
+                .setSettings(
+                        ImmutableSettings.settingsBuilder()
+                                .put("index.number_of_shards", 1)
+                                .put("index.number_of_replicas", 0)
+                                .put("index.refresh_interval", -1)
+                ).get();
+        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        client().admin().indices().preparePutMapping("test").setType("child").setSource(jsonBuilder().startObject().startObject("child")
+                .startObject("_parent").field("type", "parent").endObject()
+                .endObject().endObject()).get();
+
+
+        // index simple data
+        client().prepareIndex("test", "parent", "p1").setSource("p_field", "p_value1").get();
+        client().prepareIndex("test", "parent", "p2").setSource("p_field", "p_value2").get();
+        client().prepareIndex("test", "child", "c1").setParent("p1").setSource("c_field", "blue").get();
+        client().prepareIndex("test", "child", "c2").setParent("p1").setSource("c_field", "red").get();
+        client().prepareIndex("test", "child", "c3").setParent("p2").setSource("c_field", "red").get();
+        client().admin().indices().prepareOptimize("test").setFlush(true).setWaitForMerge(true).get();
+        client().prepareIndex("test", "parent", "p3").setSource("p_field", "p_value3").get();
+        client().prepareIndex("test", "parent", "p4").setSource("p_field", "p_value4").get();
+        client().prepareIndex("test", "child", "c4").setParent("p3").setSource("c_field", "green").get();
+        client().prepareIndex("test", "child", "c5").setParent("p3").setSource("c_field", "blue").get();
+        client().prepareIndex("test", "child", "c6").setParent("p4").setSource("c_field", "blue").get();
+        client().admin().indices().prepareFlush("test").get();
+        client().admin().indices().prepareRefresh("test").get();
+
+        for (int i = 0; i < 2; i++) {
+            SearchResponse searchResponse = client().prepareSearch()
+                    .setQuery(filteredQuery(matchAllQuery(), boolFilter()
+                            .must(FilterBuilders.hasChildFilter("child", matchQuery("c_field", "red")))
+                            .must(matchAllFilter())
+                            .cache(true)))
+                    .get();
+            assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        }
+
+
+        client().prepareIndex("test", "child", "c3").setParent("p2").setSource("c_field", "blue").get();
+        client().admin().indices().prepareRefresh("test").get();
+
+        SearchResponse searchResponse = client().prepareSearch()
+                .setQuery(filteredQuery(matchAllQuery(), boolFilter()
+                        .must(FilterBuilders.hasChildFilter("child", matchQuery("c_field", "red")))
+                        .must(matchAllFilter())
+                        .cache(true)))
+                .get();
+
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+    }
+
     private static HasChildFilterBuilder hasChildFilter(String type, QueryBuilder queryBuilder) {
         HasChildFilterBuilder hasChildFilterBuilder = FilterBuilders.hasChildFilter(type, queryBuilder);
         hasChildFilterBuilder.setShortCircuitCutoff(randomInt(10));


### PR DESCRIPTION
Made sure that any filter that wraps a p/c filter (has_child & has_parent) either directly or indirectly will never be cached by making CustomQueryWrappingFilter extend from NoCacheFilter.

This PR relies on #4768 otherwise the fix doesn't work.
