### PR TITLE
Variable renamings to reduce unnecessary variable naming diversity

### DIFF
--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -534,13 +534,13 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         XContentType xContentType = XContentFactory.xContentType(source);
         XContentParser parser = XContentFactory.xContent(xContentType).createParser(source);
         try {
-            XContentParser.Token t = parser.nextToken();
-            if (t == null) {
+            XContentParser.Token token = parser.nextToken();
+            if (token == null) {
                 return this;
             }
             String currentFieldName = null;
-            while ((t = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (t == XContentParser.Token.FIELD_NAME) {
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if ("script".equals(currentFieldName)) {
                     script = parser.textOrNull();

--- a/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -519,8 +519,8 @@ public class ClusterState implements ToXContent {
             return blocks(blocksBuilder.build());
         }
 
-        public Builder blocks(ClusterBlocks block) {
-            this.blocks = block;
+        public Builder blocks(ClusterBlocks blocks) {
+            this.blocks = blocks;
             return this;
         }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -434,28 +434,28 @@ public class MappingMetaData {
             return;
         }
 
-        XContentParser.Token t = parser.currentToken();
-        if (t == null) {
-            t = parser.nextToken();
+        XContentParser.Token token = parser.currentToken();
+        if (token == null) {
+            token = parser.nextToken();
         }
-        if (t == XContentParser.Token.START_OBJECT) {
-            t = parser.nextToken();
+        if (token == XContentParser.Token.START_OBJECT) {
+            token = parser.nextToken();
         }
         String idPart = context.idParsingStillNeeded() ? id().pathElements()[context.locationId] : null;
         String routingPart = context.routingParsingStillNeeded() ? routing().pathElements()[context.locationRouting] : null;
         String timestampPart = context.timestampParsingStillNeeded() ? timestamp().pathElements()[context.locationTimestamp] : null;
 
-        for (; t == XContentParser.Token.FIELD_NAME; t = parser.nextToken()) {
+        for (; token == XContentParser.Token.FIELD_NAME; token = parser.nextToken()) {
             // Must point to field name
             String fieldName = parser.currentName();
             // And then the value...
-            t = parser.nextToken();
+            token = parser.nextToken();
             boolean incLocationId = false;
             boolean incLocationRouting = false;
             boolean incLocationTimestamp = false;
             if (context.idParsingStillNeeded() && fieldName.equals(idPart)) {
                 if (context.locationId + 1 == id.pathElements().length) {
-                    if (!t.isValue()) {
+                    if (!token.isValue()) {
                         throw new MapperParsingException("id field must be a value but was either an object or an array");
                     }
                     context.id = parser.textOrNull();
@@ -482,7 +482,7 @@ public class MappingMetaData {
             }
 
             if (incLocationId || incLocationRouting || incLocationTimestamp) {
-                if (t == XContentParser.Token.START_OBJECT) {
+                if (token == XContentParser.Token.START_OBJECT) {
                     context.locationId += incLocationId ? 1 : 0;
                     context.locationRouting += incLocationRouting ? 1 : 0;
                     context.locationTimestamp += incLocationTimestamp ? 1 : 0;

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -271,16 +271,16 @@ public class XContentHelper {
     }
 
     public static void copyCurrentStructure(XContentGenerator generator, XContentParser parser) throws IOException {
-        XContentParser.Token t = parser.currentToken();
+        XContentParser.Token token = parser.currentToken();
 
         // Let's handle field-name separately first
-        if (t == XContentParser.Token.FIELD_NAME) {
+        if (token == XContentParser.Token.FIELD_NAME) {
             generator.writeFieldName(parser.currentName());
-            t = parser.nextToken();
+            token = parser.nextToken();
             // fall-through to copy the associated value
         }
 
-        switch (t) {
+        switch (token) {
             case START_ARRAY:
                 generator.writeStartArray();
                 while (parser.nextToken() != XContentParser.Token.END_ARRAY) {

--- a/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -260,38 +260,38 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     static Map<String, Object> readMap(XContentParser parser, MapFactory mapFactory) throws IOException {
         Map<String, Object> map = mapFactory.newMap();
-        XContentParser.Token t = parser.currentToken();
-        if (t == null) {
-            t = parser.nextToken();
+        XContentParser.Token token = parser.currentToken();
+        if (token == null) {
+            token = parser.nextToken();
         }
-        if (t == XContentParser.Token.START_OBJECT) {
-            t = parser.nextToken();
+        if (token == XContentParser.Token.START_OBJECT) {
+            token = parser.nextToken();
         }
-        for (; t == XContentParser.Token.FIELD_NAME; t = parser.nextToken()) {
+        for (; token == XContentParser.Token.FIELD_NAME; token = parser.nextToken()) {
             // Must point to field name
             String fieldName = parser.currentName();
             // And then the value...
-            t = parser.nextToken();
-            Object value = readValue(parser, mapFactory, t);
+            token = parser.nextToken();
+            Object value = readValue(parser, mapFactory, token);
             map.put(fieldName, value);
         }
         return map;
     }
 
-    private static List<Object> readList(XContentParser parser, MapFactory mapFactory, XContentParser.Token t) throws IOException {
+    private static List<Object> readList(XContentParser parser, MapFactory mapFactory, XContentParser.Token token) throws IOException {
         ArrayList<Object> list = new ArrayList<Object>();
-        while ((t = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-            list.add(readValue(parser, mapFactory, t));
+        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            list.add(readValue(parser, mapFactory, token));
         }
         return list;
     }
 
-    private static Object readValue(XContentParser parser, MapFactory mapFactory, XContentParser.Token t) throws IOException {
-        if (t == XContentParser.Token.VALUE_NULL) {
+    private static Object readValue(XContentParser parser, MapFactory mapFactory, XContentParser.Token token) throws IOException {
+        if (token == XContentParser.Token.VALUE_NULL) {
             return null;
-        } else if (t == XContentParser.Token.VALUE_STRING) {
+        } else if (token == XContentParser.Token.VALUE_STRING) {
             return parser.text();
-        } else if (t == XContentParser.Token.VALUE_NUMBER) {
+        } else if (token == XContentParser.Token.VALUE_NUMBER) {
             XContentParser.NumberType numberType = parser.numberType();
             if (numberType == XContentParser.NumberType.INT) {
                 return parser.intValue();
@@ -302,13 +302,13 @@ public abstract class AbstractXContentParser implements XContentParser {
             } else if (numberType == XContentParser.NumberType.DOUBLE) {
                 return parser.doubleValue();
             }
-        } else if (t == XContentParser.Token.VALUE_BOOLEAN) {
+        } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
             return parser.booleanValue();
-        } else if (t == XContentParser.Token.START_OBJECT) {
+        } else if (token == XContentParser.Token.START_OBJECT) {
             return readMap(parser, mapFactory);
-        } else if (t == XContentParser.Token.START_ARRAY) {
-            return readList(parser, mapFactory, t);
-        } else if (t == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
+        } else if (token == XContentParser.Token.START_ARRAY) {
+            return readList(parser, mapFactory, token);
+        } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
             return parser.binaryValue();
         }
         return null;

--- a/src/main/java/org/elasticsearch/gateway/blobstore/BlobStoreGateway.java
+++ b/src/main/java/org/elasticsearch/gateway/blobstore/BlobStoreGateway.java
@@ -119,8 +119,8 @@ public abstract class BlobStoreGateway extends SharedStorageGateway {
 
     public CommitPoint findCommitPoint(String index, int shardId) throws IOException {
         BlobPath path = BlobStoreIndexGateway.shardPath(basePath, index, shardId);
-        ImmutableBlobContainer container = blobStore.immutableBlobContainer(path);
-        ImmutableMap<String, BlobMetaData> blobs = container.listBlobs();
+        ImmutableBlobContainer blobContainer = blobStore.immutableBlobContainer(path);
+        ImmutableMap<String, BlobMetaData> blobs = blobContainer.listBlobs();
         List<CommitPoint> commitPointsList = Lists.newArrayList();
         for (BlobMetaData md : blobs.values()) {
             if (md.length() == 0) { // a commit point that was not flushed yet...
@@ -128,7 +128,7 @@ public abstract class BlobStoreGateway extends SharedStorageGateway {
             }
             if (md.name().startsWith("commit-")) {
                 try {
-                    commitPointsList.add(CommitPoints.fromXContent(container.readBlobFully(md.name())));
+                    commitPointsList.add(CommitPoints.fromXContent(blobContainer.readBlobFully(md.name())));
                 } catch (Exception e) {
                     logger.warn("failed to read commit point at path {} with name [{}]", e, path, md.name());
                 }


### PR DESCRIPTION
I've been working on a research machine learning-based tool (link: http://groups.inf.ed.ac.uk/naturalize/ ) tool that analyzes source code identifiers and makes suggestions for renaming them. The goal is to reduce unnecessary diversity in variable naming and improve code readability. This pull request is only a small sample of the suggestions made for elasticsearch.

No functional changes were made in any of the commits
