### PR TITLE
Throw exception if an additional field was placed inside the "query" body

### DIFF
--- a/rest-api-spec/test/search/issue4895.yaml
+++ b/rest-api-spec/test/search/issue4895.yaml
@@ -1,0 +1,36 @@
+---
+setup:
+  - do:
+      indices.create:
+          index:  test
+
+  - do:
+      index:
+          index:  test
+          type:   test
+          id:     1
+          body:
+              user : foo
+              amount : 35
+              data : some
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+---
+"Test with _local preference placed in query body - should fail":
+
+  - do:
+      catch: request
+      search:
+          index: test
+          type:  test
+          body:
+              query:
+                  term:
+                      data: some
+                  preference: _local
+              fields: [user,amount]
+
+

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.CacheRecycler;
@@ -574,6 +575,8 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     element.parse(parser, context);
                 } else if (token == null) {
                     break;
+                } else if ((token != XContentParser.Token.START_OBJECT)) {
+                    throw new ElasticsearchParseException("Expected field but got " + token.name() + " " + parser.currentName());
                 }
             }
         } catch (Throwable e) {

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -564,6 +564,10 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         try {
             parser = XContentFactory.xContent(source).createParser(source);
             XContentParser.Token token;
+            token = parser.nextToken();
+            if (token != XContentParser.Token.START_OBJECT) {
+                throw new ElasticsearchParseException("Expected START_OBJECT but got " + token.name() + " " + parser.currentName());
+            }
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     String fieldName = parser.currentName();
@@ -573,10 +577,12 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                         throw new SearchParseException(context, "No parser for element [" + fieldName + "]");
                     }
                     element.parse(parser, context);
-                } else if (token == null) {
-                    break;
-                } else if ((token != XContentParser.Token.START_OBJECT)) {
-                    throw new ElasticsearchParseException("Expected field but got " + token.name() + " " + parser.currentName());
+                } else {
+                    if (token == null) {
+                        throw new ElasticsearchParseException("End of query source reached but query is not complete.");
+                    } else {
+                        throw new ElasticsearchParseException("Expected field name but got " + token.name() + " \"" + parser.currentName() + "\"");
+                    }
                 }
             }
         } catch (Throwable e) {


### PR DESCRIPTION
Currently the parser accepts queries like

```
"query" : {
     "any_query": {
         ...
     },
     "any_field_name":...
}
```

The "any_field_name" is silently ignored. However, this also causes the parser
not to move to the next closing bracket which in turn can lead to additional query
paremters being ignored such as "fields", "highlight",...
This was the case in issue #4895

closes issue #4895
