### PR TITLE
Added `cross_fields` type to multi_match query

### DIFF
--- a/docs/reference/query-dsl/queries/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/queries/multi-match-query.asciidoc
@@ -1,64 +1,437 @@
 [[query-dsl-multi-match-query]]
 === Multi Match Query
 
-The `multi_match` query builds further on top of the `match` query by
-allowing multiple fields to be specified. The idea here is to allow to
-more easily build a concise match type query over multiple fields
-instead of using a relatively more expressive query by using multiple
-match queries within a `bool` query.
+The `multi_match` query builds on the <<query-dsl-match-query,`match` query>>
+to allow multi-field queries:
 
-The structure of the query is a bit different. Instead of a nested json
-object defining the query field, there is a top json level field for
-defining the query fields. Example:
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":    "this is a test", <1>
+    "fields": [ "subject", "message" ] <2>
+  }
+}
+--------------------------------------------------
+<1> The query string.
+<2> The fields to be queried.
+
+[float]
+=== `fields` and per-field boosting
+
+Fields can be specified with wildcards, eg:
+
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":    "Will Smith"
+    "fields": [ "title", "*_name" ] <1>
+  }
+}
+--------------------------------------------------
+<1> Query the `title`, `first_name` and `last_name` fields.
+
+Individual fields can be boosted with the caret (`^`) notation:
 
 [source,js]
 --------------------------------------------------
 {
   "multi_match" : {
     "query" : "this is a test",
-    "fields" : [ "subject", "message" ]
+    "fields" : [ "subject^3", "message" ] <1>
   }
 }
 --------------------------------------------------
-
-The `multi_match` query creates either a `bool` or a `dis_max` top level
-query. Each field is a query clause in this top level query. The query
-clause contains the actual query (the specified 'type' defines what
-query this will be). Each query clause is basically a `should` clause.
+<1> The `subject` field is three times as important than the `message` field.
 
 [float]
+=== `use_dis_max`
+
+deprecated[1.1.0,Use `type:best_fields` or `type:most_fields` instead. See <<multi-match-types>>]
+
+By default, the `multi_match` query generates a `match` clause per field, then wraps them
+in a `dis_max` query.  By setting `use_dis_max` to `false`, they will be wrapped in a
+`bool` query instead.
+
+[[multi-match-types]]
 [float]
-==== Options
+=== Types of `multi_match` query:
 
-All options that apply on the `match` query also apply on the
-`multi_match` query. The `match` query options apply only on the
-individual clauses inside the top level query.
+coming[1.1.0]
 
-* `fields` - Fields to be used in the query.
-* `use_dis_max` - Boolean indicating to either create a `dis_max` query
-or a `bool` query. Defaults to `true`.
-* `tie_breaker` - Multiplier value to balance the scores between lower
-and higher scoring fields. Only applicable when `use_dis_max` is set to
-true. Defaults to `0.0`.
+The way the `multi_match` query is executed internally depends on the `type`
+parameter, which can be set to:
 
-The query accepts all the options that a regular `match` query accepts.
+[horizontal]
+`best_fields`::     (*default*) Finds documents which match any field, but
+                    uses the  `_score` from the best field.  See <<type-best-fields>>.
 
-[float]
-[float]
-==== Boosting
+`most_fields`::     Finds documents which match any field and combines
+                    the `_score` from each field.  See <<type-most-fields>>.
 
-The `multi_match` query supports field boosting via `^` notation in the
-fields json field.
+`cross_fields`::    Treats fields with the same `analyzer` as though they
+                    were one big field. Looks for each word in *any*
+                    field. See <<type-cross-fields>>.
+
+`phrase`::          Runs a `match_phrase` query on each field and combines
+                    the `_score` from each field.  See <<type-phrase>>.
+
+`phrase_prefix`::   Runs a `match_phrase_prefix` query on each field and
+                    combines the `_score` from each field.  See <<type-phrase>>.
+
+[[type-best-fields]]
+==== `best_fields`
+
+The `best_fields` type is most useful when you are searching for multiple
+words best found in the same field. For instance ``brown fox'' in a single
+field is more meaningful than ``brown'' in one field and ``fox'' in the other.
+
+The `best_fields` type generates a <<query-dsl-match-query,`match` query>> for
+each field and wraps them in a <<query-dsl-dis-max-query,`dis_max`>> query, to
+find the single best matching field.  For instance, this query:
 
 [source,js]
 --------------------------------------------------
 {
   "multi_match" : {
-    "query" : "this is a test",
-    "fields" : [ "subject^2", "message" ]
+    "query":      "brown fox",
+    "type":       "best_fields",
+    "fields":     [ "subject", "message" ],
+    "tie_breaker": 0.3
   }
 }
 --------------------------------------------------
 
