### PR TITLE
Support externalValue() in mappers

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -406,16 +406,16 @@ public class ParseContext {
      * @param clazz Expected class for external value
      * @return null if no external value has been set or the value
      */
-    public Object parseExternalValue(Class<?> clazz) {
+    public <T> T parseExternalValue(Class<T> clazz) {
         if (!externalValueSet() || externalValue() == null) {
             return null;
         }
 
         if (!(externalValue().getClass().isAssignableFrom(clazz))) {
             throw new ElasticsearchIllegalArgumentException("illegal external value class ["
-                    + externalValue().getClass().getName() + "]. Should be " + clazz);
+                    + externalValue().getClass().getName() + "]. Should be " + clazz.getName());
         }
-        return externalValue();
+        return (T) externalValue();
     }
 
     public float fieldBoost(AbstractFieldMapper mapper) {

--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -398,6 +399,23 @@ public class ParseContext {
     public Object externalValue() {
         externalValueSet = false;
         return externalValue;
+    }
+
+    /**
+     * Try to parse an externalValue if any
+     * @param clazz Expected class for external value
+     * @return null if no external value has been set or the value
+     */
+    public Object parseExternalValue(Class<?> clazz) {
+        if (!externalValueSet() || externalValue() == null) {
+            return null;
+        }
+
+        if (!(externalValue().getClass().isAssignableFrom(clazz))) {
+            throw new ElasticsearchIllegalArgumentException("illegal external value class ["
+                    + externalValue().getClass().getName() + "]. Should be " + clazz);
+        }
+        return externalValue();
     }
 
     public float fieldBoost(AbstractFieldMapper mapper) {

--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -411,7 +411,7 @@ public class ParseContext {
             return null;
         }
 
-        if (!(externalValue().getClass().isAssignableFrom(clazz))) {
+        if (!clazz.isInstance(externalValue())) {
             throw new ElasticsearchIllegalArgumentException("illegal external value class ["
                     + externalValue().getClass().getName() + "]. Should be " + clazz.getName());
         }

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.mapper.core;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Base64;
 import org.elasticsearch.common.Strings;
@@ -176,18 +175,8 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
         if (!fieldType().stored()) {
             return;
         }
-        byte[] value;
-        if (context.externalValueSet()) {
-            if (context.externalValue() == null) {
-                return;
-            } else {
-                if (!(context.externalValue() instanceof byte[])) {
-                    throw new ElasticsearchIllegalArgumentException("illegal external value class ["
-                            + context.externalValue().getClass().getName() + "]. Should be " + byte[].class.getName());
-                }
-                value = (byte[]) context.externalValue();
-            }
-        } else {
+        byte[] value = (byte[]) context.parseExternalValue(byte[].class);
+        if (value == null) {
             if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
                 return;
             } else {

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -175,7 +175,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
         if (!fieldType().stored()) {
             return;
         }
-        byte[] value = (byte[]) context.parseExternalValue(byte[].class);
+        byte[] value = context.parseExternalValue(byte[].class);
         if (value == null) {
             if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
                 return;

--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -207,14 +207,29 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
         if (!fieldType().indexed() && !fieldType().stored()) {
             return;
         }
-        XContentParser.Token token = context.parser().currentToken();
         String value = null;
-        if (token == XContentParser.Token.VALUE_NULL) {
-            if (nullValue != null) {
+        if (context.externalValueSet()) {
+            Object externalValue = context.externalValue();
+            if (externalValue == null && nullValue != null) {
                 value = nullValue ? "T" : "F";
+            } else {
+                if (!(context.externalValue() instanceof Boolean)) {
+                    throw new ElasticsearchIllegalArgumentException("illegal external value class ["
+                            + context.externalValue().getClass().getName() + "]. Should be " + Boolean.class.getName());
+                }
+
+                Boolean bExternalValue = (Boolean) externalValue;
+                value = bExternalValue ? "T" : "F";
             }
         } else {
-            value = context.parser().booleanValue() ? "T" : "F";
+            XContentParser.Token token = context.parser().currentToken();
+            if (token == XContentParser.Token.VALUE_NULL) {
+                if (nullValue != null) {
+                    value = nullValue ? "T" : "F";
+                }
+            } else {
+                value = context.parser().booleanValue() ? "T" : "F";
+            }
         }
         if (value == null) {
             return;

--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -207,34 +207,23 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
         if (!fieldType().indexed() && !fieldType().stored()) {
             return;
         }
-        String value = null;
-        if (context.externalValueSet()) {
-            Object externalValue = context.externalValue();
-            if (externalValue == null && nullValue != null) {
-                value = nullValue ? "T" : "F";
-            } else {
-                if (!(context.externalValue() instanceof Boolean)) {
-                    throw new ElasticsearchIllegalArgumentException("illegal external value class ["
-                            + context.externalValue().getClass().getName() + "]. Should be " + Boolean.class.getName());
-                }
 
-                Boolean bExternalValue = (Boolean) externalValue;
-                value = bExternalValue ? "T" : "F";
-            }
-        } else {
+        Boolean value = (Boolean) context.parseExternalValue(Boolean.class);
+        if (value == null) {
             XContentParser.Token token = context.parser().currentToken();
             if (token == XContentParser.Token.VALUE_NULL) {
                 if (nullValue != null) {
-                    value = nullValue ? "T" : "F";
+                    value = nullValue;
                 }
             } else {
-                value = context.parser().booleanValue() ? "T" : "F";
+                value = context.parser().booleanValue();
             }
         }
+
         if (value == null) {
             return;
         }
-        fields.add(new Field(names.indexName(), value, fieldType));
+        fields.add(new Field(names.indexName(), value ? "T" : "F", fieldType));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -208,7 +208,7 @@ public class BooleanFieldMapper extends AbstractFieldMapper<Boolean> {
             return;
         }
 
-        Boolean value = (Boolean) context.parseExternalValue(Boolean.class);
+        Boolean value = context.parseExternalValue(Boolean.class);
         if (value == null) {
             XContentParser.Token token = context.parser().currentToken();
             if (token == XContentParser.Token.VALUE_NULL) {

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -474,47 +474,61 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         context.path().pathType(pathType);
         context.path().add(name());
 
-        XContentParser.Token token = context.parser().currentToken();
-        if (token == XContentParser.Token.START_ARRAY) {
-            token = context.parser().nextToken();
+        if (context.externalValueSet()) {
+            Object externalValue = context.externalValue();
+            if (externalValue == null) {
+                return;
+            }
+
+            if (!(externalValue instanceof GeoPoint)) {
+                throw new ElasticsearchIllegalArgumentException("illegal external value class ["
+                        + externalValue.getClass().getName() + "]. Should be " + GeoPoint.class.getName());
+            }
+            GeoPoint value = (GeoPoint) externalValue;
+            parseLatLon(context, value.lat(), value.lon());
+        } else {
+            XContentParser.Token token = context.parser().currentToken();
             if (token == XContentParser.Token.START_ARRAY) {
-                // its an array of array of lon/lat [ [1.2, 1.3], [1.4, 1.5] ]
-                while (token != XContentParser.Token.END_ARRAY) {
-                    token = context.parser().nextToken();
-                    double lon = context.parser().doubleValue();
-                    token = context.parser().nextToken();
-                    double lat = context.parser().doubleValue();
-                    while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY) {
-
-                    }
-                    parseLatLon(context, lat, lon);
-                    token = context.parser().nextToken();
-                }
-            } else {
-                // its an array of other possible values
-                if (token == XContentParser.Token.VALUE_NUMBER) {
-                    double lon = context.parser().doubleValue();
-                    token = context.parser().nextToken();
-                    double lat = context.parser().doubleValue();
-                    while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY) {
-
-                    }
-                    parseLatLon(context, lat, lon);
-                } else {
+                token = context.parser().nextToken();
+                if (token == XContentParser.Token.START_ARRAY) {
+                    // its an array of array of lon/lat [ [1.2, 1.3], [1.4, 1.5] ]
                     while (token != XContentParser.Token.END_ARRAY) {
-                        if (token == XContentParser.Token.START_OBJECT) {
-                            parseObjectLatLon(context);
-                        } else if (token == XContentParser.Token.VALUE_STRING) {
-                            parseStringLatLon(context);
+                        token = context.parser().nextToken();
+                        double lon = context.parser().doubleValue();
+                        token = context.parser().nextToken();
+                        double lat = context.parser().doubleValue();
+                        while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY) {
+
                         }
+                        parseLatLon(context, lat, lon);
                         token = context.parser().nextToken();
                     }
+                } else {
+                    // its an array of other possible values
+                    if (token == XContentParser.Token.VALUE_NUMBER) {
+                        double lon = context.parser().doubleValue();
+                        token = context.parser().nextToken();
+                        double lat = context.parser().doubleValue();
+                        while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY) {
+
+                        }
+                        parseLatLon(context, lat, lon);
+                    } else {
+                        while (token != XContentParser.Token.END_ARRAY) {
+                            if (token == XContentParser.Token.START_OBJECT) {
+                                parseObjectLatLon(context);
+                            } else if (token == XContentParser.Token.VALUE_STRING) {
+                                parseStringLatLon(context);
+                            }
+                            token = context.parser().nextToken();
+                        }
+                    }
                 }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parseObjectLatLon(context);
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                parseStringLatLon(context);
             }
-        } else if (token == XContentParser.Token.START_OBJECT) {
-            parseObjectLatLon(context);
-        } else if (token == XContentParser.Token.VALUE_STRING) {
-            parseStringLatLon(context);
         }
 
         context.path().remove();

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -474,7 +474,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         context.path().pathType(pathType);
         context.path().add(name());
 
-        GeoPoint value = (GeoPoint) context.parseExternalValue(GeoPoint.class);
+        GeoPoint value = context.parseExternalValue(GeoPoint.class);
         if (value != null) {
             parseLatLon(context, value.lat(), value.lon());
         } else {

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -474,17 +474,8 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         context.path().pathType(pathType);
         context.path().add(name());
 
-        if (context.externalValueSet()) {
-            Object externalValue = context.externalValue();
-            if (externalValue == null) {
-                return;
-            }
-
-            if (!(externalValue instanceof GeoPoint)) {
-                throw new ElasticsearchIllegalArgumentException("illegal external value class ["
-                        + externalValue.getClass().getName() + "]. Should be " + GeoPoint.class.getName());
-            }
-            GeoPoint value = (GeoPoint) externalValue;
+        GeoPoint value = (GeoPoint) context.parseExternalValue(GeoPoint.class);
+        if (value != null) {
             parseLatLon(context, value.lat(), value.lon());
         } else {
             XContentParser.Token token = context.parser().currentToken();

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -225,19 +225,8 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
     @Override
     public void parse(ParseContext context) throws IOException {
         try {
-            Shape shape;
-            if (context.externalValueSet()) {
-                Object externalValue = context.externalValue();
-                if (externalValue == null) {
-                    return;
-                }
-
-                if (!(externalValue instanceof Shape)) {
-                    throw new ElasticsearchIllegalArgumentException("illegal external value class ["
-                            + externalValue.getClass().getName() + "]. Should be " + Shape.class.getName());
-                }
-                shape = (Shape) externalValue;
-            } else {
+            Shape shape = (Shape) context.parseExternalValue(Shape.class);
+            if (shape == null) {
                 ShapeBuilder shapeBuilder = ShapeBuilder.parse(context.parser());
                 if (shapeBuilder == null) {
                     return;

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -225,7 +225,7 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper<String> {
     @Override
     public void parse(ParseContext context) throws IOException {
         try {
-            Shape shape = (Shape) context.parseExternalValue(Shape.class);
+            Shape shape = context.parseExternalValue(Shape.class);
             if (shape == null) {
                 ShapeBuilder shapeBuilder = ShapeBuilder.parse(context.parser());
                 if (shapeBuilder == null) {

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalIndexModule.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalIndexModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.externalvalues;
+
+import org.elasticsearch.common.inject.AbstractModule;
+
+/**
+ *
+ */
+public class ExternalIndexModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(RegisterExternalTypes.class).asEagerSingleton();
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.externalvalues;
+
+import com.spatial4j.core.shape.Point;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.*;
+import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
+import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * This mapper add a new sub fields
+ *  .bin Binary type
+ *  .bool Boolean type
+ *  .point GeoPoint type
+ *  .shape GeoShape type
+ */
+public class ExternalMapper implements Mapper {
+    public static class Names {
+        public static final String FIELD_BIN = "bin";
+        public static final String FIELD_BOOL = "bool";
+        public static final String FIELD_POINT = "point";
+        public static final String FIELD_SHAPE = "shape";
+    }
+
+    public static class Builder extends Mapper.Builder<Builder, ExternalMapper> {
+
+        private BinaryFieldMapper.Builder binBuilder = new BinaryFieldMapper.Builder(Names.FIELD_BIN);
+        private BooleanFieldMapper.Builder boolBuilder = new BooleanFieldMapper.Builder(Names.FIELD_BOOL);
+        private GeoPointFieldMapper.Builder pointBuilder = new GeoPointFieldMapper.Builder(Names.FIELD_POINT);
+        private GeoShapeFieldMapper.Builder shapeBuilder = new GeoShapeFieldMapper.Builder(Names.FIELD_SHAPE);
+
+        public Builder(String name) {
+            super(name);
+            this.builder = this;
+        }
+
+        @Override
+        public ExternalMapper build(BuilderContext context) {
+            ContentPath.Type origPathType = context.path().pathType();
+            context.path().pathType(ContentPath.Type.FULL);
+
+            context.path().add(name);
+            BinaryFieldMapper binMapper = binBuilder.build(context);
+            BooleanFieldMapper boolMapper = boolBuilder.build(context);
+            GeoPointFieldMapper pointMapper = pointBuilder.build(context);
+            GeoShapeFieldMapper shapeMapper = shapeBuilder.build(context);
+            context.path().remove();
+
+            context.path().pathType(origPathType);
+
+            return new ExternalMapper(name, binMapper, boolMapper, pointMapper, shapeMapper);
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        @SuppressWarnings({"unchecked"})
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            ExternalMapper.Builder builder = new ExternalMapper.Builder(name);
+            return builder;
+        }
+    }
+
+    private final String name;
+
+    private final BinaryFieldMapper binMapper;
+    private final BooleanFieldMapper boolMapper;
+    private final GeoPointFieldMapper pointMapper;
+    private final GeoShapeFieldMapper shapeMapper;
+
+    public ExternalMapper(String name,
+                          BinaryFieldMapper binMapper, BooleanFieldMapper boolMapper, GeoPointFieldMapper pointMapper, GeoShapeFieldMapper shapeMapper) {
+        this.name = name;
+        this.binMapper = binMapper;
+        this.boolMapper = boolMapper;
+        this.pointMapper = pointMapper;
+        this.shapeMapper = shapeMapper;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public void parse(ParseContext context) throws IOException {
+        ContentPath.Type origPathType = context.path().pathType();
+        context.path().pathType(ContentPath.Type.FULL);
+        context.path().add(name);
+
+        // Let's add a Dummy Binary content
+        context.path().add(Names.FIELD_BIN);
+        byte[] bytes = "Hello world".getBytes();
+        context.externalValue(bytes);
+        binMapper.parse(context);
+        context.path().remove();
+
+        // Let's add a Dummy Boolean content
+        context.path().add(Names.FIELD_BOOL);
+        context.externalValue(true);
+        boolMapper.parse(context);
+        context.path().remove();
+
+        // Let's add a Dummy Point
+        Double lat = 42.0;
+        Double lng = 51.0;
+        context.path().add(Names.FIELD_POINT);
+        GeoPoint point = new GeoPoint(lat, lng);
+        context.externalValue(point);
+        pointMapper.parse(context);
+        context.path().remove();
+
+        // Let's add a Dummy Shape
+        context.path().add(Names.FIELD_SHAPE);
+        Point shape = ShapeBuilder.newPoint(-100, 45).build();
+        context.externalValue(shape);
+        shapeMapper.parse(context);
+        context.path().remove();
+
+        context.path().pathType(origPathType);
+    }
+
+    @Override
+    public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
+        // ignore this for now
+    }
+
+    @Override
+    public void traverse(FieldMapperListener fieldMapperListener) {
+        binMapper.traverse(fieldMapperListener);
+        boolMapper.traverse(fieldMapperListener);
+        pointMapper.traverse(fieldMapperListener);
+        shapeMapper.traverse(fieldMapperListener);
+    }
+
+    @Override
+    public void traverse(ObjectMapperListener objectMapperListener) {
+    }
+
+    @Override
+    public void close() {
+        binMapper.close();
+        boolMapper.close();
+        pointMapper.close();
+        shapeMapper.close();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
+	        builder.field("type", RegisterExternalTypes.EXTERNAL);
+	        builder.startObject("fields");
+                binMapper.toXContent(builder, params);
+                boolMapper.toXContent(builder, params);
+                pointMapper.toXContent(builder, params);
+                shapeMapper.toXContent(builder, params);
+	        builder.endObject();
+        
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationTests.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.externalvalues;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ */
+@ElasticsearchIntegrationTest.ClusterScope(numNodes = 1, scope = ElasticsearchIntegrationTest.Scope.SUITE, transportClientRatio = 0.0)
+public class ExternalValuesMapperIntegrationTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("plugin.types", GeoPointExternalMapperPlugin.class.getName())
+                .put(super.nodeSettings(nodeOrdinal))
+                .build();
+    }
+
+    @Test
+    public void testExternalGeoPoint() throws Exception {
+        prepareCreate("test-idx").addMapping("doc", createMapping()).execute().get();
+        ensureYellow("test-idx");
+
+        index("test-idx", "doc", "1", "external", "dummy");
+        refresh();
+
+        SearchResponse response;
+
+        response = client().prepareSearch("test-idx")
+                .setPostFilter(FilterBuilders.termFilter("external.bool", "T"))
+                .execute().actionGet();
+
+        assertThat(response.getHits().totalHits(), equalTo((long) 1));
+
+        response = client().prepareSearch("test-idx")
+                .setPostFilter(FilterBuilders.geoDistanceRangeFilter("external.point").point(42.0, 51.0).to("1km"))
+                .execute().actionGet();
+
+        assertThat(response.getHits().totalHits(), equalTo((long) 1));
+
+        response = client().prepareSearch("test-idx")
+                .setPostFilter(FilterBuilders.geoShapeFilter("external.shape", ShapeBuilder.newPoint(-100, 45), ShapeRelation.WITHIN))
+                        .execute().actionGet();
+
+        assertThat(response.getHits().totalHits(), equalTo((long) 1));
+    }
+
+
+    private XContentBuilder createMapping() throws IOException {
+        return XContentFactory.jsonBuilder().startObject().startObject("doc").startObject("properties")
+                .startObject("external").field("type", RegisterExternalTypes.EXTERNAL).endObject()
+                .endObject().endObject().endObject();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/GeoPointExternalMapperPlugin.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/GeoPointExternalMapperPlugin.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.externalvalues;
+
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+import java.util.Collection;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class GeoPointExternalMapperPlugin extends AbstractPlugin {
+    /**
+     * The name of the plugin.
+     */
+    @Override
+    public String name() {
+        return "external-mappers";
+    }
+
+    /**
+     * The description of the plugin.
+     */
+    @Override
+    public String description() {
+        return "External Mappers Plugin";
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> indexModules() {
+        Collection<Class<? extends Module>> modules = newArrayList();
+        modules.add(ExternalIndexModule.class);
+        return modules;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/RegisterExternalTypes.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/RegisterExternalTypes.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.externalvalues;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.AbstractIndexComponent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.settings.IndexSettings;
+
+public class RegisterExternalTypes extends AbstractIndexComponent {
+    public static final String EXTERNAL = "external";
+
+    @Inject
+    public RegisterExternalTypes(Index index, @IndexSettings Settings indexSettings, MapperService mapperService) {
+        super(index, indexSettings);
+
+        mapperService.documentMapperParser().putTypeParser(EXTERNAL, new ExternalMapper.TypeParser());
+    }
+}


### PR DESCRIPTION
Some mappers do not support externalValue() to be set. So plugin developers can't use it while building their own mappers.

Support added in this PR for:
- `BinaryFieldMapper`
- `BooleanFieldMapper`
- `GeoPointFieldMapper`
- `GeoShapeFieldMapper`
