### PR TITLE
Fix logging on immediate exit on start

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -235,10 +235,10 @@ public class Bootstrap {
             }
             String errorMessage = buildErrorMessage(stage, e);
             if (foreground) {
-                logger.error(errorMessage);
-            } else {
                 System.err.println(errorMessage);
                 System.err.flush();
+            } else {
+                logger.error(errorMessage);
             }
             Loggers.disableConsoleLogging();
             if (logger.isDebugEnabled()) {


### PR DESCRIPTION
If elasticsearch was started in the foreground an immediate exit on startup
led to logging in the logfile, where as when starting in the background,
an immediate exit logged to stdout.

Closes #4805