-In the above example hits in the `subject` field are 2 times more
-important than in the `message` field.
+would be executed as:
+
+[source,js]
+--------------------------------------------------
+{
+  "dis_max": {
+    "queries": [
+      { "match": { "subject": "brown fox" }},
+      { "match": { "message": "brown fox" }}
+    ],
+    "tie_breaker": 0.3
+  }
+}
+--------------------------------------------------
+
+Normally the `best_fields` type uses the score of the *single* best matching
+field, but if `tie_breaker` is specified, then it calculates the score as
+follows:
+
+  * the score from the best matching field
+  * plus `tie_breaker * _score` for all other matching fields
+
+Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
+`fuzziness`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
+and `cutoff_frequency`, as explained in <<query-dsl-match-query, match query>>.
+
+[IMPORTANT]
+[[operator-min]]
+.`operator` and `minimum_should_match`
+==================================================
+
+The `best_fields` and `most_fields` types are _field-centric_ -- they generate
+a `match` query *per field*.  This means that the `operator` and
+`minimum_should_match` parameters are applied to each field individually,
+which is probably not what you want.
+
+Take this query for example:
+
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":      "Will Smith",
+    "type":       "best_fields",
+    "fields":     [ "first_name", "last_name" ],
+    "operator":   "and" <1>
+  }
+}
+--------------------------------------------------
+<1> All terms must be present.
+
+This query is executed as:
+
+      (+first_name:will +first_name:smith)
+    | (+last_name:will  +last_name:smith)
+
+In other words, *all terms* must be present *in a single field* for a document
+to match.
+
+See <<type-cross-fields>> for a better solution.
+
+==================================================
+
+[[type-most-fields]]
+==== `most_fields`
+
+The `most_fields` type is most useful when querying multiple fields that
+contain the same text analyzed in different ways.  For instance, the main
+field may contain synonyms, stemming and terms without diacritics. A second
+field may contain the original terms, and a third field might contain
+shingles. By combining scores from all three fields we can match as many
+documents as possible with the main field, but use the second and third fields
+to push the most similar results to the top of the list.
+
+This query:
+
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":      "quick brown fox",
+    "type":       "most_fields",
+    "fields":     [ "title", "title.original", "title.shingles" ]
+  }
+}
+--------------------------------------------------
+
+would be executed as:
+
+[source,js]
+--------------------------------------------------
+{
+  "bool": {
+    "should": [
+      { "match": { "title":          "quick brown fox" }},
+      { "match": { "title.original": "quick brown fox" }},
+      { "match": { "title.shingles": "quick brown fox" }}
+    ]
+  }
+}
+--------------------------------------------------
+
+The score from each `match` clause is added together, then divided by the
+number of `match` clauses.
+
+Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
+`fuzziness`, `prefix_length`, `max_expansions`, `rewrite`, `zero_terms_query`
+and `cutoff_frequency`, as explained in <<query-dsl-match-query,match query>>, but
+*see <<operator-min>>*.
+
+[[type-phrase]]
+==== `phrase` and `phrase_prefix`
+
+The `phrase` and `phrase_prefix` types behave just like <<type-best-fields>>,
+but they use a `match_phrase` or `match_phrase_prefix` query instead of a
+`match` query.
+
+This query:
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":      "quick brown f",
+    "type":       "phrase_prefix",
+    "fields":     [ "subject", "message" ]
+  }
+}
+--------------------------------------------------
+
+
+[source,js]
+--------------------------------------------------
+{
+  "dis_max": {
+    "queries": [
+      { "match_phrase_prefix": { "subject": "quick brown f" }},
+      { "match_phrase_prefix": { "message": "quick brown f" }}
+    ]
+  }
+}
+--------------------------------------------------
+
+Also, accepts `analyzer`, `boost`, `slop` and `zero_terms_query`  as explained
+in <<query-dsl-match-query>>.  Type `phrase_prefix` additionally accepts
+`max_expansions`.
+
+[[type-cross-fields]]
+==== `cross_fields`
+
+The `cross_fields` type is particularly useful with structured documents where
+multiple fields *should* match.  For instance, when querying the `first_name`
+and `last_name` fields for ``Will Smith'', the best match is like to have
+``Will'' in one field and ``Smith'' in the other.
+
+****
+
+This sounds like a job for <<type-most-fields>> but there are two problems
+with that approach. The first problem is that `operator` and
+`minimum_should_match` are applied per-field, instead of per-term (see
+<<operator-min,explanation above>>).
+
+The second problem is to do with relevance: the different term frequencies in
+the `first_name` and `last_name` fields   can produce unexpected results.
+
+For instance, imagine we have two people: ``Will Smith'' and ``Smith Jones''.
+``Smith'' as a last name is very common (and so is of low importance) but
+``Smith'' as a first name is very uncommon (and so is of great importance).
+
+If we do a search for ``Will Smith'', the ``Smith Jones'' document will
+probably appear above the better matching ``Will Smith'' because the score of
+`first_name:smith` has trumped the combined scores of `first_name:will` plus
+`last_name:smith`.
+
+****
+
+One way of dealing with these types of queries is simply to index the
+`first_name` and `last_name` fields into a single `full_name` field.  Of
+course, this can only be done at index time.
+
+The `cross_field` type tries to solve these problems at query time by taking a
+_term-centric_ approach.  It first analyzes the query string into individual
+terms, then looks for each term in any of the fields, as though they were one
+big field.
+
+A query like:
+
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":      "Will Smith",
+    "type":       "cross_fields",
+    "fields":     [ "first_name", "last_name" ],
+    "operator":   "and"
+  }
+}
+--------------------------------------------------
+
+is executed as:
+
+    +(first_name:will  last_name:will)
+    +(first_name:smith last_name:smith)
+
+In other words, *all terms* must be present *in at least one field* for a
+document to match.  (Compare this to
+<<operator-min,the logic used for `best_fields` and `most_fields`>>.)
+
+That solves one of the two problems. The problem of differing term frequencies
+is solved by _blending_ the term frequencies for all fields in order to even
+out the differences.  In other words, `first_name:smith` will be treated as
+though it has the same weight as `last_name:smith`. (Actually,
+`first_name:smith` is given a tiny advantage over `last_name:smith`, just to
+make the order of results more stable.)
+
+If you run the above query through the <<search-validate>>, it returns this
+explanation:
+
+    +blended("will",  fields: [first_name, last_name])
+    +blended("smith", fields: [first_name, last_name])
+
+Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
+`zero_terms_query` and `cutoff_frequency`, as explained in
+<<query-dsl-match-query, match query>>.
+
+===== `cross_field` and analysis
+
+The `cross_field` type can only work in term-centric mode on fields that have
+the same analyzer. Fields with the same analyzer are grouped together as in
+the example above.  If there are multiple groups, they are combined with a
+`bool` query.
+
+For instance, if we have a `first` and `last` field which have
+the same analyzer, plus a `first.edge` and `last.edge` which
+both use an `edge_ngram` analyzer, this query:
+
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":      "Jon",
+    "type":       "cross_fields",
+    "fields":     [
+        "first", "first.edge",
+        "last",  "last.edge"
+    ]
+  }
+}
+--------------------------------------------------
+
+would be executed as:
+
+        blended("jon", fields: [first, last])
+    | (
+        blended("j",   fields: [first.edge, last.edge])
+        blended("jo",  fields: [first.edge, last.edge])
+        blended("jon", fields: [first.edge, last.edge])
+    )
+
+In other words, `first` and `last` would be grouped together and
+treated as a single field, and `first.edge` and `last.edge` would be
+grouped together and treated as a single field.
+
+Having multiple groups is fine but, when combined with `operator` or
+`minimum_should_match`, it can suffer from the <<operator-min,same problem>>
+as `most_fields` or `best_fields`.
+
+You can easily rewrite this query yourself as two separate `cross_type`
+queries combined with a `bool` query, and apply the `minimum_should_match`
+parameter to just one of them:
+
+[source,js]
+--------------------------------------------------
+{
+    "bool": {
+        "should": [
+            {
+              "multi_match" : {
+                "query":      "Will Smith",
+                "type":       "cross_fields",
+                "fields":     [ "first", "last" ],
+                "minimum_should_match": 50% <1>
+              }
+            },
+            {
+              "multi_match" : {
+                "query":      "Will Smith",
+                "type":       "cross_fields",
+                "fields":     [ "*.edge" ]
+              }
+            }
+        ]
+    }
+}
+--------------------------------------------------
+<1> Either `will` or `smith` must be present in either of the `first`
+    or `last` fields
+
+You can force all fields into the same group by specifying the `analyzer`
+parameter in the query.
+
+[source,js]
+--------------------------------------------------
+{
+  "multi_match" : {
+    "query":      "Jon",
+    "type":       "cross_fields",
+    "analyzer":   "standard", <1>
+    "fields":     [ "first", "last", "*.edge" ]
+  }
+}
+--------------------------------------------------
+<1> Use the `standard` analyzer for all fields.
+
+which will be executed as:
+
+    blended("will",  fields: [first, first.edge, last.edge, last])
+    blended("smith", fields: [first, first.edge, last.edge, last])
+
+===== `tie_breaker`
+
+By default, each per-term `blended` query will use the best score returned by
+any field in a group, then these scores are added together to give the final
+score. The `tie_breaker` parameter can change the default behaviour of the
+per-term `blended` queries. It accepts:
+
+[horizontal]
+`0.0`::             Take the single best score out of (eg) `first_name:will`
+                    and `last_name:will` (*default*)
+`1.0`::             Add together the scores for (eg) `first_name:will` and
+                    `last_name:will`
+`0.0 < n < 1.0`::   Take the single best score plus +tie_breaker+ multiplied
+                    by each of the scores from other matching fields.

