### PR TITLE
Closes #5102 - Show stacktrace of startup exception

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -236,9 +236,10 @@ public class Bootstrap {
             String errorMessage = buildErrorMessage(stage, e);
             if (foreground) {
                 System.err.println(errorMessage);
+                e.printStackTrace();
                 System.err.flush();
             } else {
-                logger.error(errorMessage);
+                logger.error(errorMessage, e);
             }
             Loggers.disableConsoleLogging();
             if (logger.isDebugEnabled()) {


### PR DESCRIPTION
https://github.com/elasticsearch/elasticsearch/issues/5102

This makes it a lot easier to debug a problem
like

{2.0.0-SNAPSHOT}: Startup Failed ...
- NumberFormatException[For input string: ""]

because now you see from where the error comes
from (which might be from a plugin!).
