### PR TITLE
scroll REST API should support source parameter

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.search.Scroll;
 
 import java.io.IOException;
@@ -56,8 +57,8 @@ public class RestSearchScrollAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         String scrollId = request.param("scroll_id");
-        if (scrollId == null && request.hasContent()) {
-            scrollId = request.content().toUtf8();
+        if (scrollId == null) {
+            scrollId = RestActions.getRestContent(request).toUtf8();
         }
         SearchScrollRequest searchScrollRequest = new SearchScrollRequest(scrollId);
         searchScrollRequest.listenerThreaded(false);


### PR DESCRIPTION
As stated in documentation, we should support `?source=` parameter in `/_search/scroll` REST operations.

This is how to reproduce it:

``` sh
curl -XDELETE "http://localhost:9200/test"
curl -XPOST "http://localhost:9200/test/type/1" -d'
{
    "foo": "bar"
}'

# This one works
curl -XPOST "http://localhost:9200/_search/scroll" -d "FAKESCROLLID"

# This one gives: {"error":"Failed to derive xcontent from org.elasticsearch.common.bytes.BytesArray@0"}
curl -XGET "http://localhost:9200/_search/scroll/?source=FAKESCROLLID"
```

Closes #4941.
