### PR TITLE
cleanup for the internal plugin infrastructure

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
@@ -31,17 +31,9 @@ import java.io.IOException;
 import java.io.Serializable;
 
 public class PluginInfo implements Streamable, Serializable, ToXContent {
+
     public static final String DESCRIPTION_NOT_AVAILABLE = "No description found.";
     public static final String VERSION_NOT_AVAILABLE = "NA";
-
-    static final class Fields {
-        static final XContentBuilderString NAME = new XContentBuilderString("name");
-        static final XContentBuilderString DESCRIPTION = new XContentBuilderString("description");
-        static final XContentBuilderString URL = new XContentBuilderString("url");
-        static final XContentBuilderString JVM = new XContentBuilderString("jvm");
-        static final XContentBuilderString SITE = new XContentBuilderString("site");
-        static final XContentBuilderString VERSION = new XContentBuilderString("version");
-    }
 
     private String name;
     private String description;
@@ -121,6 +113,38 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         return version;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginInfo that = (PluginInfo) o;
+
+        if (!name.equals(that.name)) return false;
+        if (!version.equals(that.version)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + version.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("PluginInfo{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append(", site=").append(site);
+        sb.append(", jvm=").append(jvm);
+        sb.append(", version='").append(version).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
     public static PluginInfo readPluginInfo(StreamInput in) throws IOException {
         PluginInfo info = new PluginInfo();
         info.readFrom(in);
@@ -167,33 +191,12 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         return builder;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PluginInfo that = (PluginInfo) o;
-
-        if (!name.equals(that.name)) return false;
-        if (version != null ? !version.equals(that.version) : that.version != null) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return name.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        final StringBuffer sb = new StringBuffer("PluginInfo{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", description='").append(description).append('\'');
-        sb.append(", site=").append(site);
-        sb.append(", jvm=").append(jvm);
-        sb.append(", version='").append(version).append('\'');
-        sb.append('}');
-        return sb.toString();
+    static final class Fields {
+        static final XContentBuilderString NAME = new XContentBuilderString("name");
+        static final XContentBuilderString DESCRIPTION = new XContentBuilderString("description");
+        static final XContentBuilderString URL = new XContentBuilderString("url");
+        static final XContentBuilderString JVM = new XContentBuilderString("jvm");
+        static final XContentBuilderString SITE = new XContentBuilderString("site");
+        static final XContentBuilderString VERSION = new XContentBuilderString("version");
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsInfo.java
@@ -32,9 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PluginsInfo implements Streamable, Serializable, ToXContent {
-    static final class Fields {
-        static final XContentBuilderString PLUGINS = new XContentBuilderString("plugins");
-    }
 
     private List<PluginInfo> infos;
 
@@ -85,5 +82,9 @@ public class PluginsInfo implements Streamable, Serializable, ToXContent {
         builder.endArray();
 
         return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString PLUGINS = new XContentBuilderString("plugins");
     }
 }

--- a/src/main/java/org/elasticsearch/common/util/concurrent/CachedReference.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/CachedReference.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * A reference to a cached object that with associated {@code ttl}. The associated {@link Loader} is
+ * responsible for loading fresh instances after ttl has expired.
+ */
+public class CachedReference<T> {
+
+    /**
+     * Responsible for loading a fresh instance of the object
+     */
+    public static interface Loader<T> {
+
+        /**
+         * @return the new/fresh instance of the object.
+         */
+        T load();
+    }
+
+    private final Loader<T> loader;
+    private final long ttl;
+    private T ref;
+    private long lastLoadedMillis;
+
+
+    /**
+     * Constructs a new cached reference.
+     *
+     * @param ttl       Determines the frequency by which a fresh object will be reloaded. A negative or a {@code null} value
+     *                  disables the refresh (the object will only be loaded once - lazily). A zero {@code ttl} wll cause this
+     *                  reference to always reload and never cache.
+     *
+     * @param loader    The Loader responsible for loading a fresh instance of the object.
+     */
+    public CachedReference(TimeValue ttl, Loader<T> loader) {
+        this(ttl.millis(), loader);
+    }
+
+    /**
+     * Constructs a new cached reference.
+     *
+     * @param ttl       Determines the frequency by which a fresh object will be reloaded (in milliseconds). A negative value
+     *                  disables the refresh (the object will only be loaded once - lazily). A zero {@code ttl} wll cause this
+     *                  reference to always reload and never cache.
+     *
+     * @param loader    The Loader responsible for loading a fresh instance of the object.
+     */
+    public CachedReference(long ttl, Loader<T> loader) {
+        this.ttl = ttl;
+        this.loader = loader;
+    }
+
+    /**
+     * @return The referenced object (either previously loaded one, or a freshly loaded one)
+     */
+    public synchronized T get() {
+        if (ref != null && (ttl < 0 || lastLoadedMillis + ttl < System.currentTimeMillis())) {
+            assert lastLoadedMillis > 0;
+            return ref;
+        }
+        ref = loader.load();
+        lastLoadedMillis = System.currentTimeMillis();
+        return ref;
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/JvmPlugin.java
+++ b/src/main/java/org/elasticsearch/plugins/JvmPlugin.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.action.admin.cluster.node.info.PluginInfo;
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.CloseableIndexComponent;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * An internal wrapper around a {@link Plugin} instance that is associated with its {@code PluginInfo}.
+ */
+public class JvmPlugin implements Plugin {
+
+    private final Plugin plugin;
+    private final PluginInfo info;
+    private final List<OnModuleReference> onModuleReferences;
+    private final ESLogger logger;
+
+    public JvmPlugin(Plugin plugin, PluginInfo info, ESLogger logger) {
+        this.plugin = plugin;
+        this.info = info;
+        this.logger = logger;
+        this.onModuleReferences = loadOnModuleReferences(plugin, logger);
+    }
+
+    public PluginInfo info() {
+        return info;
+    }
+
+    @Override
+    public String name() {
+        return plugin.name();
+    }
+
+    @Override
+    public String description() {
+        return plugin.description();
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> modules() {
+        return plugin.modules();
+    }
+
+    @Override
+    public Collection<? extends Module> modules(Settings settings) {
+        return plugin.modules(settings);
+    }
+
+    @Override
+    public Collection<Class<? extends LifecycleComponent>> services() {
+        return plugin.services();
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> indexModules() {
+        return plugin.indexModules();
+    }
+
+    @Override
+    public Collection<? extends Module> indexModules(Settings settings) {
+        return plugin.indexModules(settings);
+    }
+
+    @Override
+    public Collection<Class<? extends CloseableIndexComponent>> indexServices() {
+        return plugin.indexServices();
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> shardModules() {
+        return plugin.shardModules();
+    }
+
+    @Override
+    public Collection<? extends Module> shardModules(Settings settings) {
+        return plugin.shardModules(settings);
+    }
+
+    @Override
+    public Collection<Class<? extends CloseableIndexComponent>> shardServices() {
+        return plugin.shardServices();
+    }
+
+    @Override
+    public Settings additionalSettings() {
+        return plugin.additionalSettings();
+    }
+
+    public void processModule(Module module) {
+        plugin.processModule(module);
+        // see if there are onModule references
+        for (OnModuleReference reference : onModuleReferences) {
+            if (reference.moduleClass.isAssignableFrom(module.getClass())) {
+                try {
+                    reference.onModuleMethod.invoke(plugin, module);
+                } catch (Exception e) {
+                    logger.warn("plugin {}, failed to invoke custom onModule method", e, plugin.name());
+                }
+            }
+        }
+    }
+
+    private static List<OnModuleReference> loadOnModuleReferences(Plugin plugin, ESLogger logger) {
+        List<OnModuleReference> refs = Lists.newArrayList();
+        for (Method method : plugin.getClass().getDeclaredMethods()) {
+            if (!method.getName().equals("onModule")) {
+                continue;
+            }
+            if (method.getParameterTypes().length == 0 || method.getParameterTypes().length > 1) {
+                logger.warn("Plugin: {} implementing onModule with no parameters or more than one parameter", plugin.name());
+                continue;
+            }
+            Class moduleClass = method.getParameterTypes()[0];
+            if (!Module.class.isAssignableFrom(moduleClass)) {
+                logger.warn("Plugin: {} implementing onModule by the type is not of Module type {}", plugin.name(), moduleClass);
+                continue;
+            }
+            method.setAccessible(true);
+            refs.add(new OnModuleReference(moduleClass, method));
+        }
+        return refs;
+    }
+
+    static class OnModuleReference {
+        public final Class<? extends Module> moduleClass;
+        public final Method onModuleMethod;
+
+        OnModuleReference(Class<? extends Module> moduleClass, Method onModuleMethod) {
+            this.moduleClass = moduleClass;
+            this.onModuleMethod = onModuleMethod;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -19,20 +19,21 @@
 
 package org.elasticsearch.plugins;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.node.info.PluginInfo;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsInfo;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.CachedReference;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.CloseableIndexComponent;
 
@@ -48,30 +49,14 @@ import java.util.*;
  *
  */
 public class PluginsService extends AbstractComponent {
+
     private static final String ES_PLUGIN_PROPERTIES = "es-plugin.properties";
 
     private final Environment environment;
 
-    /**
-     * We keep around a list of jvm plugins
-     */
-    private final ImmutableList<Tuple<PluginInfo, Plugin>> plugins;
+    private final ImmutableList<JvmPlugin> jvmPlugins;
 
-    private final ImmutableMap<Plugin, List<OnModuleReference>> onModuleReferences;
-
-    private PluginsInfo cachedPluginsInfo;
-    private final TimeValue refreshInterval;
-    private long lastRefresh;
-
-    static class OnModuleReference {
-        public final Class<? extends Module> moduleClass;
-        public final Method onModuleMethod;
-
-        OnModuleReference(Class<? extends Module> moduleClass, Method onModuleMethod) {
-            this.moduleClass = moduleClass;
-            this.onModuleMethod = onModuleMethod;
-        }
-    }
+    private CachedReference<PluginsInfo> pluginsInfo;
 
     /**
      * Constructs a new PluginService
@@ -82,88 +67,61 @@ public class PluginsService extends AbstractComponent {
         super(settings);
         this.environment = environment;
 
-        ImmutableList.Builder<Tuple<PluginInfo, Plugin>> tupleBuilder = ImmutableList.builder();
+        ImmutableList.Builder<JvmPlugin> jvmPluginsList = ImmutableList.builder();
+        loadJvmPluginsFromSettings(settings, jvmPluginsList);
+        loadJvmPluginsFromClasspath(settings, jvmPluginsList);
+        jvmPlugins = jvmPluginsList.build();
 
-        // first we load all the default plugins from the settings
-        String[] defaultPluginsClasses = settings.getAsArray("plugin.types");
-        for (String pluginClass : defaultPluginsClasses) {
-            Plugin plugin = loadPlugin(pluginClass, settings);
-            PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), hasSite(plugin.name()), true, PluginInfo.VERSION_NOT_AVAILABLE);
-            if (logger.isTraceEnabled()) {
-                logger.trace("plugin loaded from settings [{}]", pluginInfo);
-            }
-            tupleBuilder.add(new Tuple<PluginInfo, Plugin>(pluginInfo, plugin));
-        }
+        Set<PluginInfo> sitesInfos = loadSiteOnlyPluginsInfos();
 
-        // now, find all the ones that are in the classpath
-        loadPluginsIntoClassLoader();
-        tupleBuilder.addAll(loadPluginsFromClasspath(settings));
-        this.plugins = tupleBuilder.build();
+        verifyMandatoryPlugins(settings, jvmPlugins, sitesInfos);
 
-        // We need to build a List of jvm and site plugins for checking mandatory plugins
-        Map<String, Plugin> jvmPlugins = Maps.newHashMap();
-        List<String> sitePlugins = Lists.newArrayList();
-
-        for (Tuple<PluginInfo, Plugin> tuple : this.plugins) {
-            jvmPlugins.put(tuple.v2().name(), tuple.v2());
-            if (tuple.v1().isSite()) {
-                sitePlugins.add(tuple.v1().getName());
-            }
-        }
-
-        // we load site plugins
-        ImmutableList<Tuple<PluginInfo, Plugin>> tuples = loadSitePlugins();
-        for (Tuple<PluginInfo, Plugin> tuple : tuples) {
-            sitePlugins.add(tuple.v1().getName());
-        }
-
-        // Checking expected plugins
-        String[] mandatoryPlugins = settings.getAsArray("plugin.mandatory", null);
-        if (mandatoryPlugins != null) {
-            Set<String> missingPlugins = Sets.newHashSet();
-            for (String mandatoryPlugin : mandatoryPlugins) {
-                if (!jvmPlugins.containsKey(mandatoryPlugin) && !sitePlugins.contains(mandatoryPlugin) && !missingPlugins.contains(mandatoryPlugin)) {
-                    missingPlugins.add(mandatoryPlugin);
+        TimeValue refreshInterval = componentSettings.getAsTime("info_refresh_interval", TimeValue.timeValueSeconds(10));
+        pluginsInfo = new CachedReference<PluginsInfo>(refreshInterval, new CachedReference.Loader<PluginsInfo>() {
+            @Override
+            public PluginsInfo load() {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("starting to fetch info on plugins");
                 }
+                PluginsInfo pluginsInfo = new PluginsInfo();
+
+                for (JvmPlugin plugin : jvmPlugins) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("adding jvm plugin [{}]", plugin.info());
+                    }
+                    pluginsInfo.add(plugin.info());
+                }
+
+                // We reload site plugins (in case of some changes)
+                for (PluginInfo info : loadSiteOnlyPluginsInfos()) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("adding site plugin [{}]", info);
+                    }
+                    pluginsInfo.add(info);
+                }
+
+                return pluginsInfo;
             }
-            if (!missingPlugins.isEmpty()) {
-                throw new ElasticsearchException("Missing mandatory plugins [" + Strings.collectionToDelimitedString(missingPlugins, ", ") + "]");
+        });
+
+        // Collecting the names of the jvm plugins and the site plugins for logging
+        Set<String> sitePluginsNames = Sets.newHashSet();
+        Set<String> jvmPluginsNames = Sets.newHashSet();
+        for (JvmPlugin plugin : this.jvmPlugins) {
+            jvmPluginsNames.add(plugin.name());
+            if (plugin.info().isSite()) {
+                sitePluginsNames.add(plugin.name());
             }
         }
-
-        logger.info("loaded {}, sites {}", jvmPlugins.keySet(), sitePlugins);
-
-        MapBuilder<Plugin, List<OnModuleReference>> onModuleReferences = MapBuilder.newMapBuilder();
-        for (Plugin plugin : jvmPlugins.values()) {
-            List<OnModuleReference> list = Lists.newArrayList();
-            for (Method method : plugin.getClass().getDeclaredMethods()) {
-                if (!method.getName().equals("onModule")) {
-                    continue;
-                }
-                if (method.getParameterTypes().length == 0 || method.getParameterTypes().length > 1) {
-                    logger.warn("Plugin: {} implementing onModule with no parameters or more than one parameter", plugin.name());
-                    continue;
-                }
-                Class moduleClass = method.getParameterTypes()[0];
-                if (!Module.class.isAssignableFrom(moduleClass)) {
-                    logger.warn("Plugin: {} implementing onModule by the type is not of Module type {}", plugin.name(), moduleClass);
-                    continue;
-                }
-                method.setAccessible(true);
-                list.add(new OnModuleReference(moduleClass, method));
-            }
-            if (!list.isEmpty()) {
-                onModuleReferences.put(plugin, list);
-            }
+        for (PluginInfo siteInfo : sitesInfos) {
+            sitePluginsNames.add(siteInfo.getName());
         }
-        this.onModuleReferences = onModuleReferences.immutableMap();
-
-        this.refreshInterval = componentSettings.getAsTime("info_refresh_interval", TimeValue.timeValueSeconds(10));
+        logger.info("loaded {}, sites {}", jvmPluginsNames, sitePluginsNames);
 
     }
 
-    public ImmutableList<Tuple<PluginInfo, Plugin>> plugins() {
-        return plugins;
+    public ImmutableList<JvmPlugin> plugins() {
+        return jvmPlugins;
     }
 
     public void processModules(Iterable<Module> modules) {
@@ -173,101 +131,88 @@ public class PluginsService extends AbstractComponent {
     }
 
     public void processModule(Module module) {
-        for (Tuple<PluginInfo, Plugin> plugin : plugins()) {
-            plugin.v2().processModule(module);
-            // see if there are onModule references
-            List<OnModuleReference> references = onModuleReferences.get(plugin.v2());
-            if (references != null) {
-                for (OnModuleReference reference : references) {
-                    if (reference.moduleClass.isAssignableFrom(module.getClass())) {
-                        try {
-                            reference.onModuleMethod.invoke(plugin.v2(), module);
-                        } catch (Exception e) {
-                            logger.warn("plugin {}, failed to invoke custom onModule method", e, plugin.v2().name());
-                        }
-                    }
-                }
-            }
+        for (JvmPlugin plugin : jvmPlugins) {
+            plugin.processModule(module);
         }
     }
 
     public Settings updatedSettings() {
         ImmutableSettings.Builder builder = ImmutableSettings.settingsBuilder()
                 .put(this.settings);
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            builder.put(plugin.v2().additionalSettings());
+        for (JvmPlugin plugin : jvmPlugins) {
+            builder.put(plugin.additionalSettings());
         }
         return builder.build();
     }
 
     public Collection<Class<? extends Module>> modules() {
         List<Class<? extends Module>> modules = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            modules.addAll(plugin.v2().modules());
+        for (JvmPlugin plugin : jvmPlugins) {
+            modules.addAll(plugin.modules());
         }
         return modules;
     }
 
     public Collection<Module> modules(Settings settings) {
         List<Module> modules = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            modules.addAll(plugin.v2().modules(settings));
+        for (JvmPlugin plugin : jvmPlugins) {
+            modules.addAll(plugin.modules(settings));
         }
         return modules;
     }
 
     public Collection<Class<? extends LifecycleComponent>> services() {
         List<Class<? extends LifecycleComponent>> services = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            services.addAll(plugin.v2().services());
+        for (JvmPlugin plugin : jvmPlugins) {
+            services.addAll(plugin.services());
         }
         return services;
     }
 
     public Collection<Class<? extends Module>> indexModules() {
         List<Class<? extends Module>> modules = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            modules.addAll(plugin.v2().indexModules());
+        for (JvmPlugin plugin : jvmPlugins) {
+            modules.addAll(plugin.indexModules());
         }
         return modules;
     }
 
     public Collection<Module> indexModules(Settings settings) {
         List<Module> modules = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            modules.addAll(plugin.v2().indexModules(settings));
+        for (JvmPlugin plugin : jvmPlugins) {
+            modules.addAll(plugin.indexModules(settings));
         }
         return modules;
     }
 
     public Collection<Class<? extends CloseableIndexComponent>> indexServices() {
         List<Class<? extends CloseableIndexComponent>> services = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            services.addAll(plugin.v2().indexServices());
+        for (JvmPlugin plugin : jvmPlugins) {
+            services.addAll(plugin.indexServices());
         }
         return services;
     }
 
     public Collection<Class<? extends Module>> shardModules() {
         List<Class<? extends Module>> modules = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            modules.addAll(plugin.v2().shardModules());
+        for (JvmPlugin plugin : jvmPlugins) {
+            modules.addAll(plugin.shardModules());
         }
         return modules;
     }
 
     public Collection<Module> shardModules(Settings settings) {
         List<Module> modules = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            modules.addAll(plugin.v2().shardModules(settings));
+        for (JvmPlugin plugin : jvmPlugins) {
+            modules.addAll(plugin.shardModules(settings));
         }
         return modules;
     }
 
     public Collection<Class<? extends CloseableIndexComponent>> shardServices() {
         List<Class<? extends CloseableIndexComponent>> services = Lists.newArrayList();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-            services.addAll(plugin.v2().shardServices());
+        for (JvmPlugin plugin : jvmPlugins) {
+            services.addAll(plugin.shardServices());
         }
         return services;
     }
@@ -280,42 +225,61 @@ public class PluginsService extends AbstractComponent {
      * @return List of plugins information
      */
     synchronized public PluginsInfo info() {
-        if (refreshInterval.millis() != 0) {
-            if (cachedPluginsInfo != null &&
-                    (refreshInterval.millis() < 0 || (System.currentTimeMillis() - lastRefresh) < refreshInterval.millis())) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("using cache to retrieve plugins info");
-                }
-                return cachedPluginsInfo;
-            }
-            lastRefresh = System.currentTimeMillis();
-        }
-
-        if (logger.isTraceEnabled()) {
-            logger.trace("starting to fetch info on plugins");
-        }
-        cachedPluginsInfo = new PluginsInfo();
-
-        // We first add all JvmPlugins
-        for (Tuple<PluginInfo, Plugin> plugin : this.plugins) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("adding jvm plugin [{}]", plugin.v1());
-            }
-            cachedPluginsInfo.add(plugin.v1());
-        }
-
-        // We reload site plugins (in case of some changes)
-        for (Tuple<PluginInfo, Plugin> plugin : loadSitePlugins()) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("adding site plugin [{}]", plugin.v1());
-            }
-            cachedPluginsInfo.add(plugin.v1());
-        }
-
-        return cachedPluginsInfo;
+        return pluginsInfo.get();
     }
 
-    private void loadPluginsIntoClassLoader() {
+    private void loadJvmPluginsFromSettings(Settings settings, ImmutableList.Builder<JvmPlugin> plugins) {
+        String[] defaultPluginsClasses = settings.getAsArray("plugin.types");
+        for (String pluginClass : defaultPluginsClasses) {
+            Plugin plugin = loadPlugin(pluginClass, settings);
+            PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), hasSite(plugin.name()), true, PluginInfo.VERSION_NOT_AVAILABLE);
+            if (logger.isTraceEnabled()) {
+                logger.trace("plugin loaded from settings [{}]", pluginInfo);
+            }
+            plugins.add(new JvmPlugin(plugin, pluginInfo, logger));
+        }
+    }
+
+    private void loadJvmPluginsFromClasspath(Settings settings, ImmutableList.Builder<JvmPlugin> plugins) {
+        loadJvmPluginsIntoClassLoader();
+        // Trying JVM plugins: looking for es-plugin.properties files
+        try {
+            Enumeration<URL> pluginUrls = settings.getClassLoader().getResources(ES_PLUGIN_PROPERTIES);
+            while (pluginUrls.hasMoreElements()) {
+                URL pluginUrl = pluginUrls.nextElement();
+                Properties pluginProps = new Properties();
+                InputStream is = null;
+                try {
+                    is = pluginUrl.openStream();
+                    pluginProps.load(is);
+                    String pluginClassName = pluginProps.getProperty("plugin");
+                    String pluginVersion = pluginProps.getProperty("version", PluginInfo.VERSION_NOT_AVAILABLE);
+                    Plugin plugin = loadPlugin(pluginClassName, settings);
+
+                    // Is it a site plugin as well? Does it have also an embedded _site structure
+                    File siteFile = new File(new File(environment.pluginsFile(), plugin.name()), "_site");
+                    boolean isSite = siteFile.exists() && siteFile.isDirectory();
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("found a jvm plugin [{}], [{}]{}",
+                                plugin.name(), plugin.description(), isSite ? ": with _site structure" : "");
+                    }
+
+                    PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), isSite, true, pluginVersion);
+
+                    plugins.add(new JvmPlugin(plugin, pluginInfo, logger));
+
+                } catch (Throwable e) {
+                    logger.warn("failed to load plugin from [" + pluginUrl + "]", e);
+                } finally {
+                    IOUtils.closeWhileHandlingException(is);
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("failed to find jvm plugins from classpath", e);
+        }
+    }
+
+    private void loadJvmPluginsIntoClassLoader() {
         File pluginsFile = environment.pluginsFile();
         if (!pluginsFile.exists()) {
             return;
@@ -379,55 +343,13 @@ public class PluginsService extends AbstractComponent {
         }
     }
 
-    private ImmutableList<Tuple<PluginInfo,Plugin>> loadPluginsFromClasspath(Settings settings) {
-        ImmutableList.Builder<Tuple<PluginInfo, Plugin>> plugins = ImmutableList.builder();
-
-        // Trying JVM plugins: looking for es-plugin.properties files
-        try {
-            Enumeration<URL> pluginUrls = settings.getClassLoader().getResources(ES_PLUGIN_PROPERTIES);
-            while (pluginUrls.hasMoreElements()) {
-                URL pluginUrl = pluginUrls.nextElement();
-                Properties pluginProps = new Properties();
-                InputStream is = null;
-                try {
-                    is = pluginUrl.openStream();
-                    pluginProps.load(is);
-                    String pluginClassName = pluginProps.getProperty("plugin");
-                    String pluginVersion = pluginProps.getProperty("version", PluginInfo.VERSION_NOT_AVAILABLE);
-                    Plugin plugin = loadPlugin(pluginClassName, settings);
-
-                    // Is it a site plugin as well? Does it have also an embedded _site structure
-                    File siteFile = new File(new File(environment.pluginsFile(), plugin.name()), "_site");
-                    boolean isSite = siteFile.exists() && siteFile.isDirectory();
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("found a jvm plugin [{}], [{}]{}",
-                                plugin.name(), plugin.description(), isSite ? ": with _site structure" : "");
-                    }
-
-                    PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), isSite, true, pluginVersion);
-
-                    plugins.add(new Tuple<PluginInfo, Plugin>(pluginInfo, plugin));
-                } catch (Throwable e) {
-                    logger.warn("failed to load plugin from [" + pluginUrl + "]", e);
-                } finally {
-                    IOUtils.closeWhileHandlingException(is);
-                }
-            }
-        } catch (IOException e) {
-            logger.warn("failed to find jvm plugins from classpath", e);
-        }
-
-        return plugins.build();
-    }
-
-    private ImmutableList<Tuple<PluginInfo,Plugin>> loadSitePlugins() {
-        ImmutableList.Builder<Tuple<PluginInfo, Plugin>> sitePlugins = ImmutableList.builder();
-        List<String> loadedJvmPlugins = new ArrayList<String>();
+    private Set<PluginInfo> loadSiteOnlyPluginsInfos() {
+        Set<String> loadedJvmPlugins = Sets.newHashSet();
 
         // Already known jvm plugins are ignored
-        for(Tuple<PluginInfo, Plugin> tuple : plugins) {
-            if (tuple.v1().isSite()) {
-                loadedJvmPlugins.add(tuple.v1().getName());
+        for(JvmPlugin plugin : jvmPlugins) {
+            if (plugin.info().isSite()) {
+                loadedJvmPlugins.add(plugin.name());
             }
         }
 
@@ -435,9 +357,10 @@ public class PluginsService extends AbstractComponent {
         File pluginsFile = environment.pluginsFile();
 
         if (!pluginsFile.exists() || !pluginsFile.isDirectory()) {
-            return sitePlugins.build();
+            return Collections.emptySet();
         }
 
+        Set<PluginInfo> siteInfos = Sets.newHashSet();
         for (File pluginFile : pluginsFile.listFiles()) {
             if (!loadedJvmPlugins.contains(pluginFile.getName())) {
                 File sitePluginDir = new File(pluginFile, "_site");
@@ -470,12 +393,29 @@ public class PluginsService extends AbstractComponent {
                         logger.trace("found a site plugin name [{}], version [{}], description [{}]",
                                 name, version, description);
                     }
-                    sitePlugins.add(new Tuple<PluginInfo, Plugin>(new PluginInfo(name, description, true, false, version), null));
+                    siteInfos.add(new PluginInfo(name, description, true, false, version));
                 }
             }
         }
+        return siteInfos;
+    }
 
-        return sitePlugins.build();
+    private static void verifyMandatoryPlugins(Settings settings, List<JvmPlugin> jvmPlugins, Set<PluginInfo> siteInfos) {
+        // Checking expected plugins
+        String[] mandatoryPluginsNames = settings.getAsArray("plugin.mandatory", null);
+        if (mandatoryPluginsNames == null) {
+            return;
+        }
+        Set<String> mandatoryPlugins = Sets.newHashSet(mandatoryPluginsNames);
+        for (JvmPlugin plugin : jvmPlugins) {
+            mandatoryPlugins.remove(plugin.name());
+        }
+        for (PluginInfo siteInfo : siteInfos) {
+            mandatoryPlugins.remove(siteInfo.getName());
+        }
+        if (!mandatoryPlugins.isEmpty()) {
+            throw new ElasticsearchException("Missing mandatory plugins [" + Strings.collectionToDelimitedString(mandatoryPlugins, ", ") + "]");
+        }
     }
 
     /**


### PR DESCRIPTION
- Introduced the `JvmPlugin` wrapper (to add additional internal functionality to the plugin)
- fixed `hashcode()` on the `PluginInfo`
- extracted the `PluginsInfo` caching logic to `CachableReference` construct in utils
- cleaned up the `PluginsService` class to make the logic there more structured/understandable
