### PR TITLE
Cluster state toXContent serialization only returns needed data

### DIFF
--- a/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/api/cluster.state.json
@@ -16,7 +16,7 @@
         },
         "metric" : {
           "type" : "list",
-          "options" : ["_all", "blocks", "index_templates", "metadata", "nodes", "routing_table"],
+          "options" : ["_all", "blocks", "metadata", "nodes", "routing_table"],
           "description" : "Limit the information returned to the specified metrics"
         }
       },
@@ -28,6 +28,10 @@
         "master_timeout": {
           "type": "time",
           "description": "Specify timeout for connection to master"
+        },
+        "index_templates": {
+          "type": "list",
+          "description": "A comma separated list to return specific index templates when returning metadata"
         },
         "flat_settings": {
           "type": "boolean",

--- a/rest-api-spec/test/cluster.state/20_filtering.yaml
+++ b/rest-api-spec/test/cluster.state/20_filtering.yaml
@@ -1,0 +1,164 @@
+setup:
+  - do:
+      index:
+        index: testidx
+        type:  testtype
+        id:    testing_document
+        body:
+            "text" : "The quick brown fox is brown."
+  - do:
+      indices.refresh: {}
+
+---
+"Filtering the cluster state by blocks should return the blocks field even if the response is empty":
+  - do:
+      cluster.state:
+        metric: [ blocks ]  
+  
+  - is_true: blocks
+  - is_false: nodes
+  - is_false: metadata
+  - is_false: routing_table
+  - is_false: routing_nodes
+  - is_false: allocations
+  - length:   { blocks: 0 }
+
+---
+"Filtering the cluster state by blocks should return the blocks":
+# read only index
+# TODO: can this cause issues leaving it read only when deleting it in teardown
+  - do:
+      indices.put_settings:
+        index: testidx
+        body:
+          index.blocks.read_only: true
+  - do:
+      cluster.state:
+        metric: [ blocks ]  
+
+  - is_true: blocks
+  - is_false: nodes
+  - is_false: metadata
+  - is_false: routing_table
+  - is_false: routing_nodes
+  - is_false: allocations
+  - length:   { blocks: 1 }
+
+---
+"Filtering the cluster state by nodes only should work":
+  - do:
+      cluster.state:
+        metric: [ nodes ] 
+  
+  - is_false: blocks
+  - is_true: nodes
+  - is_false: metadata
+  - is_false: routing_table
+  - is_false: routing_nodes
+  - is_false: allocations
+
+---
+"Filtering the cluster state by metadata only should work":
+  - do:
+      cluster.state:
+        metric: [ metadata ] 
+  
+  - is_false: blocks
+  - is_false: nodes
+  - is_true: metadata
+  - is_false: routing_table
+  - is_false: routing_nodes
+  - is_false: allocations
+
+
+---
+"Filtering the cluster state by routing table only should work":
+  - do:
+      cluster.state:
+        metric: [ routing_table ] 
+  
+  - is_false: blocks
+  - is_false: nodes
+  - is_false: metadata
+  - is_true: routing_table
+  - is_true: routing_nodes
+  - is_true: allocations
+
+
+---
+"Filtering the cluster state for specific index templates should work ":
+  - do:
+      indices.put_template:
+        name: test1
+        body:
+          template: test-*
+          settings:
+            number_of_shards:   1
+  
+  - do:
+      indices.put_template:
+        name: test2
+        body:
+          template: test-*
+          settings:
+            number_of_shards:   2
+
+  - do:
+      indices.put_template:
+        name: foo
+        body:
+          template: foo-*
+          settings:
+            number_of_shards:   3
+  - do:
+      cluster.state:
+        metric: [ metadata ]
+        index_templates: [ test1, test2 ]
+  
+  - is_false: blocks
+  - is_false: nodes
+  - is_true: metadata
+  - is_false: routing_table
+  - is_false: routing_nodes
+  - is_false: allocations
+  - is_true: metadata.templates.test1
+  - is_true: metadata.templates.test2
+  - is_false: metadata.templates.foo
+
+---
+"Filtering the cluster state by indices should work in routing table and metadata":
+  - do:
+      index:
+        index: another
+        type:  type
+        id:    testing_document
+        body:
+            "text" : "The quick brown fox is brown."
+  
+  - do:
+      indices.refresh: {}
+
+  - do:
+      cluster.state:
+        metric: [ routing_table, metadata ]
+        index: [ testidx ]
+  
+  - is_false: metadata.indices.another
+  - is_false: routing_table.indices.another
+  - is_true: metadata.indices.testidx
+  - is_true: routing_table.indices.testidx
+
+---
+"Filtering the cluster state using _all for indices and metrics should work":
+  - do:
+      cluster.state:
+        metric: [ '_all' ] 
+        index: [ '_all' ] 
+  
+  - is_true: blocks
+  - is_true: nodes
+  - is_true: metadata
+  - is_true: routing_table
+  - is_true: routing_nodes
+  - is_true: allocations
+


### PR DESCRIPTION
In order to make sure, that only the requested data is returned to the client,
a couple of fixes have been applied in the ClusterState.toXContent() method.
Also some tests were added to the yaml test suite

Closes #4885
