### PR TITLE
REST Get Field Mapping API: Fix NPE if field not existent

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -108,6 +108,10 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
             return XContentHelper.convertToMap(source.array(), source.arrayOffset(), source.length(), true).v2();
         }
 
+        public boolean isNull() {
+            return NULL.fullName().equals(fullName) && NULL.source.length() == source.length();
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field("full_name", fullName);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
@@ -119,7 +119,7 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
         for (ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>> value : mappingsByIndex.values()) {
             for (ImmutableMap<String, FieldMappingMetaData> fieldValue : value.values()) {
                 for (Map.Entry<String, FieldMappingMetaData> fieldMappingMetaDataEntry : fieldValue.entrySet()) {
-                    if (fieldMappingMetaDataEntry.getValue() == FieldMappingMetaData.NULL) {
+                    if (fieldMappingMetaDataEntry.getValue().isNull()) {
                         return true;
                     }
                 }


### PR DESCRIPTION
When fixing #4738, a small issue leaked into the implementation.
The equals check in the RestAction only applied when the master node
returned the rest request, otherwise the object equality would not hold
due to being transferred over the wire and being deserialized into
another object (from and an equality point of view) than the
FieldMappingMetaData.NULL object - this could result in serialization
exceptions as an empty length bytes reference is used in toXContent.

This is not covered by our tests due to running all nodes in one JVM.
