### PR TITLE
Upgrade to Lucene 4.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <properties>
-        <lucene.version>4.6.0</lucene.version>
+        <lucene.version>4.6.1</lucene.version>
         <tests.jvms>1</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1119,15 +1119,9 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         }
     }
 
-    /*this is only used by one test right now and shoudl go away entirely once we update lucene*/
-    private static boolean allowRamBytesUsed = false;
-    static {
-        assert Version.CURRENT.luceneVersion == org.apache.lucene.util.Version.LUCENE_46 :
-                "when upgrading to a new lucene version, check if ramBytes is fixed, see https://issues.apache.org/jira/browse/LUCENE-5373";
-    }
 
     private long getReaderRamBytesUsed(AtomicReaderContext reader) {
-        return allowRamBytesUsed ? SegmentReaderUtils.segmentReader(reader.reader()).ramBytesUsed() : 0;
+        return SegmentReaderUtils.segmentReader(reader.reader()).ramBytesUsed();
     }
 
     @Override


### PR DESCRIPTION
This upgrade includes a fix for RAM estimation on IndexReader
that allows to expose the amount of used bytes per segment now
as a setting in Elasticsearch. (LUCENE-5373)

Additionally this bugfix release contained a small fix for highlighting
that was already ported to Elasticsearch when reported (LUCENE-5361)

Closes #4897
