### PR TITLE
Make highlight query also work in the percolate api

### DIFF
--- a/rest-api-spec/test/percolate/18_highligh_with_query.yaml
+++ b/rest-api-spec/test/percolate/18_highligh_with_query.yaml
@@ -1,0 +1,36 @@
+---
+"Basic percolation highlight query test":
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      index:
+        index: test_index
+        type: .percolator
+        id:  test_percolator
+        body:
+          query:
+            match:
+              foo: bar
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      percolate:
+        index: test_index
+        type:  test_type
+        body:
+          doc:
+              foo: "bar foo"
+          size: 1
+          highlight:
+              fields:
+                foo:
+                    highlight_query:
+                      match:
+                          foo: foo
+
+  - match: {'total': 1}

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -96,6 +96,7 @@ public class PercolateContext extends SearchContext {
     private final IndexShard indexShard;
     private final CacheRecycler cacheRecycler;
     private final PageCacheRecycler pageCacheRecycler;
+    private final ScriptService scriptService;
     private final ConcurrentMap<HashedBytesRef, Query> percolateQueries;
     private String[] types;
 
@@ -115,7 +116,9 @@ public class PercolateContext extends SearchContext {
     private QuerySearchResult querySearchResult;
     private Sort sort;
 
-    public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard, IndexService indexService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler) {
+    public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
+                            IndexService indexService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
+                            ScriptService scriptService) {
         this.request = request;
         this.indexShard = indexShard;
         this.indexService = indexService;
@@ -128,6 +131,7 @@ public class PercolateContext extends SearchContext {
         this.querySearchResult = new QuerySearchResult(0, searchShardTarget);
         this.engineSearcher = indexShard.acquireSearcher("percolate");
         this.searcher = new ContextIndexSearcher(this, engineSearcher);
+        this.scriptService = scriptService;
     }
 
     public void initialize(final MemoryIndex memoryIndex, ParsedDocument parsedDocument) {
@@ -465,22 +469,22 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public AnalysisService analysisService() {
-        throw new UnsupportedOperationException();
+        return indexService.analysisService();
     }
 
     @Override
     public IndexQueryParserService queryParserService() {
-        throw new UnsupportedOperationException();
+        return indexService.queryParserService();
     }
 
     @Override
     public SimilarityService similarityService() {
-        throw new UnsupportedOperationException();
+        return indexService.similarityService();
     }
 
     @Override
     public ScriptService scriptService() {
-        throw new UnsupportedOperationException();
+        return scriptService;
     }
 
     @Override
@@ -495,17 +499,17 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public FilterCache filterCache() {
-        throw new UnsupportedOperationException();
+        return indexService.cache().filter();
     }
 
     @Override
     public DocSetCache docSetCache() {
-        throw new UnsupportedOperationException();
+        return indexService.cache().docSet();
     }
 
     @Override
     public IdCache idCache() {
-        throw new UnsupportedOperationException();
+        return indexService.cache().idCache();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -76,6 +76,7 @@ import org.elasticsearch.percolator.QueryCollector.Count;
 import org.elasticsearch.percolator.QueryCollector.Match;
 import org.elasticsearch.percolator.QueryCollector.MatchAndScore;
 import org.elasticsearch.percolator.QueryCollector.MatchAndSort;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.AggregationPhase;
@@ -116,11 +117,12 @@ public class PercolatorService extends AbstractComponent {
     private final HighlightPhase highlightPhase;
     private final AggregationPhase aggregationPhase;
     private final SortParseElement sortParseElement;
+    private final ScriptService scriptService;
 
     @Inject
     public PercolatorService(Settings settings, IndicesService indicesService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
                              HighlightPhase highlightPhase, ClusterService clusterService, FacetPhase facetPhase,
-                             AggregationPhase aggregationPhase) {
+                             AggregationPhase aggregationPhase, ScriptService scriptService) {
         super(settings);
         this.indicesService = indicesService;
         this.cacheRecycler = cacheRecycler;
@@ -129,6 +131,7 @@ public class PercolatorService extends AbstractComponent {
         this.highlightPhase = highlightPhase;
         this.facetPhase = facetPhase;
         this.aggregationPhase = aggregationPhase;
+        this.scriptService = scriptService;
         this.sortParseElement = new SortParseElement();
 
         final long maxReuseBytes = settings.getAsBytesSize("indices.memory.memory_index.size_per_thread", new ByteSizeValue(1, ByteSizeUnit.MB)).bytes();
@@ -164,7 +167,7 @@ public class PercolatorService extends AbstractComponent {
 
         SearchShardTarget searchShardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
         final PercolateContext context = new PercolateContext(
-                request, searchShardTarget, indexShard, percolateIndexService, cacheRecycler, pageCacheRecycler
+                request, searchShardTarget, indexShard, percolateIndexService, cacheRecycler, pageCacheRecycler, scriptService
         );
         try {
 

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -1487,6 +1487,38 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         assertThat(matches[3].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox jumps over the lazy <em>dog</em>"));
         assertThat(matches[4].getScore(), equalTo(5.5f));
         assertThat(matches[4].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown <em>fox</em> jumps over the lazy dog"));
+
+        logger.info("--> Top percolate for doc with field1=The quick brown fox jumps over the lazy dog");
+        response = client.preparePercolate()
+                .setIndices("test").setDocumentType("type")
+                .setSize(5)
+                .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "The quick brown fox jumps over the lazy dog").endObject()))
+                .setHighlightBuilder(new HighlightBuilder().field("field1").highlightQuery(QueryBuilders.matchQuery("field1", "jumps")))
+                .setPercolateQuery(functionScoreQuery(matchAllQuery()).add(new FactorBuilder().boostFactor(5.5f)))
+                .setSortByScore(true)
+                .execute().actionGet();
+        assertMatchCount(response, 5l);
+        assertThat(response.getMatches(), arrayWithSize(5));
+        assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
+
+        matches = response.getMatches();
+        Arrays.sort(matches, new Comparator<PercolateResponse.Match>() {
+            @Override
+            public int compare(PercolateResponse.Match a, PercolateResponse.Match b) {
+                return a.getId().compareTo(b.getId());
+            }
+        });
+
+        assertThat(matches[0].getScore(), equalTo(5.5f));
+        assertThat(matches[0].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox <em>jumps</em> over the lazy dog"));
+        assertThat(matches[1].getScore(), equalTo(5.5f));
+        assertThat(matches[1].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox <em>jumps</em> over the lazy dog"));
+        assertThat(matches[2].getScore(), equalTo(5.5f));
+        assertThat(matches[2].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox <em>jumps</em> over the lazy dog"));
+        assertThat(matches[3].getScore(), equalTo(5.5f));
+        assertThat(matches[3].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox <em>jumps</em> over the lazy dog"));
+        assertThat(matches[4].getScore(), equalTo(5.5f));
+        assertThat(matches[4].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox <em>jumps</em> over the lazy dog"));
     }
 
     @Test


### PR DESCRIPTION
Percolate is throwing unsupported operation exception when highlight query is being used. This PR fixes that.
