### PR TITLE
Improve documentation

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -39,9 +39,9 @@ respond to. It provides the following settings with the
 
 |`address` |The address to bind to, defaults to `null` which means it
 will bind to all available network interfaces.
-|=======================================================================
 
-Multicast can be disabled by setting `multicast.enabled` to `false`.
+|`enabled` |Whether multicast ping discovery is enabled. Defaults to `true`.
+|=======================================================================
 
 [float]
 [[unicast]]


### PR DESCRIPTION
The way it was written before I was unsure what the actual config parameter was because of the redundant "multicast" in there. I think it makes more sense to have the "enabled" parameter in the table as well.
