### PR TITLE
Fixed the string() code literal in the java client index api doc.

### DIFF
--- a/docs/java-api/index_.asciidoc
+++ b/docs/java-api/index_.asciidoc
@@ -114,7 +114,7 @@ Note that you can also add arrays with `startArray(String)` and
 other XContentBuilder objects.
 
 If you need to see the generated JSON content, you can use the
-@string()@method.
+`string()` method.
 
 [source,java]
 --------------------------------------------------


### PR DESCRIPTION
Just a simple fix of the missing code blocks.
