### PR TITLE
SearchType randomization in integration tests.

### DIFF
--- a/src/test/java/org/elasticsearch/indices/fielddata/breaker/CircuitBreakerServiceTests.java
+++ b/src/test/java/org/elasticsearch/indices/fielddata/breaker/CircuitBreakerServiceTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.indices.fielddata.breaker;
 
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -71,9 +72,9 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
             // execute a search that loads field data (sorting on the "test" field)
             // again, this time it should trip the breaker
             try {
-                client.prepareSearch("cb-test").setSource("{\"sort\": \"test\",\"query\":{\"match_all\":{}}}")
+                SearchResponse resp = client.prepareSearch("cb-test").setSource("{\"sort\": \"test\",\"query\":{\"match_all\":{}}}")
                         .execute().actionGet();
-                fail("should not reach this point");
+                assertFalse(resp.getShardFailures().length == 0);
             } catch (SearchPhaseExecutionException e) {
             }
 
@@ -128,9 +129,9 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
             // execute a search that loads field data (sorting on the "test" field)
             // again, this time it should trip the breaker
             try {
-                client.prepareSearch("ramtest").setSource("{\"sort\": \"test\",\"query\":{\"match_all\":{}}}")
+                SearchResponse resp = client.prepareSearch("ramtest").setSource("{\"sort\": \"test\",\"query\":{\"match_all\":{}}}")
                         .execute().actionGet();
-                fail("should not reach this point");
+                assertFalse(resp.getShardFailures().length == 0);
             } catch (SearchPhaseExecutionException e) {
             }
 

--- a/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
+++ b/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
@@ -201,6 +201,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    // TODO: why does this test fail with DFS_QUERY_THEN_FETCH?
     public void testEquivalence() throws Exception {
         client().admin()
                 .indices()
@@ -228,6 +229,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
             String query = intToEnglish.split(" ")[0];
             SearchResponse rescored = client()
                     .prepareSearch()
+                    .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
                     .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR))
                     .setFrom(0)
@@ -242,6 +244,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
                     .setRescoreWindow(rescoreWindow).execute().actionGet();
 
             SearchResponse plain = client().prepareSearch()
+                    .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
                     .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR)).setFrom(0).setSize(resultSize)
                     .execute().actionGet();
@@ -251,6 +254,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
 
             rescored = client()
                     .prepareSearch()
+                    .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
                     .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR))
                     .setFrom(0)
@@ -268,6 +272,7 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
 
             rescored = client()
                     .prepareSearch()
