### PR TITLE
Migrating NodesInfo API to use plugins instead of singular plugin

### DIFF
--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -17,7 +17,7 @@ The second command selectively retrieves nodes information of only
 
 By default, it just returns all attributes and core settings for a node.
 It also allows to get only information on `settings`, `os`, `process`, `jvm`,
-`thread_pool`, `network`, `transport`, `http` and `plugin`:
+`thread_pool`, `network`, `transport`, `http` and `plugins`:
 
 [source,js]
 --------------------------------------------------
@@ -30,9 +30,9 @@ curl -XGET 'http://localhost:9200/_nodes/nodeId1,nodeId2/info/jvm,process'
 curl -XGET 'http://localhost:9200/_nodes/nodeId1,nodeId2/_all
 --------------------------------------------------
 
-The `all` flag can be set to return all the information - or you can simply omit it.
+The `_all` flag can be set to return all the information - or you can simply omit it.
 
-`plugin` - if set, the result will contain details about the loaded
+`plugins` - if set, the result will contain details about the loaded
 plugins per node:
 
 * `name`: plugin name

--- a/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/api/nodes.info.json
@@ -12,7 +12,7 @@
         },
         "metric": {
           "type": "list",
-          "options": ["settings", "os", "process", "jvm", "thread_pool", "network", "transport", "http", "plugin"],
+          "options": ["settings", "os", "process", "jvm", "thread_pool", "network", "transport", "http", "plugins"],
           "description": "A comma-separated list of metrics you wish returned. Leave empty to return all."
         }
       },

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -38,7 +38,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
     private boolean network = true;
     private boolean transport = true;
     private boolean http = true;
-    private boolean plugin = true;
+    private boolean plugins = true;
 
     public NodesInfoRequest() {
     }
@@ -63,7 +63,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         network = false;
         transport = false;
         http = false;
-        plugin = false;
+        plugins = false;
         return this;
     }
 
@@ -79,7 +79,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         network = true;
         transport = true;
         http = true;
-        plugin = true;
+        plugins = true;
         return this;
     }
 
@@ -205,19 +205,19 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
 
     /**
      * Should information about plugins be returned
-     * @param plugin true if you want info
+     * @param plugins true if you want info
      * @return The request
      */
-    public NodesInfoRequest plugin(boolean plugin) {
-        this.plugin = plugin;
+    public NodesInfoRequest plugins(boolean plugins) {
+        this.plugins = plugins;
         return this;
     }
 
     /**
      * @return true if information about plugins is requested
      */
-    public boolean plugin() {
-        return plugin;
+    public boolean plugins() {
+        return plugins;
     }
 
     @Override
@@ -231,7 +231,7 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         network = in.readBoolean();
         transport = in.readBoolean();
         http = in.readBoolean();
-        plugin = in.readBoolean();
+        plugins = in.readBoolean();
     }
 
     @Override
@@ -245,6 +245,6 @@ public class NodesInfoRequest extends NodesOperationRequest<NodesInfoRequest> {
         out.writeBoolean(network);
         out.writeBoolean(transport);
         out.writeBoolean(http);
-        out.writeBoolean(plugin);
+        out.writeBoolean(plugins);
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
@@ -113,8 +113,11 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
         return this;
     }
 
-    public NodesInfoRequestBuilder setPlugin(boolean plugin) {
-        request().plugin(plugin);
+    /**
+     * Should the node plugins info be returned.
+     */
+    public NodesInfoRequestBuilder setPlugins(boolean plugins) {
+        request().plugins(plugins);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -98,7 +98,7 @@ public class TransportNodesInfoAction extends TransportNodesOperationAction<Node
     protected NodeInfo nodeOperation(NodeInfoRequest nodeRequest) throws ElasticsearchException {
         NodesInfoRequest request = nodeRequest.request;
         return nodeService.info(request.settings(), request.os(), request.process(), request.jvm(), request.threadPool(),
-                request.network(), request.transport(), request.http(), request.plugin());
+                request.network(), request.transport(), request.http(), request.plugins());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestNodesInfoAction extends BaseRestHandler {
 
     private final SettingsFilter settingsFilter;
-    private final static Set<String> ALLOWED_METRICS = Sets.newHashSet("http", "jvm", "network", "os", "plugin", "process", "settings", "thread_pool", "transport");
+    private final static Set<String> ALLOWED_METRICS = Sets.newHashSet("http", "jvm", "network", "os", "plugins", "process", "settings", "thread_pool", "transport");
 
     @Inject
     public RestNodesInfoAction(Settings settings, Client client, RestController controller,
@@ -99,7 +99,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
             nodesInfoRequest.network(metrics.contains("network"));
             nodesInfoRequest.transport(metrics.contains("transport"));
             nodesInfoRequest.http(metrics.contains("http"));
-            nodesInfoRequest.plugin(metrics.contains("plugin"));
+            nodesInfoRequest.plugins(metrics.contains("plugins"));
         }
 
         client.admin().cluster().nodesInfo(nodesInfoRequest, new ActionListener<NodesInfoResponse>() {

--- a/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
+++ b/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
@@ -129,7 +129,7 @@ public class SimpleNodesInfoTests extends ElasticsearchIntegrationTest {
         ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus()).actionGet();
         logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
 
-        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().clear().setPlugin(true).execute().actionGet();
+        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().clear().setPlugins(true).execute().actionGet();
         logger.info("--> full json answer, status " + response.toString());
 
         assertNodeContainsPlugins(response, server1NodeId,

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -143,7 +143,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
     }
 
     private void assertPluginLoaded(String pluginName) {
-        NodesInfoResponse nodesInfoResponse = client().admin().cluster().prepareNodesInfo().clear().setPlugin(true).get();
+        NodesInfoResponse nodesInfoResponse = client().admin().cluster().prepareNodesInfo().clear().setPlugins(true).get();
         assertThat(nodesInfoResponse.getNodes().length, equalTo(1));
         assertThat(nodesInfoResponse.getNodes()[0].getPlugins().getInfos(), notNullValue());
         assertThat(nodesInfoResponse.getNodes()[0].getPlugins().getInfos().size(), equalTo(1));


### PR DESCRIPTION
In order to be consistent (and because in 1.0 we switched from
parameter driven information to specifzing the metrics as part of the URI)
this patch moves from 'plugin' to 'plugins' in the Nodes Info API.

Important: This breaks BWC for 1.0 a bit more than the switch already done, but is now documented in the migration document as well.
