### PR TITLE
percolate REST API should support source parameter

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestPercolateAction.java
@@ -26,6 +26,8 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -69,7 +71,18 @@ public class RestPercolateAction extends BaseRestHandler {
         percolateRequest.documentType(restRequest.param("type"));
         percolateRequest.routing(restRequest.param("routing"));
         percolateRequest.preference(restRequest.param("preference"));
-        percolateRequest.source(restRequest.content(), restRequest.contentUnsafe());
+
+        BytesReference content = null;
+        if (restRequest.hasContent()) {
+            content = restRequest.content();
+        } else {
+            String source = restRequest.param("source");
+            if (source != null) {
+                content = new BytesArray(source);
+            }
+        }
+
+        percolateRequest.source(content, restRequest.contentUnsafe());
 
         percolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, percolateRequest.indicesOptions()));
         executePercolate(percolateRequest, restRequest, restChannel);


### PR DESCRIPTION
As stated in documentation, we should support `?source=` parameter in percolate REST operations.

This is how to reproduce it:

``` sh
curl -XDELETE "http://localhost:9200/test"

curl -XPUT "http://localhost:9200/test/.percolator/1" -d'
{
    "query" : {
        "match" : {
            "foo" : "bar"
        }
    }
}'

# This one works
curl -XPOST "http://localhost:9200/test/message/_percolate" -d '{
  "doc" : {
    "foo" : "bar is in foo"
  }
}'

# This one gives: BroadcastShardOperationFailedException[[test][2] ]; nested: PercolateException[failed to percolate]; nested: ElasticsearchIllegalArgumentException[Nothing to percolate];
curl -XGET "http://localhost:9200/test/message/_percolate?source=%7B%22doc%22%3A%7B%22foo%22%3A%22bar%20is%20in%20foo%22%7D%7D"
```

Closes #4903.
