### PR TITLE
Run REST tests against multiple nodes

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -184,7 +184,8 @@ The following are the options supported by the REST tests runner:
 
 * `tests.rest[true|false|host:port]`: determines whether the REST tests need
 to be run and if so whether to rely on an external cluster (providing host
-and port) or fire a test cluster (default)
+and port) or fire a test cluster (default). It's possible to provide a
+comma separated list of addresses to send requests in a round-robin fashion.
 * `tests.rest.suite`: comma separated paths of the test suites to be run
 (by default loaded from /rest-api-spec/test). It is possible to run only a subset
 of the tests providing a sub-folder or even a single yaml file (the default

--- a/rest-api-spec/test/get_source/60_realtime_refresh.yaml
+++ b/rest-api-spec/test/get_source/60_realtime_refresh.yaml
@@ -1,6 +1,18 @@
 ---
 "Realtime":
 
+
+ - do:
+      indices.create:
+          index: test_1
+          body:
+              settings:
+                  refresh_interval: -1
+
+ - do:
+      cluster.health:
+          wait_for_status: yellow
+
  - do:
       index:
           index:   test_1

--- a/rest-api-spec/test/indices.delete_mapping/all_path_options.yaml
+++ b/rest-api-spec/test/indices.delete_mapping/all_path_options.yaml
@@ -258,20 +258,6 @@ setup:
         index: "non_existent"
         type: "test_type1"
 
-
----
-"check delete with blank index and blank alias":
-  - do:
-      catch: param
-      indices.delete_alias:
-        name: "alias1"
-
-  - do:
-      catch: param
-      indices.delete_alias:
-        index: "test_index1"
-
-
 ---
 "check delete with blank index and blank type":
   - do:

--- a/rest-api-spec/test/indices.delete_warmer/all_path_options.yaml
+++ b/rest-api-spec/test/indices.delete_warmer/all_path_options.yaml
@@ -2,30 +2,44 @@ setup:
   - do:
       indices.create:
         index: test_index1
+        body:
+          warmers:
+            test_warmer1:
+              source:
+                query:
+                  match_all: {}
+            test_warmer2:
+              source:
+                query:
+                  match_all: {}
 
   - do:
       indices.create:
         index: test_index2
+        body:
+          warmers:
+            test_warmer1:
+              source:
+                query:
+                  match_all: {}
+            test_warmer2:
+              source:
+                query:
+                  match_all: {}
 
   - do:
       indices.create:
         index: foo
-
-  - do:
-      indices.put_warmer:
-        index: "test_index1,test_index2,foo"
-        name: test_warmer1
         body:
-          query:
-            match_all: {}
-
-  - do:
-      indices.put_warmer:
-        index: "test_index1,test_index2,foo"
-        name: test_warmer2
-        body:
-          query:
-            match_all: {}
+          warmers:
+            test_warmer1:
+              source:
+                query:
+                  match_all: {}
+            test_warmer2:
+              source:
+                query:
+                  match_all: {}
 
 ---
 "Check setup":

--- a/rest-api-spec/test/indices.get_warmer/10_basic.yaml
+++ b/rest-api-spec/test/indices.get_warmer/10_basic.yaml
@@ -3,38 +3,27 @@ setup:
   - do:
         indices.create:
           index: test_1
+          body:
+            warmers:
+              warmer_1:
+                source: { query: { match_all: { }}}
+              warmer_2:
+                source: { query: { match_all: { }}}
+
+
   - do:
         indices.create:
           index: test_2
+          body:
+            warmers:
+              warmer_2:
+                source: { query: { match_all: { }}}
+              warmer_3:
+                source: { query: { match_all: { }}}
 
   - do:
         cluster.health:
             wait_for_status: yellow
-  - do:
-        indices.put_warmer:
-            index: test_1
-            name: warmer_1
-            body: { query: { match_all: { }}}
-
-  - do:
-        indices.put_warmer:
-            index: test_1
-            name: warmer_2
-            body: { query: { match_all: { }}}
-
-  - do:
-        indices.put_warmer:
-            index: test_2
-            name: warmer_2
-            body: { query: { match_all: { }}}
-  - do:
-        indices.put_warmer:
-            index: test_2
-            name: warmer_3
-            body: { query: { match_all: { }}}
-
-  - do:
-        indices.refresh: {}
 
 ---
 "Get /_warmer":

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -850,6 +850,16 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         return annotation == null ? -1 : annotation.numNodes();
     }
 
