### PR TITLE
msearch REST API should support source parameter

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -25,6 +25,8 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -67,8 +69,18 @@ public class RestMultiSearchAction extends BaseRestHandler {
         String[] types = Strings.splitStringByCommaToArray(request.param("type"));
         IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, multiSearchRequest.indicesOptions());
 
+        BytesReference content = null;
+        if (request.hasContent()) {
+            content = request.content();
+        } else {
+            String source = request.param("source");
+            if (source != null) {
+                content = new BytesArray(source);
+            }
+        }
+
         try {
-            multiSearchRequest.add(request.content(), request.contentUnsafe(), indices, types, request.param("search_type"), request.param("routing"), indicesOptions, allowExplicitIndex);
+            multiSearchRequest.add(content, request.contentUnsafe(), indices, types, request.param("search_type"), request.param("routing"), indicesOptions, allowExplicitIndex);
         } catch (Exception e) {
             try {
                 XContentBuilder builder = restContentBuilder(request);


### PR DESCRIPTION
As stated in documentation, we should support `?source=` parameter in msearch REST operations.

This is how to reproduce it:

``` sh
curl -XDELETE "http://localhost:9200/test"

curl -XPOST "http://localhost:9200/test/type/1?refresh" -d'{
    "foo": "bar"
}'

cat requests
{}
{"query" : {"match_all" : {}}}

# This one works
curl -XGET localhost:9200/_msearch --data-binary @requests

# This one gives: {"error":"Failed to derive xcontent from org.elasticsearch.common.bytes.BytesArray@0"}
curl -XGET "http://localhost:9200/test/type/_mget?source=%7B%7D%0A%7B%22query%22%3A%7B%22match_all%22%3A%7B%7D%7D%7D%0A"
```

Closes #4901.
