### PR TITLE
Use millis for joda DateTimeFormatter.print() in cat timestamps

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -39,6 +39,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -109,9 +110,9 @@ public class RestCountAction extends AbstractCatAction {
 
     private Table buildTable(RestRequest request, CountResponse response) {
         Table table = getTableWithHeader(request);
-        long time = System.currentTimeMillis() / 1000;
+        long time = System.currentTimeMillis();
         table.startRow();
-        table.addCell(time);
+        table.addCell(TimeUnit.SECONDS.convert(time, TimeUnit.MILLISECONDS));
         table.addCell(dateFormat.print(time));
         table.addCell(response.getCount());
         table.endRow();

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -36,6 +36,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -100,10 +101,10 @@ public class RestHealthAction extends AbstractCatAction {
     private DateTimeFormatter dateFormat = DateTimeFormat.forPattern("HH:mm:ss");
 
     private Table buildTable(final ClusterHealthResponse health, final RestRequest request) {
-        long time = System.currentTimeMillis() / 1000;
+        long time = System.currentTimeMillis();
         Table t = getTableWithHeader(request);
         t.startRow();
-        t.addCell(time);
+        t.addCell(TimeUnit.SECONDS.convert(time, TimeUnit.MILLISECONDS));
         t.addCell(dateFormat.print(time));
         t.addCell(health.getClusterName());
         t.addCell(health.getStatus().name().toLowerCase(Locale.ROOT));


### PR DESCRIPTION
Fixes #4782.