+                    .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setPreference("test") // ensure we hit the same shards for tie-breaking
                     .setQuery(QueryBuilders.matchQuery("field1", query).operator(MatchQueryBuilder.Operator.OR))
                     .setFrom(0)

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -44,6 +44,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.internal.InternalClient;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -60,6 +61,7 @@ import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchService;
+import org.elasticsearch.test.client.RandomizingClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -263,7 +265,11 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     }
 
     public static Client client() {
-        return cluster().client();
+        Client client = cluster().client();
+        if (frequently()) {
+            client = new RandomizingClient((InternalClient) client, getRandom());
+        }
+        return client;
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
+++ b/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.client;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.elasticsearch.action.*;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.count.CountRequest;
+import org.elasticsearch.action.count.CountRequestBuilder;
+import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.deletebyquery.DeleteByQueryRequest;
+import org.elasticsearch.action.deletebyquery.DeleteByQueryRequestBuilder;
+import org.elasticsearch.action.deletebyquery.DeleteByQueryResponse;
+import org.elasticsearch.action.explain.ExplainRequest;
+import org.elasticsearch.action.explain.ExplainRequestBuilder;
+import org.elasticsearch.action.explain.ExplainResponse;
+import org.elasticsearch.action.get.*;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.mlt.MoreLikeThisRequest;
+import org.elasticsearch.action.mlt.MoreLikeThisRequestBuilder;
+import org.elasticsearch.action.percolate.*;
+import org.elasticsearch.action.search.*;
+import org.elasticsearch.action.suggest.SuggestRequest;
+import org.elasticsearch.action.suggest.SuggestRequestBuilder;
+import org.elasticsearch.action.suggest.SuggestResponse;
+import org.elasticsearch.action.termvector.*;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.internal.InternalClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/** A {@link Client} that randomizes request parameters. */
+public class RandomizingClient implements InternalClient {
+
+    private final SearchType defaultSearchType;
+    private final InternalClient delegate;
+
+    public RandomizingClient(InternalClient client, Random random) {
+        this.delegate = client;
+        // we don't use the QUERY_AND_FETCH types that break quite a lot of tests
+        // given that they return `size*num_shards` hits instead of `size`
+        defaultSearchType = RandomPicks.randomFrom(random, Arrays.asList(
+                SearchType.DFS_QUERY_THEN_FETCH,
+                SearchType.QUERY_THEN_FETCH));
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public AdminClient admin() {
+        return delegate.admin();
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> ActionFuture<Response> execute(
+            Action<Request, Response, RequestBuilder> action, Request request) {
+        return delegate.execute(action, request);
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> void execute(
+            Action<Request, Response, RequestBuilder> action, Request request, ActionListener<Response> listener) {
+        delegate.execute(action, request, listener);
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder>> RequestBuilder prepareExecute(
+            Action<Request, Response, RequestBuilder> action) {
+        return delegate.prepareExecute(action);
+    }
+
+    @Override
+    public ActionFuture<IndexResponse> index(IndexRequest request) {
+        return delegate.index(request);
+    }
+
+    @Override
+    public void index(IndexRequest request, ActionListener<IndexResponse> listener) {
+        delegate.index(request, listener);
+    }
+
+    @Override
+    public IndexRequestBuilder prepareIndex() {
+        return delegate.prepareIndex();
+    }
+
+    @Override
+    public ActionFuture<UpdateResponse> update(UpdateRequest request) {
+        return delegate.update(request);
+    }
+
+    @Override
+    public void update(UpdateRequest request, ActionListener<UpdateResponse> listener) {
+        delegate.update(request, listener);
+    }
+
+    @Override
+    public UpdateRequestBuilder prepareUpdate() {
+        return delegate.prepareUpdate();
+    }
+
+    @Override
+    public UpdateRequestBuilder prepareUpdate(String index, String type, String id) {
+        return delegate.prepareUpdate(index, type, id);
+    }
+
+    @Override
+    public IndexRequestBuilder prepareIndex(String index, String type) {
+        return delegate.prepareIndex(index, type);
+    }
+
+    @Override
+    public IndexRequestBuilder prepareIndex(String index, String type, String id) {
+        return delegate.prepareIndex(index, type, id);
+    }
+
+    @Override
+    public ActionFuture<DeleteResponse> delete(DeleteRequest request) {
+        return delegate.delete(request);
+    }
+
+    @Override
+    public void delete(DeleteRequest request, ActionListener<DeleteResponse> listener) {
+        delegate.delete(request, listener);
+    }
+
+    @Override
+    public DeleteRequestBuilder prepareDelete() {
+        return delegate.prepareDelete();
+    }
+
+    @Override
+    public DeleteRequestBuilder prepareDelete(String index, String type, String id) {
+        return delegate.prepareDelete(index, type, id);
+    }
+
+    @Override
+    public ActionFuture<BulkResponse> bulk(BulkRequest request) {
+        return delegate.bulk(request);
+    }
+
+    @Override
+    public void bulk(BulkRequest request, ActionListener<BulkResponse> listener) {
+        delegate.bulk(request, listener);
+    }
+
+    @Override
+    public BulkRequestBuilder prepareBulk() {
+        return delegate.prepareBulk();
+    }
+
+    @Override
+    public ActionFuture<DeleteByQueryResponse> deleteByQuery(DeleteByQueryRequest request) {
+        return delegate.deleteByQuery(request);
+    }
+
+    @Override
+    public void deleteByQuery(DeleteByQueryRequest request, ActionListener<DeleteByQueryResponse> listener) {
+        delegate.deleteByQuery(request, listener);
+    }
+
+    @Override
+    public DeleteByQueryRequestBuilder prepareDeleteByQuery(String... indices) {
+        return delegate.prepareDeleteByQuery(indices);
+    }
+
+    @Override
+    public ActionFuture<GetResponse> get(GetRequest request) {
+        return delegate.get(request);
+    }
+
+    @Override
+    public void get(GetRequest request, ActionListener<GetResponse> listener) {
+        delegate.get(request, listener);
+    }
+
+    @Override
+    public GetRequestBuilder prepareGet() {
+        return delegate.prepareGet();
+    }
+
+    @Override
+    public GetRequestBuilder prepareGet(String index, String type, String id) {
+        return delegate.prepareGet(index, type, id);
+    }
+
+    @Override
+    public ActionFuture<MultiGetResponse> multiGet(MultiGetRequest request) {
+        return delegate.multiGet(request);
+    }
+
+    @Override
+    public void multiGet(MultiGetRequest request, ActionListener<MultiGetResponse> listener) {
+        delegate.multiGet(request, listener);
+    }
+
+    @Override
+    public MultiGetRequestBuilder prepareMultiGet() {
+        return delegate.prepareMultiGet();
+    }
+
+    @Override
+    public ActionFuture<CountResponse> count(CountRequest request) {
+        return delegate.count(request);
+    }
+
+    @Override
+    public void count(CountRequest request, ActionListener<CountResponse> listener) {
+        delegate.count(request, listener);
+    }
+
+    @Override
+    public CountRequestBuilder prepareCount(String... indices) {
+        return delegate.prepareCount(indices);
+    }
+
+    @Override
+    public ActionFuture<SuggestResponse> suggest(SuggestRequest request) {
+        return delegate.suggest(request);
+    }
+
+    @Override
+    public void suggest(SuggestRequest request, ActionListener<SuggestResponse> listener) {
+        delegate.suggest(request, listener);
+    }
+
+    @Override
+    public SuggestRequestBuilder prepareSuggest(String... indices) {
+        return delegate.prepareSuggest(indices);
+    }
+
+    @Override
+    public ActionFuture<SearchResponse> search(SearchRequest request) {
+        return delegate.search(request);
+    }
+
+    @Override
+    public void search(SearchRequest request, ActionListener<SearchResponse> listener) {
+        delegate.search(request, listener);
+    }
+
+    @Override
+    public SearchRequestBuilder prepareSearch(String... indices) {
+        return delegate.prepareSearch(indices).setSearchType(defaultSearchType);
+    }
+
+    @Override
+    public ActionFuture<SearchResponse> searchScroll(SearchScrollRequest request) {
+        return delegate.searchScroll(request);
+    }
+
+    @Override
+    public void searchScroll(SearchScrollRequest request, ActionListener<SearchResponse> listener) {
+        delegate.searchScroll(request, listener);
+    }
+
+    @Override
+    public SearchScrollRequestBuilder prepareSearchScroll(String scrollId) {
+        return delegate.prepareSearchScroll(scrollId);
+    }
+
+    @Override
+    public ActionFuture<MultiSearchResponse> multiSearch(MultiSearchRequest request) {
+        return delegate.multiSearch(request);
+    }
+
+    @Override
+    public void multiSearch(MultiSearchRequest request, ActionListener<MultiSearchResponse> listener) {
+        delegate.multiSearch(request, listener);
+    }
+
+    @Override
+    public MultiSearchRequestBuilder prepareMultiSearch() {
+        return delegate.prepareMultiSearch();
+    }
+
+    @Override
+    public ActionFuture<SearchResponse> moreLikeThis(MoreLikeThisRequest request) {
+        return delegate.moreLikeThis(request);
+    }
+
+    @Override
+    public void moreLikeThis(MoreLikeThisRequest request, ActionListener<SearchResponse> listener) {
+        delegate.moreLikeThis(request, listener);
+    }
+
+    @Override
+    public MoreLikeThisRequestBuilder prepareMoreLikeThis(String index, String type, String id) {
+        return delegate.prepareMoreLikeThis(index, type, id);
+    }
+
+    @Override
+    public ActionFuture<TermVectorResponse> termVector(TermVectorRequest request) {
+        return delegate.termVector(request);
+    }
+
+    @Override
+    public void termVector(TermVectorRequest request, ActionListener<TermVectorResponse> listener) {
+        delegate.termVector(request, listener);
+    }
+
+    @Override
+    public TermVectorRequestBuilder prepareTermVector(String index, String type, String id) {
+        return delegate.prepareTermVector(index, type, id);
+    }
+
+    @Override
+    public ActionFuture<MultiTermVectorsResponse> multiTermVectors(MultiTermVectorsRequest request) {
+        return delegate.multiTermVectors(request);
+    }
+
+    @Override
+    public void multiTermVectors(MultiTermVectorsRequest request, ActionListener<MultiTermVectorsResponse> listener) {
+        delegate.multiTermVectors(request, listener);
+    }
+
+    @Override
+    public MultiTermVectorsRequestBuilder prepareMultiTermVectors() {
+        return delegate.prepareMultiTermVectors();
+    }
+
+    @Override
+    public ActionFuture<PercolateResponse> percolate(PercolateRequest request) {
+        return delegate.percolate(request);
+    }
+
+    @Override
+    public void percolate(PercolateRequest request, ActionListener<PercolateResponse> listener) {
+        delegate.percolate(request, listener);
+    }
+
+    @Override
+    public PercolateRequestBuilder preparePercolate() {
+        return delegate.preparePercolate();
+    }
+
+    @Override
+    public ActionFuture<MultiPercolateResponse> multiPercolate(MultiPercolateRequest request) {
+        return delegate.multiPercolate(request);
+    }
+
+    @Override
+    public void multiPercolate(MultiPercolateRequest request, ActionListener<MultiPercolateResponse> listener) {
+        delegate.multiPercolate(request, listener);
+    }
+
+    @Override
+    public MultiPercolateRequestBuilder prepareMultiPercolate() {
+        return delegate.prepareMultiPercolate();
+    }
+
+    @Override
+    public ExplainRequestBuilder prepareExplain(String index, String type, String id) {
+        return delegate.prepareExplain(index, type, id);
+    }
+
+    @Override
+    public ActionFuture<ExplainResponse> explain(ExplainRequest request) {
+        return delegate.explain(request);
+    }
+
+    @Override
+    public void explain(ExplainRequest request, ActionListener<ExplainResponse> listener) {
+        delegate.explain(request, listener);
+    }
+
+    @Override
+    public ClearScrollRequestBuilder prepareClearScroll() {
+        return delegate.prepareClearScroll();
+    }
+
+    @Override
+    public ActionFuture<ClearScrollResponse> clearScroll(ClearScrollRequest request) {
+        return delegate.clearScroll(request);
+    }
+
+    @Override
+    public void clearScroll(ClearScrollRequest request, ActionListener<ClearScrollResponse> listener) {
+        delegate.clearScroll(request, listener);
+    }
+
+    @Override
+    public ThreadPool threadPool() {
+        return delegate.threadPool();
+    }
+
+    @Override
+    public Settings settings() {
+        return delegate.settings();
+    }
+
+    @Override
+    public String toString() {
+        return "randomized(" + super.toString() + ")";
+    }
+
+}


### PR DESCRIPTION
Issue #4754 showed that using DFS_QUERY_THEN_FETCH instead of QUERY_THEN_FETCH
might expose interesting bugs.

Close #4793
