### PR TITLE
Exposed shard id related to a failure in delete by query

### DIFF
--- a/src/main/java/org/elasticsearch/action/delete/index/IndexDeleteResponse.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/IndexDeleteResponse.java
@@ -35,9 +35,9 @@ public class IndexDeleteResponse extends ActionResponse {
     private int failedShards;
     private ShardDeleteResponse[] deleteResponses;
 
-    IndexDeleteResponse(String index, int successfulShards, int failedShards, ShardDeleteResponse[] deleteResponses) {
+    IndexDeleteResponse(String index, int failedShards, ShardDeleteResponse[] deleteResponses) {
         this.index = index;
-        this.successfulShards = successfulShards;
+        this.successfulShards = deleteResponses.length;
         this.failedShards = failedShards;
         this.deleteResponses = deleteResponses;
     }

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.delete.index;
 
+import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.replication.TransportIndexReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -30,8 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.List;
 
 /**
  *
@@ -50,19 +50,8 @@ public class TransportIndexDeleteAction extends TransportIndexReplicationOperati
     }
 
     @Override
-    protected IndexDeleteResponse newResponseInstance(IndexDeleteRequest request, AtomicReferenceArray shardsResponses) {
-        int successfulShards = 0;
-        int failedShards = 0;
-        ArrayList<ShardDeleteResponse> responses = new ArrayList<ShardDeleteResponse>();
-        for (int i = 0; i < shardsResponses.length(); i++) {
-            if (shardsResponses.get(i) == null) {
-                failedShards++;
-            } else {
-                responses.add((ShardDeleteResponse) shardsResponses.get(i));
-                successfulShards++;
-            }
-        }
-        return new IndexDeleteResponse(request.index(), successfulShards, failedShards, responses.toArray(new ShardDeleteResponse[responses.size()]));
+    protected IndexDeleteResponse newResponseInstance(IndexDeleteRequest request, List<ShardDeleteResponse> shardDeleteResponses, int failuresCount, List<ShardOperationFailedException> shardFailures) {
+        return new IndexDeleteResponse(request.index(), failuresCount, shardDeleteResponses.toArray(new ShardDeleteResponse[shardDeleteResponses.size()]));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.deletebyquery;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.replication.TransportIndexReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -32,9 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  *
@@ -53,20 +50,8 @@ public class TransportIndexDeleteByQueryAction extends TransportIndexReplication
     }
 
     @Override
-    protected IndexDeleteByQueryResponse newResponseInstance(IndexDeleteByQueryRequest request, AtomicReferenceArray shardsResponses) {
-        int successfulShards = 0;
-        int failedShards = 0;
-        List<ShardOperationFailedException> failures = new ArrayList<ShardOperationFailedException>(3);
-        for (int i = 0; i < shardsResponses.length(); i++) {
-            Object shardResponse = shardsResponses.get(i);
-            if (shardResponse instanceof Throwable) {
-                failedShards++;
-                failures.add(new DefaultShardOperationFailedException(request.index(), -1, (Throwable) shardResponse));
-            } else {
-                successfulShards++;
-            }
-        }
-        return new IndexDeleteByQueryResponse(request.index(), successfulShards, failedShards, failures);
+    protected IndexDeleteByQueryResponse newResponseInstance(IndexDeleteByQueryRequest request, List<ShardDeleteByQueryResponse> shardDeleteByQueryResponses, int failuresCount, List<ShardOperationFailedException> shardFailures) {
+        return new IndexDeleteByQueryResponse(request.index(), shardDeleteByQueryResponses.size(), failuresCount, shardFailures);
     }
 
     @Override


### PR DESCRIPTION
Relates to #5095, where we want to expose the potential shard failures obtained from the delete by query api. Although the failure is available, the shard id where it happened is not (always `-1`).

Refactored TransportIndexReplicationOperationAction to be able to expose the shard id related to a shard failure.

The `ShardOperationFailedException` is now created within `TransportIndexReplicationAction` passing in the current shard id as a constructor argument.
Also replaced `AtomicReferenceArray<Object>` with `AtomicReferenceArray<ShardActionResult>`, where `ShardActionResult` wraps the `ShardResponse` or the failure, containing all the needed info.
