### PR TITLE
Add SecurityManger / policy when running tests.

### DIFF
--- a/dev-tools/tests.policy
+++ b/dev-tools/tests.policy
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Policy file to prevent tests from writing outside the test sandbox directory
+// PLEASE NOTE: You may need to enable other permissions when new tests are added,
+// everything not allowed here is forbidden!
+
+grant {
+  // permissions for file access, write access only to sandbox:
+  permission java.io.FilePermission "<<ALL FILES>>", "read,execute";
+  permission java.io.FilePermission "${junit4.childvm.cwd}", "read,execute,write";
+  permission java.io.FilePermission "${junit4.childvm.cwd}${/}-", "read,execute,write,delete";
+  permission java.io.FilePermission "${junit4.tempDir}${/}*", "read,execute,write,delete";
+  
+  // Allow connecting to the internet anywhere
+  permission java.net.SocketPermission "*", "accept,listen,connect,resolve";
+  
+  // Basic permissions needed for Lucene / Elasticsearch to work:
+  permission java.util.PropertyPermission "*", "read,write";
+  permission java.lang.reflect.ReflectPermission "*";
+  permission java.lang.RuntimePermission "*";
+
+  // These two *have* to be spelled out a separate
+  permission java.lang.management.ManagementPermission "control";
+  permission java.lang.management.ManagementPermission "monitor";
+
+  permission java.net.NetPermission "*";
+  permission java.util.logging.LoggingPermission "control";
+  permission javax.management.MBeanPermission "*", "*";
+  permission javax.management.MBeanServerPermission "*";
+  permission javax.management.MBeanTrustPermission "*";
+
+  // Needed for some things in DNS caching in the JVM
+  permission java.security.SecurityPermission "getProperty.networkaddress.cache.ttl";
+  permission java.security.SecurityPermission "getProperty.networkaddress.cache.negative.ttl";
+
+};

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,7 @@
                             <seed>${tests.seed}</seed>
                             <haltOnFailure>${tests.failfast}</haltOnFailure>
                             <systemProperties>
+                                <java.io.tmpdir>.</java.io.tmpdir> <!-- we use '.' since this is different per JVM-->
                                 <!-- RandomizedTesting library system properties -->
                                 <tests.jvm.argline>${tests.jvm.argline}</tests.jvm.argline>
                                 <tests.appendseed>${tests.appendseed}</tests.appendseed>
@@ -439,6 +440,10 @@
                                 <es.node.mode>${es.node.mode}</es.node.mode>
                                 <es.logger.level>${es.logger.level}</es.logger.level>
                                 <java.awt.headless>true</java.awt.headless>
+                                <!-- everything below is for security manager / test.policy -->
+                                <java.security.manager/>
+                                <junit4.tempDir>${project.build.directory}</junit4.tempDir>
+                                <java.security.policy>${basedir}/dev-tools/tests.policy</java.security.policy>
                             </systemProperties>
                         </configuration>
                     </execution>

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.indices.template;
 
+import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -27,9 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.util.HashSet;
@@ -43,8 +42,6 @@ import static org.hamcrest.Matchers.is;
 @ClusterScope(scope=Scope.TEST, numNodes=1)
 public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest {
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
@@ -52,7 +49,7 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
         settingsBuilder.put(super.nodeSettings(nodeOrdinal));
 
         try {
-            File directory = temporaryFolder.newFolder();
+            File directory = newTempDir(LifecycleScope.SUITE);
             settingsBuilder.put("path.conf", directory.getPath());
 
             File templatesDir = new File(directory + File.separator + "templates");


### PR DESCRIPTION
This commit adds a security manager to the test JVMs
that prevents mainly writing files outside of the JVMs
current test directory.
