### PR TITLE
add redis transport plugin to plugins page

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -212,6 +212,7 @@ bin/plugin --install mobz/elasticsearch-head --timeout 0
 .Supported by the community
 * https://github.com/tlrx/transport-zeromq[ZeroMQ transport layer plugin] (by Tanguy Leroux)
 * https://github.com/sonian/elasticsearch-jetty[Jetty HTTP transport plugin] (by Sonian Inc.)
+* https://github.com/kzwang/elasticsearch-transport-redis[Redis transport plugin] (by Kevin Wang)
 
 [float]
 [[scripting]]


### PR DESCRIPTION
Add redis transport link to plugins page

https://github.com/kzwang/elasticsearch-transport-redis
