### PR TITLE
Clean up cat headers

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -91,11 +91,11 @@ public class RestAliasAction extends AbstractCatAction {
     Table getTableWithHeader(RestRequest request) {
         final Table table = new Table();
         table.startHeaders();
-        table.addCell("alias", "desc:alias name");
-        table.addCell("index", "desc:index alias points to");
-        table.addCell("filter", "desc:filter");
-        table.addCell("indexRouting", "desc:index routing");
-        table.addCell("searchRouting", "desc:search routing");
+        table.addCell("alias", "alias:a;desc:alias name");
+        table.addCell("index", "alias:i,idx;desc:index alias points to");
+        table.addCell("filter", "alias:f,fi;desc:filter");
+        table.addCell("routing.index", "alias:ri,routingIndex;desc:index routing");
+        table.addCell("routing.search", "alias:rs,routingSearch;desc:search routing");
         table.endHeaders();
         return table;
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -114,14 +114,14 @@ public class RestAllocationAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         final Table table = new Table();
         table.startHeaders();
-        table.addCell("shards", "text-align:right;desc:number of shards on node");
-        table.addCell("diskUsed", "text-align:right;desc:disk used (total, not just ES)");
-        table.addCell("diskAvail", "text-align:right;desc:disk available");
-        table.addCell("diskTotal", "text-align:right;desc:total capacity of all volumes");
-        table.addCell("diskPercent", "text-align:right;desc:percent disk used");
-        table.addCell("host", "desc:host of node");
+        table.addCell("shards", "alias:s;text-align:right;desc:number of shards on node");
+        table.addCell("disk.used", "alias:du,diskUsed;text-align:right;desc:disk used (total, not just ES)");
+        table.addCell("disk.avail", "alias:da,diskAvail;text-align:right;desc:disk available");
+        table.addCell("disk.total", "alias:dt,diskTotal;text-align:right;desc:total capacity of all volumes");
+        table.addCell("disk.percent", "alias:dp,diskPercent;text-align:right;desc:percent disk used");
+        table.addCell("host", "alias:h;desc:host of node");
         table.addCell("ip", "desc:ip of node");
-        table.addCell("node", "desc:name of node");
+        table.addCell("node", "alias:n;desc:name of node");
         table.endHeaders();
         return table;
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -99,9 +99,9 @@ public class RestCountAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         Table table = new Table();
         table.startHeaders();
-        table.addCell("epoch", "desc:seconds since 1970-01-01 00:00:00, that the count was executed");
-        table.addCell("timestamp", "desc:time that the count was executed");
-        table.addCell("count", "desc:the document count");
+        table.addCell("epoch", "alias:t,time;desc:seconds since 1970-01-01 00:00:00, that the count was executed");
+        table.addCell("timestamp", "alias:ts,hms;desc:time that the count was executed");
+        table.addCell("count", "alias:dc,docs.count,docsCount;desc:the document count");
         table.endHeaders();
         return table;
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -82,17 +82,17 @@ public class RestHealthAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         Table t = new Table();
         t.startHeaders();
-        t.addCell("epoch", "desc:seconds since 1970-01-01 00:00:00, that the count was executed");
-        t.addCell("timestamp", "desc:time that the count was executed");
-        t.addCell("cluster", "desc:cluster name");
-        t.addCell("status", "desc:health status");
-        t.addCell("nodeTotal", "text-align:right;desc:total number of nodes");
-        t.addCell("nodeData", "text-align:right;desc:number of nodes that can store data");
-        t.addCell("shards", "text-align:right;desc:total number of shards");
-        t.addCell("pri", "text-align:right;desc:number of primary shards");
-        t.addCell("relo", "text-align:right;desc:number of relocating nodes");
-        t.addCell("init", "text-align:right;desc:number of initializing nodes");
-        t.addCell("unassign", "text-align:right;desc:number of unassigned shards");
+        t.addCell("epoch", "alias:t,time;desc:seconds since 1970-01-01 00:00:00");
+        t.addCell("timestamp", "alias:ts,hms,hhmmss;desc:time in HH:MM:SS");
+        t.addCell("cluster", "alias:cl;desc:cluster name");
+        t.addCell("status", "alias:st;desc:health status");
+        t.addCell("node.total", "alias:nt,nodeTotal;text-align:right;desc:total number of nodes");
+        t.addCell("node.data", "alias:nd,nodeData;text-align:right;desc:number of nodes that can store data");
+        t.addCell("shards", "alias:t,sh,shards.total,shardsTotal;text-align:right;desc:total number of shards");
+        t.addCell("pri", "alias:p,shards.primary,shardsPrimary;text-align:right;desc:number of primary shards");
+        t.addCell("relo", "alias:r,shards.relocating,shardsRelocating;text-align:right;desc:number of relocating nodes");
+        t.addCell("init", "alias:i,shards.initializing,shardsInitializing;text-align:right;desc:number of initializing nodes");
+        t.addCell("unassign", "alias:u,shards.unassigned,shardsUnassigned;text-align:right;desc:number of unassigned shards");
         t.endHeaders();
 
         return t;

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -126,12 +126,12 @@ public class RestIndicesAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         Table table = new Table();
         table.startHeaders();
-        table.addCell("health", "desc:current health status");
-        table.addCell("index", "desc:index name");
-        table.addCell("pri", "text-align:right;desc:number of primary shards");
-        table.addCell("rep", "text-align:right;desc:number of replica shards");
-        table.addCell("docs.count", "alias:docsCount;text-align:right;desc:available docs");
-        table.addCell("docs.deleted", "alias:docsDeleted;text-align:right;desc:deleted docs");
+        table.addCell("health", "alias:h;desc:current health status");
+        table.addCell("index", "alias:i,idx;desc:index name");
+        table.addCell("pri", "alias:p,shards.primary,shardsPrimary;text-align:right;desc:number of primary shards");
+        table.addCell("rep", "alias:r,shards.replica,shardsReplica;text-align:right;desc:number of replica shards");
+        table.addCell("docs.count", "alias:dc,docsCount;text-align:right;desc:available docs");
+        table.addCell("docs.deleted", "alias:dd,docsDeleted;text-align:right;desc:deleted docs");
 
         table.addCell("store.size", "sibling:pri;alias:ss,storeSize;text-align:right;desc:store size of primaries & replicas");
         table.addCell("pri.store.size", "text-align:right;desc:store size of primaries");

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -84,9 +84,9 @@ public class RestMasterAction extends AbstractCatAction {
         Table table = new Table();
         table.startHeaders()
                 .addCell("id", "desc:node id")
-                .addCell("host", "desc:host name")
+                .addCell("host", "alias:h;desc:host name")
                 .addCell("ip", "desc:ip address ")
-                .addCell("node", "desc:node name")
+                .addCell("node", "alias:n;desc:node name")
                 .endHeaders();
         return table;
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -124,26 +124,26 @@ public class RestNodesAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         Table table = new Table();
         table.startHeaders();
-        table.addCell("nodeId", "default:false;desc:unique node id");
-        table.addCell("pid", "default:false;desc:process id");
-        table.addCell("host", "desc:host name");
-        table.addCell("ip", "desc:ip address");
-        table.addCell("port", "default:false;desc:bound transport port");
+        table.addCell("id", "default:false;alias:id,nodeId;desc:unique node id");
+        table.addCell("pid", "default:false;alias:p;desc:process id");
+        table.addCell("host", "alias:h;desc:host name");
+        table.addCell("ip", "alias:i;desc:ip address");
+        table.addCell("port", "default:false;alias:po;desc:bound transport port");
 
         table.addCell("version", "default:false;alias:v;desc:es version");
         table.addCell("build", "default:false;alias:b;desc:es build hash");
-        table.addCell("jdk", "default:false;desc:jdk version");
-        table.addCell("diskAvail", "default:false;text-align:right;desc:available disk space");
-        table.addCell("heapPercent", "text-align:right;desc:used heap ratio");
-        table.addCell("heapMax", "default:false;text-align:right;desc:max configured heap");
-        table.addCell("ramPercent", "text-align:right;desc:used machine memory ratio");
-        table.addCell("ramMax", "default:false;text-align:right;desc:total machine memory");
+        table.addCell("jdk", "default:false;alias:j;desc:jdk version");
+        table.addCell("disk.avail", "default:false;alias:d,disk,diskAvail;text-align:right;desc:available disk space");
+        table.addCell("heap.percent", "alias:hp,heapPercent;text-align:right;desc:used heap ratio");
+        table.addCell("heap.max", "default:false;alias:hm,heapMax;text-align:right;desc:max configured heap");
+        table.addCell("ram.percent", "alias:rp,ramPercent;text-align:right;desc:used machine memory ratio");
+        table.addCell("ram.max", "default:false;alias:rm,ramMax;text-align:right;desc:total machine memory");
 
-        table.addCell("load", "text-align:right;desc:most recent load avg");
-        table.addCell("uptime", "default:false;text-align:right;desc:node uptime");
-        table.addCell("data/client", "desc:d:data node, c:client node");
-        table.addCell("master", "desc:m:master-eligible, *:current master");
-        table.addCell("name", "desc:node name");
+        table.addCell("load", "alias:l;text-align:right;desc:most recent load avg");
+        table.addCell("uptime", "default:false;alias:u;text-align:right;desc:node uptime");
+        table.addCell("node.role", "alias:r,role,dc,nodeRole;desc:d:data node, c:client node");
+        table.addCell("master", "alias:m;desc:m:master-eligible, *:current master");
+        table.addCell("name", "alias:n;desc:node name");
 
         table.addCell("completion.size", "alias:cs,completionSize;default:false;text-align:right;desc:size of completion");
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -139,10 +139,6 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("ramPercent", "text-align:right;desc:used machine memory ratio");
         table.addCell("ramMax", "default:false;text-align:right;desc:total machine memory");
 
-        table.addCell("fielddata", "default:false;text-align:right;desc:used fielddata cache");
-        table.addCell("filter", "default:false;text-align:right;desc:used filter cache");
-        table.addCell("idCache", "default:false;text-align:right;desc:used id cache");
-
         table.addCell("load", "text-align:right;desc:most recent load avg");
         table.addCell("uptime", "default:false;text-align:right;desc:node uptime");
         table.addCell("data/client", "desc:d:data node, c:client node");
@@ -240,10 +236,6 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(info == null ? null : info.getJvm().getMem().getHeapMax());
             table.addCell(stats == null ? null : stats.getOs().mem() == null ? null : stats.getOs().mem().usedPercent());
             table.addCell(info == null ? null : info.getOs().mem() == null ? null : info.getOs().mem().total()); // sigar fails to load in IntelliJ
-
-            table.addCell(stats == null ? null : stats.getIndices().getFieldData().getMemorySize());
-            table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getMemorySize());
-            table.addCell(stats == null ? null : stats.getIndices().getIdCache().getMemorySize());
 
             table.addCell(stats == null ? null : stats.getOs() == null ? null : stats.getOs().getLoadAverage().length < 1 ? null : String.format(Locale.ROOT, "%.2f", stats.getOs().getLoadAverage()[0]));
             table.addCell(stats == null ? null : stats.getJvm().uptime());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -77,10 +77,10 @@ public class RestPendingClusterTasksAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         Table t = new Table();
         t.startHeaders();
-        t.addCell("insertOrder", "text-align:right;desc:task insertion order");
-        t.addCell("timeInQueue", "text-align:right;desc:how long task has been in queue");
-        t.addCell("priority", "desc:task priority");
-        t.addCell("source", "desc:task source");
+        t.addCell("insertOrder", "alias:o;text-align:right;desc:task insertion order");
+        t.addCell("timeInQueue", "alias:t;text-align:right;desc:how long task has been in queue");
+        t.addCell("priority", "alias:p;desc:task priority");
+        t.addCell("source", "alias:s;desc:task source");
         t.endHeaders();
         return t;
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -134,14 +134,14 @@ public class RestRecoveryAction extends AbstractCatAction {
     @Override
     Table getTableWithHeader(RestRequest request) {
         Table t = new Table();
-        t.startHeaders().addCell("index", "desc:index name")
-                .addCell("shard", "desc:shard name")
-                .addCell("target", "text-align:right;desc:bytes of source shard")
-                .addCell("recovered", "text-align:right;desc:bytes recovered so far")
-                .addCell("%", "text-align:right;desc:percent recovered so far")
-                .addCell("host", "desc:node host where source shard lives")
+        t.startHeaders().addCell("index", "alias:i,idx;desc:index name")
+                .addCell("shard", "alias:s,sh;desc:shard name")
+                .addCell("target", "alias:t;text-align:right;desc:bytes of source shard")
+                .addCell("recovered", "alias:r;text-align:right;desc:bytes recovered so far")
+                .addCell("percent", "alias:per,ratio;text-align:right;desc:percent recovered so far")
+                .addCell("host", "alias:h;desc:node host where source shard lives")
                 .addCell("ip", "desc:node ip where source shard lives")
-                .addCell("node", "desc:node name where source shard lives")
+                .addCell("node", "alias:n;desc:node name where source shard lives")
                 .endHeaders();
         return t;
     }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -105,14 +105,14 @@ public class RestShardsAction extends AbstractCatAction {
     Table getTableWithHeader(final RestRequest request) {
         Table table = new Table();
         table.startHeaders()
-                .addCell("index", "default:true;desc:index name")
-                .addCell("shard", "default:true;desc:shard name")
-                .addCell("prirep", "alias:pr,primaryOrReplica;default:true;desc:primary or replica")
-                .addCell("state", "default:true;desc:shard state")
-                .addCell("docs", "text-align:right;desc:number of docs in shard")
-                .addCell("store", "text-align:right;desc:store size of shard (how much disk it uses)")
+                .addCell("index", "default:true;alias:i,idx;desc:index name")
+                .addCell("shard", "default:true;alias:s,sh;desc:shard name")
+                .addCell("prirep", "alias:p,pr,primaryOrReplica;default:true;desc:primary or replica")
+                .addCell("state", "default:true;alias:st;desc:shard state")
+                .addCell("docs", "alias:d,dc;text-align:right;desc:number of docs in shard")
+                .addCell("store", "alias:sto;text-align:right;desc:store size of shard (how much disk it uses)")
                 .addCell("ip", "default:true;desc:ip of node where it lives")
-                .addCell("node", "default:true;desc:name of node where it lives");
+                .addCell("node", "default:true;alias:n;desc:name of node where it lives");
 
         table.addCell("completion.size", "alias:cs,completionSize;default:false;text-align:right;desc:size of completion");
 


### PR DESCRIPTION
Remove duplicate cache columns, add aliases, normalize header names across actions.

For example:

```
==== nodes ====
id                       | id,nodeId                 | unique node id
pid                      | p                         | process id
host                     | h                         | host name
ip                       | i                         | ip address
port                     | po                        | bound transport port
version                  | v                         | es version
build                    | b                         | es build hash
jdk                      | j                         | jdk version
disk.avail               | d,disk,diskAvail          | available disk space
heap.percent             | hp,heapPercent            | used heap ratio
heap.max                 | hm,heapMax                | max configured heap
ram.percent              | rp,ramPercent             | used machine memory ratio
ram.max                  | rm,ramMax                 | total machine memory
load                     | l                         | most recent load avg
uptime                   | u                         | node uptime
node.type                | type,dc,nodeType          | d:data node, c:client node
master                   | m                         | m:master-eligible, *:current master
name                     | n                         | node name
completion.size          | cs,completionSize         | size of completion
fielddata.memory_size    | fm,fielddataMemory        | used fielddata cache
fielddata.evictions      | fe,fielddataEvictions     | fielddata evictions
filter_cache.memory_size | fcm,filterCacheMemory     | used filter cache
```

Closes #4852
