### PR TITLE
Make all aggregators reader-context-aware.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -39,6 +39,7 @@ import org.elasticsearch.search.query.QueryPhaseExecutionException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -145,10 +146,10 @@ public class AggregationPhase implements SearchPhase {
     public static class AggregationsCollector extends XCollector {
 
         private final AggregationContext aggregationContext;
-        private final List<Aggregator> collectors;
+        private final Aggregator[] collectors;
 
-        public AggregationsCollector(List<Aggregator> collectors, AggregationContext aggregationContext) {
-            this.collectors = collectors;
+        public AggregationsCollector(Collection<Aggregator> collectors, AggregationContext aggregationContext) {
+            this.collectors = collectors.toArray(new Aggregator[collectors.size()]);
             this.aggregationContext = aggregationContext;
         }
 
@@ -159,8 +160,8 @@ public class AggregationPhase implements SearchPhase {
 
         @Override
         public void collect(int doc) throws IOException {
-            for (int i = 0; i < collectors.size(); i++) {
-                collectors.get(i).collect(doc, 0);
+            for (Aggregator collector : collectors) {
+                collector.collect(doc, 0);
             }
         }
 
@@ -176,8 +177,8 @@ public class AggregationPhase implements SearchPhase {
 
         @Override
         public void postCollection() {
-            for (int i = 0; i < collectors.size(); i++) {
-                collectors.get(i).postCollection();
+            for (Aggregator collector : collectors) {
+                collector.postCollection();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lucene.ReaderContextAware;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
@@ -28,7 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class Aggregator implements Releasable {
+public abstract class Aggregator implements Releasable, ReaderContextAware {
 
     /**
      * Defines the nature of the aggregator's aggregation execution when nested in other aggregators and the buckets they create.

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
@@ -21,22 +21,17 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.util.Bits;
-import org.elasticsearch.common.lucene.ReaderContextAware;
 import org.elasticsearch.common.lucene.docset.DocIdSets;
-import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.AggregatorFactory;
 
 import java.io.IOException;
 
 /**
  * Aggregate all docs that match a filter.
  */
-public class FilterAggregator extends SingleBucketAggregator implements ReaderContextAware {
+public class FilterAggregator extends SingleBucketAggregator {
 
     private final Filter filter;
 
@@ -88,9 +83,7 @@ public class FilterAggregator extends SingleBucketAggregator implements ReaderCo
 
         @Override
         public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
-            FilterAggregator aggregator = new FilterAggregator(name, filter, factories, context, parent);
-            context.registerReaderContextAware(aggregator);
-            return aggregator;
+            return new FilterAggregator(name, filter, factories, context, parent);
         }
 
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.index.fielddata.LongValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -45,6 +46,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     private final int shardSize;
     private final NumericValuesSource valuesSource;
     private final LongHash bucketOrds;
+    private LongValues values;
 
     public GeoHashGridAggregator(String name, AggregatorFactories factories, NumericValuesSource valuesSource,
                               int requiredSize, int shardSize, AggregationContext aggregationContext, Aggregator parent) {
@@ -61,9 +63,13 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.longValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0;
-        final LongValues values = valuesSource.longValues();
         final int valuesCount = values.setDocument(doc);
 
         for (int i = 0; i < valuesCount; ++i) {
@@ -143,6 +149,10 @@ public class GeoHashGridAggregator extends BucketsAggregator {
         @Override
         public boolean shouldCollect() {
             return false;
+        }
+
+        @Override
+        public void setNextReader(AtomicReaderContext reader) {
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -18,13 +18,10 @@
  */
 package org.elasticsearch.search.aggregations.bucket.global;
 
-import org.elasticsearch.search.aggregations.AggregationExecutionException;
-import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.AggregatorFactory;
 
 import java.io.IOException;
 
@@ -35,6 +32,10 @@ public class GlobalAggregator extends SingleBucketAggregator {
 
     public GlobalAggregator(String name, AggregatorFactories subFactories, AggregationContext aggregationContext) {
         super(name, subFactories, aggregationContext, null);
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
@@ -49,6 +50,7 @@ public class HistogramAggregator extends BucketsAggregator {
     private final AbstractHistogramBase.Factory histogramFactory;
 
     private final LongHash bucketOrds;
+    private LongValues values;
 
     public HistogramAggregator(String name,
                                AggregatorFactories factories,
@@ -79,9 +81,13 @@ public class HistogramAggregator extends BucketsAggregator {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.longValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0;
-        final LongValues values = valuesSource.longValues();
         final int valuesCount = values.setDocument(doc);
 
         long previousKey = Long.MIN_VALUE;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -119,9 +119,7 @@ public class NestedAggregator extends SingleBucketAggregator implements ReaderCo
 
         @Override
         public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
-            NestedAggregator aggregator = new NestedAggregator(name, factories, path, context, parent);
-            context.registerReaderContextAware(aggregator);
-            return aggregator;
+            return new NestedAggregator(name, factories, path, context, parent);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -44,6 +44,7 @@ public class DoubleTermsAggregator extends BucketsAggregator {
     private final long minDocCount;
     private final NumericValuesSource valuesSource;
     private final LongHash bucketOrds;
+    private DoubleValues values;
 
     public DoubleTermsAggregator(String name, AggregatorFactories factories, NumericValuesSource valuesSource, long estimatedBucketCount,
                                InternalOrder order, int requiredSize, int shardSize, long minDocCount, AggregationContext aggregationContext, Aggregator parent) {
@@ -62,9 +63,13 @@ public class DoubleTermsAggregator extends BucketsAggregator {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.doubleValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0;
-        final DoubleValues values = valuesSource.doubleValues();
         final int valuesCount = values.setDocument(doc);
 
         for (int i = 0; i < valuesCount; ++i) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -44,6 +44,7 @@ public class LongTermsAggregator extends BucketsAggregator {
     private final long minDocCount;
     private final NumericValuesSource valuesSource;
     private final LongHash bucketOrds;
+    private LongValues values;
 
     public LongTermsAggregator(String name, AggregatorFactories factories, NumericValuesSource valuesSource, long estimatedBucketCount,
                                InternalOrder order, int requiredSize, int shardSize, long minDocCount, AggregationContext aggregationContext, Aggregator parent) {
@@ -62,9 +63,13 @@ public class LongTermsAggregator extends BucketsAggregator {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.longValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0;
-        final LongValues values = valuesSource.longValues();
         final int valuesCount = values.setDocument(doc);
 
         for (int i = 0; i < valuesCount; ++i) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -108,10 +108,7 @@ public class TermsAggregatorFactory extends ValueSourceAggregatorFactory {
 
             if (execution.equals(EXECUTION_HINT_VALUE_ORDINALS)) {
                 assert includeExclude == null;
-                final StringTermsAggregator.WithOrdinals aggregator = new StringTermsAggregator.WithOrdinals(name,
-                        factories, (BytesValuesSource.WithOrdinals) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
-                aggregationContext.registerReaderContextAware(aggregator);
-                return aggregator;
+                return new StringTermsAggregator.WithOrdinals(name, factories, (BytesValuesSource.WithOrdinals) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
             } else {
                 return new StringTermsAggregator(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, includeExclude, aggregationContext, parent);
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTermsAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -44,6 +45,10 @@ public class UnmappedTermsAggregator extends Aggregator {
     @Override
     public boolean shouldCollect() {
         return false;
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.avg;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -39,6 +40,7 @@ import java.io.IOException;
 public class AvgAggregator extends MetricsAggregator.SingleValue {
 
     private final NumericValuesSource valuesSource;
+    private DoubleValues values;
 
     private LongArray counts;
     private DoubleArray sums;
@@ -59,14 +61,12 @@ public class AvgAggregator extends MetricsAggregator.SingleValue {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.doubleValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        assert valuesSource != null : "if value source is null, collect should never be called";
-
-        DoubleValues values = valuesSource.doubleValues();
-        if (values == null) {
-            return;
-        }
-
         counts = BigArrays.grow(counts, owningBucketOrdinal + 1);
         sums = BigArrays.grow(sums, owningBucketOrdinal + 1);
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.max;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -38,6 +39,7 @@ import java.io.IOException;
 public class MaxAggregator extends MetricsAggregator.SingleValue {
 
     private final NumericValuesSource valuesSource;
+    private DoubleValues values;
 
     private DoubleArray maxes;
 
@@ -57,14 +59,12 @@ public class MaxAggregator extends MetricsAggregator.SingleValue {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.doubleValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        assert valuesSource != null : "collect should only be called when value source is not null";
-
-        DoubleValues values = valuesSource.doubleValues();
-        if (values == null) {
-            return;
-        }
-
         if (owningBucketOrdinal >= maxes.size()) {
             long from = maxes.size();
             maxes = BigArrays.grow(maxes, owningBucketOrdinal + 1);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.min;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -38,6 +39,7 @@ import java.io.IOException;
 public class MinAggregator extends MetricsAggregator.SingleValue {
 
     private final NumericValuesSource valuesSource;
+    private DoubleValues values;
 
     private DoubleArray mins;
 
@@ -57,11 +59,13 @@ public class MinAggregator extends MetricsAggregator.SingleValue {
     }
 
     @Override
-    public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        assert valuesSource != null : "collect must only be called if #shouldCollect returns true";
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.doubleValues();
+    }
 
-        DoubleValues values = valuesSource.doubleValues();
-        if (values == null || values.setDocument(doc) == 0) {
+    @Override
+    public void collect(int doc, long owningBucketOrdinal) throws IOException {
+        if (values.setDocument(doc) == 0) {
             return;
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.stats;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
@@ -40,6 +41,7 @@ import java.io.IOException;
 public class StatsAggegator extends MetricsAggregator.MultiValue {
 
     private final NumericValuesSource valuesSource;
+    private DoubleValues values;
 
     private LongArray counts;
     private DoubleArray sums;
@@ -66,14 +68,12 @@ public class StatsAggegator extends MetricsAggregator.MultiValue {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.doubleValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        assert valuesSource != null : "collect must only be called if #shouldCollect returns true";
-
-        DoubleValues values = valuesSource.doubleValues();
-        if (values == null) {
-            return;
-        }
-
         if (owningBucketOrdinal >= counts.size()) {
             final long from = counts.size();
             final long overSize = BigArrays.overSize(owningBucketOrdinal + 1);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.sum;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -38,6 +39,7 @@ import java.io.IOException;
 public class SumAggregator extends MetricsAggregator.SingleValue {
 
     private final NumericValuesSource valuesSource;
+    private DoubleValues values;
 
     private DoubleArray sums;
 
@@ -56,14 +58,12 @@ public class SumAggregator extends MetricsAggregator.SingleValue {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.doubleValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        assert valuesSource != null : "collect must only be called after #shouldCollect returns true";
-
-        DoubleValues values = valuesSource.doubleValues();
-        if (values == null) {
-            return;
-        }
-
         sums = BigArrays.grow(sums, owningBucketOrdinal + 1);
 
         final int valuesCount = values.setDocument(doc);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.metrics.valuecount;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
@@ -41,6 +42,7 @@ import java.io.IOException;
 public class ValueCountAggregator extends MetricsAggregator.SingleValue {
 
     private final BytesValuesSource valuesSource;
+    private BytesValues values;
 
     // a count per bucket
     LongArray counts;
@@ -61,11 +63,12 @@ public class ValueCountAggregator extends MetricsAggregator.SingleValue {
     }
 
     @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        values = valuesSource.bytesValues();
+    }
+
+    @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        BytesValues values = valuesSource.bytesValues();
-        if (values == null) {
-            return;
-        }
         counts = BigArrays.grow(counts, owningBucketOrdinal + 1);
         counts.increment(owningBucketOrdinal, values.setDocument(doc));
     }


### PR DESCRIPTION
This removes the overhead of polling a Bytes/Double/Long-Values instance in
every call to collect.

Additionally, the AggregationsCollector has been changed to wrap a simple array
instead of an ArrayList.

HistogramAggregationSearchBenchmark reports response times that are ~10%
better.

Close #4841
