### PR TITLE
added local flag & master_timeout support to cluster pending tasks api (0.90)

### DIFF
--- a/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/api/cluster.pending_tasks.json
@@ -1,0 +1,23 @@
+{
+    "cluster.pending_tasks": {
+        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/0.90/cluster-pending.html",
+        "methods": ["GET"],
+        "url": {
+            "path": "/_cluster/pending_tasks",
+            "paths": ["/_cluster/pending_tasks"],
+            "parts": {
+            },
+            "params": {
+                "local": {
+                    "type": "boolean",
+                    "description": "Return local information, do not retrieve the state from master node (default: false)"
+                },
+                "master_timeout": {
+                    "type": "time",
+                    "description": "Specify timeout for connection to master"
+                }
+            }
+        },
+        "body": null
+    }
+}

--- a/rest-api-spec/test/cluster.pending_tasks/10_basic.yaml
+++ b/rest-api-spec/test/cluster.pending_tasks/10_basic.yaml
@@ -1,0 +1,21 @@
+---
+"Test pending tasks":
+  - do:
+      cluster.pending_tasks: {}
+
+  - is_true: tasks
+---
+"Test pending tasks with local flag":
+  - do:
+      cluster.pending_tasks:
+        local: true
+
+  - is_true: tasks
+---
+"Test pending tasks with master timeout":
+  - do:
+      cluster.pending_tasks:
+        master_timeout: 10s
+
+  - is_true: tasks
+

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
@@ -19,15 +19,47 @@
 
 package org.elasticsearch.action.admin.cluster.tasks;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
 
 /**
  */
 public class PendingClusterTasksRequest extends MasterNodeOperationRequest<PendingClusterTasksRequest> {
 
+    private boolean local = false;
+
+    public PendingClusterTasksRequest local(boolean local) {
+        this.local = local;
+        return this;
+    }
+
+    public boolean local() {
+        return local;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        if (in.getVersion().onOrAfter(Version.V_0_90_12)) {
+            local = in.readBoolean();
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_0_90_12)) {
+            out.writeBoolean(local);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -53,6 +53,11 @@ public class TransportPendingClusterTasksAction extends TransportMasterNodeOpera
     }
 
     @Override
+    protected boolean localExecute(PendingClusterTasksRequest request) {
+        return request.local();
+    }
+
+    @Override
     protected PendingClusterTasksRequest newRequest() {
         return new PendingClusterTasksRequest();
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
@@ -44,6 +44,8 @@ public class RestPendingClusterTasksAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
+        pendingClusterTasksRequest.masterNodeTimeout(request.paramAsTime("master_timeout", pendingClusterTasksRequest.masterNodeTimeout()));
+        pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         client.admin().cluster().pendingClusterTasks(pendingClusterTasksRequest, new ActionListener<PendingClusterTasksResponse>() {
 
             @Override


### PR DESCRIPTION
This PR was created against 0.90 branch so that we can backport to 0.90, in a backwards compatible manner, the support for `local` flag and `master_timeout` in cluster pending tasks api.

With #3345 we added support for the `local` flag across the board to all cluster state read operations. The change was only applied to master and 1.x branches though, while having `local` flag and `master_timeout` support backported to 0.90 for cluster pending tasks api would help a lot. 
