### PR TITLE
mpercolate REST API should support source parameter

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.percolate.MultiPercolateResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -64,8 +66,18 @@ public class RestMultiPercolateAction extends BaseRestHandler {
         multiPercolateRequest.indices(Strings.splitStringByCommaToArray(restRequest.param("index")));
         multiPercolateRequest.documentType(restRequest.param("type"));
 
+        BytesReference content = null;
+        if (restRequest.hasContent()) {
+            content = restRequest.content();
+        } else {
+            String source = restRequest.param("source");
+            if (source != null) {
+                content = new BytesArray(source);
+            }
+        }
+
         try {
-            multiPercolateRequest.add(restRequest.content(), restRequest.contentUnsafe(), allowExplicitIndex);
+            multiPercolateRequest.add(content, restRequest.contentUnsafe(), allowExplicitIndex);
         } catch (Exception e) {
             try {
                 restChannel.sendResponse(new XContentThrowableRestResponse(restRequest, e));


### PR DESCRIPTION
As stated in documentation, we should support `?source=` parameter in mpercolate REST operations.

This is how to reproduce it:

``` sh
curl -XDELETE "http://localhost:9200/test"

curl -XPUT "http://localhost:9200/test/.percolator/1" -d'
{
    "query" : {
        "match" : {
            "foo" : "bar"
        }
    }
}'

# This one works
curl -XPOST "http://localhost:9200/test/message/_mpercolate" -d '
{"percolate" : {}}
{"doc" : {"foo" : "bar is in foo"}}
'

# This one gives: BroadcastShardOperationFailedException[[test][2] ]; nested: PercolateException[failed to percolate]; nested: ElasticsearchIllegalArgumentException[Nothing to percolate];
curl -XGET "http://localhost:9200/test/message/_mpercolate?source=%7B%22percolate%22%3A%7B%7D%7D%0A%7B%22doc%22%3A%7B%22foo%22%3A%22bar is in foo%22%7D%7D%0A"
```

Closes #4900.