--- a/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
+++ b/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.lucene.queries;
+
+import com.google.common.primitives.Ints;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.*;
+import org.apache.lucene.util.ArrayUtil;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * BlendedTermQuery can be used to unify term statistics across
+ * one or more fields in the index. A common problem with structured
+ * documents is that a term that is significant in on field might not be
+ * significant in other fields like in a scenario where documents represent
+ * users with a "first_name" and a "second_name". When someone searches
+ * for "simon" it will very likely get "paul simon" first since "simon" is a
+ * an uncommon last name ie. has a low document frequency. This query
+ * tries to "lie" about the global statistics like document frequency as well
+ * total term frequency to rank based on the estimated statistics.
+ * <p>
+ * While aggregating the total term frequency is trivial since it
+ * can be summed up not every {@link org.apache.lucene.search.similarities.Similarity}
+ * makes use of this statistic. The document frequency which is used in the
+ * {@link org.apache.lucene.search.similarities.DefaultSimilarity}
+ * can only be estimated as an lower-bound since it is a document based statistic. For
+ * the document frequency the maximum frequency across all fields per term is used
+ * which is the minimum number of documents the terms occurs in.
+ * </p>
+ */
+// TODO maybe contribute to Lucene
+public abstract class BlendedTermQuery extends Query {
+
+    private final Term[] terms;
+
+
+    public BlendedTermQuery(Term[] terms) {
+        if (terms == null || terms.length == 0) {
+            throw new IllegalArgumentException("terms must not be null or empty");
+        }
+        this.terms = terms;
+    }
+
+    @Override
+    public Query rewrite(IndexReader reader) throws IOException {
+        IndexReaderContext context = reader.getContext();
+        TermContext[] ctx = new TermContext[terms.length];
+        int[] docFreqs = new int[ctx.length];
+        for (int i = 0; i < terms.length; i++) {
+            ctx[i] = TermContext.build(context, terms[i]);
+            docFreqs[i] = ctx[i].docFreq();
+        }
+
+        final int maxDoc = reader.maxDoc();
+        blend(ctx, maxDoc, reader);
+        Query query = topLevelQuery(terms, ctx, docFreqs, maxDoc);
+        query.setBoost(getBoost());
+        return query;
+    }
+
+    protected abstract Query topLevelQuery(Term[] terms, TermContext[] ctx, int[] docFreqs, int maxDoc);
+
+    protected void blend(TermContext[] contexts, int maxDoc, IndexReader reader) throws IOException {
+        if (contexts.length <= 1) {
+            return;
+        }
+        int max = 0;
+        long minSumTTF = Long.MAX_VALUE;
+        for (int i = 0; i < contexts.length; i++) {
+            TermContext ctx = contexts[i];
+            int df = ctx.docFreq();
+            // we use the max here since it's the only "true" estimation we can make here
+            // at least max(df) documents have that term. Sum or Averages don't seem
+            // to have a significant meaning here.
+            // TODO: Maybe it could also make sense to assume independent distributions of documents and eg. have:
+            //   df = df1 + df2 - (df1 * df2 / maxDoc)?
+            max = Math.max(df, max);
+            if (minSumTTF != -1 && ctx.totalTermFreq() != -1) {
+                // we need to find out the minimum sumTTF to adjust the statistics
+                // otherwise the statistics don't match
+                minSumTTF = Math.min(minSumTTF, reader.getSumTotalTermFreq(terms[i].field()));
+            } else {
+                minSumTTF = -1;
+            }
+
+        }
+        if (minSumTTF != -1 && maxDoc > minSumTTF) {
+            maxDoc = (int)minSumTTF;
+        }
+
+        if (max == 0) {
+            return; // we are done that term doesn't exist at all
+        }
+        long sumTTF = minSumTTF == -1 ? -1 : 0;
+        final TermContext[] tieBreak = new TermContext[contexts.length];
+        System.arraycopy(contexts, 0, tieBreak, 0, contexts.length);
+        ArrayUtil.timSort(tieBreak, new Comparator<TermContext>() {
+            @Override
+            public int compare(TermContext o1, TermContext o2) {
+                return Ints.compare(o2.docFreq(), o1.docFreq());
+            }
+        });
+        int prev = tieBreak[0].docFreq();
+        int actualDf = Math.min(maxDoc, max);
+        assert actualDf >=0 : "DF must be >= 0";
+
+
+        // here we try to add a little bias towards
+        // the more popular (more frequent) fields
+        // that acts as a tie breaker
+        for (TermContext ctx : tieBreak) {
+            if (ctx.docFreq() == 0) {
+                break;
+            }
+            final int current = ctx.docFreq();
+            if (prev > current) {
+                actualDf++;
+            }
+            ctx.setDocFreq(Math.min(maxDoc, actualDf));
+            prev = current;
+            if (sumTTF >= 0 && ctx.totalTermFreq() >= 0) {
+                sumTTF += ctx.totalTermFreq();
+            } else {
+                sumTTF = -1;  // omit once TF is omitted anywhere!
+            }
+        }
+        sumTTF = Math.min(sumTTF, minSumTTF);
+        for (int i = 0; i < contexts.length; i++) {
+            int df = contexts[i].docFreq();
+            if (df == 0) {
+                continue;
+            }
+            // the blended sumTTF can't be greater than the sumTTTF on the field
+            final long fixedTTF = sumTTF == -1 ? -1 : sumTTF;
+            contexts[i] = adjustTTF(contexts[i], fixedTTF);
+        }
+    }
+
+    private TermContext adjustTTF(TermContext termContext, long sumTTF) {
+        if (sumTTF == -1 && termContext.totalTermFreq() == -1) {
+            return termContext;
+        }
+        TermContext newTermContext = new TermContext(termContext.topReaderContext);
+        List<AtomicReaderContext> leaves = termContext.topReaderContext.leaves();
+        final int len;
+        if (leaves == null) {
+            len = 1;
+        } else {
+            len = leaves.size();
+        }
+        int df = termContext.docFreq();
+        long ttf = sumTTF;
+        for (int i = 0; i < len; i++) {
+            TermState termState = termContext.get(i);
+            if (termState == null) {
+                continue;
+            }
+            newTermContext.register(termState, i, df, ttf);
+            df = 0;
+            ttf = 0;
+        }
+        return newTermContext;
+    }
+
+    @Override
+    public String toString(String field) {
+        return "blended(terms: " + Arrays.toString(terms) + ")";
+
+    }
+
+    private volatile Term[] equalTerms = null;
+
+    private Term[] equalsTerms() {
+        if (terms.length == 1) {
+            return terms;
+        }
+        if (equalTerms == null) {
+            // sort the terms to make sure equals and hashCode are consistent
+            // this should be a very small cost and equivalent to a HashSet but less object creation
+            final Term[] t = new Term[terms.length];
+            System.arraycopy(terms, 0, t, 0, terms.length);
+            ArrayUtil.timSort(t);
+            equalTerms = t;
+        }
+        return equalTerms;
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        BlendedTermQuery that = (BlendedTermQuery) o;
+        if (!Arrays.equals(equalsTerms(), that.equalsTerms())) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(equalsTerms());
+        return result;
+    }
+
+    public static BlendedTermQuery booleanBlendedQuery(Term[] terms, final boolean disableCoord) {
+        return booleanBlendedQuery(terms, null, disableCoord);
+    }
+
+    public static BlendedTermQuery booleanBlendedQuery(Term[] terms, final float[] boosts, final boolean disableCoord) {
+        return new BlendedTermQuery(terms) {
+            protected Query topLevelQuery(Term[] terms, TermContext[] ctx, int[] docFreqs, int maxDoc) {
+                BooleanQuery query = new BooleanQuery(disableCoord);
+                for (int i = 0; i < terms.length; i++) {
+                    TermQuery termQuery = new TermQuery(terms[i], ctx[i]);
+                    if (boosts != null) {
+                        termQuery.setBoost(boosts[i]);
+                    }
+                    query.add(termQuery, BooleanClause.Occur.SHOULD);
+                }
+                return query;
+            }
+        };
+    }
+
+    public static BlendedTermQuery commonTermsBlendedQuery(Term[] terms, final float[] boosts, final boolean disableCoord, final float maxTermFrequency) {
+        return new BlendedTermQuery(terms) {
+            protected Query topLevelQuery(Term[] terms, TermContext[] ctx, int[] docFreqs, int maxDoc) {
+                BooleanQuery query = new BooleanQuery(true);
+                BooleanQuery high = new BooleanQuery(disableCoord);
+                BooleanQuery low = new BooleanQuery(disableCoord);
+                for (int i = 0; i < terms.length; i++) {
+                    TermQuery termQuery = new TermQuery(terms[i], ctx[i]);
+                    if (boosts != null) {
+                        termQuery.setBoost(boosts[i]);
+                    }
+                    if ((maxTermFrequency >= 1f && docFreqs[i] > maxTermFrequency)
+                            || (docFreqs[i] > (int) Math.ceil(maxTermFrequency
+                            * (float) maxDoc))) {
+                        high.add(termQuery, BooleanClause.Occur.SHOULD);
+                    } else {
+                        low.add(termQuery, BooleanClause.Occur.SHOULD);
+                    }
+                }
+                if (low.clauses().isEmpty()) {
+                    for (BooleanClause booleanClause : high) {
+                        booleanClause.setOccur(BooleanClause.Occur.MUST);
+                    }
+                    return high;
+                } else if (high.clauses().isEmpty()) {
+                    return low;
+                } else {
+                    query.add(high, BooleanClause.Occur.SHOULD);
+                    query.add(low, BooleanClause.Occur.MUST);
+                    return query;
+                }
+            }
+        };
+    }
+
+    public static BlendedTermQuery dismaxBlendedQuery(Term[] terms, final float tieBreakerMultiplier) {
+        return dismaxBlendedQuery(terms, null, tieBreakerMultiplier);
+    }
+
+    public static BlendedTermQuery dismaxBlendedQuery(Term[] terms, final float[] boosts, final float tieBreakerMultiplier) {
+        return new BlendedTermQuery(terms) {
+            protected Query topLevelQuery(Term[] terms, TermContext[] ctx, int[] docFreqs, int maxDoc) {
+                DisjunctionMaxQuery query = new DisjunctionMaxQuery(tieBreakerMultiplier);
+                for (int i = 0; i < terms.length; i++) {
+                    TermQuery termQuery = new TermQuery(terms[i], ctx[i]);
+                    if (boosts != null) {
+                        termQuery.setBoost(boosts[i]);
+                    }
+                    query.add(termQuery);
+                }
+                return query;
+            }
+        };
+    }
+}

