### PR TITLE
Accept the same boolean values in RestRequest

### DIFF
--- a/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -136,11 +136,7 @@ public abstract class RestRequest implements ToXContent.Params {
 
     @Override
     public Boolean paramAsBooleanOptional(String key, Boolean defaultValue) {
-        String sValue = param(key);
-        if (sValue == null) {
-            return defaultValue;
-        }
-        return !(sValue.equals("false") || sValue.equals("0") || sValue.equals("off"));
+        return Booleans.parseBoolean(param(key), defaultValue);
     }
 
     public TimeValue paramAsTime(String key, TimeValue defaultValue) {


### PR DESCRIPTION
Added `no` as a possible value to `paramBooleanAsOptional`, also reused existing code from `Booleans.parseBoolean`

Closes #4808
