### PR TITLE
Upgrading analysis plugins fails

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -25,8 +25,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.analysis.PreBuiltAnalyzers;
 
-import java.util.Locale;
-
 /**
  *
  */
@@ -42,8 +40,11 @@ public class PreBuiltAnalyzerProviderFactory implements AnalyzerProviderFactory 
     public AnalyzerProvider create(String name, Settings settings) {
         Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
         if (!Version.CURRENT.equals(indexVersion)) {
-            Analyzer analyzer = PreBuiltAnalyzers.valueOf(name.toUpperCase(Locale.ROOT)).getAnalyzer(indexVersion);
-            return new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, analyzer);
+            PreBuiltAnalyzers preBuiltAnalyzers = PreBuiltAnalyzers.getOrDefault(name, null);
+            if (preBuiltAnalyzers != null) {
+                Analyzer analyzer = preBuiltAnalyzers.getAnalyzer(indexVersion);
+                return new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, analyzer);
+            }
         }
 
         return analyzerProvider;

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltCharFilterFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltCharFilterFactoryFactory.java
@@ -24,8 +24,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.analysis.PreBuiltCharFilters;
 
-import java.util.Locale;
-
 public class PreBuiltCharFilterFactoryFactory implements CharFilterFactoryFactory {
 
     private final CharFilterFactory charFilterFactory;
@@ -38,7 +36,10 @@ public class PreBuiltCharFilterFactoryFactory implements CharFilterFactoryFactor
     public CharFilterFactory create(String name, Settings settings) {
         Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
         if (!Version.CURRENT.equals(indexVersion)) {
-            return PreBuiltCharFilters.valueOf(name.toUpperCase(Locale.ROOT)).getCharFilterFactory(indexVersion);
+            PreBuiltCharFilters preBuiltCharFilters = PreBuiltCharFilters.getOrDefault(name, null);
+            if (preBuiltCharFilters != null) {
+                return preBuiltCharFilters.getCharFilterFactory(indexVersion);
+            }
         }
 
         return charFilterFactory;

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenFilterFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenFilterFactoryFactory.java
@@ -24,8 +24,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.analysis.PreBuiltTokenFilters;
 
-import java.util.Locale;
-
 public class PreBuiltTokenFilterFactoryFactory implements TokenFilterFactoryFactory {
 
     private final TokenFilterFactory tokenFilterFactory;
@@ -38,7 +36,10 @@ public class PreBuiltTokenFilterFactoryFactory implements TokenFilterFactoryFact
     public TokenFilterFactory create(String name, Settings settings) {
         Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
         if (!Version.CURRENT.equals(indexVersion)) {
-            return PreBuiltTokenFilters.valueOf(name.toUpperCase(Locale.ROOT)).getTokenFilterFactory(indexVersion);
+            PreBuiltTokenFilters preBuiltTokenFilters = PreBuiltTokenFilters.getOrDefault(name, null);
+            if (preBuiltTokenFilters != null) {
+                return preBuiltTokenFilters.getTokenFilterFactory(indexVersion);
+            }
         }
         return tokenFilterFactory;
     }

--- a/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenizerFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PreBuiltTokenizerFactoryFactory.java
@@ -24,8 +24,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.analysis.PreBuiltTokenizers;
 
-import java.util.Locale;
-
 public class PreBuiltTokenizerFactoryFactory implements TokenizerFactoryFactory {
 
     private final TokenizerFactory tokenizerFactory;
@@ -38,8 +36,10 @@ public class PreBuiltTokenizerFactoryFactory implements TokenizerFactoryFactory 
     public TokenizerFactory create(String name, Settings settings) {
         Version indexVersion = settings.getAsVersion(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
         if (!Version.CURRENT.equals(indexVersion)) {
-            TokenizerFactory versionedTokenizerFactory = PreBuiltTokenizers.valueOf(name.toUpperCase(Locale.ROOT)).getTokenizerFactory(indexVersion);
-            return versionedTokenizerFactory;
+            PreBuiltTokenizers preBuiltTokenizers = PreBuiltTokenizers.getOrDefault(name, null);
+            if (preBuiltTokenizers != null) {
+                return preBuiltTokenizers.getTokenizerFactory(indexVersion);
+            }
         }
 
         return tokenizerFactory;

--- a/src/main/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzers.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzers.java
@@ -65,6 +65,8 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.analysis.StandardHtmlStripAnalyzer;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 
+import java.util.Locale;
+
 /**
  *
  */
@@ -399,6 +401,19 @@ public enum PreBuiltAnalyzers {
         }
 
         return analyzer;
+    }
+
+    /**
+     * Get a pre built Analyzer by its name or fallback to the default one
+     * @param name Analyzer name
+     * @param defaultAnalyzer default Analyzer if name not found
+     */
+    public static PreBuiltAnalyzers getOrDefault(String name, PreBuiltAnalyzers defaultAnalyzer) {
+        try {
+            return valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return defaultAnalyzer;
+        }
     }
 
 }

--- a/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCharFilters.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCharFilters.java
@@ -67,4 +67,17 @@ public enum PreBuiltCharFilters {
 
         return charFilterFactory;
     }
+
+    /**
+     * Get a pre built CharFilter by its name or fallback to the default one
+     * @param name CharFilter name
+     * @param defaultCharFilter default CharFilter if name not found
+     */
+    public static PreBuiltCharFilters getOrDefault(String name, PreBuiltCharFilters defaultCharFilter) {
+        try {
+            return valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return defaultCharFilter;
+        }
+    }
 }

--- a/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
@@ -309,4 +309,16 @@ public enum PreBuiltTokenFilters {
         return factory;
     }
 
+    /**
+     * Get a pre built TokenFilter by its name or fallback to the default one
+     * @param name TokenFilter name
+     * @param defaultTokenFilter default TokenFilter if name not found
+     */
+    public static PreBuiltTokenFilters getOrDefault(String name, PreBuiltTokenFilters defaultTokenFilter) {
+        try {
+            return valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return defaultTokenFilter;
+        }
+    }
 }

--- a/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenizers.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenizers.java
@@ -151,4 +151,16 @@ public enum PreBuiltTokenizers {
         return tokenizerFactory;
     }
 
+    /**
+     * Get a pre built Tokenizer by its name or fallback to the default one
+     * @param name Tokenizer name
+     * @param defaultTokenizer default Tokenizer if name not found
+     */
+    public static PreBuiltTokenizers getOrDefault(String name, PreBuiltTokenizers defaultTokenizer) {
+        try {
+            return valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return defaultTokenizer;
+        }
+    }
 }

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyAnalysisBinderProcessor.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyAnalysisBinderProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.elasticsearch.index.analysis.AnalysisModule;
+
+/**
+ */
+public class DummyAnalysisBinderProcessor extends AnalysisModule.AnalysisBinderProcessor {
+
+    @Override
+    public void processAnalyzers(AnalyzersBindings analyzersBindings) {
+        analyzersBindings.processAnalyzer("dummy", DummyAnalyzerProvider.class);
+    }
+
+    @Override
+    public void processTokenFilters(TokenFiltersBindings tokenFiltersBindings) {
+        tokenFiltersBindings.processTokenFilter("dummy_token_filter", DummyTokenFilterFactory.class);
+    }
+
+    @Override
+    public void processTokenizers(TokenizersBindings tokenizersBindings) {
+        tokenizersBindings.processTokenizer("dummy_tokenizer", DummyTokenizerFactory.class);
+    }
+
+    @Override
+    public void processCharFilters(CharFiltersBindings charFiltersBindings) {
+        charFiltersBindings.processCharFilter("dummy_char_filter", DummyCharFilterFactory.class);
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyAnalysisPlugin.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyAnalysisPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.index.analysis.AnalysisModule;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+import java.util.Collection;
+
+public class DummyAnalysisPlugin extends AbstractPlugin {
+    /**
+     * The name of the plugin.
+     */
+    @Override
+    public String name() {
+        return "analysis-dummy";
+    }
+
+    /**
+     * The description of the plugin.
+     */
+    @Override
+    public String description() {
+        return "Analysis Dummy Plugin";
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> modules() {
+        return ImmutableList.<Class<? extends Module>>of(DummyIndicesAnalysisModule.class);
+    }
+
+    public void onModule(AnalysisModule module) {
+        module.addProcessor(new DummyAnalysisBinderProcessor());
+    }
+
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyAnalyzer.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyAnalyzer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.apache.lucene.analysis.util.StopwordAnalyzerBase;
+import org.apache.lucene.util.Version;
+
+import java.io.Reader;
+
+public class DummyAnalyzer extends StopwordAnalyzerBase {
+
+    protected DummyAnalyzer(Version version) {
+        super(version);
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
+        return null;
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyAnalyzerProvider.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyAnalyzerProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.analysis.AnalyzerProvider;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+
+public class DummyAnalyzerProvider implements AnalyzerProvider<DummyAnalyzer> {
+    @Override
+    public String name() {
+        return "dummy";
+    }
+
+    @Override
+    public AnalyzerScope scope() {
+        return AnalyzerScope.INDICES;
+    }
+
+    @Override
+    public DummyAnalyzer get() {
+        return new DummyAnalyzer(Lucene.ANALYZER_VERSION);
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyCharFilterFactory.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyCharFilterFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.elasticsearch.index.analysis.CharFilterFactory;
+
+import java.io.Reader;
+
+public class DummyCharFilterFactory implements CharFilterFactory {
+    @Override
+    public String name() {
+        return "dummy_char_filter";
+    }
+
+    @Override
+    public Reader create(Reader reader) {
+        return null;
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyIndicesAnalysis.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyIndicesAnalysis.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.analysis.*;
+
+public class DummyIndicesAnalysis extends AbstractComponent {
+
+    @Inject
+    public DummyIndicesAnalysis(Settings settings, IndicesAnalysisService indicesAnalysisService) {
+        super(settings);
+        indicesAnalysisService.analyzerProviderFactories().put("dummy",
+                new PreBuiltAnalyzerProviderFactory("dummy", AnalyzerScope.INDICES,
+                        new DummyAnalyzer(Lucene.ANALYZER_VERSION)));
+        indicesAnalysisService.tokenFilterFactories().put("dummy_token_filter",
+                new PreBuiltTokenFilterFactoryFactory(new DummyTokenFilterFactory()));
+        indicesAnalysisService.charFilterFactories().put("dummy_char_filter",
+                new PreBuiltCharFilterFactoryFactory(new DummyCharFilterFactory()));
+        indicesAnalysisService.tokenizerFactories().put("dummy_tokenizer",
+                new PreBuiltTokenizerFactoryFactory(new DummyTokenizerFactory()));
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyIndicesAnalysisModule.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyIndicesAnalysisModule.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.elasticsearch.common.inject.AbstractModule;
+
+public class DummyIndicesAnalysisModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(DummyIndicesAnalysis.class).asEagerSingleton();
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyTokenFilterFactory.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyTokenFilterFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.index.analysis.TokenFilterFactory;
+
+public class DummyTokenFilterFactory implements TokenFilterFactory {
+    @Override public String name() {
+        return "dummy_token_filter";
+    }
+
+    @Override public TokenStream create(TokenStream tokenStream) {
+        return null;
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/analysis/DummyTokenizerFactory.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/DummyTokenizerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.elasticsearch.index.analysis.TokenizerFactory;
+
+import java.io.Reader;
+
+public class DummyTokenizerFactory implements TokenizerFactory {
+    @Override
+    public String name() {
+        return "dummy_tokenizer";
+    }
+
+    @Override
+    public Tokenizer create(Reader reader) {
+        return null;
+    }
+}


### PR DESCRIPTION
When an analysis plugins provides default index settings using `PreBuiltAnalyzerProviderFactory`,  `PreBuiltTokenFilterFactoryFactory`, `PreBuiltTokenizerFactoryFactory` or `PreBuiltCharFilterFactoryFactory` it fails when upgrading it with elasticsearch superior or equal to 0.90.5.

Related issue: #4936

Fix is needed in core. But, in the meantime, analysis plugins developers can fix that issue by overloading default prebuilt factories.

For example:

``` java
public class StempelAnalyzerProviderFactory extends PreBuiltAnalyzerProviderFactory {

    private final PreBuiltAnalyzerProvider analyzerProvider;

    public StempelAnalyzerProviderFactory(String name, AnalyzerScope scope, Analyzer analyzer) {
        super(name, scope, analyzer);
        analyzerProvider = new PreBuiltAnalyzerProvider(name, scope, analyzer);
    }

    @Override
    public AnalyzerProvider create(String name, Settings settings) {
        return analyzerProvider;
    }

    public Analyzer analyzer() {
        return analyzerProvider.get();
    }
}
```

And instead of:

``` java
    @Inject
    public PolishIndicesAnalysis(Settings settings, IndicesAnalysisService indicesAnalysisService) {
        super(settings);
        indicesAnalysisService.analyzerProviderFactories().put("polish", new PreBuiltAnalyzerProviderFactory("polish", AnalyzerScope.INDICES, new PolishAnalyzer(Lucene.ANALYZER_VERSION)));
    }
```

do

``` java
    @Inject
    public PolishIndicesAnalysis(Settings settings, IndicesAnalysisService indicesAnalysisService) {
        super(settings);
        indicesAnalysisService.analyzerProviderFactories().put("polish", new StempelAnalyzerProviderFactory("polish", AnalyzerScope.INDICES, new PolishAnalyzer(Lucene.ANALYZER_VERSION)));
    }
```

Closes #5030
