### PR TITLE
Add RamUsageEstimator#sizeOf(Object) to forbidden APIs

### DIFF
--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -17,3 +17,6 @@ java.util.Collections#sort(java.util.List)
 java.util.Collections#sort(java.util.List,java.util.Comparator)
 
 java.io.StringReader#<init>(java.lang.String) @ Use FastStringReader instead
+
+org.apache.lucene.util.RamUsageEstimator#sizeOf(java.lang.Object) @ This can be a perfromance trap 
+

--- a/pom.xml
+++ b/pom.xml
@@ -982,6 +982,7 @@
                                 <exclude>org/elasticsearch/plugins/PluginManager.class</exclude>
                                 <exclude>org/elasticsearch/bootstrap/Bootstrap.class</exclude>
                                 <exclude>org/elasticsearch/Version.class</exclude>
+				<exclude>org/elasticsearch/index/percolator/stats/ShardPercolateService$RamEstimator.class</exclude>
                                 <!-- end excludes for valid system-out -->
                                 <!-- start excludes for Unsafe -->
                                 <exclude>org/elasticsearch/common/util/UnsafeUtils.class</exclude>

--- a/src/main/java/org/elasticsearch/index/percolator/stats/ShardPercolateService.java
+++ b/src/main/java/org/elasticsearch/index/percolator/stats/ShardPercolateService.java
@@ -86,8 +86,16 @@ public class ShardPercolateService extends AbstractIndexShardComponent {
 
     private static long computeSizeInMemory(HashedBytesRef id, Query query) {
         long size = (3 * RamUsageEstimator.NUM_BYTES_INT) + RamUsageEstimator.NUM_BYTES_OBJECT_REF + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + id.bytes.bytes.length;
-        size += RamUsageEstimator.sizeOf(query);
+        size += RamEstimator.sizeOf(query);
         return size;
+    }
+
+    private static final class RamEstimator {
+        // we move this into it's own class to exclude it from the forbidden API checks
+        // it's fine to use here!
+        static long sizeOf(Query query) {
+            return RamUsageEstimator.sizeOf(query);
+        }
     }
 
 }


### PR DESCRIPTION
This method can be a performance trap since it traverse the
entire object tree that is referenced by the provided object.
See LUCENE-5373
