### PR TITLE
Use num of actual threads if busiestThreads is larger

### DIFF
--- a/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -130,6 +130,7 @@ public class HotThreads {
             }
             // sort by delta CPU time on thread.
             List<MyThreadInfo> hotties = new ArrayList<MyThreadInfo>(threadInfos.values());
+            final int busiestThreads = Math.min(this.busiestThreads, hotties.size());
             // skip that for now
             CollectionUtil.introSort(hotties, new Comparator<MyThreadInfo>() {
                 public int compare(MyThreadInfo o1, MyThreadInfo o2) {


### PR DESCRIPTION
We currently use the number of hot threads that we are
interested in as the value for iterating over the actual
hot threads which can lead to AIOOB is the actual number
of threads is less than the given number.

Closes #4927
