### PR TITLE
Recovery API

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -94,6 +94,8 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
 import org.elasticsearch.action.admin.indices.open.TransportOpenIndexAction;
 import org.elasticsearch.action.admin.indices.optimize.OptimizeAction;
 import org.elasticsearch.action.admin.indices.optimize.TransportOptimizeAction;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
+import org.elasticsearch.action.admin.indices.recovery.TransportRecoveryAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.TransportRefreshAction;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
@@ -284,6 +286,7 @@ public class ActionModule extends AbstractModule {
         registerAction(MultiPercolateAction.INSTANCE, TransportMultiPercolateAction.class, TransportShardMultiPercolateAction.class);
         registerAction(ExplainAction.INSTANCE, TransportExplainAction.class);
         registerAction(ClearScrollAction.INSTANCE, TransportClearScrollAction.class);
+        registerAction(RecoveryAction.INSTANCE, TransportRecoveryAction.class);
 
         // register Name -> GenericAction Map that can be injected to instances.
         MapBinder<String, GenericAction> actionsBinder

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryAction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.recovery;
+
+import org.elasticsearch.action.admin.indices.IndicesAction;
+import org.elasticsearch.client.IndicesAdminClient;
+
+/**
+ *
+ */
+public class RecoveryAction extends IndicesAction<RecoveryRequest, RecoveryResponse, RecoveryRequestBuilder> {
+
+    public static final RecoveryAction INSTANCE = new RecoveryAction();
+    public static final String NAME = "indices/recovery";
+
+    private RecoveryAction() {
+        super(NAME);
+    }
+
+    @Override
+    public RecoveryRequestBuilder newRequestBuilder(IndicesAdminClient client) {
+        return new RecoveryRequestBuilder(client);
+    }
+
+    @Override
+    public RecoveryResponse newResponse() {
+        return new RecoveryResponse();
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.recovery;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+/**
+ *
+ */
+public class RecoveryRequest extends BroadcastOperationRequest<RecoveryRequest> {
+
+    private boolean detailed = false;
+
+    public RecoveryRequest() {
+        this(Strings.EMPTY_ARRAY);
+    }
+
+    public RecoveryRequest(String... indices) {
+        super(indices);
+    }
+
+    public boolean detailed() {
+        return detailed;
+    }
+
+    public void detailed(boolean detailed) {
+        this.detailed = detailed;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequestBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.recovery;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.broadcast.BroadcastOperationRequestBuilder;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.client.internal.InternalIndicesAdminClient;
+
+/**
+ *
+ */
+public class RecoveryRequestBuilder extends BroadcastOperationRequestBuilder<RecoveryRequest, RecoveryResponse, RecoveryRequestBuilder> {
+
+    public RecoveryRequestBuilder(IndicesAdminClient indicesClient) {
+        super((InternalIndicesAdminClient) indicesClient, new RecoveryRequest());
+    }
+
+    @Override
+    protected void doExecute(ActionListener<RecoveryResponse> listener) {
+        ((IndicesAdminClient) client).recoveries(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.recovery;
+
+import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ *
+ */
+public class RecoveryResponse extends BroadcastOperationResponse implements ToXContent {
+
+    private boolean detailed = false;
+    private Map<String, List<ShardRecoveryResponse>> shardResponses = new HashMap<String, List<ShardRecoveryResponse>>();
+
+    public RecoveryResponse() { }
+
+    public RecoveryResponse(int totalShards, int successfulShards, int failedShards,
+                            Map<String, List<ShardRecoveryResponse>> shardResponses, List<ShardOperationFailedException> shardFailures) {
+        super(totalShards, successfulShards, failedShards, shardFailures);
+        this.shardResponses = shardResponses;
+    }
+
+    public boolean hasRecoveries() {
+        return shardResponses.size() > 0;
+    }
+
+    public void addShardRecovery(String index, ShardRecoveryResponse shardRecoveryResponse) {
+
+        List<ShardRecoveryResponse> shardRecoveries = shardResponses.get(index);
+        if (shardRecoveries == null) {
+            shardRecoveries = new ArrayList<ShardRecoveryResponse>();
+            shardResponses.put(index, shardRecoveries);
+        }
+
+        shardRecoveries.add(shardRecoveryResponse);
+    }
+
+    public boolean detailed() {
+        return detailed;
+    }
+
+    public void detailed(boolean detailed) {
+        this.detailed = detailed;
+    }
+
+    public Map<String, List<ShardRecoveryResponse>> shardResponses() {
+        return shardResponses;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        for (String index : shardResponses.keySet()) {
+            builder.startObject(index);
+            builder.startArray("shards");
+            for (ShardRecoveryResponse recoveryResponse : shardResponses.get(index)) {
+                builder.startObject();
+                recoveryResponse.toXContent(builder, params);
+                builder.endObject();
+            }
+            builder.endArray();
+            builder.endObject();
+        }
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/ShardRecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/ShardRecoveryResponse.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.recovery;
+
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationResponse;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class ShardRecoveryResponse extends BroadcastShardOperationResponse implements ToXContent {
+
+    boolean recovering = false;
+    IndexShardState state;
+    RecoveryMetrics recoveryMetrics;
+
+    public ShardRecoveryResponse() { }
+
+    public ShardRecoveryResponse(String index, int shardId) {
+        super(index, shardId);
+    }
+
+    public boolean recovering() {
+        return recovering;
+    }
+
+    public void recovering(boolean recovering) {
+        this.recovering = recovering;
+    }
+
+    public void recoveryMetrics(RecoveryMetrics recoveryMetrics) {
+        this.recoveryMetrics = recoveryMetrics;
+    }
+
+    public RecoveryMetrics recoveryMetrics() {
+        return recoveryMetrics;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        recoveryMetrics.toXContent(builder, params);
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(recovering);
+        out.writeByte(state.id());
+        out.writeOptionalStreamable(recoveryMetrics);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        recovering = in.readBoolean();
+        state = IndexShardState.fromId(in.readByte());
+        recoveryMetrics = RecoveryMetrics.readOptionalRecoveryMetricsFrom(in);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.action.admin.indices.recovery;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.recovery.RecoveryTarget;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.index.service.InternalIndexService;
+import org.elasticsearch.index.gateway.IndexShardGatewayService;
+import org.elasticsearch.index.shard.service.InternalIndexShard;
+import org.elasticsearch.indices.recovery.RecoveryStatus;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
+import org.elasticsearch.index.shard.IndexShardState;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ *
+ */
+public class TransportRecoveryAction extends
+        TransportBroadcastOperationAction<RecoveryRequest, RecoveryResponse, TransportRecoveryAction.ShardRecoveryRequest, ShardRecoveryResponse> {
+
+    private final IndicesService indicesService;
+    private final RecoveryTarget recoveryTarget;
+
+    @Inject
+    public TransportRecoveryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                   TransportService transportService, IndicesService indicesService, RecoveryTarget recoveryTarget) {
+
+        super(settings, threadPool, clusterService, transportService);
+        this.indicesService = indicesService;
+        this.recoveryTarget = recoveryTarget;
+    }
+
+    @Override
+    protected String transportAction() {
+        return RecoveryAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.MANAGEMENT;
+    }
+
+    @Override
+    protected RecoveryRequest newRequest() {
+        return new RecoveryRequest();
+    }
+
+    @Override
+    protected RecoveryResponse newResponse(RecoveryRequest request, AtomicReferenceArray shardsResponses, ClusterState clusterState) {
+
+        int successfulShards = 0;
+        int failedShards = 0;
+        List<ShardOperationFailedException> shardFailures = null;
+        Map<String, List<ShardRecoveryResponse>> shardResponses = new HashMap<String, List<ShardRecoveryResponse>>();
+
+        for (int i = 0; i < shardsResponses.length(); i++) {
+            Object shardResponse = shardsResponses.get(i);
+            if (shardResponse == null) {
+                // simply ignore non active shards
+            } else if (shardResponse instanceof BroadcastShardOperationFailedException) {
+                failedShards++;
+                if (shardFailures == null) {
+                    shardFailures = new ArrayList<ShardOperationFailedException>();
+                }
+                shardFailures.add(new DefaultShardOperationFailedException((BroadcastShardOperationFailedException) shardResponse));
+            } else {
+                ShardRecoveryResponse recoveryResponse = (ShardRecoveryResponse) shardResponse;
+                successfulShards++;
+
+                if (recoveryResponse.recovering()) {
+                    String indexName = recoveryResponse.recoveryMetrics().shardId().index().name();
+                    List<ShardRecoveryResponse> responses = shardResponses.get(indexName);
+                    if (responses == null) {
+                        responses = new ArrayList<ShardRecoveryResponse>();
+                        shardResponses.put(indexName, responses);
+                    }
+                    responses.add(recoveryResponse);
+                }
+            }
+        }
+
+        RecoveryResponse response = new RecoveryResponse(shardsResponses.length(), successfulShards, failedShards, shardResponses, shardFailures);
+        return response;
+    }
+
+    @Override
+    protected ShardRecoveryRequest newShardRequest() {
+        return new ShardRecoveryRequest();
+    }
+
+    @Override
+    protected ShardRecoveryRequest newShardRequest(ShardRouting shard, RecoveryRequest request) {
+        return new ShardRecoveryRequest(shard.index(), shard.id(), request);
+    }
+
+    @Override
+    protected ShardRecoveryResponse newShardResponse() {
+        return new ShardRecoveryResponse();
+    }
+
+    @Override
+    protected ShardRecoveryResponse shardOperation(ShardRecoveryRequest request) throws ElasticsearchException {
+
+        InternalIndexService indexService = (InternalIndexService) indicesService.indexServiceSafe(request.index());
+        InternalIndexShard indexShard = (InternalIndexShard) indexService.shardSafe(request.shardId());
+        ShardRouting shardRouting = indexShard.routingEntry();
+        ShardRecoveryResponse shardRecoveryResponse = new ShardRecoveryResponse(shardRouting.index(), shardRouting.id());
+
+        // XXX - (andrew) - Should have a tighter coupling between index_shard_state and recovery_metrics.state; look into this
+        boolean isShardRecovering = indexShard.state() == IndexShardState.RECOVERING;
+
+        // Can remove isShardRecovering state variable
+
+        shardRecoveryResponse.recovering(isShardRecovering);
+        shardRecoveryResponse.state = indexShard.state();
+
+        if (!isShardRecovering) {
+            // Would get historical recovery data here.
+            return shardRecoveryResponse;
+        }
+
+        RecoveryMetrics recoveryMetrics = null;
+
+        RecoveryStatus recoveryStatus = indexShard.peerRecoveryStatus();
+        if (recoveryStatus == null) {
+            recoveryStatus = recoveryTarget.peerRecoveryStatus(indexShard.shardId());
+        }
+
+        if (recoveryStatus != null) {
+            recoveryMetrics = recoveryStatus.metrics();
+        } else {
+            IndexShardGatewayService gatewayService =
+                    indexService.shardInjector(request.shardId()).getInstance(IndexShardGatewayService.class);
+            recoveryMetrics = gatewayService.recoveryMetrics();
+        }
+
+        shardRecoveryResponse.recoveryMetrics(recoveryMetrics);
+        return shardRecoveryResponse;
+    }
+
+
+    // XXX - (andrew) - DON'T BROADCAST HERE UNLESS USER WANTS ALREADY RECOVERED SHARDS
+
+    @Override
+    protected GroupShardsIterator shards(ClusterState state, RecoveryRequest request, String[] concreteIndices) {
+        return state.routingTable().allAssignedShardsGrouped(concreteIndices, true);
+    }
+
+    @Override
+    protected ClusterBlockException checkGlobalBlock(ClusterState state, RecoveryRequest request) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA);
+    }
+
+    @Override
+    protected ClusterBlockException checkRequestBlock(ClusterState state, RecoveryRequest request, String[] concreteIndices) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA, concreteIndices);
+    }
+
+    public static class ShardRecoveryRequest extends BroadcastShardOperationRequest {
+
+        ShardRecoveryRequest() { }
+
+        ShardRecoveryRequest(String index, int shardId, RecoveryRequest request) {
+            super(index, shardId, request);
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -87,6 +87,9 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.status.IndicesStatusRequest;
 import org.elasticsearch.action.admin.indices.status.IndicesStatusRequestBuilder;
 import org.elasticsearch.action.admin.indices.status.IndicesStatusResponse;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequestBuilder;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateResponse;
@@ -183,6 +186,21 @@ public interface IndicesAdminClient {
      * Indices stats.
      */
     IndicesStatsRequestBuilder prepareStats(String... indices);
+
+    /**
+     * Indices recoveries
+     */
+    ActionFuture<RecoveryResponse> recoveries(RecoveryRequest request);
+
+    /**
+     * Indices recoveries
+     */
+    void recoveries(RecoveryRequest request, ActionListener<RecoveryResponse> listener);
+
+    /**
+     * Indices recoveries
+     */
+    RecoveryRequestBuilder prepareRecoveries(String... indices);
 
     /**
      * The status of one or more indices.

--- a/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractIndicesAdminClient.java
@@ -89,6 +89,10 @@ import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequestBuilder;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequestBuilder;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
@@ -448,6 +452,21 @@ public abstract class AbstractIndicesAdminClient implements InternalIndicesAdmin
     @Override
     public IndicesStatusRequestBuilder prepareStatus(String... indices) {
         return new IndicesStatusRequestBuilder(this).setIndices(indices);
+    }
+
+    @Override
+    public ActionFuture<RecoveryResponse> recoveries(final RecoveryRequest request) {
+        return execute(RecoveryAction.INSTANCE, request);
+    }
+
+    @Override
+    public void recoveries(final RecoveryRequest request, final ActionListener<RecoveryResponse> listener) {
+        execute(RecoveryAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public RecoveryRequestBuilder prepareRecoveries(String... indices) {
+        return new RecoveryRequestBuilder(this).setIndices(indices);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/gateway/IndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/IndexShardGateway.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.CloseableIndexComponent;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
 import org.elasticsearch.index.shard.IndexShardComponent;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
 
 /**
  *
@@ -51,7 +52,7 @@ public interface IndexShardGateway extends IndexShardComponent, CloseableIndexCo
     /**
      * Recovers the state of the shard from the gateway.
      */
-    void recover(boolean indexShouldExists, RecoveryStatus recoveryStatus) throws IndexShardGatewayRecoveryException;
+    void recover(boolean indexShouldExists, RecoveryMetrics recoveryMetrics) throws IndexShardGatewayRecoveryException;
 
     /**
      * Snapshots the given shard into the gateway.

--- a/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
+++ b/src/main/java/org/elasticsearch/index/gateway/none/NoneIndexShardGateway.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
 
 import java.io.IOException;
 
@@ -60,8 +61,8 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
     }
 
     @Override
-    public void recover(boolean indexShouldExists, RecoveryStatus recoveryStatus) throws IndexShardGatewayRecoveryException {
-        recoveryStatus.index().startTime(System.currentTimeMillis());
+    public void recover(boolean indexShouldExists, RecoveryMetrics recoveryMetrics) throws IndexShardGatewayRecoveryException {
+        recoveryMetrics.state(RecoveryMetrics.State.INDEX);
         // in the none case, we simply start the shard
         // clean the store, there should be nothing there...
         try {
@@ -71,9 +72,7 @@ public class NoneIndexShardGateway extends AbstractIndexShardComponent implement
             logger.warn("failed to clean store before starting shard", e);
         }
         indexShard.postRecovery("post recovery from gateway");
-        recoveryStatus.index().time(System.currentTimeMillis() - recoveryStatus.index().startTime());
-        recoveryStatus.translog().startTime(System.currentTimeMillis());
-        recoveryStatus.translog().time(System.currentTimeMillis() - recoveryStatus.index().startTime());
+        recoveryMetrics.indexTimer().stop();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardRepository.java
@@ -21,8 +21,8 @@ package org.elasticsearch.index.snapshots;
 
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
-import org.elasticsearch.index.gateway.RecoveryStatus;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
 
 /**
  * Shard-level snapshot repository
@@ -56,8 +56,8 @@ public interface IndexShardRepository {
      * @param snapshotId      snapshot id
      * @param shardId         shard id (in the current index)
      * @param snapshotShardId shard id (in the snapshot)
-     * @param recoveryStatus  recovery status
+     * @param recoveryMetrics recovery metrics
      */
-    void restore(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryStatus recoveryStatus);
+    void restore(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryMetrics recoveryMetrics);
 
 }

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.RestoreService;
 
@@ -104,9 +105,9 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
     /**
      * Restores shard from {@link RestoreSource} associated with this shard in routing table
      *
-     * @param recoveryStatus recovery status
+     * @param recoveryMetrics recovery metrics
      */
-    public void restore(final RecoveryStatus recoveryStatus) {
+    public void restore(final RecoveryMetrics recoveryMetrics) {
         RestoreSource restoreSource = indexShard.routingEntry().restoreSource();
         if (restoreSource == null) {
             throw new IndexShardRestoreFailedException(shardId, "empty restore source");
@@ -120,7 +121,7 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
             if (!shardId.getIndex().equals(restoreSource.index())) {
                 snapshotShardId = new ShardId(restoreSource.index(), shardId.id());
             }
-            indexShardRepository.restore(restoreSource.snapshotId(), shardId, snapshotShardId, recoveryStatus);
+            indexShardRepository.restore(restoreSource.snapshotId(), shardId, snapshotShardId, recoveryMetrics);
             restoreService.indexShardRestoreCompleted(restoreSource.snapshotId(), shardId);
         } catch (Throwable t) {
             throw new IndexShardRestoreFailedException(shardId, "restore failed", t);

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -38,13 +38,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
-import org.elasticsearch.index.gateway.RecoveryStatus;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.snapshots.*;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
 import org.elasticsearch.repositories.RepositoryName;
 
 import java.io.IOException;
@@ -141,13 +141,11 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
      * {@inheritDoc}
      */
     @Override
-    public void restore(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryStatus recoveryStatus) {
-        RestoreContext snapshotContext = new RestoreContext(snapshotId, shardId, snapshotShardId, recoveryStatus);
+    public void restore(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryMetrics recoveryMetrics) {
+        RestoreContext snapshotContext = new RestoreContext(snapshotId, shardId, snapshotShardId, recoveryMetrics);
 
         try {
-            recoveryStatus.index().startTime(System.currentTimeMillis());
             snapshotContext.restore();
-            recoveryStatus.index().time(System.currentTimeMillis() - recoveryStatus.index().startTime());
         } catch (Throwable e) {
             throw new IndexShardRestoreFailedException(shardId, "failed to restore snapshot [" + snapshotId.getSnapshot() + "]", e);
         }
@@ -553,7 +551,6 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
             // no file, not exact and not multipart
             return false;
         }
-
     }
 
     /**
@@ -562,8 +559,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
     private class RestoreContext extends Context {
 
         private final Store store;
-
-        private final RecoveryStatus recoveryStatus;
+        private final RecoveryMetrics recoveryMetrics;
 
         /**
          * Constructs new restore context
@@ -571,12 +567,12 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
          * @param snapshotId      snapshot id
          * @param shardId         shard to be restored
          * @param snapshotShardId shard in the snapshot that data should be restored from
-         * @param recoveryStatus  recovery status to report progress
+         * @param recoveryMetrics recovery metrics to report progress
          */
-        public RestoreContext(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryStatus recoveryStatus) {
+        public RestoreContext(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryMetrics recoveryMetrics) {
             super(snapshotId, shardId, snapshotShardId);
             store = indicesService.indexServiceSafe(shardId.getIndex()).shardInjectorSafe(shardId.id()).getInstance(Store.class);
-            this.recoveryStatus = recoveryStatus;
+            this.recoveryMetrics = recoveryMetrics;
         }
 
         /**
@@ -585,13 +581,14 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
         public void restore() {
             logger.debug("[{}] [{}] restoring to [{}] ...", snapshotId, repositoryName, shardId);
             BlobStoreIndexShardSnapshot snapshot;
+            recoveryMetrics.state(RecoveryMetrics.State.INDEX);
+
             try {
                 snapshot = readSnapshot(blobContainer.readBlobFully(snapshotBlobName(snapshotId)));
             } catch (IOException ex) {
                 throw new IndexShardRestoreFailedException(shardId, "failed to read shard snapshot file", ex);
             }
 
-            recoveryStatus.updateStage(RecoveryStatus.Stage.INDEX);
             int numberOfFiles = 0;
             long totalSize = 0;
             int numberOfReusedFiles = 0;
@@ -618,6 +615,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                 } else {
                     totalSize += fileInfo.length();
                     filesToRecover.add(fileInfo);
+                    recoveryMetrics.index().addFile(fileInfo.name(), fileInfo.length());
                     if (logger.isTraceEnabled()) {
                         if (md == null) {
                             logger.trace("recovering [{}], does not exists in local store", fileInfo.physicalName());
@@ -628,7 +626,8 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                 }
             }
 
-            recoveryStatus.index().files(numberOfFiles, totalSize, numberOfReusedFiles, reusedTotalSize);
+            recoveryMetrics.index().files(numberOfFiles, totalSize, numberOfReusedFiles, reusedTotalSize);
+
             if (filesToRecover.isEmpty()) {
                 logger.trace("no files to recover, all exists within the local store");
             }
@@ -664,7 +663,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
             } catch (IOException e) {
                 throw new IndexShardRestoreFailedException(shardId, "Failed to fetch index version after copying it over", e);
             }
-            recoveryStatus.index().updateVersion(version);
+            recoveryMetrics.index().version(version);
 
             /// now, go over and clean files that are in the store, but were not in the snapshot
             try {
@@ -709,8 +708,11 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
             blobContainer.readBlob(firstFileToRecover, new BlobContainer.ReadBlobListener() {
                 @Override
                 public synchronized void onPartial(byte[] data, int offset, int size) throws IOException {
-                    recoveryStatus.index().addCurrentFilesSize(size);
+
+                    recoveryMetrics.index().addBytesRecovered(size);
+                    recoveryMetrics.index().getFile(fileInfo.name()).bytesRecovered(size);
                     indexOutput.writeBytes(data, offset, size);
+
                     if (restoreRateLimiter != null) {
                         rateLimiterListener.onRestorePause(restoreRateLimiter.pause(size));
                     }
@@ -733,6 +735,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                                 store.writeChecksum(fileInfo.physicalName(), fileInfo.checksum());
                             }
                             store.directory().sync(Collections.singleton(fileInfo.physicalName()));
+                            recoveryMetrics.index().fileCompleted(fileInfo.name());
                         } catch (IOException e) {
                             onFailure(e);
                             return;
@@ -748,7 +751,6 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                 }
             });
         }
-
     }
 
     public interface RateLimiterListener {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryMetrics.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryMetrics.java
@@ -1,0 +1,632 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.recovery;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.cluster.routing.RestoreSource;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+
+public class RecoveryMetrics implements ToXContent, Streamable {
+
+    private ShardId shardId;
+
+    private Type type;
+    private State state;
+    private Index index;
+    private Translog translog;
+
+    private Timer timer;
+    private Timer indexTimer;
+    private Timer translogTimer;
+
+    private boolean failed = false;
+    private boolean ignored = false;
+    private boolean completed = false;
+    private int retries = 0;
+
+    private String exceptionMessage;
+    private String ignoredReason;
+
+    // in the case of snapshot restore, sourceNode will be null and
+    // restoreSource will have details on the source of the data
+    DiscoveryNode sourceNode;
+    DiscoveryNode targetNode;
+    RestoreSource restoreSource;
+
+    private RecoveryMetrics() { }
+
+    public RecoveryMetrics(ShardId shardId, DiscoveryNode sourceNode, DiscoveryNode targetNode) {
+        this.shardId = shardId;
+        this.sourceNode = sourceNode;
+        this.targetNode = targetNode;
+        this.state = State.INIT;
+        this.timer = new Timer();
+        this.indexTimer = new Timer();
+        this.translogTimer = new Timer();
+        this.index = new Index();
+        this.translog = new Translog();
+        timer.start();
+    }
+
+    public RecoveryMetrics(ShardId shardId) {
+        this(shardId, null, null);
+    }
+
+    public enum Type {
+        GATEWAY((byte) 0),
+        RESTORE((byte) 1),
+        PEER((byte) 2),
+        RELOCATION((byte) 3);
+
+        private final byte id;
+        private static final Type[] TYPES = new Type[Type.values().length];
+
+        static {
+            for (Type type : Type.values()) {
+                assert type.id() < TYPES.length && type.id() >= 0;
+                TYPES[type.id()] = type;
+            }
+        }
+
+        Type(byte id) {
+            this.id = id;
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public static Type fromByte(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id >= TYPES.length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return TYPES[id];
+        }
+    }
+
+    public enum State {
+        INIT((byte) 0),
+        INDEX((byte) 1),
+        TRANSLOG((byte) 2),
+        COMPLETE((byte) 3),
+        FAILED((byte) 4),
+        IGNORED((byte) 5);
+
+        private final byte id;
+        private static final State[] STATES = new State[State.values().length];
+
+        static {
+            for (State state : State.values()) {
+                assert state.id() < STATES.length && state.id() >= 0;
+                STATES[state.id()] = state;
+            }
+        }
+
+        State(byte id) {
+            this.id = id;
+        }
+
+        public byte id() {
+            return this.id;
+        }
+
+        public static State fromByte(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id >= STATES.length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return STATES[id];
+        }
+    }
+
+    public ShardId shardId() {
+        return shardId;
+    }
+
+    public Timer timer() {
+        return timer;
+    }
+
+    public Timer indexTimer() {
+        return indexTimer;
+    }
+
+    public Timer translogTimer() {
+        return translogTimer;
+    }
+
+    public void state(State state) {
+        this.state = state;
+
+        switch (state) {
+            case INDEX:
+                indexTimer.start();
+                break;
+            case TRANSLOG:
+                indexTimer.stop();
+                translogTimer.start();
+                break;
+            case COMPLETE:
+                completed = true;
+                stopTimers();
+                break;
+            case FAILED:
+                failed = true;
+                stopTimers();
+                break;
+            case IGNORED:
+                ignored = true;
+                stopTimers();
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void type(Type type) {
+        this.type = type;
+    }
+
+    public Type type() {
+        return type;
+    }
+
+    public State state() {
+        return state;
+    }
+
+    public void sourceNode(DiscoveryNode sourceNode) {
+        this.sourceNode = sourceNode;
+    }
+
+    public DiscoveryNode sourceNode() {
+        return sourceNode;
+    }
+
+    public void targetNode(DiscoveryNode targetNode) {
+        this.targetNode = targetNode;
+    }
+
+    public DiscoveryNode targetNode() {
+        return targetNode;
+    }
+
+    public void restoreSource(RestoreSource restoreSource) {
+        this.restoreSource = restoreSource;
+    }
+
+    public RestoreSource restoreSource() {
+        return restoreSource;
+    }
+
+    public void ignored(String reason) {
+        this.ignoredReason = reason;
+        state(State.IGNORED);
+    }
+
+    public boolean ignored() {
+        return ignored;
+    }
+
+    public void failed(Exception exception) {
+        this.exceptionMessage = exception.getMessage();
+        state(State.FAILED);
+    }
+
+    public boolean failed() {
+        return failed;
+    }
+
+    public void completed(boolean completed) {
+        this.completed = completed;
+        if (completed) {
+            state(State.COMPLETE);
+        }
+    }
+
+    public int retries() {
+        return retries;
+    }
+
+    public void incrementRetries() {
+        retries++;
+    }
+
+    public boolean completed() {
+        return completed;
+    }
+
+    public Index index() {
+        return index;
+    }
+
+    public Translog translog() {
+        return translog;
+    }
+
+    private void stopTimers() {
+        indexTimer.stop();
+        translogTimer.stop();
+        timer.stop();
+    }
+
+    public static RecoveryMetrics readOptionalRecoveryMetricsFrom(StreamInput in) throws IOException {
+        return in.readOptionalStreamable(new RecoveryMetrics());
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        shardId = ShardId.readShardId(in);
+        type = Type.fromByte(in.readByte());
+        state = State.fromByte(in.readByte());
+        index = Index.readIndexFrom(in);
+        translog = Translog.readTranslogFrom(in);
+        timer = Timer.readTimerFrom(in);
+        indexTimer = Timer.readTimerFrom(in);
+        translogTimer = Timer.readTimerFrom(in);
+        failed = in.readBoolean();
+        ignored = in.readBoolean();
+        completed = in.readBoolean();
+        retries = in.readVInt();
+        exceptionMessage = in.readOptionalString();
+        ignoredReason = in.readOptionalString();
+        sourceNode = DiscoveryNode.readNode(in);
+        targetNode = DiscoveryNode.readNode(in);
+        restoreSource = RestoreSource.readOptionalRestoreSource(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        shardId.writeTo(out);
+        out.writeByte(type.id());
+        out.writeByte(state.id());
+        index.writeTo(out);
+        translog.writeTo(out);
+        timer.writeTo(out);
+        indexTimer.writeTo(out);
+        translogTimer.writeTo(out);
+        out.writeBoolean(failed);
+        out.writeBoolean(ignored);
+        out.writeBoolean(completed);
+        out.writeVInt(retries);
+        out.writeOptionalString(exceptionMessage);
+        out.writeOptionalString(ignoredReason);
+        sourceNode.writeTo(out);
+        targetNode.writeTo(out);
+        out.writeOptionalStreamable(restoreSource);
+    }
+    
+    public static class Index implements Streamable {
+        long version = -1;
+        int numberOfFiles = 0;
+        long totalSize = 0;
+        int numberOfReusedFiles = 0;
+        long reusedTotalSize = 0;
+        long checkIndexTime = 0;
+
+        private AtomicLong numberOfFilesRecovered = new AtomicLong();
+        private AtomicLong numberOfBytesRecovered = new AtomicLong();
+
+        Map<String, File> files = new HashMap<String, File>();
+
+        private Index() { }
+
+        public void version(long version) {
+            this.version = version;
+        }
+
+        public long version() {
+            return version;
+        }
+
+        public void files(int numberOfFiles, long totalSize, int numberOfReusedFiles, long reusedTotalSize) {
+            this.numberOfFiles = numberOfFiles;
+            this.totalSize = totalSize;
+            this.numberOfReusedFiles = numberOfReusedFiles;
+            this.reusedTotalSize = reusedTotalSize;
+        }
+
+        public long numberOfBytes() {
+            return totalSize;
+        }
+
+        public long numberOfBytesRecovered() {
+            return numberOfBytesRecovered.longValue();
+        }
+
+        public void addBytesRecovered(long count) {
+            numberOfBytesRecovered.addAndGet(count);
+        }
+
+        public int numberOfFiles() {
+            return numberOfFiles;
+        }
+
+        public long numberOfFilesRecovered() {
+            return numberOfFilesRecovered.longValue();
+        }
+
+        public void fileCompleted(String fileName) {
+            getFile(fileName).complete();
+            numberOfFilesRecovered.incrementAndGet();
+        }
+
+        public long checkIndexTime() {
+            return checkIndexTime;
+        }
+
+        public void checkIndexTime(long checkIndexTime) {
+            this.checkIndexTime = checkIndexTime;
+        }
+
+        public Map<String, File> files() {
+            return files;
+        }
+
+        public void addFile(String name, long length) {
+            files.put(name, new File(name, length));
+        }
+
+        public void addFiles(List<String> names, List<Long> sizes) {
+            long totalSize = 0;
+            for (int i = 0; i < names.size(); i++) {
+                addFile(names.get(i), sizes.get(i));
+                totalSize += sizes.get(i);
+            }
+
+            this.totalSize = totalSize;
+            this.numberOfFiles = names.size();
+        }
+
+        public File getFile(String name) {
+            return files.get(name);
+        }
+
+        public static Index readIndexFrom(StreamInput in) throws IOException {
+            Index index = new Index();
+            index.readFrom(in);
+            return index;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            version = in.readLong();
+            numberOfFiles = in.readVInt();
+            totalSize = in.readVLong();
+            numberOfReusedFiles = in.readVInt();
+            reusedTotalSize = in.readVLong();
+            checkIndexTime = in.readVLong();
+            int size = in.readVInt();
+            for (int i = 0; i < size; i++) {
+                files.put(in.readString(), File.readFileFrom(in));
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(version);
+            out.writeVInt(numberOfFiles);
+            out.writeVLong(totalSize);
+            out.writeVInt(numberOfReusedFiles);
+            out.writeVLong(reusedTotalSize);
+            out.writeVLong(checkIndexTime);
+            out.writeVInt(files == null ? 0 : files.size());
+            for (Map.Entry<String, File> entry : files.entrySet()) {
+                out.writeString(entry.getKey());
+                entry.getValue().writeTo(out);
+            }
+        }
+    }
+
+    public static class File implements Streamable {
+        String name;
+        long length;
+        long bytesRecovered = 0;
+        boolean complete = false;
+
+        private File() { }
+
+        public File(String name, long length) {
+            this.name = name;
+            this.length = length;
+        }
+
+        public void bytesRecovered(long bytesRecovered) {
+            this.bytesRecovered += bytesRecovered;
+        }
+
+        public long bytesRecovered() {
+            return bytesRecovered;
+        }
+
+        public void complete() {
+            complete = true;
+        }
+
+        public static File readFileFrom(StreamInput in) throws IOException {
+            File f = new File();
+            f.readFrom(in);
+            return f;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            name = in.readString();
+            length = in.readVLong();
+            bytesRecovered = in.readVLong();
+            complete = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeVLong(length);
+            out.writeVLong(bytesRecovered);
+            out.writeBoolean(complete);
+        }
+    }
+
+    public static class Translog implements Streamable {
+        private volatile int currentTranslogOperations = 0;
+
+        private Translog() { }
+
+        public void addTranslogOperations(int count) {
+            this.currentTranslogOperations += count;
+        }
+
+        public int currentTranslogOperations() {
+            return this.currentTranslogOperations;
+        }
+
+        public static Translog readTranslogFrom(StreamInput in) throws IOException {
+            Translog t = new Translog();
+            t.readFrom(in);
+            return t;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            currentTranslogOperations = in.readVInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(currentTranslogOperations);
+        }
+    }
+
+    // XXX - (andrew) - Change timing to setters/getters for long values
+
+    public static class Timer implements Streamable {
+        private long start = 0;
+        private long stop = 0;
+
+        private Timer() { }
+
+        public void start() {
+            start = System.currentTimeMillis();
+        }
+
+        public long startTime() {
+            return start;
+        }
+
+        public void stop() {
+            stop = System.currentTimeMillis();
+        }
+
+        public long stopTime() {
+            return stop;
+        }
+
+        public long elapsed() {
+            if (start == 0) {
+                return 0;
+            } else if (stop == 0) {
+                return System.currentTimeMillis() - start;
+            } else {
+                return stop - start;
+            }
+        }
+
+        public static Timer readTimerFrom(StreamInput in) throws IOException {
+            Timer timer = new Timer();
+            timer.readFrom(in);
+            return timer;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            start = in.readVLong();
+            stop = in.readVLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(start);
+            out.writeVLong(stop);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        builder.field("id", shardId.id());
+        builder.field("type", type.toString().toLowerCase(Locale.ROOT));
+        builder.field("state", state.toString().toLowerCase(Locale.ROOT));
+        builder.field("complete", completed);
+        builder.field("elapsed", timer.elapsed());
+
+        builder.startObject("source");
+        if (restoreSource != null) {
+            restoreSource.toXContent(builder, params);
+        } else if (sourceNode != null) {
+            builder.field("id", sourceNode.getId());
+            builder.field("hostname", sourceNode.getHostName());
+            builder.field("address", sourceNode.getHostAddress());
+        }
+        builder.endObject();
+
+        builder.startObject("target");
+        if (targetNode != null) {
+            builder.field("id", targetNode.getId());
+            builder.field("hostname", targetNode.getHostName());
+            builder.field("address", targetNode.getHostAddress());
+        }
+        builder.endObject();
+
+        builder.startObject("index_metrics");
+        builder.field("elapsed", indexTimer.elapsed());
+        builder.field("version", index.version);
+        builder.field("number_of_files", index.numberOfFiles);
+        builder.field("number_of_files_recovered", index.numberOfFilesRecovered());
+        builder.field("percent_of_files_recovered", safePercent(index.numberOfFilesRecovered(), index.numberOfFiles));
+        builder.field("total_size_in_bytes", index.totalSize);
+        builder.field("number_of_bytes_recovered", index.numberOfBytesRecovered());
+        builder.field("percent_of_bytes_recovered", safePercent(index.numberOfBytesRecovered(), index.totalSize));
+        builder.endObject();
+
+        builder.startObject("translog_metrics");
+        builder.field("elapsed", translogTimer.elapsed());
+        builder.field("current_translog_operations", translog.currentTranslogOperations());
+        builder.endObject();
+
+        return builder;
+    }
+
+    private String safePercent(long a, long b) {
+        if (b == 0) {
+            return String.format(Locale.ROOT, "%1.1f%%", 0.0f);
+        } else {
+            return String.format(Locale.ROOT, "%1.1f%%", 100.0 * (float) a / b);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -78,6 +78,7 @@ import org.elasticsearch.rest.action.admin.indices.validate.query.RestValidateQu
 import org.elasticsearch.rest.action.admin.indices.warmer.delete.RestDeleteWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.get.RestGetWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.put.RestPutWarmerAction;
+import org.elasticsearch.rest.action.admin.indices.recovery.RestRecoveryAction;
 import org.elasticsearch.rest.action.bulk.RestBulkAction;
 import org.elasticsearch.rest.action.cat.*;
 import org.elasticsearch.rest.action.delete.RestDeleteAction;
@@ -205,10 +206,9 @@ public class RestActionModule extends AbstractModule {
         bind(RestMultiSearchAction.class).asEagerSingleton();
 
         bind(RestValidateQueryAction.class).asEagerSingleton();
-
         bind(RestMoreLikeThisAction.class).asEagerSingleton();
-
         bind(RestExplainAction.class).asEagerSingleton();
+        bind(RestRecoveryAction.class).asEagerSingleton();
 
         // cat API
         Multibinder<AbstractCatAction> catActionMultibinder = Multibinder.newSetBinder(binder(), AbstractCatAction.class);
@@ -219,7 +219,8 @@ public class RestActionModule extends AbstractModule {
         catActionMultibinder.addBinding().to(RestIndicesAction.class).asEagerSingleton();
         // Fully qualified to prevent interference with rest.action.count.RestCountAction
         catActionMultibinder.addBinding().to(org.elasticsearch.rest.action.cat.RestCountAction.class).asEagerSingleton();
-        catActionMultibinder.addBinding().to(RestRecoveryAction.class).asEagerSingleton();
+        // Fully qualified to prevent interference with rest.action.indices.RestRecoveryAction
+        catActionMultibinder.addBinding().to(org.elasticsearch.rest.action.cat.RestRecoveryAction.class).asEagerSingleton();
         catActionMultibinder.addBinding().to(RestHealthAction.class).asEagerSingleton();
         catActionMultibinder.addBinding().to(org.elasticsearch.rest.action.cat.RestPendingClusterTasksAction.class).asEagerSingleton();
         catActionMultibinder.addBinding().to(RestAliasAction.class).asEagerSingleton();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices.recovery;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.support.RestXContentBuilder;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastShardsHeader;
+
+/**
+ * REST handler to report on index recoveries.
+ */
+public class RestRecoveryAction extends BaseRestHandler  {
+
+    @Inject
+    public RestRecoveryAction(Settings settings, Client client, RestController controller) {
+        super(settings, client);
+        controller.registerHandler(GET, "/_recovery", this);
+        controller.registerHandler(GET, "/{index}/_recovery", this);
+    }
+
+    @Override
+    public void handleRequest(final RestRequest request, final RestChannel channel) {
+
+        final RecoveryRequest recoveryRequest = new RecoveryRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        recoveryRequest.detailed(request.paramAsBoolean("details", false));
+        recoveryRequest.listenerThreaded(false);
+        recoveryRequest.indicesOptions(IndicesOptions.fromRequest(request, recoveryRequest.indicesOptions()));
+
+        client.admin().indices().recoveries(recoveryRequest, new ActionListener<RecoveryResponse>() {
+
+            @Override
+            public void onResponse(RecoveryResponse response) {
+                try {
+                    XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
+
+                    if (response.hasRecoveries()) {
+                        response.detailed(recoveryRequest.detailed());
+                        builder.startObject();
+                        response.toXContent(builder, request);
+                        builder.endObject();
+                    }
+                    channel.sendResponse(new XContentRestResponse(request, OK, builder));
+                } catch (Throwable e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                try {
+                    channel.sendResponse(new XContentThrowableRestResponse(request, e));
+                } catch (IOException ioe) {
+                    logger.error("Failed to send failure response", ioe);
+                }
+            }
+        });
+
+    }
+}

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -19,20 +19,20 @@
 
 package org.elasticsearch.rest.action.cat;
 
+import org.joda.time.format.ISODateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.action.admin.indices.status.IndicesStatusRequest;
-import org.elasticsearch.action.admin.indices.status.IndicesStatusResponse;
-import org.elasticsearch.action.admin.indices.status.ShardStatus;
-import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryRequest;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
+import org.elasticsearch.action.admin.indices.recovery.ShardRecoveryResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.indices.recovery.RecoveryMetrics;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -51,6 +51,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  */
 public class RestRecoveryAction extends AbstractCatAction {
 
+    private static final DateTimeFormatter dateFormatter = ISODateTimeFormat.dateHourMinuteSecond();
+
     @Inject
     protected RestRecoveryAction(Settings settings, Client client, RestController restController) {
         super(settings, client);
@@ -66,57 +68,25 @@ public class RestRecoveryAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.clear().nodes(true);
-        clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
 
-        client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
+        final RecoveryRequest recoveryRequest = new RecoveryRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        recoveryRequest.detailed(request.paramAsBoolean("details", false));
+        recoveryRequest.listenerThreaded(false);
+        recoveryRequest.indicesOptions(IndicesOptions.fromRequest(request, recoveryRequest.indicesOptions()));
+
+        client.admin().indices().recoveries(recoveryRequest, new ActionListener<RecoveryResponse>() {
+
             @Override
-            public void onResponse(final ClusterStateResponse clusterStateResponse) {
-                IndicesStatusRequest indicesStatusRequest = new IndicesStatusRequest(indices);
-                indicesStatusRequest.recovery(true);
-                indicesStatusRequest.operationThreading(BroadcastOperationThreading.SINGLE_THREAD);
-
-                client.admin().indices().status(indicesStatusRequest, new ActionListener<IndicesStatusResponse>() {
-                    @Override
-                    public void onResponse(IndicesStatusResponse indicesStatusResponse) {
-                        Map<String, Long> primarySizes = new HashMap<String, Long>();
-                        Set<ShardStatus> replicas = new HashSet<ShardStatus>();
-
-                        // Loop through all the shards in the index status, keeping
-                        // track of the primary shard size with a Map and the
-                        // recovering shards in a Set of ShardStatus objects
-                        for (ShardStatus shardStatus : indicesStatusResponse.getShards()) {
-                            if (shardStatus.getShardRouting().primary()) {
-                                primarySizes.put(shardStatus.getShardRouting().getIndex() + shardStatus.getShardRouting().getId(),
-                                        shardStatus.getStoreSize().bytes());
-                            } else if (shardStatus.getState() == IndexShardState.RECOVERING) {
-                                replicas.add(shardStatus);
-                            }
-                        }
-
-                        try {
-                            channel.sendResponse(RestTable.buildResponse(buildRecoveryTable(request, clusterStateResponse, primarySizes, replicas), request, channel));
-                        } catch (Throwable e) {
-                            try {
-                                channel.sendResponse(new XContentThrowableRestResponse(request, e));
-                            } catch (IOException e2) {
-                                logger.error("Unable to send recovery status response", e2);
-                            }
-                        }
+            public void onResponse(final RecoveryResponse response) {
+                try {
+                    channel.sendResponse(RestTable.buildResponse(buildRecoveryTable(request, response), request, channel));
+                } catch (Throwable e) {
+                    try {
+                        channel.sendResponse(new XContentThrowableRestResponse(request, e));
+                    } catch (IOException e2) {
+                        logger.error("Unable to send recovery status response", e2);
                     }
-
-                    @Override
-                    public void onFailure(Throwable e) {
-                        try {
-                            channel.sendResponse(new XContentThrowableRestResponse(request, e));
-                        } catch (IOException e1) {
-                            logger.error("Failed to send failure response", e1);
-                        }
-                    }
-                });
+                }
             }
 
             @Override
@@ -128,54 +98,73 @@ public class RestRecoveryAction extends AbstractCatAction {
                 }
             }
         });
-
     }
 
     @Override
     Table getTableWithHeader(RestRequest request) {
         Table t = new Table();
-        t.startHeaders().addCell("index", "alias:i,idx;desc:index name")
+        t.startHeaders()
+                .addCell("index", "alias:i,idx;desc:index name")
                 .addCell("shard", "alias:s,sh;desc:shard name")
-                .addCell("target", "alias:t;text-align:right;desc:bytes of source shard")
-                .addCell("recovered", "alias:r;text-align:right;desc:bytes recovered so far")
-                .addCell("percent", "alias:per,ratio;text-align:right;desc:percent recovered so far")
-                .addCell("host", "alias:h;desc:node host where source shard lives")
-                .addCell("ip", "desc:node ip where source shard lives")
-                .addCell("node", "alias:n;desc:node name where source shard lives")
+                .addCell("start", "alias:sta;desc:start time")
+                .addCell("stop", "alias:sto;desc:stop time")
+                .addCell("elapsed", "alias:t,ti;desc:recovery time")
+                .addCell("type", "alias:ty;desc:recovery type")
+                .addCell("stage", "alias:st;desc:recovery stage")
+                .addCell("files", "alias:f;desc:number of files")
+                .addCell("files_recovered", "alias:fr;desc:number of files recovered")
+                .addCell("files_percent", "alias:fp;desc:percent of files recovered")
+                .addCell("bytes", "alias:b;desc:size in bytes")
+                .addCell("bytes_recovered", "alias:br;desc:bytes recovered")
+                .addCell("bytes_percent", "alias:bp;desc:percent of bytes recovered")
+                .addCell("source_host", "alias:th;desc:source host")
+                .addCell("target_host", "alias:th;desc:target host")
+                .addCell("repository", "alias:rep;desc:repository")
+                .addCell("snapshot", "alias:snap;desc:snapshot")
                 .endHeaders();
         return t;
     }
 
-    /**
-     * buildRecoveryTable will build a table of recovery information suitable
-     * for displaying at the command line.
-     *
-     * @param request
-     * @param state              Current cluster state.
-     * @param primarySizes       A Map of {@code index + shardId} strings to store size for all primary shards.
-     * @param recoveringReplicas A Set of {@link org.elasticsearch.action.admin.indices.status.ShardStatus} objects for each recovering replica to be displayed.
-     * @return A table containing index, shardId, node, target size, recovered size and percentage for each recovering replica
-     */
-    public Table buildRecoveryTable(RestRequest request, ClusterStateResponse state, Map<String, Long> primarySizes, Set<ShardStatus> recoveringReplicas) {
-        Table t = getTableWithHeader(request);
-        for (ShardStatus status : recoveringReplicas) {
-            DiscoveryNode node = state.getState().nodes().get(status.getShardRouting().currentNodeId());
+    public Table buildRecoveryTable(RestRequest request, RecoveryResponse response) {
 
-            String index = status.getShardRouting().getIndex();
-            int id = status.getShardId();
-            long replicaSize = status.getStoreSize().bytes();
-            Long primarySize = primarySizes.get(index + id);
-            t.startRow();
-            t.addCell(index);
-            t.addCell(id);
-            t.addCell(primarySize);
-            t.addCell(replicaSize);
-            t.addCell(primarySize == null ? null : String.format(Locale.ROOT, "%1.1f%%", 100.0 * (float) replicaSize / primarySize));
-            t.addCell(node == null ? null : node.getHostName());
-            t.addCell(node == null ? null : node.getHostAddress());
-            t.addCell(node == null ? null : node.name());
-            t.endRow();
+        Table t = getTableWithHeader(request);
+        for (String index : response.shardResponses().keySet()) {
+
+            List<ShardRecoveryResponse> shardRecoveryResponses = response.shardResponses().get(index);
+            for (ShardRecoveryResponse shardRecoveryResponse : shardRecoveryResponses) {
+
+                RecoveryMetrics metrics = shardRecoveryResponse.recoveryMetrics();
+                boolean isSnapshotRestore = metrics.type() == RecoveryMetrics.Type.RESTORE;
+
+                t.startRow();
+                t.addCell(index);
+                t.addCell(shardRecoveryResponse.getShardId());
+                t.addCell(metrics.timer().startTime() > 0 ? dateFormatter.print(metrics.timer().startTime()) : 0);
+                t.addCell(metrics.timer().stopTime() > 0 ? dateFormatter.print(metrics.timer().stopTime()) : 0);
+                t.addCell(metrics.timer().elapsed());
+                t.addCell(metrics.type().toString().toLowerCase(Locale.ROOT));
+                t.addCell(metrics.state().toString().toLowerCase(Locale.ROOT));
+                t.addCell(metrics.index().numberOfFiles());
+                t.addCell(metrics.index().numberOfFilesRecovered());
+                t.addCell(safePercent(metrics.index().numberOfFilesRecovered(), metrics.index().numberOfFiles()));
+                t.addCell(metrics.index().numberOfBytes());
+                t.addCell(metrics.index().numberOfBytesRecovered());
+                t.addCell(safePercent(metrics.index().numberOfBytesRecovered(), metrics.index().numberOfBytes()));
+                t.addCell(isSnapshotRestore ? "n/a" : metrics.sourceNode().getHostName());
+                t.addCell(metrics.targetNode().getHostName());
+                t.addCell(isSnapshotRestore ? metrics.restoreSource().snapshotId().getRepository() : "n/a");
+                t.addCell(isSnapshotRestore ? metrics.restoreSource().snapshotId().getSnapshot() : "n/a");
+                t.endRow();
+            }
         }
         return t;
+    }
+
+    private String safePercent(long a, long b) {
+        if (b == 0) {
+            return String.format(Locale.ROOT, "%1.1f%%", 0.0f);
+        } else {
+            return String.format(Locale.ROOT, "%1.1f%%", 100.0 * (float) a / b);
+        }
     }
 }


### PR DESCRIPTION
Unifies all recovery code to use common state tracking classes and
methods. Reports on all cluster-wide shard recoveries from snapshots,
gateways and peers.

Refactors the cat API to use this new internal recovery API.

See #4637
