### PR TITLE
Serving _site plugins do not pick up on index.html for sub directories

### DIFF
--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -177,8 +177,13 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
             return;
         }
         if (!file.isFile()) {
+            // If it's not a dir, we send a 403
+            if (!file.isDirectory()) {
+                channel.sendResponse(new StringRestResponse(FORBIDDEN));
+                return;
+            }
             // We don't serve dir but if index.html exists in dir we should serve it
-            file = new File(siteFile, sitePath + "/index.html");
+            file = new File(siteFile, sitePath + File.separatorChar + "index.html");
             if (!file.exists() || file.isHidden() || !file.isFile()) {
                 channel.sendResponse(new StringRestResponse(FORBIDDEN));
                 return;

--- a/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -177,8 +177,12 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
             return;
         }
         if (!file.isFile()) {
-            channel.sendResponse(new StringRestResponse(FORBIDDEN));
-            return;
+            // We don't serve dir but if index.html exists in dir we should serve it
+            file = new File(siteFile, sitePath + "/index.html");
+            if (!file.exists() || file.isHidden() || !file.isFile()) {
+                channel.sendResponse(new StringRestResponse(FORBIDDEN));
+                return;
+            }
         }
         if (!file.getAbsolutePath().startsWith(siteFile.getAbsolutePath())) {
             channel.sendResponse(new StringRestResponse(FORBIDDEN));

--- a/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
@@ -73,4 +73,17 @@ public class SitePluginTests extends ElasticsearchIntegrationTest {
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin</title>"));
     }
+
+    /**
+     * Test case for #4845: https://github.com/elasticsearch/elasticsearch/issues/4845
+     * Serving _site plugins do not pick up on index.html for sub directories
+     * @throws Exception
+     */
+    @Test
+    public void testWelcomePageInSubDirs() throws Exception {
+        // We use an HTTP Client to test redirection
+        HttpClientResponse response = httpClient("test").request("/_plugin/subdir/dir/");
+        assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
+        assertThat(response.response(), containsString("<title>Dummy Site Plugin (subdir)</title>"));
+    }
 }

--- a/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
@@ -75,15 +75,30 @@ public class SitePluginTests extends ElasticsearchIntegrationTest {
     }
 
     /**
+     * Test direct access to an existing file (index.html)
+     */
+    @Test
+    public void testAnyPage() throws Exception {
+        HttpClientResponse response = httpClient("test").request("/_plugin/dummy/index.html");
+        assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
+        assertThat(response.response(), containsString("<title>Dummy Site Plugin</title>"));
+    }
+
+    /**
      * Test case for #4845: https://github.com/elasticsearch/elasticsearch/issues/4845
      * Serving _site plugins do not pick up on index.html for sub directories
-     * @throws Exception
      */
     @Test
     public void testWelcomePageInSubDirs() throws Exception {
-        // We use an HTTP Client to test redirection
         HttpClientResponse response = httpClient("test").request("/_plugin/subdir/dir/");
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin (subdir)</title>"));
+
+        response = httpClient("test").request("/_plugin/subdir/dir_without_index/");
+        assertThat(response.errorCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
+
+        response = httpClient("test").request("/_plugin/subdir/dir_without_index/page.html");
+        assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
+        assertThat(response.response(), containsString("<title>Dummy Site Plugin (page)</title>"));
     }
 }

--- a/src/test/resources/org/elasticsearch/plugin/subdir/_site/dir/index.html
+++ b/src/test/resources/org/elasticsearch/plugin/subdir/_site/dir/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dummy Site Plugin (subdir)</title>
+</head>
+<body>
+<p>Welcome to this dummy elasticsearch plugin</p>
+</body>
+</html>

--- a/src/test/resources/org/elasticsearch/plugin/subdir/_site/dir_without_index/page.html
+++ b/src/test/resources/org/elasticsearch/plugin/subdir/_site/dir_without_index/page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dummy Site Plugin (page)</title>
+</head>
+<body>
+<p>Welcome to this dummy elasticsearch plugin</p>
+</body>
+</html>


### PR DESCRIPTION
If one asks for `http://es:9200/_plugin/PLUGIN_NAME/` and the the plugin's _site directory contains an index.html file, it will be correctly served.

This is not the case for sub directories: a _site/folder/index.html is not served when requesting  `http://es:9200/_plugin/PLUGIN_NAME/folder/` but one gets a 403 Forbidden response as if trying to browse the folder.

Closes #4845.
