### PR TITLE
[TEST] Added ability to skip REST test suites/sections based on their required features

### DIFF
--- a/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/test/README.asciidoc
@@ -84,6 +84,23 @@ to a string with sufficient digits to allow string comparison, eg
 Snapshot versions and versions of the form `1.0.0.Beta1` can be treated
 as the rounded down version, eg `1.0.0`.
 
+The skip section can also be used to list new features that need to be
+supported in order to run a test. This way the up-to-date runners will
+run the test, while the ones that don't support the feature yet can
+temporarily skip it, and avoid having lots of test failures in the meantime.
+
+....
+    "Parent":
+     - skip:
+          features:    regex
+
+     - do:
+       ... test definitions ...
+....
+
+The `features` field can either be a string or an array of strings.
+The skip section requires to specify either a `version` or a `features` list.
+
 Required operators:
 -------------------
 

--- a/src/test/java/org/elasticsearch/test/rest/parser/RestTestSectionParser.java
+++ b/src/test/java/org/elasticsearch/test/rest/parser/RestTestSectionParser.java
@@ -39,7 +39,7 @@ public class RestTestSectionParser implements RestTestFragmentParser<TestSection
         parser.nextToken();
         testSection.setSkipSection(parseContext.parseSkipSection());
 
-        boolean skip = testSection.getSkipSection().skipVersion(parseContext.getCurrentVersion());
+        boolean skip = testSection.getSkipSection().skip(parseContext.getCurrentVersion());
 
         while ( parser.currentToken() != XContentParser.Token.END_ARRAY) {
             if (skip) {

--- a/src/test/java/org/elasticsearch/test/rest/parser/RestTestSuiteParser.java
+++ b/src/test/java/org/elasticsearch/test/rest/parser/RestTestSuiteParser.java
@@ -67,7 +67,7 @@ public class RestTestSuiteParser implements RestTestFragmentParser<RestTestSuite
 
         restTestSuite.setSetupSection(parseContext.parseSetupSection());
 
-        boolean skip = restTestSuite.getSetupSection().getSkipSection().skipVersion(parseContext.getCurrentVersion());
+        boolean skip = restTestSuite.getSetupSection().getSkipSection().skip(parseContext.getCurrentVersion());
 
         while(true) {
             //the "---" section separator is not understood by the yaml parser. null is returned, same as when the parser is closed

--- a/src/test/java/org/elasticsearch/test/rest/parser/SetupSectionParser.java
+++ b/src/test/java/org/elasticsearch/test/rest/parser/SetupSectionParser.java
@@ -36,7 +36,7 @@ public class SetupSectionParser implements RestTestFragmentParser<SetupSection> 
         SetupSection setupSection = new SetupSection();
         setupSection.setSkipSection(parseContext.parseSkipSection());
 
-        boolean skip = setupSection.getSkipSection().skipVersion(parseContext.getCurrentVersion());
+        boolean skip = setupSection.getSkipSection().skip(parseContext.getCurrentVersion());
 
         while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
             if (skip) {

--- a/src/test/java/org/elasticsearch/test/rest/support/Features.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/Features.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.support;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * Allows to register additional features supported by the tests runner.
+ * This way any runner can add extra features and use proper skip sections to avoid
+ * breaking others runners till they have implemented the new feature as well.
+ */
+public final class Features {
+
+    private static final List<String> SUPPORTED = Lists.newArrayList();
+
+    private Features() {
+
+    }
+
+    /**
+     * Tells whether all the features provided as argument are supported
+     */
+    public static boolean areAllSupported(List<String> features) {
+        for (String feature : features) {
+            if (!SUPPORTED.contains(feature)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns all the supported features
+     */
+    public static List<String> getSupported() {
+        return SUPPORTED;
+    }
+}


### PR DESCRIPTION
As we have different runners for the REST tests we need a mechanism that allows to add features to any of them without breaking all other runners builds.
The idea is to name features and temporarily use skip sections that mention the required new features, so that runners that don't support it yet will skip the test.

Added support for `features` field in skip section.
Added `Features` class that contains a static list of the features supported by the runner. If a feature mentioned in a skip section is not listed here, the test will be skipped.
