### PR TITLE
mget REST API should support source parameter

### DIFF
--- a/rest-api-spec/api/mget.json
+++ b/rest-api-spec/api/mget.json
@@ -32,6 +32,10 @@
           "type" : "boolean",
           "description" : "Refresh the shard containing the document before performing the operation"
         },
+        "source": {
+          "type" : "string",
+          "description" : "The URL-encoded request definition using the Query DSL (instead of using request body)"
+        },
         "_source": {
           "type" : "list",
           "description" : "True or false to return the _source field or not, or a list of fields to return"
@@ -48,7 +52,7 @@
     },
     "body": {
       "description" : "Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.",
-      "required" : true
+      "required" : false
     }
   }
 }

--- a/rest-api-spec/test/mget/55_source.yaml
+++ b/rest-api-spec/test/mget/55_source.yaml
@@ -1,0 +1,27 @@
+---
+"Source":
+
+ - do:
+      indices.create:
+          index: test_1
+ - do:
+      cluster.health:
+          wait_for_status: yellow
+
+ - do:
+      index:
+          index:   test_1
+          type:    test
+          id:      1
+          body:    { foo: bar }
+
+ - do:
+      mget:
+        index:  test_1
+        type:   test
+        source: "{\"ids\":[\"1\"]}"
+
+ - is_true:  docs.0.found
+ - match:   { docs.0._index:          test_1 }
+ - match:   { docs.0._type:           test   }
+ - match:   { docs.0._id:             "1"    }

--- a/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -71,8 +73,18 @@ public class RestMultiGetAction extends BaseRestHandler {
 
         FetchSourceContext defaultFetchSource = FetchSourceContext.parseFromRestRequest(request);
 
+        BytesReference content = null;
+        if (request.hasContent()) {
+            content = request.content();
+        } else {
+            String source = request.param("source");
+            if (source != null) {
+                content = new BytesArray(source);
+            }
+        }
+
         try {
-            multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource, request.param("routing"), request.content(), allowExplicitIndex);
+            multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource, request.param("routing"), content, allowExplicitIndex);
         } catch (Exception e) {
             try {
                 XContentBuilder builder = restContentBuilder(request);


### PR DESCRIPTION
As stated in documentation, we should support `?source=` parameter in mget REST operations.

This is how to reproduce it:

``` sh
curl -XDELETE "http://localhost:9200/test"

curl -XPOST "http://localhost:9200/test/type/1?refresh" -d'{
    "foo": "bar"
}'

# This one works
curl -XPOST "http://localhost:9200/test/type/_mget" -d'{
    "ids": ["1"]
}'

# This one gives: {"error":"Failed to derive xcontent from org.elasticsearch.common.bytes.BytesArray@0"}
curl -XGET "http://localhost:9200/test/type/_mget?source=%7B%22ids%22%3A%20%5B%221%22%5D%7D"
```

Closes #4892.
