### PR TITLE
Added support for aliases to create index api

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -185,12 +185,34 @@ Adding user alias:
 [source,js]
 --------------------------------------------------
 curl -XPUT 'localhost:9200/users/_alias/user_12' -d '{
-        "routing" : "12",
+    "routing" : "12",
     "filter" : {
         "term" : {
             "user_id" : 12
         }
     }       
+}'
+--------------------------------------------------
+
+[float]
+[[alias-index-creation]]
+=== Aliases during index creation
+
+coming[1.1.0]
+
+Aliases can also be specified during <<create-index-aliases,index creation>>:
+
+[source,js]
+--------------------------------------------------
+curl -XPUT localhost:9200/logs_20142801 -d '{
+    "aliases" : {
+        "current_day" : {},
+        "2014" : {
+            "filter" : {
+                "term" : {"year" : 2014 }
+            }
+        }
+    }
 }'
 --------------------------------------------------
 

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -103,3 +103,26 @@ curl -XPUT localhost:9200/test -d '{
     }
 }'
 --------------------------------------------------
+
+[float]
+[[create-index-aliases]]
+=== Aliases
+
+coming[1.1.0]
+
+The create index API allows also to provide a set of <<indices-aliases,aliases>>:
+
+[source,js]
+--------------------------------------------------
+curl -XPUT localhost:9200/test -d '{
+    "aliases" : {
+        "alias_1" : {},
+        "alias_2" : {
+            "filter" : {
+                "term" : {"user" : "kimchy" }
+            },
+            "routing" : "kimchy"
+        }
+    }
+}'
+--------------------------------------------------

--- a/rest-api-spec/test/indices.create/10_basic.yaml
+++ b/rest-api-spec/test/indices.create/10_basic.yaml
@@ -50,7 +50,35 @@
   - match: {test_index.warmers.test_warmer.source.query.match_all: {}}
 
 ---
-"Create index with mappings, settings and warmers":
+"Create index with aliases":
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          aliases:
+            test_alias: {}
+            test_blias:
+              routing: b
+            test_clias:
+              filter:
+                term:
+                  field : value
+
+  - do:
+      indices.get_alias:
+        index: test_index
+
+  - match: {test_index.aliases.test_alias: {}}
+  - match: {test_index.aliases.test_blias.search_routing: b}
+  - match: {test_index.aliases.test_blias.index_routing: b}
+  - is_false: test_index.aliases.test_blias.filter
+  - match: {test_index.aliases.test_clias.filter.term.field: value}
+  - is_false: test_index.aliases.test_clias.index_routing
+  - is_false: test_index.aliases.test_clias.search_routing
+
+---
+"Create index with mappings, settings, warmers and aliases":
 
   - do:
       indices.create:
@@ -65,6 +93,9 @@
               source:
                 query:
                   match_all: {}
+          aliases:
+            test_alias: {}
+            test_blias: {routing: b}
 
   - do:
       indices.get_mapping:
@@ -83,3 +114,11 @@
         index: test_index
 
   - match: { test_index.warmers.test_warmer.source.query.match_all: {}}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+
+  - match: { test_index.aliases.test_alias: {}}
+  - match: { test_index.aliases.test_blias.search_routing: b}
+  - match: { test_index.aliases.test_blias.index_routing: b}

--- a/rest-api-spec/test/indices.get_alias/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_alias/10_basic.yaml
@@ -4,30 +4,18 @@ setup:
   - do:
       indices.create:
         index: test_index
+        body:
+          aliases:
+            test_alias: {}
+            test_blias: {}
 
   - do:
       indices.create:
         index: test_index_2
