### PR TITLE
Added `fields` support to `geo_point` and `completion` field type

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.index.mapper.MapperBuilders.completionField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
 
 /**
  *
@@ -160,6 +161,8 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
                     builder.preservePositionIncrements(Boolean.parseBoolean(fieldNode.toString()));
                 } else if (Fields.MAX_INPUT_LENGTH.match(fieldName)) {
                     builder.maxInputLength(Integer.parseInt(fieldNode.toString()));
+                } else if ("fields".equals(fieldName) || "path".equals(fieldName)) {
+                    parseMultiField(builder, name, node, parserContext, fieldName, fieldNode);
                 } else {
                     throw new MapperParsingException("Unknown field [" + fieldName + "]");
                 }
@@ -224,6 +227,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
 
         if (token == XContentParser.Token.VALUE_STRING) {
             inputs.add(parser.text());
+            multiFields.parse(this, context);
         } else {
             String currentFieldName = null;
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -355,6 +359,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
         builder.field(Fields.PRESERVE_SEPARATORS.getPreferredName(), this.preserveSeparators);
         builder.field(Fields.PRESERVE_POSITION_INCREMENTS.getPreferredName(), this.preservePositionIncrements);
         builder.field(Fields.MAX_INPUT_LENGTH.getPreferredName(), this.maxInputLength);
+        multiFields.toXContent(builder, params);
         return builder.endObject();
     }
 

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -27,15 +27,14 @@ import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperTestUtils;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.LongFieldMapper;
-import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
+import org.elasticsearch.index.mapper.core.*;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.common.io.Streams.copyToBytesFromClasspath;
 import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.mapper.MapperBuilders.*;
 import static org.hamcrest.Matchers.*;
 
@@ -235,5 +234,175 @@ public class MultiFieldTests extends ElasticsearchTestCase {
         assertThat(docMapper.mappers().fullName("age.stored").mapper().fieldType().indexed(), equalTo(true));
         assertThat(docMapper.mappers().fullName("age.stored").mapper().fieldType().stored(), equalTo(true));
         assertThat(docMapper.mappers().fullName("age.stored").mapper().fieldType().tokenized(), equalTo(false));
+    }
+
+    @Test
+    public void testConvertMultiFieldGeoPoint() throws Exception {
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/test-multi-field-type-geo_point.json");
+        DocumentMapper docMapper = MapperTestUtils.newParser().parse(mapping);
+
+        assertThat(docMapper.mappers().fullName("a").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("a").mapper(), instanceOf(StringFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().tokenized(), equalTo(false));
+
+        assertThat(docMapper.mappers().fullName("a.b").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("a.b").mapper(), instanceOf(GeoPointFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().tokenized(), equalTo(false));
+
+        BytesReference json = jsonBuilder().startObject()
+                .field("_id", "1")
+                .field("a", "-1,-1")
+                .endObject().bytes();
+        Document doc = docMapper.parse(json).rootDoc();
+
+        IndexableField f = doc.getField("a");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("a"));
+        assertThat(f.stringValue(), equalTo("-1,-1"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        f = doc.getField("a.b");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("a.b"));
+        assertThat(f.stringValue(), equalTo("-1.0,-1.0"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        assertThat(docMapper.mappers().fullName("b").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("b").mapper(), instanceOf(GeoPointFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().tokenized(), equalTo(false));
+
+        assertThat(docMapper.mappers().fullName("b.a").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("b.a").mapper(), instanceOf(StringFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().tokenized(), equalTo(false));
+
+        json = jsonBuilder().startObject()
+                .field("_id", "1")
+                .field("b", "-1,-1")
+                .endObject().bytes();
+        doc = docMapper.parse(json).rootDoc();
+
+        f = doc.getField("b");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b"));
+        assertThat(f.stringValue(), equalTo("-1.0,-1.0"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        f = doc.getField("b.a");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b.a"));
+        assertThat(f.stringValue(), equalTo("-1,-1"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        json = jsonBuilder().startObject()
+                .field("_id", "1")
+                .startArray("b").startArray().value(-1).value(-1).endArray().startArray().value(-2).value(-2).endArray().endArray()
+                .endObject().bytes();
+        doc = docMapper.parse(json).rootDoc();
+
+        f = doc.getFields("b")[0];
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b"));
+        assertThat(f.stringValue(), equalTo("-1.0,-1.0"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        f = doc.getFields("b")[1];
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b"));
+        assertThat(f.stringValue(), equalTo("-2.0,-2.0"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        f = doc.getField("b.a");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b.a"));
+        // NOTE: "]" B/c the lat,long aren't specified as a string, we miss the actual values when parsing the multi
+        // fields. We already skipped over the coordinates values and can't get to the coordinates.
+        // This happens if coordinates are specified as array and object.
+        assertThat(f.stringValue(), equalTo("]"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+    }
+
+    @Test
+    public void testConvertMultiFieldCompletion() throws Exception {
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/test-multi-field-type-completion.json");
+        DocumentMapper docMapper = MapperTestUtils.newParser().parse(mapping);
+
+        assertThat(docMapper.mappers().fullName("a").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("a").mapper(), instanceOf(StringFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("a").mapper().fieldType().tokenized(), equalTo(false));
+
+        assertThat(docMapper.mappers().fullName("a.b").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("a.b").mapper(), instanceOf(CompletionFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("a.b").mapper().fieldType().tokenized(), equalTo(true));
+
+        BytesReference json = jsonBuilder().startObject()
+                .field("_id", "1")
+                .field("a", "complete me")
+                .endObject().bytes();
+        Document doc = docMapper.parse(json).rootDoc();
+
+        IndexableField f = doc.getField("a");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("a"));
+        assertThat(f.stringValue(), equalTo("complete me"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        f = doc.getField("a.b");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("a.b"));
+        assertThat(f.stringValue(), equalTo("complete me"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        assertThat(docMapper.mappers().fullName("b").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("b").mapper(), instanceOf(CompletionFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("b").mapper().fieldType().tokenized(), equalTo(true));
+
+        assertThat(docMapper.mappers().fullName("b.a").mapper(), notNullValue());
+        assertThat(docMapper.mappers().fullName("b.a").mapper(), instanceOf(StringFieldMapper.class));
+        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().indexed(), equalTo(true));
+        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().fullName("b.a").mapper().fieldType().tokenized(), equalTo(false));
+
+        json = jsonBuilder().startObject()
+                .field("_id", "1")
+                .field("b", "complete me")
+                .endObject().bytes();
+        doc = docMapper.parse(json).rootDoc();
+
+        f = doc.getField("b");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b"));
+        assertThat(f.stringValue(), equalTo("complete me"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
+
+        f = doc.getField("b.a");
+        assertThat(f, notNullValue());
+        assertThat(f.name(), equalTo("b.a"));
+        assertThat(f.stringValue(), equalTo("complete me"));
+        assertThat(f.fieldType().stored(), equalTo(false));
+        assertThat(f.fieldType().indexed(), equalTo(true));
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/test-multi-field-type-completion.json
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/test-multi-field-type-completion.json
@@ -1,0 +1,30 @@
+{
+  "type":{
+    "properties":{
+      "a":{
+        "type":"multi_field",
+        "fields":{
+          "a":{
+            "type":"string",
+            "index":"not_analyzed"
+          },
+          "b":{
+            "type":"completion"
+          }
+        }
+      },
+      "b":{
+        "type":"multi_field",
+        "fields":{
+          "a":{
+            "type":"string",
+            "index":"not_analyzed"
+          },
+          "b":{
+            "type":"completion"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/test-multi-field-type-geo_point.json
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/test-multi-field-type-geo_point.json
@@ -1,0 +1,30 @@
+{
+  "type":{
+    "properties":{
+      "a":{
+        "type":"multi_field",
+        "fields":{
+          "a":{
+            "type":"string",
+            "index":"not_analyzed"
+          },
+          "b":{
+            "type":"geo_point"
+          }
+        }
+      },
+      "b":{
+        "type":"multi_field",
+        "fields":{
+          "a":{
+            "type":"string",
+            "index":"not_analyzed"
+          },
+          "b":{
+            "type":"geo_point"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Upgrading 0.90.x `multi_field` type that has a `geo_point` or `completion` field type as default field would otherwise fail.
Also it make sense to support these field types, because both support specifying the actual values as string.
