### PR TITLE
ClearScrollRequest should set a type parameter

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  */
-public class ClearScrollRequest extends ActionRequest {
+public class ClearScrollRequest extends ActionRequest<ClearScrollRequest> {
 
     private List<String> scrollIds;
 


### PR DESCRIPTION
Since ActionRequest requires a bounded type parameter.
