### PR TITLE
[TEST] Added REST test assertion that allows to test apis which don't return json

### DIFF
--- a/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/test/README.asciidoc
@@ -164,6 +164,17 @@ testing indexing a document without a specified ID:
     - match: { _id: $id } # the returned `response._id` matches the stashed `id`
 ....
 
+The last response obtained gets always stashed automatically as a string, called `body`.
+This is useful when needing to test apis that return text rather than json (e.g. cat api),
+as it allows to treat the whole body as an ordinary string field.
+
+Note that not only expected values can be retrieved from the stashed values (as in the
+example above), but the same goes for actual values:
+
+....
+    - match: { $body: /^.+$/ } # the returned `body` matches the provided regex
+....
+
 The stash should be reset at the beginning of each test file.
 
 === `is_true`
@@ -191,6 +202,15 @@ should be identical, eg:
 
 ....
     - match: { _source: { foo: bar }}
+....
+
+Supports also regular expressions with flag X for more readability (accepts whitespaces and comments):
+
+....
+  - match:
+      $body: >
+               /^  epoch  \s+  timestamp          \s+  count  \s+  \n
+                   \d+    \s+  \d{2}:\d{2}:\d{2}  \s+  \d+    \s+  \n  $/
 ....
 
 === `lt` and `gt`

--- a/rest-api-spec/test/cat.count/10_basic.yaml
+++ b/rest-api-spec/test/cat.count/10_basic.yaml
@@ -1,0 +1,77 @@
+---
+setup:
+  - skip:
+      features: regex
+
+---
+"Test cat count help":
+  - do:
+      cat.count:
+        help: true
+
+  - match:
+      $body: >
+               /^  epoch      .+   \n
+                   timestamp  .+   \n
+                   count      .+   \n  $/
+
+---
+"Test cat count output":
+
+  - do:
+      cat.count: {}
+
+  - match:
+      $body: >
+               /^  \d+  \s  \d{2}:\d{2}:\d{2}  \s  0  \s  $/
+
+  - do:
+      index:
+        index:  index1
+        type:   type1
+        id:     1
+        body:   { foo: bar }
+        refresh: true
+
+  - do:
+      cat.count: {}
+
+  - match:
+      $body: >
+               /^  \d+  \s  \d{2}:\d{2}:\d{2}  \s  1  \s  $/
+
+  - do:
+      index:
+        index:  index2
+        type:   type2
+        id:     1
+        body:   { foo: bar }
+        refresh: true
+
+  - do:
+      cat.count:
+        h: count
+
+  - match:
+      $body: >
+               /^  2  \s  $/
+
+
+  - do:
+      cat.count:
+        index: index1
+
+  - match:
+      $body: >
+               /^  \d+  \s  \d{2}:\d{2}:\d{2}  \s  1  \s  $/
+
+  - do:
+      cat.count:
+        index: index2
+        v: true
+
+  - match:
+      $body: >
+               /^  epoch  \s+  timestamp          \s+  count  \s+  \n
+                   \d+    \s+  \d{2}:\d{2}:\d{2}  \s+  \d+    \s+  \n  $/
+

--- a/src/test/java/org/elasticsearch/test/hamcrest/RegexMatcher.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/RegexMatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.hamcrest;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.regex.Pattern;
+
+/**
+ * Matcher that supports regular expression and allows to provide optional flags
+ */
+public class RegexMatcher extends TypeSafeMatcher<String> {
+
+    private final String regex;
+    private final Pattern pattern;
+
+    public RegexMatcher(String regex) {
+        this.regex = regex;
+        this.pattern = Pattern.compile(regex);
+    }
+
+    public RegexMatcher(String regex, int flag) {
+        this.regex = regex;
+        this.pattern = Pattern.compile(regex, flag);
+    }
+
+    @Override
+    protected boolean matchesSafely(String item) {
+        return pattern.matcher(item).find();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(regex);
+    }
+
+    public static RegexMatcher matches(String regex) {
+        return new RegexMatcher(regex);
+    }
+
+    public static RegexMatcher matches(String regex, int flag) {
+        return new RegexMatcher(regex, flag);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -70,7 +70,10 @@ public class RestTestExecutionContext implements Closeable {
             }
         }
         try {
-            return response = callApiInternal(apiName, requestParams, body);
+            response = callApiInternal(apiName, requestParams, body);
+            //we always stash the last response body
+            stash("body", response.getBody());
+            return response;
         } catch(RestException e) {
             response = e.restResponse();
             throw e;

--- a/src/test/java/org/elasticsearch/test/rest/section/Assertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/Assertion.java
@@ -51,6 +51,9 @@ public abstract class Assertion implements ExecutableSection {
     }
 
     protected final Object getActualValue(RestTestExecutionContext executionContext) throws IOException {
+        if (executionContext.isStashed(field)) {
+            return executionContext.unstash(field);
+        }
         return executionContext.response(field);
     }
 

--- a/src/test/java/org/elasticsearch/test/rest/support/Features.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/Features.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public final class Features {
 
-    private static final List<String> SUPPORTED = Lists.newArrayList();
+    private static final List<String> SUPPORTED = Lists.newArrayList("regex");
 
     private Features() {
 


### PR DESCRIPTION
The new match_re assertion is based on a regular expression that needs to match the response body returned by an api call.
Added also example tests for cat count api, here is what a test would look like for instance:

```
"Test cat count output":

   - do:
       cat.count: {}

   - match_re: "^[0-9]+ +[0-9]{2}:[0-9]{2}:[0-9]{2} 0 $"

```
