### PR TITLE
Add support for `lowercase_expanded_terms` flag to simple_query_string

### DIFF
--- a/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/queries/simple-query-string-query.asciidoc
@@ -39,6 +39,10 @@ creating composite queries.
 
 |`flags` |Flags specifying which features of the `simple_query_string` to
 enable. Defaults to `ALL`.
+
+|`lowercase_expanded_terms` | Whether terms of prefix and fuzzy queries are to
+be automatically lower-cased or not (since they are not analyzed). Defaults to
+true.
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryParser.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.queryparser.XSimpleQueryParser;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
+
+/**
+ * Wrapper class for Lucene's SimpleQueryParser that allows us to redefine
+ * different types of queries.
+ */
+public class SimpleQueryParser extends XSimpleQueryParser {
+
+    private final boolean lowercaseExpandedTerms;
+
+    /** Creates a new parser with custom flags used to enable/disable certain features. */
+    public SimpleQueryParser(Analyzer analyzer, Map<String, Float> weights, int flags, boolean lowercaseExpandedTerms) {
+        super(analyzer, weights, flags);
+        this.lowercaseExpandedTerms = lowercaseExpandedTerms;
+    }
+
+    /**
+     * Dispatches to Lucene's SimpleQueryParser's newFuzzyQuery, optionally
+     * lowercasing the term first
+     */
+    @Override
+    public Query newFuzzyQuery(String text, int fuzziness) {
+        if (lowercaseExpandedTerms) {
+            text = text.toLowerCase(Locale.ROOT);
+        }
+        return super.newFuzzyQuery(text, fuzziness);
+    }
+
+    /**
+     * Dispatches to Lucene's SimpleQueryParser's newPrefixQuery, optionally
+     * lowercasing the term first
+     */
+    @Override
+    public Query newPrefixQuery(String text) {
+        if (lowercaseExpandedTerms) {
+            text = text.toLowerCase(Locale.ROOT);
+        }
+        return super.newPrefixQuery(text);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -36,6 +36,7 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
     private Operator operator;
     private final String queryText;
     private int flags = -1;
+    private Boolean lowercaseExpandedTerms;
 
     /**
      * Operators for the default_operator
@@ -101,6 +102,11 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
         return this;
     }
 
+    public SimpleQueryStringBuilder lowercaseExpandedTerms(boolean lowercaseExpandedTerms) {
+        this.lowercaseExpandedTerms = lowercaseExpandedTerms;
+        return this;
+    }
+
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(SimpleQueryStringParser.NAME);
@@ -131,6 +137,10 @@ public class SimpleQueryStringBuilder extends BaseQueryBuilder {
 
         if (operator != null) {
             builder.field("default_operator", operator.name().toLowerCase(Locale.ROOT));
+        }
+
+        if (lowercaseExpandedTerms != null) {
+            builder.field("lowercase_expanded_terms", lowercaseExpandedTerms);
         }
 
         builder.endObject();

--- a/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -90,6 +90,7 @@ public class SimpleQueryStringParser implements QueryParser {
         Map<String, Float> fieldsAndWeights = null;
         BooleanClause.Occur defaultOperator = null;
         Analyzer analyzer = null;
+        boolean lowercaseExpandedTerms = true;
         int flags = -1;
 
         XContentParser.Token token;
@@ -167,6 +168,8 @@ public class SimpleQueryStringParser implements QueryParser {
                             flags = SimpleQueryStringFlag.ALL.value();
                         }
                     }
+                } else if ("lowercase_expanded_terms".equals(currentFieldName)) {
+                    lowercaseExpandedTerms = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[" + NAME + "] unsupported field [" + parser.currentName() + "]");
                 }
@@ -193,12 +196,10 @@ public class SimpleQueryStringParser implements QueryParser {
             analyzer = parseContext.mapperService().searchAnalyzer();
         }
 
-        XSimpleQueryParser sqp;
-        if (fieldsAndWeights != null) {
-            sqp = new XSimpleQueryParser(analyzer, fieldsAndWeights, flags);
-        } else {
-            sqp = new XSimpleQueryParser(analyzer, Collections.singletonMap(field, 1.0F), flags);
+        if (fieldsAndWeights == null) {
+            fieldsAndWeights = Collections.singletonMap(field, 1.0F);
         }
+        SimpleQueryParser sqp = new SimpleQueryParser(analyzer, fieldsAndWeights, flags, lowercaseExpandedTerms);
 
         if (defaultOperator != null) {
             sqp.setDefaultOperator(defaultOperator);

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -1980,6 +1980,30 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testSimpleQueryStringLowercasing() {
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(SETTING_NUMBER_OF_SHARDS, 1));
+        client().prepareIndex("test", "type1", "1").setSource("body", "Professional").get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryString("Professio*")).get();
+        assertHitCount(searchResponse, 1l);
+        assertSearchHits(searchResponse, "1");
+
+        searchResponse = client().prepareSearch().setQuery(
+                simpleQueryString("Professio*").lowercaseExpandedTerms(false)).get();
+        assertHitCount(searchResponse, 0l);
+
+        searchResponse = client().prepareSearch().setQuery(
+                simpleQueryString("Professionan~1")).get();
+        assertHitCount(searchResponse, 1l);
+        assertSearchHits(searchResponse, "1");
+
+        searchResponse = client().prepareSearch().setQuery(
+                simpleQueryString("Professionan~1").lowercaseExpandedTerms(false)).get();
+        assertHitCount(searchResponse, 0l);
+    }
+
+    @Test
     public void testNestedFieldSimpleQueryString() throws IOException {
         assertAcked(client().admin().indices().prepareCreate("test").setSettings(SETTING_NUMBER_OF_SHARDS, 1)
                 .addMapping("type1", jsonBuilder()


### PR DESCRIPTION
Default the flag to true, making `simple_query_string` behave similarly to `query_string`.

Fixes #5008
