### PR TITLE
Add note to statistical facet docs about documents missing faceted field

### DIFF
--- a/docs/reference/search/facets/statistical-facet.asciidoc
+++ b/docs/reference/search/facets/statistical-facet.asciidoc
@@ -99,3 +99,9 @@ should be enough memory to contain them. Since by default, dynamic
 introduced types are `long` and `double`, one option to reduce the
 memory footprint is to explicitly set the types for the relevant fields
 to either `short`, `integer`, or `float` when possible.
+
+==== Note on documents missing faceted field
+
+Statistical data is computed only for documents that have the numeric
+field which we are faceting on. Any documents that are missing the
+numeric field in question are excluded.


### PR DESCRIPTION
Hey,

I was not sure how the computing of statistical facets worked in terms of how it treated documents that were missing the faceted field. I visited the #elasticsearch channel on irc.freenode.net, where @HonzaKral was very helpful with what happens - `"documents with missing fields are excluded"` - so I thought it would be a good idea to add a note to the docs and share this knowledge with the rest of the community in an accessible way :)

Cheers!