--- a/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -19,27 +19,34 @@
 
 package org.elasticsearch.index.search;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.BlendedTermQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MultiMatchQuery extends MatchQuery {
 
-    private boolean useDisMax = true;
-    private float tieBreaker;
-
-    public void setUseDisMax(boolean useDisMax) {
-        this.useDisMax = useDisMax;
-    }
+    private Float groupTieBreaker = null;
 
     public void setTieBreaker(float tieBreaker) {
-        this.tieBreaker = tieBreaker;
+        this.groupTieBreaker = tieBreaker;
     }
 
     public MultiMatchQuery(QueryParseContext parseContext) {
@@ -57,36 +64,205 @@ public class MultiMatchQuery extends MatchQuery {
         return query;
     }
 
-    public Query parse(Type type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) throws IOException {
+    public Query parse(MultiMatchQueryBuilder.Type type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) throws IOException {
         if (fieldNames.size() == 1) {
             Map.Entry<String, Float> fieldBoost = fieldNames.entrySet().iterator().next();
             Float boostValue = fieldBoost.getValue();
-            return parseAndApply(type, fieldBoost.getKey(), value, minimumShouldMatch, boostValue);
+            return parseAndApply(type.matchQueryType(), fieldBoost.getKey(), value, minimumShouldMatch, boostValue);
         }
 
-        if (useDisMax) {
-            DisjunctionMaxQuery disMaxQuery = new DisjunctionMaxQuery(tieBreaker);
-            boolean clauseAdded = false;
+        final float tieBreaker = groupTieBreaker == null ? type.tieBreaker() : groupTieBreaker;
+        switch (type) {
+            case PHRASE:
+            case PHRASE_PREFIX:
+            case BEST_FIELDS:
+            case MOST_FIELDS:
+                queryBuilder = new QueryBuilder(tieBreaker);
+                break;
+            case CROSS_FIELDS:
+                queryBuilder = new CrossFieldsQueryBuilder(tieBreaker);
+                break;
+            default:
+                throw new ElasticsearchIllegalStateException("No such type: " + type);
+        }
+        final List<? extends Query> queries = queryBuilder.buildGroupedQueries(type, fieldNames, value, minimumShouldMatch);
+        return queryBuilder.conbineGrouped(queries);
+    }
+
+    private QueryBuilder queryBuilder;
+
+    public class QueryBuilder {
+        protected final boolean groupDismax;
+        protected final float tieBreaker;
+
+        public QueryBuilder(float tieBreaker) {
+            this(tieBreaker != 1.0f, tieBreaker);
+        }
+
+        public QueryBuilder(boolean groupDismax, float tieBreaker) {
+            this.groupDismax = groupDismax;
+            this.tieBreaker = tieBreaker;
+        }
+
+        public  List<Query> buildGroupedQueries(MultiMatchQueryBuilder.Type type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) throws IOException{
+            List<Query> queries = new ArrayList<Query>();
             for (String fieldName : fieldNames.keySet()) {
                 Float boostValue = fieldNames.get(fieldName);
-                Query query = parseAndApply(type, fieldName, value, minimumShouldMatch, boostValue);
+                Query query = parseGroup(type.matchQueryType(), fieldName, boostValue, value, minimumShouldMatch);
                 if (query != null) {
-                    clauseAdded = true;
+                    queries.add(query);
+                }
+            }
+            return queries;
+        }
+
+        public Query parseGroup(Type type, String field, Float boostValue, Object value, String minimumShouldMatch) throws IOException {
+            return parseAndApply(type, field, value, minimumShouldMatch, boostValue);
+        }
+
+        public Query conbineGrouped(List<? extends Query> groupQuery) {
+            if (groupQuery == null || groupQuery.isEmpty()) {
+                return null;
+            }
+            if (groupQuery.size() == 1) {
+                return groupQuery.get(0);
+            }
+            if (groupDismax) {
+                DisjunctionMaxQuery disMaxQuery = new DisjunctionMaxQuery(tieBreaker);
+                for (Query query : groupQuery) {
                     disMaxQuery.add(query);
                 }
-            }
-            return clauseAdded ? disMaxQuery : null;
-        } else {
-            BooleanQuery booleanQuery = new BooleanQuery();
-            for (String fieldName : fieldNames.keySet()) {
-                Float boostValue = fieldNames.get(fieldName);
-                Query query = parseAndApply(type, fieldName, value, minimumShouldMatch, boostValue);
-                if (query != null) {
+                return disMaxQuery;
+            } else {
+                final BooleanQuery booleanQuery = new BooleanQuery();
+                for (Query query : groupQuery) {
                     booleanQuery.add(query, BooleanClause.Occur.SHOULD);
                 }
+                return booleanQuery;
             }
-            return !booleanQuery.clauses().isEmpty() ? booleanQuery : null;
+        }
+
+        public Query blendTerm(Term term, FieldMapper mapper) {
+            return MultiMatchQuery.super.blendTermQuery(term, mapper);
+        }
+
+        public boolean forceAnalyzeQueryString() {
+            return false;
         }
     }
 
+    public class CrossFieldsQueryBuilder extends QueryBuilder {
+        private FieldAndMapper[] blendedFields;
+
+        public CrossFieldsQueryBuilder(float tieBreaker) {
+            super(false, tieBreaker);
+        }
+
+        public List<Query> buildGroupedQueries(MultiMatchQueryBuilder.Type type, Map<String, Float> fieldNames, Object value, String minimumShouldMatch) throws IOException {
+            Map<Analyzer, List<FieldAndMapper>> groups = new HashMap<Analyzer, List<FieldAndMapper>>();
+            List<Tuple<String, Float>> missing = new ArrayList<Tuple<String, Float>>();
+            for (Map.Entry<String, Float> entry : fieldNames.entrySet()) {
+                String name = entry.getKey();
+                MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(name);
+                if (smartNameFieldMappers != null && smartNameFieldMappers.hasMapper()) {
+                    Analyzer actualAnalyzer = getAnalyzer(smartNameFieldMappers.mapper(), smartNameFieldMappers);
+                    name = smartNameFieldMappers.mapper().names().indexName();
+                    if (!groups.containsKey(actualAnalyzer)) {
+                       groups.put(actualAnalyzer, new ArrayList<FieldAndMapper>());
+                    }
+                    Float boost = entry.getValue();
+                    boost = boost == null ? Float.valueOf(1.0f) : boost;
+                    groups.get(actualAnalyzer).add(new FieldAndMapper(name, smartNameFieldMappers.mapper(), boost));
+                } else {
+                    missing.add(new Tuple(name, entry.getValue()));
+                }
+
+            }
+            List<Query> queries = new ArrayList<Query>();
+            for (Tuple<String, Float> tuple : missing) {
+                Query q = parseGroup(type.matchQueryType(), tuple.v1(), tuple.v2(), value, minimumShouldMatch);
+                if (q != null) {
+                    queries.add(q);
+                }
+            }
+            for (List<FieldAndMapper> group : groups.values()) {
+                if (group.size() > 1) {
+                    blendedFields = new FieldAndMapper[group.size()];
+                    int i = 0;
+                    for (FieldAndMapper fieldAndMapper : group) {
+                        blendedFields[i++] = fieldAndMapper;
+                    }
+                } else {
+                    blendedFields = null;
+                }
+                final FieldAndMapper fieldAndMapper= group.get(0);
+                Query q = parseGroup(type.matchQueryType(), fieldAndMapper.field, fieldAndMapper.boost, value, minimumShouldMatch);
+                if (q != null) {
+                    queries.add(q);
+                }
+            }
+
+            return queries.isEmpty() ? null : queries;
+        }
+
+        public boolean forceAnalyzeQueryString() {
+            return blendedFields != null;
+        }
+
+        public Query blendTerm(Term term, FieldMapper mapper) {
+            if (blendedFields == null) {
+                return super.blendTerm(term, mapper);
+            }
+            final Term[] terms = new Term[blendedFields.length];
+            float[] blendedBoost = new float[blendedFields.length];
+            for (int i = 0; i < blendedFields.length; i++) {
+                terms[i] = blendedFields[i].newTerm(term.text());
+                blendedBoost[i] = blendedFields[i].boost;
+            }
+            if (commonTermsCutoff != null) {
+                return BlendedTermQuery.commonTermsBlendedQuery(terms, blendedBoost, false, commonTermsCutoff);
+            }
+
+            if (tieBreaker == 1.0f) {
+                return BlendedTermQuery.booleanBlendedQuery(terms, blendedBoost, false);
+            }
+            return BlendedTermQuery.dismaxBlendedQuery(terms, blendedBoost, tieBreaker);
+        }
+    }
+
+    @Override
+    protected Query blendTermQuery(Term term, FieldMapper mapper) {
+        if (queryBuilder == null) {
+            return super.blendTermQuery(term, mapper);
+        }
+        return queryBuilder.blendTerm(term, mapper);
+    }
+
+    private static final class FieldAndMapper {
+        final String field;
+        final FieldMapper mapper;
+        final float boost;
+
+
+        private FieldAndMapper(String field, FieldMapper mapper, float boost) {
+            this.field = field;
+            this.mapper = mapper;
+            this.boost = boost;
+        }
+
+        public Term newTerm(String value) {
+            try {
+                final BytesRef bytesRef = mapper.indexedValueForSearch(value);
+                return new Term(field, bytesRef);
+            } catch (Exception ex) {
+                // we can't parse it just use the incoming value -- it will
+                // just have a DF of 0 at the end of the day and will be ignored
+            }
+            return new Term(field, value);
+        }
+    }
+
+    protected boolean forceAnalyzeQueryString() {
+        return this.queryBuilder.forceAnalyzeQueryString();
+    }
 }

--- a/src/test/java/org/apache/lucene/queries/BlendedTermQueryTest.java
+++ b/src/test/java/org/apache/lucene/queries/BlendedTermQueryTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.lucene.queries;
+
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.*;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.search.similarities.DefaultSimilarity;
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util._TestUtil;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ */
+public class BlendedTermQueryTest extends LuceneTestCase {
+
+    public void testBooleanQuery() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random())));
+        String[] firstNames = new String[]{
+                "simon", "paul"
+        };
+        String[] surNames = new String[]{
+                "willnauer", "simon"
+        };
+        for (int i = 0; i < surNames.length; i++) {
+            Document d = new Document();
+            d.add(new TextField("id", Integer.toString(i), Field.Store.YES));
+            d.add(new TextField("firstname", firstNames[i], Field.Store.NO));
+            d.add(new TextField("surname", surNames[i], Field.Store.NO));
+            w.addDocument(d);
+        }
+        int iters = atLeast(25);
+        for (int j = 0; j < iters; j++) {
+            Document d = new Document();
+            d.add(new TextField("id", Integer.toString(firstNames.length + j), Field.Store.YES));
+            d.add(new TextField("firstname", rarely() ? "some_other_name" : "simon", Field.Store.NO));
+            d.add(new TextField("surname", "bogus", Field.Store.NO));
+            w.addDocument(d);
+        }
+        w.commit();
+        DirectoryReader reader = DirectoryReader.open(w, true);
+        IndexSearcher searcher = setSimilarity(newSearcher(reader));
+
+        {
+            Term[] terms = new Term[]{new Term("firstname", "simon"), new Term("surname", "simon")};
+            BlendedTermQuery query = BlendedTermQuery.booleanBlendedQuery(terms, true);
+            TopDocs search = searcher.search(query, 3);
+            ScoreDoc[] scoreDocs = search.scoreDocs;
+            assertEquals(3, scoreDocs.length);
+            assertEquals(Integer.toString(0), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+        }
+        {
+            BooleanQuery query = new BooleanQuery(false);
+            query.add(new TermQuery(new Term("firstname", "simon")), BooleanClause.Occur.SHOULD);
+            query.add(new TermQuery(new Term("surname", "simon")), BooleanClause.Occur.SHOULD);
+            TopDocs search = searcher.search(query, 1);
+            ScoreDoc[] scoreDocs = search.scoreDocs;
+            assertEquals(Integer.toString(1), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+
+        }
+        reader.close();
+        w.close();
+        dir.close();
+
+    }
+
+    public void testDismaxQuery() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random())));
+        String[] username = new String[]{
+                "foo fighters", "some cool fan", "cover band"};
+        String[] song = new String[]{
+                "generator", "foo fighers - generator", "foo fighters generator"
+        };
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? FieldInfo.IndexOptions.DOCS_ONLY : FieldInfo.IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+
+        FieldType ft1 = new FieldType(TextField.TYPE_NOT_STORED);
+        ft1.setIndexOptions(random().nextBoolean() ? FieldInfo.IndexOptions.DOCS_ONLY : FieldInfo.IndexOptions.DOCS_AND_FREQS);
+        ft1.setOmitNorms(random().nextBoolean());
+        ft1.freeze();
+        for (int i = 0; i < username.length; i++) {
+            Document d = new Document();
+            d.add(new TextField("id", Integer.toString(i), Field.Store.YES));
+            d.add(new Field("username", username[i], ft));
+            d.add(new Field("song", song[i], ft));
+            w.addDocument(d);
+        }
+        int iters = atLeast(25);
+        for (int j = 0; j < iters; j++) {
+            Document d = new Document();
+            d.add(new TextField("id", Integer.toString(username.length + j), Field.Store.YES));
+            d.add(new Field("username", "foo fighters", ft1));
+            d.add(new Field("song", "some bogus text to bump up IDF", ft1));
+            w.addDocument(d);
+        }
+        w.commit();
+        DirectoryReader reader = DirectoryReader.open(w, true);
+        IndexSearcher searcher = setSimilarity(newSearcher(reader));
+        {
+            String[] fields = new String[]{"username", "song"};
+            BooleanQuery query = new BooleanQuery(false);
+            query.add(BlendedTermQuery.dismaxBlendedQuery(toTerms(fields, "foo"), 0.1f), BooleanClause.Occur.SHOULD);
+            query.add(BlendedTermQuery.dismaxBlendedQuery(toTerms(fields, "fighters"), 0.1f), BooleanClause.Occur.SHOULD);
+            query.add(BlendedTermQuery.dismaxBlendedQuery(toTerms(fields, "generator"), 0.1f), BooleanClause.Occur.SHOULD);
+            TopDocs search = searcher.search(query, 10);
+            ScoreDoc[] scoreDocs = search.scoreDocs;
+            assertEquals(Integer.toString(0), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+        }
+        {
+            BooleanQuery query = new BooleanQuery(false);
+            DisjunctionMaxQuery uname = new DisjunctionMaxQuery(0.0f);
+            uname.add(new TermQuery(new Term("username", "foo")));
+            uname.add(new TermQuery(new Term("song", "foo")));
+
+            DisjunctionMaxQuery s = new DisjunctionMaxQuery(0.0f);
+            s.add(new TermQuery(new Term("username", "fighers")));
+            s.add(new TermQuery(new Term("song", "fighers")));
+            DisjunctionMaxQuery gen = new DisjunctionMaxQuery(0f);
+            gen.add(new TermQuery(new Term("username", "generator")));
+            gen.add(new TermQuery(new Term("song", "generator")));
+            query.add(uname, BooleanClause.Occur.SHOULD);
+            query.add(s, BooleanClause.Occur.SHOULD);
+            query.add(gen, BooleanClause.Occur.SHOULD);
+            TopDocs search = searcher.search(query, 4);
+            ScoreDoc[] scoreDocs = search.scoreDocs;
+            assertEquals(Integer.toString(1), reader.document(scoreDocs[0].doc).getField("id").stringValue());
+
+        }
+        reader.close();
+        w.close();
+        dir.close();
+    }
+
+    public void testBasics() {
+        final int iters = atLeast(5);
+        for (int j = 0; j < iters; j++) {
+            String[] fields = new String[1 + random().nextInt(10)];
+            for (int i = 0; i < fields.length; i++) {
+                fields[i] = _TestUtil.randomRealisticUnicodeString(random(), 1, 10);
+            }
+            String term = _TestUtil.randomRealisticUnicodeString(random(), 1, 10);
+            Term[] terms = toTerms(fields, term);
+            boolean disableCoord = random().nextBoolean();
+            boolean useBoolean = random().nextBoolean();
+            float tieBreaker = random().nextFloat();
+            BlendedTermQuery query = useBoolean ? BlendedTermQuery.booleanBlendedQuery(terms, disableCoord) : BlendedTermQuery.dismaxBlendedQuery(terms, tieBreaker);
+            QueryUtils.check(query);
+            terms = toTerms(fields, term);
+            BlendedTermQuery query2 = useBoolean ? BlendedTermQuery.booleanBlendedQuery(terms, disableCoord) : BlendedTermQuery.dismaxBlendedQuery(terms, tieBreaker);
+            assertEquals(query, query2);
+        }
+    }
+
+    public Term[] toTerms(String[] fields, String term) {
+        Term[] terms = new Term[fields.length];
+        List<String> fieldsList = Arrays.asList(fields);
+        Collections.shuffle(fieldsList, random());
+        fields = fieldsList.toArray(new String[0]);
+        for (int i = 0; i < fields.length; i++) {
+            terms[i] = new Term(fields[i], term);
+        }
+        return terms;
+    }
+
+    public IndexSearcher setSimilarity(IndexSearcher searcher) {
+        Similarity similarity = random().nextBoolean() ? new BM25Similarity() : new DefaultSimilarity();
+        searcher.setSimilarity(similarity);
+        return searcher;
+    }
+}


### PR DESCRIPTION
`cross_fields` attempts to treat fields with the same analysis
configuration as a single field and uses maximum score promotion or
combination of the scores based depending on the `use_dis_max` setting.
By default scores are combined.

Relates to #2959
