### PR TITLE
add delete cluster setting and throw exception when validation fails

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -40,8 +40,10 @@ import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryActi
 import org.elasticsearch.action.admin.cluster.repositories.put.TransportPutRepositoryAction;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction;
 import org.elasticsearch.action.admin.cluster.reroute.TransportClusterRerouteAction;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
-import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.delete.TransportClusterDeleteSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.update.TransportClusterUpdateSettingsAction;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
@@ -207,6 +209,7 @@ public class ActionModule extends AbstractModule {
         registerAction(ClusterStateAction.INSTANCE, TransportClusterStateAction.class);
         registerAction(ClusterHealthAction.INSTANCE, TransportClusterHealthAction.class);
         registerAction(ClusterUpdateSettingsAction.INSTANCE, TransportClusterUpdateSettingsAction.class);
+        registerAction(ClusterDeleteSettingsAction.INSTANCE, TransportClusterDeleteSettingsAction.class);
         registerAction(ClusterRerouteAction.INSTANCE, TransportClusterRerouteAction.class);
         registerAction(ClusterSearchShardsAction.INSTANCE, TransportClusterSearchShardsAction.class);
         registerAction(PendingClusterTasksAction.INSTANCE, TransportPendingClusterTasksAction.class);

--- a/src/main/java/org/elasticsearch/action/UpdateSettingValidationException.java
+++ b/src/main/java/org/elasticsearch/action/UpdateSettingValidationException.java
@@ -22,21 +22,5 @@ package org.elasticsearch.action;
 /**
  *
  */
-public class ValidateActions {
-
-    public static ActionRequestValidationException addValidationError(String error, ActionRequestValidationException validationException) {
-        if (validationException == null) {
-            validationException = new ActionRequestValidationException();
-        }
-        validationException.addValidationError(error);
-        return validationException;
-    }
-
-    public static UpdateSettingValidationException addValidationError(String error, UpdateSettingValidationException validationException) {
-        if (validationException == null) {
-            validationException = new UpdateSettingValidationException();
-        }
-        validationException.addValidationError(error);
-        return validationException;
-    }
+public class UpdateSettingValidationException extends ActionRequestValidationException {
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsAction.java
@@ -17,29 +17,29 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.cluster.settings;
+package org.elasticsearch.action.admin.cluster.settings.delete;
 
 import org.elasticsearch.action.admin.cluster.ClusterAction;
 import org.elasticsearch.client.ClusterAdminClient;
 
 /**
  */
-public class ClusterUpdateSettingsAction extends ClusterAction<ClusterUpdateSettingsRequest, ClusterUpdateSettingsResponse, ClusterUpdateSettingsRequestBuilder> {
+public class ClusterDeleteSettingsAction extends ClusterAction<ClusterDeleteSettingsRequest, ClusterDeleteSettingsResponse, ClusterDeleteSettingsRequestBuilder> {
 
-    public static final ClusterUpdateSettingsAction INSTANCE = new ClusterUpdateSettingsAction();
-    public static final String NAME = "cluster/settings/update";
+    public static final ClusterDeleteSettingsAction INSTANCE = new ClusterDeleteSettingsAction();
+    public static final String NAME = "cluster/settings/delete";
 
-    private ClusterUpdateSettingsAction() {
+    private ClusterDeleteSettingsAction() {
         super(NAME);
     }
 
     @Override
-    public ClusterUpdateSettingsResponse newResponse() {
-        return new ClusterUpdateSettingsResponse();
+    public ClusterDeleteSettingsResponse newResponse() {
+        return new ClusterDeleteSettingsResponse();
     }
 
     @Override
-    public ClusterUpdateSettingsRequestBuilder newRequestBuilder(ClusterAdminClient client) {
-        return new ClusterUpdateSettingsRequestBuilder(client);
+    public ClusterDeleteSettingsRequestBuilder newRequestBuilder(ClusterAdminClient client) {
+        return new ClusterDeleteSettingsRequestBuilder(client);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.settings.delete;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.common.settings.ImmutableSettings.readSettingsFromStream;
+import static org.elasticsearch.common.settings.ImmutableSettings.writeSettingsToStream;
+
+/**
+ * Request for an delete cluster settings action
+ */
+public class ClusterDeleteSettingsRequest extends AcknowledgedRequest<ClusterDeleteSettingsRequest> {
+
+    /**
+     * set to false to keep transient settings
+     */
+    private boolean deleteTransient = true;
+
+    /**
+     * set to false to keep persistent settings
+     */
+    private boolean deletePersistent = true;
+
+    public ClusterDeleteSettingsRequest() {
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (!deleteTransient && !deletePersistent) {
+            validationException = addValidationError("no settings to delete", validationException);
+        }
+        return validationException;
+    }
+
+    boolean deleteTransient() {
+        return deleteTransient;
+    }
+
+    boolean deletePersistent() {
+        return deletePersistent;
+    }
+
+    public ClusterDeleteSettingsRequest deleteTransient(boolean deleteTransient) {
+        this.deleteTransient = deleteTransient;
+        return this;
+    }
+
+    public ClusterDeleteSettingsRequest deletePersistent(boolean deletePersistent) {
+        this.deletePersistent = deletePersistent;
+        return this;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        deleteTransient = in.readBoolean();
+        deletePersistent = in.readBoolean();
+        readTimeout(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(deleteTransient);
+        out.writeBoolean(deletePersistent);
+        writeTimeout(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsRequestBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.settings.delete;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.client.internal.InternalClusterAdminClient;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
+
+/**
+ * Builder for a cluster delete settings request
+ */
+public class ClusterDeleteSettingsRequestBuilder extends AcknowledgedRequestBuilder<ClusterDeleteSettingsRequest, ClusterDeleteSettingsResponse, ClusterDeleteSettingsRequestBuilder> {
+
+    public ClusterDeleteSettingsRequestBuilder(ClusterAdminClient clusterClient) {
+        super((InternalClusterAdminClient) clusterClient, new ClusterDeleteSettingsRequest());
+    }
+
+    public ClusterDeleteSettingsRequestBuilder deleteTransient(boolean deleteTransient) {
+        request.deleteTransient(deleteTransient);
+        return this;
+    }
+
+    public ClusterDeleteSettingsRequestBuilder deletePersistent(boolean deletePersistent) {
+        request.deletePersistent(deletePersistent);
+        return this;
+    }
+
+
+    @Override
+    protected void doExecute(ActionListener<ClusterDeleteSettingsResponse> listener) {
+        ((ClusterAdminClient) client).deleteSettings(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/ClusterDeleteSettingsResponse.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.cluster.settings;
+package org.elasticsearch.action.admin.cluster.settings.delete;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,19 +28,19 @@ import org.elasticsearch.common.settings.Settings;
 import java.io.IOException;
 
 /**
- * A response for a cluster update settings action.
+ * A response for a cluster delete settings action.
  */
-public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
+public class ClusterDeleteSettingsResponse extends AcknowledgedResponse {
 
     Settings transientSettings;
     Settings persistentSettings;
 
-    ClusterUpdateSettingsResponse() {
+    ClusterDeleteSettingsResponse() {
         this.persistentSettings = ImmutableSettings.EMPTY;
         this.transientSettings = ImmutableSettings.EMPTY;
     }
 
-    ClusterUpdateSettingsResponse(boolean acknowledged, Settings transientSettings, Settings persistentSettings) {
+    ClusterDeleteSettingsResponse(boolean acknowledged, Settings transientSettings, Settings persistentSettings) {
         super(acknowledged);
         this.persistentSettings = persistentSettings;
         this.transientSettings = transientSettings;

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/TransportClusterDeleteSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/delete/TransportClusterDeleteSettingsAction.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.settings.delete;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.settings.ClusterDynamicSettings;
+import org.elasticsearch.cluster.settings.DynamicSettings;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Map;
+
+import static org.elasticsearch.cluster.ClusterState.builder;
+
+/**
+ *
+ */
+public class TransportClusterDeleteSettingsAction extends TransportMasterNodeOperationAction<ClusterDeleteSettingsRequest, ClusterDeleteSettingsResponse> {
+
+    private final AllocationService allocationService;
+
+    private final DynamicSettings dynamicSettings;
+
+    @Inject
+    public TransportClusterDeleteSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
+                                                AllocationService allocationService, @ClusterDynamicSettings DynamicSettings dynamicSettings) {
+        super(settings, transportService, clusterService, threadPool);
+        this.allocationService = allocationService;
+        this.dynamicSettings = dynamicSettings;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected String transportAction() {
+        return ClusterDeleteSettingsAction.NAME;
+    }
+
+    @Override
+    protected ClusterDeleteSettingsRequest newRequest() {
+        return new ClusterDeleteSettingsRequest();
+    }
+
+    @Override
+    protected ClusterDeleteSettingsResponse newResponse() {
+        return new ClusterDeleteSettingsResponse();
+    }
+
+    @Override
+    protected void masterOperation(final ClusterDeleteSettingsRequest request, final ClusterState state, final ActionListener<ClusterDeleteSettingsResponse> listener) throws ElasticsearchException {
+        final ImmutableSettings.Builder transientDeletes = ImmutableSettings.settingsBuilder();
+        final ImmutableSettings.Builder persistentDeletes = ImmutableSettings.settingsBuilder();
+
+        clusterService.submitStateUpdateTask("cluster_delete_settings", Priority.URGENT, new AckedClusterStateUpdateTask() {
+
+            private volatile boolean changed = false;
+
+            @Override
+            public boolean mustAck(DiscoveryNode discoveryNode) {
+                return true;
+            }
+
+            @Override
+            public void onAllNodesAcked(@Nullable Throwable t) {
+                if (changed) {
+                    reroute(true);
+                } else {
+                    listener.onResponse(new ClusterDeleteSettingsResponse(true, transientDeletes.build(), persistentDeletes.build()));
+                }
+
+            }
+
+            @Override
+            public void onAckTimeout() {
+                if (changed) {
+                    reroute(false);
+                } else {
+                    listener.onResponse(new ClusterDeleteSettingsResponse(false, transientDeletes.build(), persistentDeletes.build()));
+                }
+            }
+
+            private void reroute(final boolean deleteSettingsAcked) {
+                clusterService.submitStateUpdateTask("reroute_after_cluster_delete_settings", Priority.URGENT, new AckedClusterStateUpdateTask() {
+
+                    @Override
+                    public boolean mustAck(DiscoveryNode discoveryNode) {
+                        //we wait for the reroute ack only if the update settings was acknowledged
+                        return deleteSettingsAcked;
+                    }
+
+                    @Override
+                    public void onAllNodesAcked(@Nullable Throwable t) {
+                        //we return when the cluster reroute is acked (the acknowledged flag depends on whether the update settings was acknowledged)
+                        listener.onResponse(new ClusterDeleteSettingsResponse(deleteSettingsAcked, transientDeletes.build(), persistentDeletes.build()));
+                    }
+
+                    @Override
+                    public void onAckTimeout() {
+                        //we return when the cluster reroute ack times out (acknowledged false)
+                        listener.onResponse(new ClusterDeleteSettingsResponse(false, transientDeletes.build(), persistentDeletes.build()));
+                    }
+
+                    @Override
+                    public TimeValue ackTimeout() {
+                        return request.timeout();
+                    }
+
+                    @Override
+                    public TimeValue timeout() {
+                        return request.masterNodeTimeout();
+                    }
+
+                    @Override
+                    public void onFailure(String source, Throwable t) {
+                        //if the reroute fails we only log
+                        logger.debug("failed to perform [{}]", t, source);
+                    }
+
+                    @Override
+                    public ClusterState execute(final ClusterState currentState) {
+                        // now, reroute in case things that require it changed (e.g. number of replicas)
+                        RoutingAllocation.Result routingResult = allocationService.reroute(currentState);
+                        if (!routingResult.changed()) {
+                            return currentState;
+                        }
+                        return ClusterState.builder(currentState).routingResult(routingResult).build();
+                    }
+
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    }
+                });
+            }
+
+            @Override
+            public TimeValue ackTimeout() {
+                return request.timeout();
+            }
+
+            @Override
+            public TimeValue timeout() {
+                return request.masterNodeTimeout();
+            }
+
+            @Override
+            public void onFailure(String source, Throwable t) {
+                logger.debug("failed to perform [{}]", t, source);
+                listener.onFailure(t);
+            }
+
+            @Override
+            public ClusterState execute(final ClusterState currentState) {
+                Settings transientSettings;
+                Settings existTransientSettings = currentState.metaData().transientSettings();
+                if (!request.deleteTransient()) {  // don't need to delete transient settings
+                    transientSettings = existTransientSettings;
+                } else {
+                    transientSettings = ImmutableSettings.settingsBuilder().build();
+                    if (!existTransientSettings.getAsMap().isEmpty()) {  // has exist settings, need to set the changed to true
+                        changed = true;
+                        for (Map.Entry<String, String> entry : existTransientSettings.getAsMap().entrySet()) {
+                            transientDeletes.put(entry.getKey(), entry.getValue());  // response with current value
+                        }
+                    }
+                }
+
+
+                Settings persistentSettings;
+                Settings existPersistentSettings = currentState.metaData().persistentSettings();
+                if (!request.deletePersistent()) {  // don't need to delete persistent settings
+                    persistentSettings = existPersistentSettings;
+                } else {
+                    persistentSettings = ImmutableSettings.settingsBuilder().build();
+                    if (!existPersistentSettings.getAsMap().isEmpty()) {  // has exist settings, need to set the changed to true
+                        changed = true;
+                        for (Map.Entry<String, String> entry : existPersistentSettings.getAsMap().entrySet()) {
+                            persistentDeletes.put(entry.getKey(), entry.getValue());  // response with current value
+                        }
+                    }
+                }
+
+
+
+                if (!changed) {
+                    return currentState;
+                }
+
+                MetaData.Builder metaData = MetaData.builder(currentState.metaData())
+                        .persistentSettings(persistentSettings)
+                        .transientSettings(transientSettings);
+
+                ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+                boolean updatedReadOnly = metaData.persistentSettings().getAsBoolean(MetaData.SETTING_READ_ONLY, false) || metaData.transientSettings().getAsBoolean(MetaData.SETTING_READ_ONLY, false);
+                if (updatedReadOnly) {
+                    blocks.addGlobalBlock(MetaData.CLUSTER_READ_ONLY_BLOCK);
+                } else {
+                    blocks.removeGlobalBlock(MetaData.CLUSTER_READ_ONLY_BLOCK);
+                }
+
+                return builder(currentState).metaData(metaData).blocks(blocks).build();
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+
+            }
+        });
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsAction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.settings.update;
+
+import org.elasticsearch.action.admin.cluster.ClusterAction;
+import org.elasticsearch.client.ClusterAdminClient;
+
+/**
+ */
+public class ClusterUpdateSettingsAction extends ClusterAction<ClusterUpdateSettingsRequest, ClusterUpdateSettingsResponse, ClusterUpdateSettingsRequestBuilder> {
+
+    public static final ClusterUpdateSettingsAction INSTANCE = new ClusterUpdateSettingsAction();
+    public static final String NAME = "cluster/settings/update";
+
+    private ClusterUpdateSettingsAction() {
+        super(NAME);
+    }
+
+    @Override
+    public ClusterUpdateSettingsResponse newResponse() {
+        return new ClusterUpdateSettingsResponse();
+    }
+
+    @Override
+    public ClusterUpdateSettingsRequestBuilder newRequestBuilder(ClusterAdminClient client) {
+        return new ClusterUpdateSettingsRequestBuilder(client);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsRequest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.cluster.settings;
+package org.elasticsearch.action.admin.cluster.settings.update;
 
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -46,6 +46,11 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
     private Settings transientSettings = EMPTY_SETTINGS;
     private Settings persistentSettings = EMPTY_SETTINGS;
 
+    /**
+     * set to true to clear all existing settings and put new settings
+     */
+    private boolean override = false;
+
     public ClusterUpdateSettingsRequest() {
     }
 
@@ -64,6 +69,10 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
 
     Settings persistentSettings() {
         return persistentSettings;
+    }
+
+    boolean override() {
+        return override;
     }
 
     /**
@@ -144,11 +153,17 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         return this;
     }
 
+    public ClusterUpdateSettingsRequest override(boolean override) {
+        this.override = override;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         transientSettings = readSettingsFromStream(in);
         persistentSettings = readSettingsFromStream(in);
+        override = in.readBoolean();
         readTimeout(in);
     }
 
@@ -157,6 +172,7 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         super.writeTo(out);
         writeSettingsToStream(transientSettings, out);
         writeSettingsToStream(persistentSettings, out);
+        out.writeBoolean(override);
         writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsRequestBuilder.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.cluster.settings;
+package org.elasticsearch.action.admin.cluster.settings.update;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
@@ -97,6 +97,14 @@ public class ClusterUpdateSettingsRequestBuilder extends AcknowledgedRequestBuil
      */
     public ClusterUpdateSettingsRequestBuilder setPersistentSettings(Map settings) {
         request.persistentSettings(settings);
+        return this;
+    }
+
+    /**
+     * Set override to true to clear all existing settings
+     */
+    public ClusterUpdateSettingsRequestBuilder override(boolean override) {
+        request.override(override);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/update/ClusterUpdateSettingsResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.settings.update;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+
+/**
+ * A response for a cluster update settings action.
+ */
+public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
+
+    Settings transientSettings;
+    Settings persistentSettings;
+
+    ClusterUpdateSettingsResponse() {
+        this.persistentSettings = ImmutableSettings.EMPTY;
+        this.transientSettings = ImmutableSettings.EMPTY;
+    }
+
+    ClusterUpdateSettingsResponse(boolean acknowledged, Settings transientSettings, Settings persistentSettings) {
+        super(acknowledged);
+        this.persistentSettings = persistentSettings;
+        this.transientSettings = transientSettings;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        transientSettings = ImmutableSettings.readSettingsFromStream(in);
+        persistentSettings = ImmutableSettings.readSettingsFromStream(in);
+        readAcknowledged(in);
+    }
+
+    public Settings getTransientSettings() {
+        return transientSettings;
+    }
+
+    public Settings getPersistentSettings() {
+        return persistentSettings;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        ImmutableSettings.writeSettingsToStream(transientSettings, out);
+        ImmutableSettings.writeSettingsToStream(persistentSettings, out);
+        writeAcknowledged(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -51,9 +51,12 @@ import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResp
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequestBuilder;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequestBuilder;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsRequestBuilder;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsRequestBuilder;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequestBuilder;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
@@ -155,6 +158,21 @@ public interface ClusterAdminClient {
      * Update settings in the cluster.
      */
     ClusterUpdateSettingsRequestBuilder prepareUpdateSettings();
+
+    /**
+     * Delete settings in the cluster.
+     */
+    ActionFuture<ClusterDeleteSettingsResponse> deleteSettings(ClusterDeleteSettingsRequest request);
+
+    /**
+     * Delete settings in the cluster.
+     */
+    void deleteSettings(ClusterDeleteSettingsRequest request, ActionListener<ClusterDeleteSettingsResponse> listener);
+
+    /**
+     * Delete settings in the cluster.
+     */
+    ClusterDeleteSettingsRequestBuilder prepareDeleteSettings();
 
     /**
      * Reroutes allocation of shards. Advance API.

--- a/src/main/java/org/elasticsearch/client/Requests.java
+++ b/src/main/java/org/elasticsearch/client/Requests.java
@@ -28,7 +28,8 @@ import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteReposito
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
@@ -354,6 +355,10 @@ public class Requests {
 
     public static ClusterUpdateSettingsRequest clusterUpdateSettingsRequest() {
         return new ClusterUpdateSettingsRequest();
+    }
+
+    public static ClusterDeleteSettingsRequest clusterDeleteSettingsRequest() {
+        return new ClusterDeleteSettingsRequest();
     }
 
     /**

--- a/src/main/java/org/elasticsearch/client/support/AbstractClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClusterAdminClient.java
@@ -61,10 +61,14 @@ import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequestBuilder;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequestBuilder;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsRequestBuilder;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsRequestBuilder;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequestBuilder;
@@ -171,6 +175,21 @@ public abstract class AbstractClusterAdminClient implements InternalClusterAdmin
     @Override
     public ClusterUpdateSettingsRequestBuilder prepareUpdateSettings() {
         return new ClusterUpdateSettingsRequestBuilder(this);
+    }
+
+    @Override
+    public ActionFuture<ClusterDeleteSettingsResponse> deleteSettings(ClusterDeleteSettingsRequest request) {
+        return execute(ClusterDeleteSettingsAction.INSTANCE, request);
+    }
+
+    @Override
+    public void deleteSettings(ClusterDeleteSettingsRequest request, ActionListener<ClusterDeleteSettingsResponse> listener) {
+        execute(ClusterDeleteSettingsAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public ClusterDeleteSettingsRequestBuilder prepareDeleteSettings() {
+        return new ClusterDeleteSettingsRequestBuilder(this);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -71,17 +71,22 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
     public static final String SETTING_SHARD_BALANCE_FACTOR = "cluster.routing.allocation.balance.shard";
     public static final String SETTING_PRIMARY_BALANCE_FACTOR = "cluster.routing.allocation.balance.primary";
 
-    private static final float DEFAULT_INDEX_BALANCE_FACTOR = 0.5f;
-    private static final float DEFAULT_SHARD_BALANCE_FACTOR = 0.45f;
-    private static final float DEFAULT_PRIMARY_BALANCE_FACTOR = 0.05f;
+    public static final float DEFAULT_INDEX_BALANCE_FACTOR = 0.5f;
+    public static final float DEFAULT_SHARD_BALANCE_FACTOR = 0.45f;
+    public static final float DEFAULT_PRIMARY_BALANCE_FACTOR = 0.05f;
+    public static final float DEFAULT_THRESHOLD = 1.0f;
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
-            final float indexBalance = settings.getAsFloat(SETTING_INDEX_BALANCE_FACTOR, weightFunction.indexBalance);
-            final float shardBalance = settings.getAsFloat(SETTING_SHARD_BALANCE_FACTOR, weightFunction.shardBalance);
-            final float primaryBalance = settings.getAsFloat(SETTING_PRIMARY_BALANCE_FACTOR, weightFunction.primaryBalance);
-            float threshold = settings.getAsFloat(SETTING_THRESHOLD, BalancedShardsAllocator.this.threshold);
+            final float indexBalance = settings.getAsFloat(SETTING_INDEX_BALANCE_FACTOR, DEFAULT_INDEX_BALANCE_FACTOR);
+            final float shardBalance = settings.getAsFloat(SETTING_SHARD_BALANCE_FACTOR, DEFAULT_SHARD_BALANCE_FACTOR);
+            final float primaryBalance = settings.getAsFloat(SETTING_PRIMARY_BALANCE_FACTOR, DEFAULT_PRIMARY_BALANCE_FACTOR);
+            float threshold = settings.getAsFloat(SETTING_THRESHOLD, DEFAULT_THRESHOLD);
             if (threshold <= 0.0f) {
                 throw new ElasticsearchIllegalArgumentException("threshold must be greater than 0.0f but was: " + threshold);
             }
@@ -92,7 +97,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
     private volatile WeightFunction weightFunction = new WeightFunction(DEFAULT_INDEX_BALANCE_FACTOR, DEFAULT_SHARD_BALANCE_FACTOR, DEFAULT_PRIMARY_BALANCE_FACTOR);
 
-    private volatile float threshold = 1.0f;
+    private volatile float threshold = DEFAULT_THRESHOLD;
 
 
     public BalancedShardsAllocator(Settings settings) {
@@ -102,9 +107,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
     @Inject
     public BalancedShardsAllocator(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        ApplySettings applySettings = new ApplySettings();
-        applySettings.onRefreshSettings(settings);
-        nodeSettingsService.addListener(applySettings);
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -87,7 +87,11 @@ public class AwarenessAllocationDecider extends AllocationDecider {
     public static final String CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTES = "cluster.routing.allocation.awareness.attributes";
     public static final String CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP = "cluster.routing.allocation.awareness.force.";
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
             String[] awarenessAttributes = settings.getAsArray(CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTES, null);
@@ -135,18 +139,8 @@ public class AwarenessAllocationDecider extends AllocationDecider {
     @Inject
     public AwarenessAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        this.awarenessAttributes = settings.getAsArray(CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTES);
 
-        forcedAwarenessAttributes = Maps.newHashMap();
-        Map<String, Settings> forceGroups = settings.getGroups(CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP);
-        for (Map.Entry<String, Settings> entry : forceGroups.entrySet()) {
-            String[] aValues = entry.getValue().getAsArray("values");
-            if (aValues.length > 0) {
-                forcedAwarenessAttributes.put(entry.getKey(), aValues);
-            }
-        }
-
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     /**

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -43,10 +43,16 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
 
     public static final String CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE = "cluster.routing.allocation.cluster_concurrent_rebalance";
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    public static final int DEFAULT_CLUSTER_CONCURRENT_REBALANCE = 2;
+
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
-            int clusterConcurrentRebalance = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance);
+            int clusterConcurrentRebalance = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, DEFAULT_CLUSTER_CONCURRENT_REBALANCE);
             if (clusterConcurrentRebalance != ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance) {
                 logger.info("updating [cluster.routing.allocation.cluster_concurrent_rebalance] from [{}], to [{}]", ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance, clusterConcurrentRebalance);
                 ConcurrentRebalanceAllocationDecider.this.clusterConcurrentRebalance = clusterConcurrentRebalance;
@@ -54,14 +60,12 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
         }
     }
 
-    private volatile int clusterConcurrentRebalance;
+    private volatile int clusterConcurrentRebalance = DEFAULT_CLUSTER_CONCURRENT_REBALANCE;
 
     @Inject
     public ConcurrentRebalanceAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        this.clusterConcurrentRebalance = settings.getAsInt(CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE, 2);
-        logger.debug("using [cluster_concurrent_rebalance] with [{}]", clusterConcurrentRebalance);
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DisableAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DisableAllocationDecider.java
@@ -66,22 +66,30 @@ public class DisableAllocationDecider extends AllocationDecider {
     public static final String INDEX_ROUTING_ALLOCATION_DISABLE_ALLOCATION = "index.routing.allocation.disable_allocation";
     public static final String INDEX_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION = "index.routing.allocation.disable_replica_allocation";
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    public static final boolean DEFAULT_DISABLE_NEW_ALLOCATION = false;
+    public static final boolean DEFAULT_DISABLE_ALLOCATION = false;
+    public static final boolean DEFAULT_DISABLE_REPLICA_ALLOCATION = false;
+
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
-            boolean disableNewAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, DisableAllocationDecider.this.disableNewAllocation);
+            boolean disableNewAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, DEFAULT_DISABLE_NEW_ALLOCATION);
             if (disableNewAllocation != DisableAllocationDecider.this.disableNewAllocation) {
                 logger.info("updating [cluster.routing.allocation.disable_new_allocation] from [{}] to [{}]", DisableAllocationDecider.this.disableNewAllocation, disableNewAllocation);
                 DisableAllocationDecider.this.disableNewAllocation = disableNewAllocation;
             }
 
-            boolean disableAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, DisableAllocationDecider.this.disableAllocation);
+            boolean disableAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, DEFAULT_DISABLE_ALLOCATION);
             if (disableAllocation != DisableAllocationDecider.this.disableAllocation) {
                 logger.info("updating [cluster.routing.allocation.disable_allocation] from [{}] to [{}]", DisableAllocationDecider.this.disableAllocation, disableAllocation);
                 DisableAllocationDecider.this.disableAllocation = disableAllocation;
             }
 
-            boolean disableReplicaAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION, DisableAllocationDecider.this.disableReplicaAllocation);
+            boolean disableReplicaAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION, DEFAULT_DISABLE_REPLICA_ALLOCATION);
             if (disableReplicaAllocation != DisableAllocationDecider.this.disableReplicaAllocation) {
                 logger.info("updating [cluster.routing.allocation.disable_replica_allocation] from [{}] to [{}]", DisableAllocationDecider.this.disableReplicaAllocation, disableReplicaAllocation);
                 DisableAllocationDecider.this.disableReplicaAllocation = disableReplicaAllocation;
@@ -89,18 +97,14 @@ public class DisableAllocationDecider extends AllocationDecider {
         }
     }
 
-    private volatile boolean disableNewAllocation;
-    private volatile boolean disableAllocation;
-    private volatile boolean disableReplicaAllocation;
+    private volatile boolean disableNewAllocation = DEFAULT_DISABLE_NEW_ALLOCATION;
+    private volatile boolean disableAllocation = DEFAULT_DISABLE_ALLOCATION;
+    private volatile boolean disableReplicaAllocation = DEFAULT_DISABLE_REPLICA_ALLOCATION;
 
     @Inject
     public DisableAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        this.disableNewAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_NEW_ALLOCATION, false);
-        this.disableAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, false);
-        this.disableReplicaAllocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION, false);
-
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -77,25 +77,7 @@ public class FilterAllocationDecider extends AllocationDecider {
     @Inject
     public FilterAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        ImmutableMap<String, String> requireMap = settings.getByPrefix(CLUSTER_ROUTING_REQUIRE_GROUP).getAsMap();
-        if (requireMap.isEmpty()) {
-            clusterRequireFilters = null;
-        } else {
-            clusterRequireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
-        }
-        ImmutableMap<String, String> includeMap = settings.getByPrefix(CLUSTER_ROUTING_INCLUDE_GROUP).getAsMap();
-        if (includeMap.isEmpty()) {
-            clusterIncludeFilters = null;
-        } else {
-            clusterIncludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
-        }
-        ImmutableMap<String, String> excludeMap = settings.getByPrefix(CLUSTER_ROUTING_EXCLUDE_GROUP).getAsMap();
-        if (excludeMap.isEmpty()) {
-            clusterExcludeFilters = null;
-        } else {
-            clusterExcludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
-        }
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     @Override
@@ -145,19 +127,29 @@ public class FilterAllocationDecider extends AllocationDecider {
         return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require filters");
     }
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
             ImmutableMap<String, String> requireMap = settings.getByPrefix(CLUSTER_ROUTING_REQUIRE_GROUP).getAsMap();
-            if (!requireMap.isEmpty()) {
+            if (requireMap.isEmpty()) {
+                clusterRequireFilters = null;
+            } else {
                 clusterRequireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
             }
             ImmutableMap<String, String> includeMap = settings.getByPrefix(CLUSTER_ROUTING_INCLUDE_GROUP).getAsMap();
-            if (!includeMap.isEmpty()) {
+            if (includeMap.isEmpty()) {
+                clusterIncludeFilters = null;
+            } else {
                 clusterIncludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
             }
             ImmutableMap<String, String> excludeMap = settings.getByPrefix(CLUSTER_ROUTING_EXCLUDE_GROUP).getAsMap();
-            if (!excludeMap.isEmpty()) {
+            if (excludeMap.isEmpty()) {
+                clusterExcludeFilters = null;
+            } else {
                 clusterExcludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
             }
         }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -41,10 +41,16 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
      */
     public static final String CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED = "cluster.routing.allocation.snapshot.relocation_enabled";
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    public static final boolean DEFAULT_ENABLE_RELOCATION = false;
+
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
-            boolean newEnableRelocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, enableRelocation);
+            boolean newEnableRelocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, DEFAULT_ENABLE_RELOCATION);
             if (newEnableRelocation != enableRelocation) {
                 logger.info("updating [{}] from [{}], to [{}]", CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, enableRelocation, newEnableRelocation);
                 enableRelocation = newEnableRelocation;
@@ -52,7 +58,7 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
         }
     }
 
-    private volatile boolean enableRelocation = false;
+    private volatile boolean enableRelocation = DEFAULT_ENABLE_RELOCATION;
 
     /**
      * Creates a new {@link org.elasticsearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider} instance
@@ -73,8 +79,7 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
     @Inject
     public SnapshotInProgressAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        enableRelocation = settings.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_SNAPSHOT_RELOCATION_ENABLED, enableRelocation);
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     /**

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -39,7 +39,7 @@ public class DiscoverySettings extends AbstractComponent {
     @Inject
     public DiscoverySettings(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     /**
@@ -49,15 +49,17 @@ public class DiscoverySettings extends AbstractComponent {
         return publishTimeout;
     }
 
-    private class ApplySettings implements NodeSettingsService.Listener {
+    private class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
-            TimeValue newPublishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, null);
-            if (newPublishTimeout != null) {
-                if (newPublishTimeout.millis() != publishTimeout.millis()) {
-                    logger.info("updating [{}] from [{}] to [{}]", PUBLISH_TIMEOUT, publishTimeout, newPublishTimeout);
-                    publishTimeout = newPublishTimeout;
-                }
+            TimeValue newPublishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, DEFAULT_PUBLISH_TIMEOUT);
+            if (newPublishTimeout.millis() != publishTimeout.millis()) {
+                logger.info("updating [{}] from [{}] to [{}]", PUBLISH_TIMEOUT, publishTimeout, newPublishTimeout);
+                publishTimeout = newPublishTimeout;
             }
         }
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -142,7 +142,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         logger.debug("using ping.timeout [{}], master_election.filter_client [{}], master_election.filter_data [{}]", pingTimeout, masterElectionFilterClientNodes, masterElectionFilterDataNodes);
 
         this.electMaster = new ElectMasterService(settings);
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
 
         this.masterFD = new MasterFaultDetection(settings, threadPool, transportService, this);
         this.masterFD.addListener(new MasterNodeFailureListener());
@@ -963,11 +963,15 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         }
     }
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
             int minimumMasterNodes = settings.getAsInt(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
-                    ZenDiscovery.this.electMaster.minimumMasterNodes());
+                    ElectMasterService.DEFAULT_MINIMUM_MASTER_NODES);
             if (minimumMasterNodes != ZenDiscovery.this.electMaster.minimumMasterNodes()) {
                 logger.info("updating {} from [{}] to [{}]", ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
                         ZenDiscovery.this.electMaster.minimumMasterNodes(), minimumMasterNodes);

--- a/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/elect/ElectMasterService.java
@@ -38,14 +38,14 @@ public class ElectMasterService extends AbstractComponent {
 
     public static final String DISCOVERY_ZEN_MINIMUM_MASTER_NODES = "discovery.zen.minimum_master_nodes";
 
+    public static int DEFAULT_MINIMUM_MASTER_NODES = -1;
+
     private final NodeComparator nodeComparator = new NodeComparator();
 
     private volatile int minimumMasterNodes;
 
     public ElectMasterService(Settings settings) {
         super(settings);
-        this.minimumMasterNodes = settings.getAsInt(DISCOVERY_ZEN_MINIMUM_MASTER_NODES, -1);
-        logger.debug("using minimum_master_nodes [{}]", minimumMasterNodes);
     }
 
     public void minimumMasterNodes(int minimumMasterNodes) {

--- a/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -70,6 +70,8 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
     public static final String INDICES_TTL_INTERVAL = "indices.ttl.interval";
     public static final String INDEX_TTL_DISABLE_PURGE = "index.ttl.disable_purge";
 
+    public static final TimeValue DEFAULT_INTERVAL = TimeValue.timeValueSeconds(60);
+
     private final ClusterService clusterService;
     private final IndicesService indicesService;
     private final TransportBulkAction bulkAction;
@@ -82,12 +84,12 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
         super(settings);
         this.clusterService = clusterService;
         this.indicesService = indicesService;
-        TimeValue interval = componentSettings.getAsTime("interval", TimeValue.timeValueSeconds(60));
+        TimeValue interval = componentSettings.getAsTime("interval", DEFAULT_INTERVAL);
         this.bulkAction = bulkAction;
         this.bulkSize = componentSettings.getAsInt("bulk_size", 10000);
         this.purgerThread = new PurgerThread(EsExecutors.threadName(settings, "[ttl_expire]"), interval);
 
-        nodeSettingsService.addListener(new ApplySettings());
+        nodeSettingsService.addListener(new ApplySettings(settings));
     }
 
     @Override
@@ -294,11 +296,15 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
         return bulkRequest;
     }
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
             final TimeValue currentInterval = IndicesTTLService.this.purgerThread.getInterval();
-            final TimeValue interval = settings.getAsTime(INDICES_TTL_INTERVAL, currentInterval);
+            final TimeValue interval = settings.getAsTime(INDICES_TTL_INTERVAL, DEFAULT_INTERVAL);
             if (!interval.equals(currentInterval)) {
                 logger.info("updating indices.ttl.interval from [{}] to [{}]",currentInterval, interval);
                 IndicesTTLService.this.purgerThread.resetInterval(interval);

--- a/src/main/java/org/elasticsearch/node/settings/NodeSettingsService.java
+++ b/src/main/java/org/elasticsearch/node/settings/NodeSettingsService.java
@@ -79,9 +79,10 @@ public class NodeSettingsService extends AbstractComponent implements ClusterSta
             return;
         }
 
+        Settings allSettings = ImmutableSettings.builder().put(globalSettings).put(event.state().metaData().settings()).build();  // add node settings first, cluster settings will override node settings
         for (Listener listener : listeners) {
             try {
-                listener.onRefreshSettings(event.state().metaData().settings());
+                listener.onRefreshSettings(allSettings);
             } catch (Exception e) {
                 logger.warn("failed to refresh settings for [{}]", e, listener);
             }
@@ -117,7 +118,11 @@ public class NodeSettingsService extends AbstractComponent implements ClusterSta
         this.listeners.remove(listener);
     }
 
-    public static interface Listener {
-        void onRefreshSettings(Settings settings);
+    public static abstract class Listener {
+        public Listener(Settings settings) {
+            onRefreshSettings(settings);
+        }
+
+        public abstract void onRefreshSettings(Settings settings);
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -33,6 +33,7 @@ import org.elasticsearch.rest.action.admin.cluster.repositories.delete.RestDelet
 import org.elasticsearch.rest.action.admin.cluster.repositories.get.RestGetRepositoriesAction;
 import org.elasticsearch.rest.action.admin.cluster.repositories.put.RestPutRepositoryAction;
 import org.elasticsearch.rest.action.admin.cluster.reroute.RestClusterRerouteAction;
+import org.elasticsearch.rest.action.admin.cluster.settings.RestClusterDeleteSettingsAction;
 import org.elasticsearch.rest.action.admin.cluster.settings.RestClusterGetSettingsAction;
 import org.elasticsearch.rest.action.admin.cluster.settings.RestClusterUpdateSettingsAction;
 import org.elasticsearch.rest.action.admin.cluster.shards.RestClusterSearchShardsAction;
@@ -132,6 +133,7 @@ public class RestActionModule extends AbstractModule {
         bind(RestClusterStateAction.class).asEagerSingleton();
         bind(RestClusterHealthAction.class).asEagerSingleton();
         bind(RestClusterUpdateSettingsAction.class).asEagerSingleton();
+        bind(RestClusterDeleteSettingsAction.class).asEagerSingleton();
         bind(RestClusterGetSettingsAction.class).asEagerSingleton();
         bind(RestClusterRerouteAction.class).asEagerSingleton();
         bind(RestClusterSearchShardsAction.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterDeleteSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterDeleteSettingsAction.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster.settings;
+
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.delete.ClusterDeleteSettingsResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
+
+import java.io.IOException;
+
+/**
+ */
+public class RestClusterDeleteSettingsAction extends BaseRestHandler {
+
+    @Inject
+    public RestClusterDeleteSettingsAction(Settings settings, Client client, RestController controller) {
+        super(settings, client);
+        controller.registerHandler(RestRequest.Method.DELETE, "/_cluster/settings", this);
+    }
+
+    @Override
+    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception{
+        final ClusterDeleteSettingsRequest clusterDeleteSettingsRequest = Requests.clusterDeleteSettingsRequest();
+        clusterDeleteSettingsRequest.listenerThreaded(false);
+        clusterDeleteSettingsRequest.timeout(request.paramAsTime("timeout", clusterDeleteSettingsRequest.timeout()));
+        clusterDeleteSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterDeleteSettingsRequest.masterNodeTimeout()));
+
+        if ("false".equals(request.param("delete_transient"))){
+            clusterDeleteSettingsRequest.deleteTransient(false);
+        }
+        if ("false".equals(request.param("delete_persistent"))){
+            clusterDeleteSettingsRequest.deletePersistent(false);
+        }
+
+        client.admin().cluster().deleteSettings(clusterDeleteSettingsRequest, new AcknowledgedRestListener<ClusterDeleteSettingsResponse>(channel) {
+
+            @Override
+            protected void addCustomFields(XContentBuilder builder, ClusterDeleteSettingsResponse response) throws IOException {
+                builder.startObject("persistent");
+                response.getPersistentSettings().toXContent(builder, request);
+                builder.endObject();
+
+                builder.startObject("transient");
+                response.getTransientSettings().toXContent(builder, request);
+                builder.endObject();
+            }
+        });
+    }
+}

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -134,7 +134,7 @@ public class ThreadPool extends AbstractComponent {
         this.scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
         this.scheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
         if (nodeSettingsService != null) {
-            nodeSettingsService.addListener(new ApplySettings());
+            nodeSettingsService.addListener(new ApplySettings(settings));
         }
 
         TimeValue estimatedTimeInterval = componentSettings.getAsTime("estimated_time_interval", TimeValue.timeValueMillis(200));
@@ -658,7 +658,11 @@ public class ThreadPool extends AbstractComponent {
 
     }
 
-    class ApplySettings implements NodeSettingsService.Listener {
+    class ApplySettings extends NodeSettingsService.Listener {
+        public ApplySettings(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public void onRefreshSettings(Settings settings) {
             updateSettings(settings);

--- a/src/test/java/org/elasticsearch/cluster/BlockClusterStatsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/BlockClusterStatsTests.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
 import org.elasticsearch.common.settings.ImmutableSettings;

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -554,7 +554,7 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
 
         Settings newSettings = settingsBuilder()
                 .put("discovery.zen.minimum_master_nodes", 2)
-                .put("discovery.type", "zen")
+//                .put("discovery.type", "zen")  // this setting is not dynamically updateable
                 .build();
         client().admin().cluster().prepareUpdateSettings().setTransientSettings(newSettings).execute().actionGet();
 

--- a/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.cluster.ack;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.settings.update.ClusterUpdateSettingsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;

--- a/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
@@ -360,7 +360,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
 
         logger.info("--> shutting down the nodes");
         // Disable allocations while we are closing nodes
-        client().admin().cluster().prepareUpdateSettings().setTransientSettings(settingsBuilder().put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)).execute().actionGet();
+        client().admin().cluster().prepareUpdateSettings().setTransientSettings(ImmutableSettings.settingsBuilder().put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)).execute().actionGet(); // "gateway.type" can't be dynamically updated
         cluster().fullRestart();
 
         logger.info("Running Cluster Health");
@@ -368,7 +368,7 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
 
         logger.info("--> shutting down the nodes");
         // Disable allocations while we are closing nodes
-        client().admin().cluster().prepareUpdateSettings().setTransientSettings(settingsBuilder().put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)).execute().actionGet();
+        client().admin().cluster().prepareUpdateSettings().setTransientSettings(ImmutableSettings.settingsBuilder().put(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION, true)).execute().actionGet(); // "gateway.type" can't be dynamically updated
         cluster().fullRestart();
 
 


### PR DESCRIPTION
Added `DELETE`, `POST` and modified `PUT` method for "/_cluster/settings"

`DELETE` request will delete transient and persistent settings, there are two parameters `delete_transient` and `delete_persistent` to control delete transient and persistent settings, they are all default to true. It will return the deleted settings

`POST` will add the settings in request to the cluster settings (same as previous `PUT`)

`PUT` will clear the existing settings and add the settings in the request

Also will throw exception when validation for settings fail

cloeses #3670 and #5018
