### PR TITLE
Startup: Add ES_HOME to ES_INCLUDE search path

### DIFF
--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -83,12 +83,13 @@ ES_HOME=`cd "$ES_HOME"; pwd`
 
 
 # If an include wasn't specified in the environment, then search for one...
-if [ "x$ES_INCLUDE" = "x" ]; then
+if [ -z "$ES_INCLUDE" ]; then
     # Locations (in order) to use when searching for an include file.
     for include in /usr/share/elasticsearch/elasticsearch.in.sh \
                    /usr/local/share/elasticsearch/elasticsearch.in.sh \
                    /opt/elasticsearch/elasticsearch.in.sh \
                    ~/.elasticsearch.in.sh \
+                   $ES_HOME/bin/elasticsearch.in.sh \
                    "`dirname "$0"`"/elasticsearch.in.sh; do
         if [ -r "$include" ]; then
             . "$include"


### PR DESCRIPTION
With this change, the elasticsearch script can be linked to another path without having to set ES_INCLUDE to match the installation path. Previously, the elasticsearch would find ES_HOME correctly even if linked but could not find the include script, and finding it would be expected behavior to me based on its current search path.

I'm going straight to a pull request on this, as it's a minor improvement to the executable and solutions to ES_INCLUDES are generally workarounds listed on closed issues.
