### PR TITLE
Added support for local flag to all cluster state read operations

### DIFF
--- a/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/api/cluster.pending_tasks.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "local": {
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
+        }
       }
     },
     "body": null

--- a/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/api/indices.exists.json
@@ -26,6 +26,10 @@
             "options" : ["open","closed"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "local": {
+            "type": "boolean",
+            "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/api/indices.exists_alias.json
@@ -29,6 +29,10 @@
            "options" : ["open","closed"],
            "default" : ["open", "closed"],
            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "local": {
+           "type": "boolean",
+           "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/api/indices.exists_template.json
@@ -11,6 +11,12 @@
           "required" : true,
           "description" : "The name of the template"
         }
+      },
+      "params": {
+        "local": {
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
+        }
       }
     },
     "body": null

--- a/rest-api-spec/api/indices.exists_type.json
+++ b/rest-api-spec/api/indices.exists_type.json
@@ -31,6 +31,10 @@
             "options" : ["open","closed"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "local": {
+            "type": "boolean",
+            "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/api/indices.get_alias.json
@@ -29,6 +29,10 @@
             "options" : ["open","closed"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "local": {
+            "type": "boolean",
+            "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/indices.get_aliases.json
+++ b/rest-api-spec/api/indices.get_aliases.json
@@ -19,6 +19,10 @@
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"
+        },
+        "local": {
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/api/indices.get_settings.json
@@ -33,6 +33,10 @@
         "flat_settings": {
           "type": "boolean",
           "description": "Return settings in flat format (default: false)"
+        },
+        "local": {
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/api/indices.get_template.json
@@ -16,6 +16,10 @@
           "flat_settings": {
               "type": "boolean",
               "description": "Return settings in flat format (default: false)"
+          },
+          "local": {
+              "type": "boolean",
+              "description": "Return local information, do not retrieve the state from master node (default: false)"
           }
       }
     },

--- a/rest-api-spec/api/indices.get_warmer.json
+++ b/rest-api-spec/api/indices.get_warmer.json
@@ -33,6 +33,10 @@
             "options" : ["open","closed"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "local": {
+            "type": "boolean",
+            "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/api/snapshot.get_repository.json
@@ -15,6 +15,10 @@
         "master_timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout for connection to master node"
+        },
+        "local": {
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/test/cluster.pending_tasks/10_basic.yaml
+++ b/rest-api-spec/test/cluster.pending_tasks/10_basic.yaml
@@ -1,0 +1,13 @@
+---
+"Test pending tasks":
+  - do:
+      cluster.pending_tasks: {}
+
+  - is_true: tasks
+---
+"Test pending tasks with local flag":
+  - do:
+      cluster.pending_tasks:
+        local: true
+
+  - is_true: tasks

--- a/rest-api-spec/test/indices.exists/10_basic.yaml
+++ b/rest-api-spec/test/indices.exists/10_basic.yaml
@@ -15,4 +15,11 @@
         index: test_index
 
   - is_true: ''
+---
+"Test indices.exists with local flag":
+  - do:
+      indices.exists:
+        index: test_index
+        local: true
 
+  - is_false: ''

--- a/rest-api-spec/test/indices.exists_alias/10_basic.yaml
+++ b/rest-api-spec/test/indices.exists_alias/10_basic.yaml
@@ -1,0 +1,45 @@
+---
+"Test indices.exists_alias":
+  - do:
+      indices.exists_alias:
+        name: test_alias
+
+  - is_false: ''
+
+  - do:
+        indices.create:
+          index: test_index
+
+  - do:
+        indices.put_alias:
+          index: test_index
+          name: test_alias
+
+  - do:
+      indices.exists_alias:
+        name: test_alias
+
+  - is_true: ''
+
+  - do:
+      indices.exists_alias:
+        index: test_index
+        name: test_alias
+
+  - is_true: ''
+
+  - do:
+      indices.exists_alias:
+        index: test_index1
+        name: test_alias
+
+  - is_false: ''
+
+---
+"Test indices.exists_alias with local flag":
+  - do:
+      indices.exists_alias:
+        name: test_alias
+        local: true
+
+  - is_false: ''

--- a/rest-api-spec/test/indices.exists_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.exists_template/10_basic.yaml
@@ -1,0 +1,31 @@
+---
+"Test indices.exists_template":
+  - do:
+      indices.exists_template:
+        name: test
+
+  - is_false: ''
+
+  - do:
+      indices.put_template:
+        name: test
+        body:
+          template: test-*
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      indices.exists_template:
+        name: test
+
+  - is_true: ''
+
+---
+"Test indices.exists_template with local flag":
+  - do:
+      indices.exists_template:
+        name: test
+        local: true
+
+  - is_false: ''

--- a/rest-api-spec/test/indices.exists_type/10_basic.yaml
+++ b/rest-api-spec/test/indices.exists_type/10_basic.yaml
@@ -1,0 +1,40 @@
+---
+"Exists type":
+ - do:
+   indices.create:
+     index: test_1
+     body:
+       mappings:
+         type_1: {}
+         type_2: {}
+
+ - do:
+    indices.exists_type:
+      index: test_2
+      type: type_1
+
+ - is_false: ''
+
+ - do:
+    indices.exists_type:
+      index: test_1
+      type: type_3
+
+ - is_false: ''
+
+ - do:
+    indices.exists_type:
+      index: test_1
+      type: type_1
+
+ - is_true: ''
+---
+"Exists type with local flag":
+
+ - do:
+    indices.exists_type:
+      index: test_1
+      type: type_1
+      local: true
+
+ - is_false: ''

--- a/rest-api-spec/test/indices.get_alias/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_alias/10_basic.yaml
@@ -207,5 +207,13 @@ setup:
         index: non-existent
         name: foo
 
+---
+"Get alias with local flag":
 
+  - do:
+      indices.get_alias:
+        local: true
 
+  - is_true: test_index
+
+  - is_true: test_index_2

--- a/rest-api-spec/test/indices.get_aliases/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_aliases/10_basic.yaml
@@ -210,5 +210,15 @@ setup:
         index: non-existent
         name: foo
 
+---
+"Get aliases with local flag":
+
+  - do:
+      indices.get_aliases:
+        local: true
+
+  - is_true: test_index
+
+  - is_true: test_index_2
 
 

--- a/rest-api-spec/test/indices.get_settings/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_settings/10_basic.yaml
@@ -153,3 +153,13 @@ setup:
  - match: { test_2.settings.index.number_of_shards: "5"}
  - is_false: test_1
  - is_false: test_2.settings.index.number_of_replicas
+
+---
+"Get /_settings with local flag":
+
+ - do:
+    indices.get_settings:
+        local: true
+
+ - is_true: test_1
+ - is_true: test_2

--- a/rest-api-spec/test/indices.get_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_template/10_basic.yaml
@@ -1,5 +1,4 @@
----
-"Get template":
+setup:
   - do:
       indices.put_template:
         name: test
@@ -8,6 +7,9 @@
           settings:
             number_of_shards:   1
             number_of_replicas: 0
+
+---
+"Get template":
 
   - do:
       indices.get_template:
@@ -18,13 +20,6 @@
 ---
 "Get all templates":
 
-  - do:
-      indices.put_template:
-        name: test
-        body:
-          template: test-*
-          settings:
-            number_of_shards:   1
   - do:
       indices.put_template:
         name: test2
@@ -39,3 +34,12 @@
   - match: {test.template: "test-*"}
   - match: {test2.template: "test2-*"}
 
+---
+"Get template with local flag":
+
+  - do:
+      indices.get_template:
+        name: test
+        local: true
+
+  - is_true: test

--- a/rest-api-spec/test/indices.get_warmer/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_warmer/10_basic.yaml
@@ -200,4 +200,13 @@ setup:
         index: non_existent
         name:  '*'
 
+---
+"Get /_warmer with local flag":
+
+ - do:
+    indices.get_warmer:
+        local: true
+
+ - is_true: test_1
+ - is_true: test_2
 

--- a/rest-api-spec/test/snapshot.get_repository/10_basic.yaml
+++ b/rest-api-spec/test/snapshot.get_repository/10_basic.yaml
@@ -1,0 +1,50 @@
+---
+setup:
+
+  - do:
+      snapshot.create_repository:
+        repository: test_repo1
+        body:
+          type: url
+          settings:
+            url: "http://snapshot.test1"
+
+  - do:
+      snapshot.create_repository:
+        repository: test_repo2
+        body:
+          type: url
+          settings:
+            url: "http://snapshot.test2"
+
+---
+"Get all repositories":
+  - do:
+      snapshot.get_repository: {}
+
+  - is_true: test_repo1
+  - is_true: test_repo2
+
+---
+"Get repository by name":
+  - do:
+      snapshot.get_repository:
+        repository: test_repo1
+
+  - is_true: test_repo1
+  - is_false: test_repo2
+
+---
+"Get missing repository by name":
+  - do:
+      snapshot.get_repository:
+        repository: test_repo2
+
+---
+"Get all repositories with local flag":
+  - do:
+      snapshot.get_repository:
+        local: true
+
+  - is_true: test_repo1
+  - is_true: test_repo2

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.health;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -35,7 +35,7 @@ import static org.elasticsearch.common.unit.TimeValue.readTimeValue;
 /**
  *
  */
-public class ClusterHealthRequest extends MasterNodeOperationRequest<ClusterHealthRequest> {
+public class ClusterHealthRequest extends MasterNodeReadOperationRequest<ClusterHealthRequest> {
 
     private String[] indices;
     private TimeValue timeout = new TimeValue(30, TimeUnit.SECONDS);
@@ -43,7 +43,6 @@ public class ClusterHealthRequest extends MasterNodeOperationRequest<ClusterHeal
     private int waitForRelocatingShards = -1;
     private int waitForActiveShards = -1;
     private String waitForNodes = "";
-    private boolean local = false;
     private Priority waitForEvents = null;
 
     ClusterHealthRequest() {
@@ -125,15 +124,6 @@ public class ClusterHealthRequest extends MasterNodeOperationRequest<ClusterHeal
         return this;
     }
 
-    public ClusterHealthRequest local(boolean local) {
-        this.local = local;
-        return this;
-    }
-
-    public boolean local() {
-        return this.local;
-    }
-
     public ClusterHealthRequest waitForEvents(Priority waitForEvents) {
         this.waitForEvents = waitForEvents;
         return this;
@@ -167,7 +157,7 @@ public class ClusterHealthRequest extends MasterNodeOperationRequest<ClusterHeal
         waitForRelocatingShards = in.readInt();
         waitForActiveShards = in.readInt();
         waitForNodes = in.readString();
-        local = in.readBoolean();
+        readLocal(in);
         if (in.readBoolean()) {
             waitForEvents = Priority.fromByte(in.readByte());
         }
@@ -194,7 +184,7 @@ public class ClusterHealthRequest extends MasterNodeOperationRequest<ClusterHeal
         out.writeInt(waitForRelocatingShards);
         out.writeInt(waitForActiveShards);
         out.writeString(waitForNodes);
-        out.writeBoolean(local);
+        writeLocal(out);
         if (waitForEvents == null) {
             out.writeBoolean(false);
         } else {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.health;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.internal.InternalClusterAdminClient;
 import org.elasticsearch.common.Priority;
@@ -29,7 +29,7 @@ import org.elasticsearch.common.unit.TimeValue;
 /**
  *
  */
-public class ClusterHealthRequestBuilder extends MasterNodeOperationRequestBuilder<ClusterHealthRequest, ClusterHealthResponse, ClusterHealthRequestBuilder> {
+public class ClusterHealthRequestBuilder extends MasterNodeReadOperationRequestBuilder<ClusterHealthRequest, ClusterHealthResponse, ClusterHealthRequestBuilder> {
 
     public ClusterHealthRequestBuilder(ClusterAdminClient clusterClient) {
         super((InternalClusterAdminClient) clusterClient, new ClusterHealthRequest());
@@ -85,11 +85,6 @@ public class ClusterHealthRequestBuilder extends MasterNodeOperationRequestBuild
 
     public ClusterHealthRequestBuilder setWaitForEvents(Priority waitForEvents) {
         request.waitForEvents(waitForEvents);
-        return this;
-    }
-
-    public ClusterHealthRequestBuilder setLocal(boolean local) {
-        request.local(local);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.health;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 /**
  *
  */
-public class TransportClusterHealthAction extends TransportMasterNodeOperationAction<ClusterHealthRequest, ClusterHealthResponse> {
+public class TransportClusterHealthAction extends TransportMasterNodeReadOperationAction<ClusterHealthRequest, ClusterHealthResponse> {
 
     private final ClusterName clusterName;
 
@@ -69,11 +69,6 @@ public class TransportClusterHealthAction extends TransportMasterNodeOperationAc
     @Override
     protected ClusterHealthResponse newResponse() {
         return new ClusterHealthResponse();
-    }
-
-    @Override
-    protected boolean localExecute(ClusterHealthRequest request) {
-        return request.local();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequest.java
@@ -19,8 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.repositories.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,7 +33,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  * Get repository request
  */
-public class GetRepositoriesRequest extends MasterNodeOperationRequest<GetRepositoriesRequest> {
+public class GetRepositoriesRequest extends MasterNodeReadOperationRequest<GetRepositoriesRequest> {
 
     private String[] repositories = Strings.EMPTY_ARRAY;
 
@@ -87,11 +88,13 @@ public class GetRepositoriesRequest extends MasterNodeOperationRequest<GetReposi
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         repositories = in.readStringArray();
+        readLocal(in, Version.V_1_0_0);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(repositories);
+        writeLocal(out, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequestBuilder.java
@@ -21,14 +21,14 @@ package org.elasticsearch.action.admin.cluster.repositories.get;
 
 import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.internal.InternalClusterAdminClient;
 
 /**
  * Get repository request builder
  */
-public class GetRepositoriesRequestBuilder extends MasterNodeOperationRequestBuilder<GetRepositoriesRequest, GetRepositoriesResponse, GetRepositoriesRequestBuilder> {
+public class GetRepositoriesRequestBuilder extends MasterNodeReadOperationRequestBuilder<GetRepositoriesRequest, GetRepositoriesResponse, GetRepositoriesRequestBuilder> {
 
     /**
      * Creates new get repository request builder

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.repositories.get;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -39,7 +39,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Transport action for get repositories operation
  */
-public class TransportGetRepositoriesAction extends TransportMasterNodeOperationAction<GetRepositoriesRequest, GetRepositoriesResponse> {
+public class TransportGetRepositoriesAction extends TransportMasterNodeReadOperationAction<GetRepositoriesRequest, GetRepositoriesResponse> {
 
     @Inject
     public TransportGetRepositoriesAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.admin.cluster.shards;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -32,13 +32,12 @@ import java.io.IOException;
 
 /**
  */
-public class ClusterSearchShardsRequest extends MasterNodeOperationRequest<ClusterSearchShardsRequest> {
+public class ClusterSearchShardsRequest extends MasterNodeReadOperationRequest<ClusterSearchShardsRequest> {
     private String[] indices;
     @Nullable
     private String routing;
     @Nullable
     private String preference;
-    private boolean local = false;
     private String[] types = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.lenient();
 
@@ -142,15 +141,6 @@ public class ClusterSearchShardsRequest extends MasterNodeOperationRequest<Clust
         return this.preference;
     }
 
-    public ClusterSearchShardsRequest local(boolean local) {
-        this.local = local;
-        return this;
-    }
-
-    public boolean local() {
-        return this.local;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -165,7 +155,7 @@ public class ClusterSearchShardsRequest extends MasterNodeOperationRequest<Clust
 
         types = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        local = in.readBoolean();
+        readLocal(in);
     }
 
     @Override
@@ -182,7 +172,7 @@ public class ClusterSearchShardsRequest extends MasterNodeOperationRequest<Clust
 
         out.writeStringArray(types);
         indicesOptions.writeIndicesOptions(out);
-        out.writeBoolean(local);
+        writeLocal(out);
     }
 
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestBuilder.java
@@ -21,13 +21,13 @@ package org.elasticsearch.action.admin.cluster.shards;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.internal.InternalClusterAdminClient;
 
 /**
  */
-public class ClusterSearchShardsRequestBuilder extends MasterNodeOperationRequestBuilder<ClusterSearchShardsRequest, ClusterSearchShardsResponse, ClusterSearchShardsRequestBuilder> {
+public class ClusterSearchShardsRequestBuilder extends MasterNodeReadOperationRequestBuilder<ClusterSearchShardsRequest, ClusterSearchShardsResponse, ClusterSearchShardsRequestBuilder> {
 
     public ClusterSearchShardsRequestBuilder(ClusterAdminClient clusterClient) {
         super((InternalClusterAdminClient) clusterClient, new ClusterSearchShardsRequest());
@@ -84,15 +84,6 @@ public class ClusterSearchShardsRequestBuilder extends MasterNodeOperationReques
         request().indicesOptions(indicesOptions);
         return this;
     }
-
-    /**
-     * Specifies if request should be executed on local node rather than on master.
-     */
-    public ClusterSearchShardsRequestBuilder setLocal(boolean local) {
-        request().local(local);
-        return this;
-    }
-
 
     @Override
     protected void doExecute(ActionListener<ClusterSearchShardsResponse> listener) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.shards;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -40,7 +40,7 @@ import static com.google.common.collect.Sets.newHashSet;
 
 /**
  */
-public class TransportClusterSearchShardsAction extends TransportMasterNodeOperationAction<ClusterSearchShardsRequest, ClusterSearchShardsResponse> {
+public class TransportClusterSearchShardsAction extends TransportMasterNodeReadOperationAction<ClusterSearchShardsRequest, ClusterSearchShardsResponse> {
 
     @Inject
     public TransportClusterSearchShardsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
@@ -56,11 +56,6 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeOpera
     protected String executor() {
         // all in memory work here...
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected boolean localExecute(ClusterSearchShardsRequest request) {
-        return request.local();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.admin.cluster.state;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterStateRequest> {
+public class ClusterStateRequest extends MasterNodeReadOperationRequest<ClusterStateRequest> {
 
     private boolean routingTable = true;
     private boolean nodes = true;
@@ -38,7 +38,6 @@ public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterState
     private boolean blocks = true;
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] indexTemplates = Strings.EMPTY_ARRAY;
-    private boolean local = false;
 
     public ClusterStateRequest() {
     }
@@ -122,15 +121,6 @@ public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterState
         return this;
     }
 
-    public ClusterStateRequest local(boolean local) {
-        this.local = local;
-        return this;
-    }
-
-    public boolean local() {
-        return this.local;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -140,7 +130,7 @@ public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterState
         blocks = in.readBoolean();
         indices = in.readStringArray();
         indexTemplates = in.readStringArray();
-        local = in.readBoolean();
+        readLocal(in);
     }
 
     @Override
@@ -152,6 +142,6 @@ public class ClusterStateRequest extends MasterNodeOperationRequest<ClusterState
         out.writeBoolean(blocks);
         out.writeStringArray(indices);
         out.writeStringArray(indexTemplates);
-        out.writeBoolean(local);
+        writeLocal(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -20,14 +20,14 @@
 package org.elasticsearch.action.admin.cluster.state;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.internal.InternalClusterAdminClient;
 
 /**
  *
  */
-public class ClusterStateRequestBuilder extends MasterNodeOperationRequestBuilder<ClusterStateRequest, ClusterStateResponse, ClusterStateRequestBuilder> {
+public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBuilder<ClusterStateRequest, ClusterStateResponse, ClusterStateRequestBuilder> {
 
     public ClusterStateRequestBuilder(ClusterAdminClient clusterClient) {
         super((InternalClusterAdminClient) clusterClient, new ClusterStateRequest());
@@ -92,14 +92,6 @@ public class ClusterStateRequestBuilder extends MasterNodeOperationRequestBuilde
 
     public ClusterStateRequestBuilder setIndexTemplates(String... templates) {
         request.indexTemplates(templates);
-        return this;
-    }
-
-    /**
-     * Sets if the cluster state request should be executed locally on the node, and not go to the master.
-     */
-    public ClusterStateRequestBuilder setLocal(boolean local) {
-        request.local(local);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.state;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,7 +37,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  *
  */
-public class TransportClusterStateAction extends TransportMasterNodeOperationAction<ClusterStateRequest, ClusterStateResponse> {
+public class TransportClusterStateAction extends TransportMasterNodeReadOperationAction<ClusterStateRequest, ClusterStateResponse> {
 
     private final ClusterName clusterName;
 
@@ -67,11 +67,6 @@ public class TransportClusterStateAction extends TransportMasterNodeOperationAct
     @Override
     protected ClusterStateResponse newResponse() {
         return new ClusterStateResponse();
-    }
-
-    @Override
-    protected boolean localExecute(ClusterStateRequest request) {
-        return request.local();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
@@ -19,15 +19,32 @@
 
 package org.elasticsearch.action.admin.cluster.tasks;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
 
 /**
  */
-public class PendingClusterTasksRequest extends MasterNodeOperationRequest<PendingClusterTasksRequest> {
+public class PendingClusterTasksRequest extends MasterNodeReadOperationRequest<PendingClusterTasksRequest> {
 
     @Override
     public ActionRequestValidationException validate() {
         return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readLocal(in, Version.V_1_0_0);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeLocal(out, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequestBuilder.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.internal.InternalClusterAdminClient;
 
 /**
  */
-public class PendingClusterTasksRequestBuilder extends MasterNodeOperationRequestBuilder<PendingClusterTasksRequest, PendingClusterTasksResponse, PendingClusterTasksRequestBuilder> {
+public class PendingClusterTasksRequestBuilder extends MasterNodeReadOperationRequestBuilder<PendingClusterTasksRequest, PendingClusterTasksResponse, PendingClusterTasksRequestBuilder> {
 
     public PendingClusterTasksRequestBuilder(ClusterAdminClient client) {
         super((InternalClusterAdminClient) client, new PendingClusterTasksRequest());

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.inject.Inject;
@@ -31,7 +31,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public class TransportPendingClusterTasksAction extends TransportMasterNodeOperationAction<PendingClusterTasksRequest, PendingClusterTasksResponse> {
+public class TransportPendingClusterTasksAction extends TransportMasterNodeReadOperationAction<PendingClusterTasksRequest, PendingClusterTasksResponse> {
 
     private final ClusterService clusterService;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.alias.exists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.inject.Inject;
@@ -31,7 +31,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public class TransportAliasesExistAction extends TransportMasterNodeOperationAction<GetAliasesRequest, AliasesExistResponse> {
+public class TransportAliasesExistAction extends TransportMasterNodeReadOperationAction<GetAliasesRequest, AliasesExistResponse> {
 
     @Inject
     public TransportAliasesExistAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/BaseAliasesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/BaseAliasesRequestBuilder.java
@@ -22,13 +22,13 @@ package org.elasticsearch.action.admin.indices.alias.get;
 import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
 
 /**
  */
-public abstract class BaseAliasesRequestBuilder<Response extends ActionResponse, Builder extends BaseAliasesRequestBuilder<Response, Builder>> extends MasterNodeOperationRequestBuilder<GetAliasesRequest, Response, Builder> {
+public abstract class BaseAliasesRequestBuilder<Response extends ActionResponse, Builder extends BaseAliasesRequestBuilder<Response, Builder>> extends MasterNodeReadOperationRequestBuilder<GetAliasesRequest, Response, Builder> {
 
     public BaseAliasesRequestBuilder(IndicesAdminClient client, String... aliases) {
         super((InternalIndicesAdminClient) client, new GetAliasesRequest(aliases));

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -18,20 +18,19 @@
  */
 package org.elasticsearch.action.admin.indices.alias.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-import static org.elasticsearch.action.ValidateActions.addValidationError;
-
 /**
  */
-public class GetAliasesRequest extends MasterNodeOperationRequest<GetAliasesRequest> {
+public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliasesRequest> {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
@@ -87,6 +86,7 @@ public class GetAliasesRequest extends MasterNodeOperationRequest<GetAliasesRequ
         indices = in.readStringArray();
         aliases = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        readLocal(in, Version.V_1_0_0);
     }
 
     @Override
@@ -95,5 +95,6 @@ public class GetAliasesRequest extends MasterNodeOperationRequest<GetAliasesRequ
         out.writeStringArray(indices);
         out.writeStringArray(aliases);
         indicesOptions.writeIndicesOptions(out);
+        writeLocal(out, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
@@ -34,7 +34,7 @@ import java.util.List;
 
 /**
  */
-public class TransportGetAliasesAction extends TransportMasterNodeOperationAction<GetAliasesRequest, GetAliasesResponse> {
+public class TransportGetAliasesAction extends TransportMasterNodeReadOperationAction<GetAliasesRequest, GetAliasesResponse> {
 
     @Inject
     public TransportGetAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.exists.indices;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,7 +31,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class IndicesExistsRequest extends MasterNodeOperationRequest<IndicesExistsRequest> {
+public class IndicesExistsRequest extends MasterNodeReadOperationRequest<IndicesExistsRequest> {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
@@ -71,6 +72,7 @@ public class IndicesExistsRequest extends MasterNodeOperationRequest<IndicesExis
         super.readFrom(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        readLocal(in, Version.V_1_0_0);
     }
 
     @Override
@@ -78,5 +80,6 @@ public class IndicesExistsRequest extends MasterNodeOperationRequest<IndicesExis
         super.writeTo(out);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
+        writeLocal(out, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequestBuilder.java
@@ -21,14 +21,14 @@ package org.elasticsearch.action.admin.indices.exists.indices;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
 
 /**
  *
  */
-public class IndicesExistsRequestBuilder extends MasterNodeOperationRequestBuilder<IndicesExistsRequest, IndicesExistsResponse, IndicesExistsRequestBuilder> {
+public class IndicesExistsRequestBuilder extends MasterNodeReadOperationRequestBuilder<IndicesExistsRequest, IndicesExistsResponse, IndicesExistsRequestBuilder> {
 
     public IndicesExistsRequestBuilder(IndicesAdminClient indicesClient, String... indices) {
         super((InternalIndicesAdminClient) indicesClient, new IndicesExistsRequest(indices));

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.exists.indices;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -35,7 +35,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Indices exists action.
  */
-public class TransportIndicesExistsAction extends TransportMasterNodeOperationAction<IndicesExistsRequest, IndicesExistsResponse> {
+public class TransportIndicesExistsAction extends TransportMasterNodeReadOperationAction<IndicesExistsRequest, IndicesExistsResponse> {
 
     @Inject
     public TransportIndicesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.exists.types;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -35,7 +35,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  * Types exists transport action.
  */
-public class TransportTypesExistsAction extends TransportMasterNodeOperationAction<TypesExistsRequest, TypesExistsResponse> {
+public class TransportTypesExistsAction extends TransportMasterNodeReadOperationAction<TypesExistsRequest, TypesExistsResponse> {
 
     @Inject
     public TransportTypesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
@@ -18,9 +18,10 @@
  */
 package org.elasticsearch.action.admin.indices.exists.types;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -30,7 +31,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  */
-public class TypesExistsRequest extends MasterNodeOperationRequest<TypesExistsRequest> {
+public class TypesExistsRequest extends MasterNodeReadOperationRequest<TypesExistsRequest> {
 
     private String[] indices;
     private String[] types;
@@ -88,6 +89,7 @@ public class TypesExistsRequest extends MasterNodeOperationRequest<TypesExistsRe
         out.writeStringArray(indices);
         out.writeStringArray(types);
         indicesOptions.writeIndicesOptions(out);
+        writeLocal(out, Version.V_1_0_0);
     }
 
     @Override
@@ -96,5 +98,6 @@ public class TypesExistsRequest extends MasterNodeOperationRequest<TypesExistsRe
         indices = in.readStringArray();
         types = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        readLocal(in, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequestBuilder.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.exists.types;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
 import org.elasticsearch.common.Strings;
@@ -28,7 +28,7 @@ import org.elasticsearch.common.Strings;
 /**
  * A builder for {@link TypesExistsRequest}.
  */
-public class TypesExistsRequestBuilder extends MasterNodeOperationRequestBuilder<TypesExistsRequest, TypesExistsResponse, TypesExistsRequestBuilder> {
+public class TypesExistsRequestBuilder extends MasterNodeReadOperationRequestBuilder<TypesExistsRequest, TypesExistsResponse, TypesExistsRequestBuilder> {
 
     /**
      * @param indices What indices to check for types

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -19,10 +19,11 @@
 
 package org.elasticsearch.action.admin.indices.settings.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,7 +32,7 @@ import java.io.IOException;
 
 /**
  */
-public class GetSettingsRequest extends MasterNodeOperationRequest<GetSettingsRequest> {
+public class GetSettingsRequest extends MasterNodeReadOperationRequest<GetSettingsRequest> {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
@@ -79,6 +80,7 @@ public class GetSettingsRequest extends MasterNodeOperationRequest<GetSettingsRe
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         names = in.readStringArray();
+        readLocal(in, Version.V_1_0_0);
     }
 
     @Override
@@ -87,5 +89,6 @@ public class GetSettingsRequest extends MasterNodeOperationRequest<GetSettingsRe
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
         out.writeStringArray(names);
+        writeLocal(out, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
@@ -22,13 +22,13 @@ package org.elasticsearch.action.admin.indices.settings.get;
 import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalGenericClient;
 
 /**
  */
-public class GetSettingsRequestBuilder extends MasterNodeOperationRequestBuilder<GetSettingsRequest, GetSettingsResponse, GetSettingsRequestBuilder> {
+public class GetSettingsRequestBuilder extends MasterNodeReadOperationRequestBuilder<GetSettingsRequest, GetSettingsResponse, GetSettingsRequestBuilder> {
 
     public GetSettingsRequestBuilder(InternalGenericClient client, String... indices) {
         super(client, new GetSettingsRequest().indices(indices));

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.admin.indices.settings.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -39,7 +39,7 @@ import java.util.Map;
 
 /**
  */
-public class TransportGetSettingsAction extends TransportMasterNodeOperationAction<GetSettingsRequest, GetSettingsResponse> {
+public class TransportGetSettingsAction extends TransportMasterNodeReadOperationAction<GetSettingsRequest, GetSettingsResponse> {
 
     private final SettingsFilter settingsFilter;
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.admin.indices.template.get;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,9 +30,9 @@ import java.io.IOException;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
- *
+ * Request that allows to retrieve index templates
  */
-public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetIndexTemplatesRequest> {
+public class GetIndexTemplatesRequest extends MasterNodeReadOperationRequest<GetIndexTemplatesRequest> {
 
     private String[] names;
 
@@ -82,6 +82,7 @@ public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetInde
             names = new String[1];
             names[0] = in.readString();
         }
+        readLocal(in, Version.V_1_0_0);
     }
 
     @Override
@@ -92,5 +93,6 @@ public class GetIndexTemplatesRequest extends MasterNodeOperationRequest<GetInde
         } else {
             out.writeString(names.length == 0 ? "*" : names[0]);
         }
+        writeLocal(out, Version.V_1_0_0);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
@@ -19,14 +19,14 @@
 package org.elasticsearch.action.admin.indices.template.get;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
 
 /**
  *
  */
-public class GetIndexTemplatesRequestBuilder extends MasterNodeOperationRequestBuilder<GetIndexTemplatesRequest, GetIndexTemplatesResponse, GetIndexTemplatesRequestBuilder> {
+public class GetIndexTemplatesRequestBuilder extends MasterNodeReadOperationRequestBuilder<GetIndexTemplatesRequest, GetIndexTemplatesResponse, GetIndexTemplatesRequestBuilder> {
 
     public GetIndexTemplatesRequestBuilder(IndicesAdminClient indicesClient) {
         super((InternalIndicesAdminClient) indicesClient, new GetIndexTemplatesRequest());

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -22,7 +22,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  *
  */
-public class TransportGetIndexTemplatesAction extends TransportMasterNodeOperationAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
+public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadOperationAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
 
     @Inject
     public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {

--- a/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadOperationRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support.master;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Base request for master based read operations that allows to read the cluster state from the local node if needed
+ */
+public abstract class MasterNodeReadOperationRequest<T extends MasterNodeReadOperationRequest> extends MasterNodeOperationRequest<T> {
+
+    protected boolean local = false;
+
+    @SuppressWarnings("unchecked")
+    public final T local(boolean local) {
+        this.local = local;
+        return (T) this;
+    }
+
+    public final boolean local() {
+        return local;
+    }
+
+    /**
+     * Reads the local flag
+     */
+    protected void readLocal(StreamInput in) throws IOException {
+        readLocal(in, null);
+    }
+
+    /**
+     * Reads the local flag if on or after the specified min version or if the version is <code>null</code>.
+     */
+    protected void readLocal(StreamInput in, Version minVersion) throws IOException {
+        if (minVersion == null || in.getVersion().onOrAfter(minVersion)) {
+            local = in.readBoolean();
+        }
+    }
+
+    /**
+     * writes the local flag
+     */
+    protected void writeLocal(StreamOutput out) throws IOException {
+        writeLocal(out, null);
+    }
+
+    /**
+     * writes the local flag if on or after the specified min version or if the version is <code>null</code>.
+     */
+    protected void writeLocal(StreamOutput out, Version minVersion) throws IOException {
+        if (minVersion == null || out.getVersion().onOrAfter(minVersion)) {
+            out.writeBoolean(local);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support.master;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.internal.InternalGenericClient;
+
+/**
+ * Base request builder for master node read operations that can be executed on the local node as well
+ */
+public abstract class MasterNodeReadOperationRequestBuilder<Request extends MasterNodeReadOperationRequest<Request>, Response extends ActionResponse, RequestBuilder extends MasterNodeReadOperationRequestBuilder<Request, Response, RequestBuilder>>
+        extends MasterNodeOperationRequestBuilder<Request, Response, RequestBuilder> {
+
+    protected MasterNodeReadOperationRequestBuilder(InternalGenericClient client, Request request) {
+        super(client, request);
+    }
+
+    /**
+     * Specifies if the request should be executed on local node rather than on master
+     */
+    @SuppressWarnings("unchecked")
+    public final RequestBuilder setLocal(boolean local) {
+        request.local(local);
+        return (RequestBuilder) this;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadOperationAction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support.master;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+/**
+ * A base class for read operations that needs to be performed on the master node.
+ * Can also be executed on the local node if needed.
+ */
+public abstract class TransportMasterNodeReadOperationAction<Request extends MasterNodeReadOperationRequest, Response extends ActionResponse> extends TransportMasterNodeOperationAction<Request, Response> {
+
+    protected TransportMasterNodeReadOperationAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
+        super(settings, transportService, clusterService, threadPool);
+    }
+
+    protected final boolean localExecute(Request request) {
+        return request.local();
+    }
+}

--- a/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.action.support.master.info;
 
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -29,13 +29,12 @@ import java.io.IOException;
 
 /**
  */
-public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeOperationRequest<T> {
+public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeReadOperationRequest<T> {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
 
     private IndicesOptions indicesOptions = IndicesOptions.strict();
-    private boolean local = false;
 
     @SuppressWarnings("unchecked")
     public T indices(String... indices) {
@@ -55,12 +54,6 @@ public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends M
         return (T) this;
     }
 
-    @SuppressWarnings("unchecked")
-    public T local(boolean local) {
-        this.local = local;
-        return (T) this;
-    }
-
     public String[] indices() {
         return indices;
     }
@@ -73,17 +66,13 @@ public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends M
         return indicesOptions;
     }
 
-    public boolean local() {
-        return local;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         indices = in.readStringArray();
         types = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        local = in.readBoolean();
+        readLocal(in);
     }
 
     @Override
@@ -92,6 +81,6 @@ public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends M
         out.writeStringArray(indices);
         out.writeStringArray(types);
         indicesOptions.writeIndicesOptions(out);
-        out.writeBoolean(local);
+        writeLocal(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequestBuilder.java
@@ -21,12 +21,12 @@ package org.elasticsearch.action.support.master.info;
 import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
+import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.internal.InternalGenericClient;
 
 /**
  */
-public abstract class ClusterInfoRequestBuilder<Request extends ClusterInfoRequest<Request>, Response extends ActionResponse, Builder extends ClusterInfoRequestBuilder<Request, Response, Builder>> extends MasterNodeOperationRequestBuilder<Request, Response, Builder> {
+public abstract class ClusterInfoRequestBuilder<Request extends ClusterInfoRequest<Request>, Response extends ActionResponse, Builder extends ClusterInfoRequestBuilder<Request, Response, Builder>> extends MasterNodeReadOperationRequestBuilder<Request, Response, Builder> {
 
     protected ClusterInfoRequestBuilder(InternalGenericClient client, Request request) {
         super(client, request);
@@ -61,11 +61,4 @@ public abstract class ClusterInfoRequestBuilder<Request extends ClusterInfoReque
         request.indicesOptions(indicesOptions);
         return (Builder) this;
     }
-
-    @SuppressWarnings("unchecked")
-    public Builder setLocal(boolean local) {
-        request.local(local);
-        return (Builder) this;
-    }
-
 }

--- a/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.support.master.info;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.TransportService;
 
 /**
  */
-public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeOperationAction<Request, Response> {
+public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeReadOperationAction<Request, Response> {
 
     public TransportClusterInfoAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
         super(settings, transportService, clusterService, threadPool);
@@ -40,11 +40,6 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
     protected String executor() {
         // read operation, lightweight...
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected final boolean localExecute(Request request) {
-        return request.local();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
@@ -55,6 +55,7 @@ public class RestGetRepositoriesAction extends BaseRestHandler {
         final String[] repositories = request.paramAsStringArray("repository", Strings.EMPTY_ARRAY);
         GetRepositoriesRequest getRepositoriesRequest = getRepositoryRequest(repositories);
         getRepositoriesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getRepositoriesRequest.masterNodeTimeout()));
+        getRepositoriesRequest.local(request.paramAsBoolean("local", getRepositoriesRequest.local()));
         client.admin().cluster().getRepositories(getRepositoriesRequest, new ActionListener<GetRepositoriesResponse>() {
             @Override
             public void onResponse(GetRepositoriesResponse response) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
@@ -48,6 +48,7 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
                 .listenerThreaded(false)
                 .routingTable(false)
                 .nodes(false);
+        clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
             @Override
             public void onResponse(ClusterStateResponse response) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
@@ -44,6 +44,7 @@ public class RestPendingClusterTasksAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
+        pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         client.admin().cluster().pendingClusterTasks(pendingClusterTasksRequest, new ActionListener<PendingClusterTasksResponse>() {
 
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
@@ -62,6 +62,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
         final GetAliasesRequest getAliasesRequest = new GetAliasesRequest(aliases);
         getAliasesRequest.indices(indices);
         getAliasesRequest.indicesOptions(IndicesOptions.fromRequest(request, getAliasesRequest.indicesOptions()));
+        getAliasesRequest.local(request.paramAsBoolean("local", getAliasesRequest.local()));
 
         client.admin().indices().getAliases(getAliasesRequest, new ActionListener<GetAliasesResponse>() {
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
@@ -65,7 +65,7 @@ public class RestGetIndicesAliasesAction extends BaseRestHandler {
                                 .routingTable(false)
                                 .nodes(false)
                                 .indices(indices);
-
+        clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.listenerThreaded(false);
 
         client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
@@ -53,6 +53,7 @@ public class RestAliasesExistAction extends BaseRestHandler {
         GetAliasesRequest getAliasesRequest = new GetAliasesRequest(aliases);
         getAliasesRequest.indices(indices);
         getAliasesRequest.indicesOptions(IndicesOptions.fromRequest(request, getAliasesRequest.indicesOptions()));
+        getAliasesRequest.local(request.paramAsBoolean("local", getAliasesRequest.local()));
 
         client.admin().indices().aliasesExist(getAliasesRequest, new ActionListener<AliasesExistResponse>() {
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
@@ -55,6 +55,7 @@ public class RestIndicesExistsAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         indicesExistsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesExistsRequest.indicesOptions()));
+        indicesExistsRequest.local(request.paramAsBoolean("local", indicesExistsRequest.local()));
         indicesExistsRequest.listenerThreaded(false);
         client.admin().indices().exists(indicesExistsRequest, new ActionListener<IndicesExistsResponse>() {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
@@ -50,6 +50,7 @@ public class RestTypesExistsAction extends BaseRestHandler {
                 Strings.splitStringByCommaToArray(request.param("index")), Strings.splitStringByCommaToArray(request.param("type"))
         );
         typesExistsRequest.listenerThreaded(false);
+        typesExistsRequest.local(request.paramAsBoolean("local", typesExistsRequest.local()));
         typesExistsRequest.indicesOptions(IndicesOptions.fromRequest(request, typesExistsRequest.indicesOptions()));
         client.admin().indices().typesExists(typesExistsRequest, new ActionListener<TypesExistsResponse>() {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
@@ -59,11 +59,11 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] types = request.paramAsStringArrayOrEmptyIfAll("type");
-        boolean local = request.paramAsBooleanOptional("local", false);
         final String[] fields = Strings.splitStringByCommaToArray(request.param("fields"));
         GetFieldMappingsRequest getMappingsRequest = new GetFieldMappingsRequest();
-        getMappingsRequest.indices(indices).types(types).local(local).fields(fields).includeDefaults(request.paramAsBoolean("include_defaults", false));
+        getMappingsRequest.indices(indices).types(types).fields(fields).includeDefaults(request.paramAsBoolean("include_defaults", false));
         getMappingsRequest.indicesOptions(IndicesOptions.fromRequest(request, getMappingsRequest.indicesOptions()));
+        getMappingsRequest.local(request.paramAsBoolean("local", getMappingsRequest.local()));
         client.admin().indices().getFieldMappings(getMappingsRequest, new ActionListener<GetFieldMappingsResponse>() {
 
             @SuppressWarnings("unchecked")

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -63,10 +63,10 @@ public class RestGetMappingAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] types = request.paramAsStringArrayOrEmptyIfAll("type");
-        boolean local = request.paramAsBooleanOptional("local", false);
         GetMappingsRequest getMappingsRequest = new GetMappingsRequest();
-        getMappingsRequest.indices(indices).types(types).local(local);
+        getMappingsRequest.indices(indices).types(types);
         getMappingsRequest.indicesOptions(IndicesOptions.fromRequest(request, getMappingsRequest.indicesOptions()));
+        getMappingsRequest.local(request.paramAsBoolean("local", getMappingsRequest.local()));
         client.admin().indices().getMappings(getMappingsRequest, new ActionListener<GetMappingsResponse>() {
 
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -36,7 +36,6 @@ import org.elasticsearch.rest.action.support.RestXContentBuilder;
 import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestGetSettingsAction extends BaseRestHandler {
@@ -58,6 +57,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
                 .indices(Strings.splitStringByCommaToArray(request.param("index")))
                 .indicesOptions(IndicesOptions.fromRequest(request, IndicesOptions.strict()))
                 .names(names);
+        getSettingsRequest.local(request.paramAsBoolean("local", getSettingsRequest.local()));
 
         client.admin().indices().getSettings(getSettingsRequest, new ActionListener<GetSettingsResponse>() {
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -56,6 +56,7 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
         final String[] names = Strings.splitStringByCommaToArray(request.param("name"));
 
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(names);
+        getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
         getIndexTemplatesRequest.listenerThreaded(false);
 
         final boolean implicitAll = getIndexTemplatesRequest.names().length == 0;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -46,6 +46,7 @@ public class RestHeadIndexTemplateAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
+        getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
         client.admin().indices().getTemplates(getIndexTemplatesRequest, new ActionListener<GetIndexTemplatesResponse>() {
             @Override
             public void onResponse(GetIndexTemplatesResponse getIndexTemplatesResponse) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
@@ -29,8 +29,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
@@ -61,10 +59,10 @@ public class RestGetWarmerAction extends BaseRestHandler {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] types = Strings.splitStringByCommaToArray(request.param("type"));
         final String[] names = request.paramAsStringArray("name", Strings.EMPTY_ARRAY);
-        boolean local = request.paramAsBooleanOptional("local", false);
 
         GetWarmersRequest getWarmersRequest = new GetWarmersRequest();
-        getWarmersRequest.indices(indices).types(types).warmers(names).local(local);
+        getWarmersRequest.indices(indices).types(types).warmers(names);
+        getWarmersRequest.local(request.paramAsBoolean("local", getWarmersRequest.local()));
         getWarmersRequest.indicesOptions(IndicesOptions.fromRequest(request, getWarmersRequest.indicesOptions()));
         client.admin().indices().getWarmers(getWarmersRequest, new ActionListener<GetWarmersResponse>() {
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -57,6 +57,7 @@ public class RestAliasAction extends AbstractCatAction {
         final GetAliasesRequest getAliasesRequest = request.hasParam("alias") ?
                 new GetAliasesRequest(request.param("alias")) :
                 new GetAliasesRequest();
+        getAliasesRequest.local(request.paramAsBoolean("local", getAliasesRequest.local()));
 
         client.admin().indices().getAliases(getAliasesRequest, new ActionListener<GetAliasesResponse>() {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -49,6 +49,7 @@ public class RestPendingClusterTasksAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
+        pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         client.admin().cluster().pendingClusterTasks(pendingClusterTasksRequest, new ActionListener<PendingClusterTasksResponse>() {
             @Override
             public void onResponse(PendingClusterTasksResponse pendingClusterTasks) {


### PR DESCRIPTION
Added base Request class for read operations that usually happen on the master but can be executed locally.

Added base TransportAction class for master read operations that execute locally or not depending on the request class (local flag).

Added support for local flag where missing, in a backwards compatible manner:
     - IndicesExistsRequest
     - GetAliasesRequest (get alias api, aliases exist api)
     - TypesExistsRequest
     - GetIndexTemplatesRequest (get template, template exists)
     - GetSettingsRequest
     - GetRepositoriesRequest
     - PendingClusterTasks

 Added parsing of the local flag where missing in Rest*Action.

 Updated SPEC adding local flag param where missing and added REST tests that contain use of the local flag where it was just added.

Closes #3345
