### PR TITLE
mtermvectors REST API should support source parameter

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
@@ -25,6 +25,8 @@ import org.elasticsearch.action.termvector.MultiTermVectorsResponse;
 import org.elasticsearch.action.termvector.TermVectorRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -59,8 +61,18 @@ public class RestMultiTermVectorsAction extends BaseRestHandler {
         RestTermVectorAction.readURIParameters(template, request);
         multiTermVectorsRequest.ids(Strings.commaDelimitedListToStringArray(request.param("ids")));
 
+        BytesReference content = null;
+        if (request.hasContent()) {
+            content = request.content();
+        } else {
+            String source = request.param("source");
+            if (source != null) {
+                content = new BytesArray(source);
+            }
+        }
+
         try {
-            multiTermVectorsRequest.add(template, request.content());
+            multiTermVectorsRequest.add(template, content);
         } catch (Throwable t) {
             try {
                 channel.sendResponse(new XContentThrowableRestResponse(request, t));


### PR DESCRIPTION
As stated in documentation, we should support `?source=` parameter in msearch REST operations.

This is how to reproduce it:

``` sh
curl -XDELETE "http://localhost:9200/test"

curl -XPOST "http://localhost:9200/test/type/1?refresh" -d'{
    "foo": "bar"
}'

# This one works
curl -XPOST "http://localhost:9200/test/type/_mtermvectors" -d'
{
    "ids" : ["1"]
}'

# This one gives: "ActionRequestValidationException[Validation Failed: 1: multi term vectors: no documents requested;]"
curl -XGET "http://localhost:9200/test/type/_mtermvectors?source=%7B%22ids%22%3A%5B%221%22%5D%7D"
```

Closes #4902.
