### PR TITLE
Install SecurityManager inside ElasticsearchTestCase for easier randomization

### DIFF
--- a/dev-tools/build_randomization.rb
+++ b/dev-tools/build_randomization.rb
@@ -66,17 +66,19 @@ def get_env_matrix(data_array)
   tests_nightly = get_random_one([false]) #bug
 
   test_assert_off = (rand(10) == 9) #10 percent chance turning it off 
-
+  tests_security_manager = (rand(10) != 9) #10 percent chance running without security manager
+  arg_line = [es_test_jvm_option1, es_test_jvm_option2, es_test_jvm_option3]
   [*data_array].map do |x|
     data_hash = {
       'PATH' => File.join(x,'bin') + ':' + ENV['PATH'],
       'JAVA_HOME' => x,
-      'BUILD_DESC' => "%s,%s,%s%s,%s %s%s"%[File.basename(x), es_node_mode, tests_nightly ? 'nightly,':'',
+      'BUILD_DESC' => "%s,%s,%s%s,%s %s%s%s"%[File.basename(x), es_node_mode, tests_nightly ? 'nightly,':'',
                                             es_test_jvm_option1[1..-1], es_test_jvm_option2[4..-1], es_test_jvm_option3[4..-1],
-                                            test_assert_off ? ',assert off' : ''], 
+                                            test_assert_off ? ',assert off' : '', tests_security_manager ? ', security manager enabled' : ''], 
       'es.node.mode' => es_node_mode,
       'tests.nightly' => tests_nightly,
-      'tests.jvm.argline' => "%s %s %s"%[es_test_jvm_option1, es_test_jvm_option2, es_test_jvm_option3],
+      'tests.security.manager' => tests_security_manager,
+      'tests.jvm.argline' => arg_line.join(" "),
     }
     data_hash['tests.assertion.disabled'] = 'org.elasticsearch' if test_assert_off
     data_hash

--- a/pom.xml
+++ b/pom.xml
@@ -439,9 +439,9 @@
                                 <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
                                 <es.node.mode>${es.node.mode}</es.node.mode>
                                 <es.logger.level>${es.logger.level}</es.logger.level>
+                                <tests.security.manager>${tests.security.manager}</tests.security.manager>
                                 <java.awt.headless>true</java.awt.headless>
                                 <!-- everything below is for security manager / test.policy -->
-                                <java.security.manager/>
                                 <junit4.tempDir>${project.build.directory}</junit4.tempDir>
                                 <java.security.policy>${basedir}/dev-tools/tests.policy</java.security.policy>
                             </systemProperties>

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -28,6 +28,7 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.Version;
 import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
@@ -64,11 +65,19 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
 
     public static final String CHILD_VM_ID = System.getProperty("junit4.childvm.id", "" + System.currentTimeMillis());
 
+    public static final String TESTS_SECURITY_MANAGER = System.getProperty("tests.security.manager");
+
+    public static final String JAVA_SECURTY_POLICY = System.getProperty("java.security.policy");
+
     public static final boolean ASSERTIONS_ENABLED;
     static {
         boolean enabled = false;
         assert enabled = true;
         ASSERTIONS_ENABLED = enabled;
+        if (Boolean.parseBoolean(Strings.hasLength(TESTS_SECURITY_MANAGER) ? TESTS_SECURITY_MANAGER : "true") && JAVA_SECURTY_POLICY != null) {
+            System.setSecurityManager(new SecurityManager());
+        }
+
     }
 
     public static boolean awaitBusy(Predicate<?> breakPredicate) throws InterruptedException {

--- a/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -131,7 +131,7 @@ public class ReproduceInfoPrinter extends RunListener {
 
         public ReproduceErrorMessageBuilder appendESProperties() {
             appendProperties("es.logger.level", "es.node.mode", "es.node.local", TestCluster.TESTS_ENABLE_MOCK_MODULES,
-                    "tests.assertion.disabled");
+                    "tests.assertion.disabled", "tests.security.manager");
             if (System.getProperty("tests.jvm.argline") != null && !System.getProperty("tests.jvm.argline").isEmpty()) {
                 appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");
             }


### PR DESCRIPTION
We currently run always with SecurityManager installed. To make sure we work also without we should randomly swap it out ie. run without the security manager.
