### PR TITLE
Percolator response always returns the `matches` key.

### DIFF
--- a/rest-api-spec/test/percolate/17_empty.yaml
+++ b/rest-api-spec/test/percolate/17_empty.yaml
@@ -1,0 +1,31 @@
+---
+"Basic percolation tests on an empty cluster":
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      percolate:
+        index: test_index
+        type:  test_type
+        body:
+          doc:
+            foo: bar
+
+  - match: {'total': 0}
+  - match: {'matches': []}
+
+  - do:
+      count_percolate:
+        index: test_index
+        type:  test_type
+        body:
+          doc:
+            foo: bar
+
+  - is_false:  matches
+  - match: {'total': 0}

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateResponse.java
@@ -42,7 +42,7 @@ import java.util.*;
  */
 public class PercolateResponse extends BroadcastOperationResponse implements Iterable<PercolateResponse.Match>, ToXContent {
 
-    private static final Match[] EMPTY = new Match[0];
+    public static final Match[] EMPTY = new Match[0];
 
     private long tookInMillis;
     private Match[] matches;
@@ -60,10 +60,10 @@ public class PercolateResponse extends BroadcastOperationResponse implements Ite
         this.aggregations = aggregations;
     }
 
-    public PercolateResponse(int totalShards, int successfulShards, int failedShards, List<ShardOperationFailedException> shardFailures, long tookInMillis) {
+    public PercolateResponse(int totalShards, int successfulShards, int failedShards, List<ShardOperationFailedException> shardFailures, long tookInMillis, Match[] matches) {
         super(totalShards, successfulShards, failedShards, shardFailures);
         this.tookInMillis = tookInMillis;
-        this.matches = EMPTY;
+        this.matches = matches;
     }
 
     PercolateResponse() {
@@ -116,7 +116,7 @@ public class PercolateResponse extends BroadcastOperationResponse implements Ite
         RestActions.buildBroadcastShardsHeader(builder, this);
 
         builder.field(Fields.TOTAL, count);
-        if (matches.length != 0) {
+        if (matches != null) {
             builder.startArray(Fields.MATCHES);
             boolean justIds = "ids".equals(params.param("percolate_format"));
             if (justIds) {

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -155,7 +155,8 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
 
         if (shardResults == null) {
             long tookInMillis = System.currentTimeMillis() - request.startTime;
-            return new PercolateResponse(shardsResponses.length(), successfulShards, failedShards, shardFailures, tookInMillis);
+            PercolateResponse.Match[] matches = request.onlyCount() ? null : PercolateResponse.EMPTY;
+            return new PercolateResponse(shardsResponses.length(), successfulShards, failedShards, shardFailures, tookInMillis, matches);
         } else {
             PercolatorService.ReduceResult result = percolatorService.reduce(percolatorTypeId, shardResults);
             long tookInMillis = System.currentTimeMillis() - request.startTime;

--- a/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -811,7 +811,7 @@ public class PercolatorService extends AbstractComponent {
 
         public ReduceResult(long count, InternalFacets reducedFacets, InternalAggregations reducedAggregations) {
             this.count = count;
-            this.matches = EMPTY;
+            this.matches = null;
             this.reducedFacets = reducedFacets;
             this.reducedAggregations = reducedAggregations;
         }


### PR DESCRIPTION
Relates to  #4881
