### PR TITLE
REST API: Consistent get field mapping response

### DIFF
--- a/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yaml
+++ b/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yaml
@@ -1,5 +1,5 @@
 ---
-"Raise 404 when field doesn't exist":
+"Return empty object if field doesn't exist, but type and index do":
 
   - do:
         indices.create:
@@ -13,9 +13,9 @@
                       analyzer: whitespace
 
   - do:
-      catch: missing
       indices.get_field_mapping:
         index: test_index
         type: test_type
-        field: not_text
+        field: not_existent
   
+  - match: { '': {}}

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -88,6 +89,8 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
     }
 
     public static class FieldMappingMetaData implements ToXContent {
+        public static final FieldMappingMetaData NULL = new FieldMappingMetaData("", BytesArray.EMPTY);
+
         private String fullName;
         private BytesReference source;
 


### PR DESCRIPTION
If a get field mapping request is issued, and all but the field can be
found, the response should return an empty JSON object instead of a 404.

Closes #4738