-
-  - do:
-      indices.put_alias:
-        index: test_index
-        name: test_alias
-
-  - do:
-      indices.put_alias:
-        index: test_index
-        name: test_blias
-
-  - do:
-      indices.put_alias:
-        index: test_index_2
-        name: test_alias
-
-  - do:
-      indices.put_alias:
-        index: test_index_2
-        name: test_blias
+        body:
+          aliases:
+            test_alias: {}
+            test_blias: {}
 
 ---
 "Get all aliases via /_alias":

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.alias;
+
+import org.elasticsearch.ElasticsearchGenerationException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.index.query.FilterBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Represents an alias, to be associated with an index
+ */
+public class Alias implements Streamable {
+
+    private String name;
+
+    @Nullable
+    private String filter;
+
+    @Nullable
+    private String indexRouting;
+
+    @Nullable
+    private String searchRouting;
+
+    private Alias() {
+
+    }
+
+    public Alias(String name) {
+        this.name = name;
+    }
+
+    public Alias(String name, String filter) {
+        this.name = name;
+        this.filter = filter;
+    }
+
+    /**
+     * Returns the alias name
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the filter associated with the alias
+     */
+    public String filter() {
+        return filter;
+    }
+
+    /**
+     * Associates a filter to the alias
+     */
+    public Alias filter(String filter) {
+        this.filter = filter;
+        return this;
+    }
+
+    /**
+     * Associates a filter to the alias
+     */
+    public Alias filter(Map<String, Object> filter) {
+        if (filter == null || filter.isEmpty()) {
+            this.filter = null;
+            return this;
+        }
+        try {
+            XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+            builder.map(filter);
+            this.filter = builder.string();
+            return this;
+        } catch (IOException e) {
+            throw new ElasticsearchGenerationException("Failed to generate [" + filter + "]", e);
+        }
+    }
+
+    /**
+     * Associates a filter to the alias
+     */
+    public Alias filter(FilterBuilder filterBuilder) {
+        if (filterBuilder == null) {
+            this.filter = null;
+            return this;
+        }
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            filterBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.close();
+            this.filter = builder.string();
+            return this;
+        } catch (IOException e) {
+            throw new ElasticsearchGenerationException("Failed to build json for alias request", e);
+        }
+    }
+
+    /**
+     * Associates a routing value to the alias
+     */
+    public Alias routing(String routing) {
+        this.indexRouting = routing;
+        this.searchRouting = routing;
+        return this;
+    }
+
+    /**
+     * Returns the index routing value associated with the alias
+     */
+    public String indexRouting() {
+        return indexRouting;
+    }
+
+    /**
+     * Associates an index routing value to the alias
+     */
+    public Alias indexRouting(String indexRouting) {
+        this.indexRouting = indexRouting;
+        return this;
+    }
+
+    /**
+     * Returns the search routing value associated with the alias
+     */
+    public String searchRouting() {
+        return searchRouting;
+    }
+
+    /**
+     * Associates a search routing value to the alias
+     */
+    public Alias searchRouting(String searchRouting) {
+        this.searchRouting = searchRouting;
+        return this;
+    }
+
+    /**
+     * Allows to read an alias from the provided input stream
+     */
+    public static Alias read(StreamInput in) throws IOException {
+        Alias alias = new Alias();
+        alias.readFrom(in);
+        return alias;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        name = in.readString();
+        filter = in.readOptionalString();
+        indexRouting = in.readOptionalString();
+        searchRouting = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeOptionalString(filter);
+        out.writeOptionalString(indexRouting);
+        out.writeOptionalString(searchRouting);
+    }
+
+    /**
+     * Parses an alias and returns its parsed representation
+     */
+    public static Alias fromXContent(XContentParser parser) throws IOException {
+        Alias alias = new Alias(parser.currentName());
+
+        String currentFieldName = null;
+        XContentParser.Token token = parser.nextToken();
+        if (token == null) {
+            throw new ElasticsearchIllegalArgumentException("No alias is specified");
+        }
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if ("filter".equals(currentFieldName)) {
+                    Map<String, Object> filter = parser.mapOrdered();
+                    alias.filter(filter);
+                }
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                if ("routing".equals(currentFieldName)) {
+                    alias.routing(parser.text());
+                } else if ("index_routing".equals(currentFieldName) || "indexRouting".equals(currentFieldName) || "index-routing".equals(currentFieldName)) {
+                    alias.indexRouting(parser.text());
+                } else if ("search_routing".equals(currentFieldName) || "searchRouting".equals(currentFieldName) || "search-routing".equals(currentFieldName)) {
+                    alias.searchRouting(parser.text());
+                }
+            }
+        }
+        return alias;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Alias alias = (Alias) o;
+
+        if (name != null ? !name.equals(alias.name) : alias.name != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.create;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -44,11 +45,13 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     private Settings settings = ImmutableSettings.Builder.EMPTY_SETTINGS;
 
-    private Map<String, String> mappings = Maps.newHashMap();
+    private final Map<String, String> mappings = Maps.newHashMap();
 
-    private Map<String, IndexMetaData.Custom> customs = newHashMap();
+    private final Set<Alias> aliases = Sets.newHashSet();
 
-    private Set<ClusterBlock> blocks = Sets.newHashSet();
+    private final Map<String, IndexMetaData.Custom> customs = newHashMap();
+
+    private final Set<ClusterBlock> blocks = Sets.newHashSet();
 
 
     CreateIndexClusterStateUpdateRequest(String cause, String index) {
@@ -63,6 +66,11 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     public CreateIndexClusterStateUpdateRequest mappings(Map<String, String> mappings) {
         this.mappings.putAll(mappings);
+        return this;
+    }
+
+    public CreateIndexClusterStateUpdateRequest aliases(Set<Alias> aliases) {
+        this.aliases.addAll(aliases);
         return this;
     }
 
@@ -99,6 +107,10 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     public Map<String, String> mappings() {
         return mappings;
+    }
+
+    public Set<Alias> aliases() {
+        return aliases;
     }
 
     public Map<String, IndexMetaData.Custom> customs() {

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.create;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
@@ -146,6 +147,38 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
      */
     public CreateIndexRequestBuilder addMapping(String type, Object... source) {
         request.mapping(type, source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public CreateIndexRequestBuilder setAliases(Map source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public CreateIndexRequestBuilder setAliases(String source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public CreateIndexRequestBuilder setAliases(XContentBuilder source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Adds an alias that will be associated with the index when it gets created
+     */
+    public CreateIndexRequestBuilder addAlias(Alias alias) {
+        request.alias(alias);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -85,7 +85,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeOperationActi
         CreateIndexClusterStateUpdateRequest updateRequest = new CreateIndexClusterStateUpdateRequest(cause, request.index())
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .settings(request.settings()).mappings(request.mappings())
-                .customs(request.customs());
+                .aliases(request.aliases()).customs(request.customs());
 
         createIndexService.createIndex(updateRequest, new ClusterStateUpdateListener() {
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.IndexQueryParserService;
+import org.elasticsearch.indices.InvalidAliasNameException;
+
+/**
+ * Validator for an alias, to be used before adding an alias to the index metadata
+ * and make sure the alias is valid
+ */
+public class AliasValidator extends AbstractComponent {
+
+    @Inject
+    public AliasValidator(Settings settings) {
+        super(settings);
+    }
+
+    /**
+     * Allows to validate an {@link org.elasticsearch.cluster.metadata.AliasAction} and make sure
+     * it's valid before it gets added to the index metadata
+     */
+    public void validateAliasAction(AliasAction aliasAction, MetaData metaData) {
+        validateAlias(aliasAction.alias(), aliasAction.index(), aliasAction.indexRouting(), metaData);
+    }
+
+    /**
+     * Allows to validate an {@link org.elasticsearch.action.admin.indices.alias.Alias} and make sure
+     * it's valid before it gets added to the index metadata
+     */
+    public void validateAlias(Alias alias, String index, MetaData metaData) {
+        validateAlias(alias.name(), index, alias.indexRouting(), metaData);
+    }
+
+    private void validateAlias(String alias, String index, String indexRouting, MetaData metaData) {
+        assert metaData != null;
+        if (!Strings.hasText(alias) || !Strings.hasText(index)) {
+            throw new ElasticsearchIllegalArgumentException("index name and alias name are required");
+        }
+
+        if (metaData.hasIndex(alias)) {
+            throw new InvalidAliasNameException(new Index(index), alias, "an index exists with the same name as the alias");
+        }
+
+        if (indexRouting != null && indexRouting.indexOf(',') != -1) {
+            throw new ElasticsearchIllegalArgumentException("alias [" + alias + "] has several index routing values associated with it");
+        }
+    }
+
+    /**
+     * Validates an alias filter by parsing it using the
+     * provided {@link org.elasticsearch.index.query.IndexQueryParserService}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the filter is not valid
+     */
+    public void validateAliasFilter(String alias, String filter, IndexQueryParserService indexQueryParserService) {
+        assert indexQueryParserService != null;
+        try {
+            XContentParser parser = XContentFactory.xContent(filter).createParser(filter);
+            try {
+                indexQueryParserService.parseInnerFilter(parser);
+            } finally {
+                parser.close();
+            }
+        } catch (Throwable e) {
+            throw new ElasticsearchIllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);
+        }
+    }
+}


### PR DESCRIPTION
It is now possible to specify aliases during index creation:

```
curl -XPUT 'http://localhost:9200/test' -d '
{
    "aliases" : {
        "alias1" : {},
        "alias2" : {
            "filter" : { "term" : {"field":"value"}}
        }
    }
}'
```

Closes #4920