+    private int getMinNumNodes() {
+        ClusterScope annotation = getAnnotation(this.getClass());
+        return annotation == null ? TestCluster.DEFAULT_MIN_NUM_NODES : annotation.minNumNodes();
+    }
+
+    private int getMaxNumNodes() {
+        ClusterScope annotation = getAnnotation(this.getClass());
+        return annotation == null ? TestCluster.DEFAULT_MAX_NUM_NODES : annotation.maxNumNodes();
+    }
+
     /**
      * This method is used to obtain settings for the <tt>Nth</tt> node in the cluster.
      * Nodes in this cluster are associated with an ordinal number such that nodes can
@@ -880,7 +890,15 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             };
         }
 
-        return new TestCluster(currentClusterSeed, numNodes, clusterName(scope.name(), ElasticsearchTestCase.CHILD_VM_ID, currentClusterSeed), nodeSettingsSource);
+        int minNumNodes, maxNumNodes;
+        if (numNodes >= 0) {
+            minNumNodes = maxNumNodes = numNodes;
+        } else {
+            minNumNodes = getMinNumNodes();
+            maxNumNodes = getMaxNumNodes();
+        }
+
+        return new TestCluster(currentClusterSeed, minNumNodes, maxNumNodes, clusterName(scope.name(), ElasticsearchTestCase.CHILD_VM_ID, currentClusterSeed), nodeSettingsSource);
     }
 
     /**
@@ -898,9 +916,22 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
         /**
          * Returns the number of nodes in the cluster. Default is <tt>-1</tt> which means
-         * a random number of nodes but at least <code>2</code></tt> is used./
+         * a random number of nodes is used, where the minimum and maximum number of nodes
+         * are either the specified ones or the default ones if not specified.
          */
         int numNodes() default -1;
+
+        /**
+         * Returns the minimum number of nodes in the cluster. Default is {@link TestCluster#DEFAULT_MIN_NUM_NODES}.
+         * Ignored when {@link ClusterScope#numNodes()} is set.
+         */
+        int minNumNodes() default TestCluster.DEFAULT_MIN_NUM_NODES;
+
+        /**
+         * Returns the maximum number of nodes in the cluster.  Default is {@link TestCluster#DEFAULT_MAX_NUM_NODES}.
+         * Ignored when {@link ClusterScope#numNodes()} is set.
+         */
+        int maxNumNodes() default TestCluster.DEFAULT_MAX_NUM_NODES;
 
         /**
          * Returns the transport client ratio. By default this returns <code>-1</code> which means a random

--- a/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -29,6 +29,7 @@ import org.elasticsearch.test.rest.spec.RestSpec;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,9 +51,8 @@ public class RestTestExecutionContext implements Closeable {
 
     private RestResponse response;
 
-    public RestTestExecutionContext(String host, int port, RestSpec restSpec) throws RestException, IOException {
-
-        this.restClient = new RestClient(host, port, restSpec);
+    public RestTestExecutionContext(InetSocketAddress[] addresses, RestSpec restSpec) throws RestException, IOException {
+        this.restClient = new RestClient(addresses, restSpec);
         this.esVersion = restClient.getEsVersion();
     }
 

--- a/src/test/java/org/elasticsearch/tribe/TribeTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeTests.java
@@ -52,7 +52,7 @@ public class TribeTests extends ElasticsearchIntegrationTest {
     @Before
     public void setupSecondCluster() {
         // create another cluster
-        cluster2 = new TestCluster(randomLong(), 2, cluster().getClusterName() + "-2");
+        cluster2 = new TestCluster(randomLong(), 2, 2, cluster().getClusterName() + "-2");
         cluster2.beforeTest(getRandom(), getPerTestTransportClientRatio());
         cluster2.ensureAtLeastNumNodes(2);
 


### PR DESCRIPTION
Multiple nodes are now started when running REST tests against the `TestCluster` (default randomized settings are now used instead of the hardcoded `1`)

Added also randomized round-robin based on all available nodes, and ability to provide multiple addresses when running tests against an external cluster to have the same behaviour.

Also sped up a few warmer tests and fixed get_source realtime test which might fail in some cases due to automatic refresh.
