### PR TITLE
Fix `highlight_query` in percolator

### DIFF
--- a/rest-api-spec/test/percolate/highlight_percolator.yaml
+++ b/rest-api-spec/test/percolate/highlight_percolator.yaml
@@ -1,0 +1,37 @@
+---
+"Basic percolation highlight query test":
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      index:
+        index: test_index
+        type: .percolator
+        id:   test_percolator
+        body:
+          query:
+            match:
+              foo: bar
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      percolate:
+        index: test_index
+        type:  test_type
+        body:
+           doc:
+              foo: "bar foo"
+           size: 1
+           highlight:
+              fields:
+                 foo:
+                    highlight_query:
+                       match:
+                          foo: foo
+
+  - match: {'total': 1}
+

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -470,7 +470,7 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public IndexQueryParserService queryParserService() {
-        throw new UnsupportedOperationException();
+        return indexService.queryParserService();
     }
 
     @Override


### PR DESCRIPTION
When highlighting with the percolator a `highlight_query` caused UnsupportedOperationException
