### PR TITLE
Add support for distances in nautical miles

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -164,6 +164,7 @@ The full list of units is listed below:
 
 [horizontal]
 Mile::          `mi` or `miles`
+Nautical mile:: 'NM' or 'nmi' or 'nauticalmiles'
 Yard::          `yd` or `yards`
 Feet::          `ft` or `feet`
 Inch::          `in` or `inch`

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -164,6 +164,7 @@ The full list of units is listed below:
 
 [horizontal]
 Mile::          `mi` or `miles`
+Nautical_mile:: 'NM' or 'nmi' or 'nauticalmiles'
 Yard::          `yd` or `yards`
 Feet::          `ft` or `feet`
 Inch::          `in` or `inch`

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -164,7 +164,7 @@ The full list of units is listed below:
 
 [horizontal]
 Mile::          `mi` or `miles`
-Nautical mile:: 'NM' or 'nmi' or 'nauticalmiles'
+Nautical mile:: `NM` or `nmi` or `nauticalmiles`
 Yard::          `yd` or `yards`
 Feet::          `ft` or `feet`
 Inch::          `in` or `inch`

--- a/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
+++ b/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
@@ -39,6 +39,7 @@ public enum DistanceUnit {
     FEET(0.3048, "ft", "feet"),
     MILES(1609.344, "mi", "miles"),
     KILOMETERS(1000.0, "km", "kilometers"),
+    NAUTICALMILES(1852.0, "nm", "nauticalmiles"),
     MILLIMETERS(0.001, "mm", "millimeters"),
     CENTIMETERS(0.01, "cm", "centimeters"),
 

--- a/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
+++ b/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
@@ -37,11 +37,13 @@ public enum DistanceUnit {
     INCH(0.0254, "in", "inch"),
     YARD(0.9144, "yd", "yards"),
     FEET(0.3048, "ft", "feet"),
-    MILES(1609.344, "mi", "miles"),
     KILOMETERS(1000.0, "km", "kilometers"),
-    NAUTICALMILES(1852.0, "nm", "nauticalmiles"),
+    NAUTICALMILES(1852.0, "NM", "nmi", "nauticalmiles"),
     MILLIMETERS(0.001, "mm", "millimeters"),
     CENTIMETERS(0.01, "cm", "centimeters"),
+
+    // 'm' is a suffix of 'nmi' so it must follow 'nmi'
+    MILES(1609.344, "mi", "miles"),
 
     // since 'm' is suffix of other unit
     // it must be the last entry of unit

--- a/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
+++ b/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
@@ -35,6 +35,7 @@ public class DistanceUnitTests extends ElasticsearchTestCase {
         assertThat(DistanceUnit.KILOMETERS.convert(10, DistanceUnit.MILES), closeTo(16.09344, 0.001));
         assertThat(DistanceUnit.MILES.convert(10, DistanceUnit.MILES), closeTo(10, 0.001));
         assertThat(DistanceUnit.MILES.convert(10, DistanceUnit.KILOMETERS), closeTo(6.21371192, 0.001));
+        assertThat(DistanceUnit.NAUTICALMILES.convert(10, DistanceUnit.MILES), closeTo(8.689762, 0.001));
         assertThat(DistanceUnit.KILOMETERS.convert(10, DistanceUnit.KILOMETERS), closeTo(10, 0.001));
         assertThat(DistanceUnit.KILOMETERS.convert(10, DistanceUnit.METERS), closeTo(0.01, 0.00001));
         assertThat(DistanceUnit.KILOMETERS.convert(1000,DistanceUnit.METERS), closeTo(1, 0.001));
@@ -46,6 +47,7 @@ public class DistanceUnitTests extends ElasticsearchTestCase {
         assertThat(DistanceUnit.Distance.parseDistance("50km").unit, equalTo(DistanceUnit.KILOMETERS));
         assertThat(DistanceUnit.Distance.parseDistance("500m").unit, equalTo(DistanceUnit.METERS));
         assertThat(DistanceUnit.Distance.parseDistance("51mi").unit, equalTo(DistanceUnit.MILES));
+        assertThat(DistanceUnit.Distance.parseDistance("53nm").unit, equalTo(DistanceUnit.NAUTICALMILES));
         assertThat(DistanceUnit.Distance.parseDistance("52yd").unit, equalTo(DistanceUnit.YARD));
         assertThat(DistanceUnit.Distance.parseDistance("12in").unit, equalTo(DistanceUnit.INCH));
         assertThat(DistanceUnit.Distance.parseDistance("23mm").unit, equalTo(DistanceUnit.MILLIMETERS));

--- a/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
+++ b/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
@@ -47,7 +47,8 @@ public class DistanceUnitTests extends ElasticsearchTestCase {
         assertThat(DistanceUnit.Distance.parseDistance("50km").unit, equalTo(DistanceUnit.KILOMETERS));
         assertThat(DistanceUnit.Distance.parseDistance("500m").unit, equalTo(DistanceUnit.METERS));
         assertThat(DistanceUnit.Distance.parseDistance("51mi").unit, equalTo(DistanceUnit.MILES));
-        assertThat(DistanceUnit.Distance.parseDistance("53nm").unit, equalTo(DistanceUnit.NAUTICALMILES));
+        assertThat(DistanceUnit.Distance.parseDistance("53nmi").unit, equalTo(DistanceUnit.NAUTICALMILES));
+        assertThat(DistanceUnit.Distance.parseDistance("53NM").unit, equalTo(DistanceUnit.NAUTICALMILES));
         assertThat(DistanceUnit.Distance.parseDistance("52yd").unit, equalTo(DistanceUnit.YARD));
         assertThat(DistanceUnit.Distance.parseDistance("12in").unit, equalTo(DistanceUnit.INCH));
         assertThat(DistanceUnit.Distance.parseDistance("23mm").unit, equalTo(DistanceUnit.MILLIMETERS));


### PR DESCRIPTION
Added the DistanceUnit.NAUTICALMILES enumeration label with the corresponding "nm" unit suffix.

Closes #5085
