### PR TITLE
Add explanations for all AllocationDeciders

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -109,7 +109,7 @@ public class TransportClusterRerouteAction extends TransportMasterNodeOperationA
 
             @Override
             public ClusterState execute(ClusterState currentState) {
-                RoutingAllocation.Result routingResult = allocationService.reroute(currentState, request.commands);
+                RoutingAllocation.Result routingResult = allocationService.reroute(currentState, request.commands, true);
                 ClusterState newState = ClusterState.builder(currentState).routingResult(routingResult).build();
                 clusterStateToSend = newState;
                 if (request.dryRun) {

--- a/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -153,4 +153,34 @@ public class DiscoveryNodeFilters {
             return true;
         }
     }
+
+    /**
+     * Generates a human-readable string for the DiscoverNodeFilters.
+     * Example: {@code _id:"id1 OR blah",name:"blah OR name2"}
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        int entryCount = filters.size();
+        for (Map.Entry<String, String[]> entry : filters.entrySet()) {
+            String attr = entry.getKey();
+            String[] values = entry.getValue();
+            sb.append(attr);
+            sb.append(":\"");
+            int valueCount = values.length;
+            for (String value : values) {
+                sb.append(value);
+                if (valueCount > 1) {
+                    sb.append(" " + opType.toString() + " ");
+                }
+                valueCount--;
+            }
+            sb.append("\"");
+            if (entryCount > 1) {
+                sb.append(",");
+            }
+            entryCount--;
+        }
+        return sb.toString();
+    }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.HashMap;
@@ -98,6 +99,8 @@ public class RoutingAllocation {
     private Map<ShardId, String> ignoredShardToNodes = null;
 
     private boolean ignoreDisable = false;
+
+    private boolean debugDecision = false;
 
     /**
      * Creates a new {@link RoutingAllocation}
@@ -173,6 +176,14 @@ public class RoutingAllocation {
         return this.ignoreDisable;
     }
 
+    public void debugDecision(boolean debug) {
+        this.debugDecision = debug;
+    }
+
+    public boolean debugDecision() {
+        return this.debugDecision;
+    }
+
     public void addIgnoreShardForNode(ShardId shardId, String nodeId) {
         if (ignoredShardToNodes == null) {
             ignoredShardToNodes = new HashMap<ShardId, String>();
@@ -182,5 +193,17 @@ public class RoutingAllocation {
 
     public boolean shouldIgnoreShardForNode(ShardId shardId, String nodeId) {
         return ignoredShardToNodes != null && nodeId.equals(ignoredShardToNodes.get(shardId));
+    }
+
+    /**
+     * Create a routing decision, including the reason if the debug flag is
+     * turned on
+     */
+    public Decision decision(Decision decision, String reason, Object... params) {
+        if (debugDecision()) {
+            return Decision.single(decision.type(), reason, params);
+        } else {
+            return decision;
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -52,7 +52,11 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canRebalance(shardRouting, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
-                return decision;
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
             } else if (decision != Decision.ALWAYS) {
                 ret.add(decision);
             }
@@ -73,7 +77,12 @@ public class AllocationDeciders extends AllocationDecider {
                 if (logger.isTraceEnabled()) {
                     logger.trace("Can not allocate [{}] on node [{}] due to [{}]", shardRouting, node.nodeId(), allocationDecider.getClass().getSimpleName());
                 }
-                return decision;
+                // short circuit only if debugging is not enabled
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
             } else if (decision != Decision.ALWAYS) {
                 // the assumption is that a decider that returns the static instance Decision#ALWAYS
                 // does not really implements canAllocate
@@ -99,7 +108,11 @@ public class AllocationDeciders extends AllocationDecider {
                 if (logger.isTraceEnabled()) {
                     logger.trace("Shard [{}] can not remain on node [{}] due to [{}]", shardRouting, node.nodeId(), allocationDecider.getClass().getSimpleName());
                 }
-                return decision;
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
             } else if (decision != Decision.ALWAYS) {
                 ret.add(decision);
             }
@@ -113,7 +126,11 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canAllocate(shardRouting, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
-                return decision;
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
             } else if (decision != Decision.ALWAYS) {
                 ret.add(decision);
             }
@@ -127,7 +144,11 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canAllocate(node, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
-                return decision;
+                if (!allocation.debugDecision()) {
+                    return decision;
+                } else {
+                    ret.add(decision);
+                }
             } else if (decision != Decision.ALWAYS) {
                 ret.add(decision);
             }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -19,15 +19,11 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import org.elasticsearch.cluster.routing.MutableShardRouting;
-import org.elasticsearch.cluster.routing.RoutingNode;
-import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.List;
 import java.util.Locale;
 
 /**
@@ -91,27 +87,27 @@ public class ClusterRebalanceAllocationDecider extends AllocationDecider {
         if (type == ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE) {
             // check if there are unassigned primaries.
             if ( allocation.routingNodes().hasUnassignedPrimaries() ) {
-                return Decision.NO;
+                return allocation.decision(Decision.NO, "cluster has unassigned primary shards");
             }
             // check if there are initializing primaries that don't have a relocatingNodeId entry.
             if ( allocation.routingNodes().hasInactivePrimaries() ) {
-                return Decision.NO;
+                return allocation.decision(Decision.NO, "cluster has inactive primary shards");
             }
 
-            return Decision.YES;
+            return allocation.decision(Decision.YES, "all primary shards are active");
         }
         if (type == ClusterRebalanceType.INDICES_ALL_ACTIVE) {
             // check if there are unassigned shards.
             if ( allocation.routingNodes().hasUnassignedShards() ) {
-                return Decision.NO;
+                return allocation.decision(Decision.NO, "cluster has unassigned shards");
             }
             // in case all indices are assigned, are there initializing shards which
             // are not relocating?
             if ( allocation.routingNodes().hasInactiveShards() ) {
-                return Decision.NO;
+                return allocation.decision(Decision.NO, "cluster has inactive shards");
             }
         }
         // type == Type.ALWAYS
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "all shards are active");
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -65,11 +65,12 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
     @Override
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
         if (clusterConcurrentRebalance == -1) {
-            return Decision.YES;
+            return allocation.decision(Decision.YES, "all concurrent rebalances are allowed");
         }
         if (allocation.routingNodes().getRelocatingShardCount() >= clusterConcurrentRebalance) {
-            return Decision.NO;
+            return allocation.decision(Decision.NO, "too man concurrent rebalances [%d], limit: [%d]",
+                    allocation.routingNodes().getRelocatingShardCount(), clusterConcurrentRebalance);
         }
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "below threshold [%d] for concurrent rebalances", clusterConcurrentRebalance);
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
@@ -39,8 +39,8 @@ public class RebalanceOnlyWhenActiveAllocationDecider extends AllocationDecider 
         // its ok to check for active here, since in relocation, a shard is split into two in routing
         // nodes, once relocating, and one initializing
         if (!allocation.routingNodes().allReplicasActive(shardRouting)) {
-            return Decision.NO;
+            return allocation.decision(Decision.NO, "not all replicas are active in cluster");
         }
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "all replicas are active in cluster");
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
@@ -43,12 +43,12 @@ public class ReplicaAfterPrimaryActiveAllocationDecider extends AllocationDecide
 
     public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
         if (shardRouting.primary()) {
-            return Decision.YES;
+            return allocation.decision(Decision.YES, "shard is primary");
         }
         MutableShardRouting primary = allocation.routingNodes().activePrimary(shardRouting);
         if (primary == null) {
-            return Decision.NO;
+            return allocation.decision(Decision.NO, "primary shard is not yet active");
         }
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "primary is already active");
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -60,7 +60,7 @@ public class SameShardAllocationDecider extends AllocationDecider {
         Iterable<MutableShardRouting> assignedShards = allocation.routingNodes().assignedShards(shardRouting);
         for (MutableShardRouting assignedShard : assignedShards) {
             if (node.nodeId().equals(assignedShard.currentNodeId())) {
-                return Decision.NO;
+                return allocation.decision(Decision.NO, "shard cannot be allocated on same node [%s] it already exists on", node.nodeId());
             }
         }
         if (sameHost) {
@@ -83,13 +83,14 @@ public class SameShardAllocationDecider extends AllocationDecider {
                     if (checkNodeOnSameHost) {
                         for (MutableShardRouting assignedShard : assignedShards) {
                             if (checkNode.nodeId().equals(assignedShard.currentNodeId())) {
-                                return Decision.NO;
+                                return allocation.decision(Decision.NO, "shard cannot be allocated on same host [%s] it already exists on",
+                                        node.nodeId());
                             }
                         }
                     }
                 }
             }
         }
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "shard is not allocated to same node or host");
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
@@ -65,7 +65,7 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
         IndexMetaData indexMd = allocation.routingNodes().metaData().index(shardRouting.index());
         int totalShardsPerNode = indexMd.settings().getAsInt(INDEX_TOTAL_SHARDS_PER_NODE, -1);
         if (totalShardsPerNode <= 0) {
-            return Decision.YES;
+            return allocation.decision(Decision.YES, "total shard limit disabled: [%d] <= 0", totalShardsPerNode);
         }
 
         int nodeCount = 0;
@@ -80,9 +80,10 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
             nodeCount++;
         }
         if (nodeCount >= totalShardsPerNode) {
-            return Decision.NO;
+            return allocation.decision(Decision.NO, "too many shards for this index on node [%d], limit: [%d]",
+                    nodeCount, totalShardsPerNode);
         }
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "shard count under limit [%d] of total shards per node", totalShardsPerNode);
     }
 
     @Override
@@ -90,7 +91,7 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
         IndexMetaData indexMd = allocation.routingNodes().metaData().index(shardRouting.index());
         int totalShardsPerNode = indexMd.settings().getAsInt(INDEX_TOTAL_SHARDS_PER_NODE, -1);
         if (totalShardsPerNode <= 0) {
-            return Decision.YES;
+            return allocation.decision(Decision.YES, "total shard limit disabled: [%d] <= 0", totalShardsPerNode);
         }
 
         int nodeCount = 0;
@@ -105,8 +106,9 @@ public class ShardsLimitAllocationDecider extends AllocationDecider {
             nodeCount++;
         }
         if (nodeCount > totalShardsPerNode) {
-            return Decision.NO;
+            return allocation.decision(Decision.NO, "too many shards for this index on node [%d], limit: [%d]",
+                    nodeCount, totalShardsPerNode);
         }
-        return Decision.YES;
+        return allocation.decision(Decision.YES, "shard count under limit [%d] of total shards per node", totalShardsPerNode);
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -85,9 +85,10 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
                     }
                 }
                 if (primariesInRecovery >= primariesInitialRecoveries) {
-                    return Decision.THROTTLE;
+                    return allocation.decision(Decision.THROTTLE, "too many primaries currently recovering [%d], limit: [%d]",
+                            primariesInRecovery, primariesInitialRecoveries);
                 } else {
-                    return Decision.YES;
+                    return allocation.decision(Decision.YES, "below primary recovery limit of [%d]", primariesInitialRecoveries);
                 }
             }
         }
@@ -106,9 +107,10 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             }
         }
         if (currentRecoveries >= concurrentRecoveries) {
-            return Decision.THROTTLE;
+            return allocation.decision(Decision.THROTTLE, "too many shards currently recovering [%d], limit: [%d]",
+                    currentRecoveries, concurrentRecoveries);
         } else {
-            return Decision.YES;
+            return allocation.decision(Decision.YES, "below shard recovery limit of [%d]", concurrentRecoveries);
         }
     }
 


### PR DESCRIPTION
This adds explanations for all of the allocation deciders for their `yes` and `no` answers. It should help when using the reroute API to explain why a shard can or cannot be moved to a different node.

I would like to move to a full explain-like API for shard allocation, but I wanted to submit this as a separate PR since it can easily be backported to all branches to be useful without any breaking changes.

I tried to keep the explanations short but distinct.

Related to #4380 and #2483
