### PR TITLE
Failed preparsing does not fail whole bulk request

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -264,7 +264,7 @@ public class BulkItemResponse implements Streamable {
         if (in.readBoolean()) {
             String fIndex = in.readSharedString();
             String fType = in.readSharedString();
-            String fId = in.readString();
+            String fId = in.readOptionalString();
             String fMessage = in.readString();
             RestStatus status = RestStatus.readFrom(in);
             failure = new Failure(fIndex, fType, fId, fMessage, status);
@@ -294,7 +294,7 @@ public class BulkItemResponse implements Streamable {
             out.writeBoolean(true);
             out.writeSharedString(failure.getIndex());
             out.writeSharedString(failure.getType());
-            out.writeString(failure.getId());
+            out.writeOptionalString(failure.getId());
             out.writeString(failure.getMessage());
             RestStatus.writeTo(out, failure.getStatus());
         }

--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -566,7 +566,7 @@ public class IndexRequest extends ShardReplicationOperationRequest<IndexRequest>
                         timestamp = MappingMetaData.Timestamp.parseStringTimestamp(timestamp, mappingMd.timestamp().dateTimeFormatter());
                     }
                 } catch (Exception e) {
-                    throw new ElasticsearchParseException("failed to parse doc to extract routing/timestamp", e);
+                    throw new ElasticsearchParseException("failed to parse doc to extract routing/timestamp/id", e);
                 } finally {
                     if (parser != null) {
                         parser.close();

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
 import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -52,6 +53,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -147,6 +149,11 @@ public class ElasticsearchAssertions {
             fail("Count is " + percolateResponse.getCount() + " but " + expectedHitCount + " was expected. " + formatShardStatus(percolateResponse));
         }
         assertVersionSerializable(percolateResponse);
+    }
+
+    public static void assertExists(GetResponse response) {
+        String message = String.format(Locale.ROOT, "Expected %s/%s/%s to exist, but does not", response.getIndex(), response.getType(), response.getId());
+        assertThat(message, response.isExists(), is(true));
     }
 
     public static void assertFirstHit(SearchResponse searchResponse, Matcher<SearchHit> matcher) {


### PR DESCRIPTION
If a preparsing of the source is needed (due to mapping configuration,
which extracts the routing/id value from the source) and the source is not
valid JSON, then the whole bulk request is failed instead of a single
BulkRequest.

This commit ensures, that a broken JSON request is not forwarded to the
destination shard and creates an appropriate BulkItemResponse, which
includes a failure.

This also implied changing the BulkItemResponse serialization, because one
cannot be sure anymore, if a response includes an ID, in case it was not
specified and could not be extracted from the JSON.

Closes #4745
