### PR TITLE
Add page tracking to MockPageCacheRecycler.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BytesRefHash.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BytesRefHash.java
@@ -162,7 +162,7 @@ public final class BytesRefHash extends AbstractHash {
             super.release();
             success = true;
         } finally {
-            Releasables.release(success, bytes, hashes);
+            Releasables.release(success, bytes, hashes, startOffsets);
         }
         return true;
     }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/BytesRefHashTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/BytesRefHashTests.java
@@ -36,6 +36,9 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
     BytesRefHash hash;
 
     private void newHash() {
+        if (hash != null) {
+            hash.release();
+        }
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
         hash = new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randomCacheRecycler());
@@ -48,7 +51,8 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
     }
 
     public void testDuell() {
-        final BytesRef[] values = new BytesRef[randomIntBetween(1, 100000)];
+        final int len = randomIntBetween(1, 100000);
+        final BytesRef[] values = new BytesRef[len];
         for (int i = 0; i < values.length; ++i) {
             values[i] = new BytesRef(randomAsciiOfLength(5));
         }
@@ -111,6 +115,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
                 }
             }
         }
+        hash.release();
     }
 
     /**
@@ -150,6 +155,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
             }
             newHash();
         }
+        hash.release();
     }
 
     /**
@@ -190,6 +196,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
             assertAllIn(strings, hash);
             newHash();
         }
+        hash.release();
     }
 
     @Test
@@ -225,6 +232,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
             assertAllIn(strings, hash);
             newHash();
         }
+        hash.release();
     }
 
     private void assertAllIn(Set<String> strings, BytesRefHash hash) {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.AbstractRandomizedTest;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.Version;
+import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
@@ -34,6 +35,7 @@ import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.test.engine.MockInternalEngine;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.store.MockDirectoryHelper;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -107,6 +109,11 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     public File getResource(String relativePath) {
         URI uri = URI.create(getClass().getResource(relativePath).toString());
         return new File(uri);
+    }
+
+    @After
+    public void ensureAllPagesReleased() {
+        MockPageCacheRecycler.ensureAllPagesAreReleased();
     }
 
     public static void ensureAllFilesClosed() throws IOException {


### PR DESCRIPTION
This found an issue in BytesRefHash that forgot to release the start offsets.

Close #4814
