### PR TITLE
Range filter no cache behaviour for `now` with rounding

### DIFF
--- a/docs/reference/query-dsl/filters/numeric-range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/numeric-range-filter.asciidoc
@@ -56,3 +56,6 @@ If caching the *result* of the filter is desired (for example, using the
 same "teen" filter with ages between 10 and 20), then it is advisable to
 simply use the <<query-dsl-range-filter,range>>
 filter.
+
+If the `now` date math expression is used without rounding then a range numeric filter will never be cached even
+if `_cache` is set to `true`. Also any filter that wraps this filter will never be cached.

--- a/docs/reference/query-dsl/filters/range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/range-filter.asciidoc
@@ -54,3 +54,6 @@ already faceting or sorting by.
 
 The result of the filter is only automatically cached by default if the `execution` is set to `index`. The
 `_cache` can be set to `false` to turn it off.
+
+If the `now` date math expression is used without rounding then a range filter will never be cached even if `_cache` is
+set to `true`. Also any filter that wraps this filter will never be cached.

--- a/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterCachingTests.java
+++ b/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterCachingTests.java
@@ -153,7 +153,24 @@ public class IndexQueryParserFilterCachingTests extends ElasticsearchTestCase {
         assertThat(((XBooleanFilter) ((ConstantScoreQuery) parsedQuery).getFilter()).clauses().get(1).getFilter(), instanceOf(NoCacheFilter.class));
         assertThat(((XBooleanFilter) ((ConstantScoreQuery) parsedQuery).getFilter()).clauses().size(), is(2));
 
+        query = copyToStringFromClasspath("/org/elasticsearch/index/query/date_range_in_boolean_cached_complex_now.json");
+        parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(ConstantScoreQuery.class));
+        assertThat(((ConstantScoreQuery) parsedQuery).getFilter(), instanceOf(XBooleanFilter.class));
+        assertThat(((XBooleanFilter) ((ConstantScoreQuery) parsedQuery).getFilter()).clauses().get(1).getFilter(), instanceOf(NoCacheFilter.class));
+        assertThat(((XBooleanFilter) ((ConstantScoreQuery) parsedQuery).getFilter()).clauses().size(), is(2));
+
         query = copyToStringFromClasspath("/org/elasticsearch/index/query/date_range_in_boolean_cached.json");
+        parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(ConstantScoreQuery.class));
+        assertThat(((ConstantScoreQuery) parsedQuery).getFilter(), instanceOf(CachedFilter.class));
+
+        query = copyToStringFromClasspath("/org/elasticsearch/index/query/date_range_in_boolean_cached_now_with_rounding.json");
+        parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(ConstantScoreQuery.class));
+        assertThat(((ConstantScoreQuery) parsedQuery).getFilter(), instanceOf(CachedFilter.class));
+
+        query = copyToStringFromClasspath("/org/elasticsearch/index/query/date_range_in_boolean_cached_complex_now_with_rounding.json");
         parsedQuery = queryParser.parse(query).query();
         assertThat(parsedQuery, instanceOf(ConstantScoreQuery.class));
         assertThat(((ConstantScoreQuery) parsedQuery).getFilter(), instanceOf(CachedFilter.class));

--- a/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_cached_complex_now.json
+++ b/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_cached_complex_now.json
@@ -1,0 +1,26 @@
+{
+    "constant_score": {
+        "filter": {
+            "bool": {
+                "_cache" : true,
+                "must": [
+                    {
+                        "term": {
+                            "foo": {
+                                "value": "bar"
+                            }
+                        }
+                    },
+                    {
+                        "range" : {
+                            "born" : {
+                                "gte": "2012-01-01",
+                                "lte": "now+1m+1s"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_cached_complex_now_with_rounding.json
+++ b/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_cached_complex_now_with_rounding.json
@@ -1,0 +1,26 @@
+{
+    "constant_score": {
+        "filter": {
+            "bool": {
+                "_cache" : true,
+                "must": [
+                    {
+                        "term": {
+                            "foo": {
+                                "value": "bar"
+                            }
+                        }
+                    },
+                    {
+                        "range" : {
+                            "born" : {
+                                "gte": "2012-01-01",
+                                "lte": "now+1m+1s/m"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_cached_now_with_rounding.json
+++ b/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_cached_now_with_rounding.json
@@ -1,0 +1,26 @@
+{
+    "constant_score": {
+        "filter": {
+            "bool": {
+                "_cache" : true,
+                "must": [
+                    {
+                        "term": {
+                            "foo": {
+                                "value": "bar"
+                            }
+                        }
+                    },
+                    {
+                        "range" : {
+                            "born" : {
+                                "gte": "2012-01-01",
+                                "lte": "now/d"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
The forceful no cache behaviour for range filter with now date match expression should only be active if no rounding has been specified for `now` in the date range range expression (for example: `now/d`).

 Closes #4947
 Relates to #4846
