### PR TITLE
ESLogger logs wrong class name

### DIFF
--- a/src/main/java/org/elasticsearch/common/logging/jdk/ESLogRecord.java
+++ b/src/main/java/org/elasticsearch/common/logging/jdk/ESLogRecord.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging.jdk;
+
+import org.elasticsearch.common.logging.support.AbstractESLogger;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+public class ESLogRecord extends LogRecord {
+
+    private static final long serialVersionUID = 1107741560233585726L;
+    private static final String FQCN = AbstractESLogger.class.getName();
+    private String sourceClassName;
+    private String sourceMethodName;
+    private transient boolean needToInferCaller;
+
+    public ESLogRecord(Level level, String msg) {
+        super(level, msg);
+        needToInferCaller = true;
+    }
+
+    public String getSourceClassName() {
+        if (needToInferCaller) {
+            inferCaller();
+        }
+        return sourceClassName;
+    }
+
+    public void setSourceClassName(String sourceClassName) {
+        this.sourceClassName = sourceClassName;
+        needToInferCaller = false;
+    }
+
+    public String getSourceMethodName() {
+        if (needToInferCaller) {
+            inferCaller();
+        }
+        return sourceMethodName;
+    }
+
+    public void setSourceMethodName(String sourceMethodName) {
+        this.sourceMethodName = sourceMethodName;
+        needToInferCaller = false;
+    }
+
+    // Private method to infer the caller's class and method names
+    private void inferCaller() {
+        needToInferCaller = false;
+        Throwable throwable = new Throwable();
+
+        boolean lookingForLogger = true;
+        for (final StackTraceElement frame : throwable.getStackTrace()) {
+            String cname = frame.getClassName();
+            boolean isLoggerImpl = isLoggerImplFrame(cname);
+            if (lookingForLogger) {
+                // Skip all frames until we have found the first logger frame.
+                if (isLoggerImpl) {
+                    lookingForLogger = false;
+                }
+            } else {
+                if (!isLoggerImpl) {
+                    // skip reflection call
+                    if (!cname.startsWith("java.lang.reflect.") && !cname.startsWith("sun.reflect.")) {
+                       // We've found the relevant frame.
+                       setSourceClassName(cname);
+                       setSourceMethodName(frame.getMethodName());
+                       return;
+                    }
+                }
+            }
+        }
+        // We haven't found a suitable frame, so just punt.  This is
+        // OK as we are only committed to making a "best effort" here.
+    }
+
+    private boolean isLoggerImplFrame(String cname) {
+        // the log record could be created for a platform logger
+        return cname.equals(FQCN);
+    }
+}

--- a/src/main/java/org/elasticsearch/common/logging/jdk/JdkESLogger.java
+++ b/src/main/java/org/elasticsearch/common/logging/jdk/JdkESLogger.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.logging.jdk;
 import org.elasticsearch.common.logging.support.AbstractESLogger;
 
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 /**
@@ -31,12 +32,9 @@ public class JdkESLogger extends AbstractESLogger {
 
     private final Logger logger;
 
-    private final String name;
-
-    public JdkESLogger(String prefix, String name, Logger logger) {
+    public JdkESLogger(String prefix, Logger logger) {
         super(prefix);
         this.logger = logger;
-        this.name = name;
     }
 
     @Override
@@ -96,51 +94,66 @@ public class JdkESLogger extends AbstractESLogger {
 
     @Override
     protected void internalTrace(String msg) {
-        logger.logp(Level.FINEST, name, null, msg);
+        LogRecord record = new ESLogRecord(Level.FINEST, msg);
+        logger.log(record);
     }
 
     @Override
     protected void internalTrace(String msg, Throwable cause) {
-        logger.logp(Level.FINEST, name, null, msg, cause);
+        LogRecord record = new ESLogRecord(Level.FINEST, msg);
+        record.setThrown(cause);
+        logger.log(record);
     }
 
     @Override
     protected void internalDebug(String msg) {
-        logger.logp(Level.FINE, name, null, msg);
+        LogRecord record = new ESLogRecord(Level.FINE, msg);
+        logger.log(record);
     }
 
     @Override
     protected void internalDebug(String msg, Throwable cause) {
-        logger.logp(Level.FINE, name, null, msg, cause);
+        LogRecord record = new ESLogRecord(Level.FINE, msg);
+        record.setThrown(cause);
+        logger.log(record);
     }
 
     @Override
     protected void internalInfo(String msg) {
-        logger.logp(Level.INFO, name, null, msg);
+        LogRecord record = new ESLogRecord(Level.INFO, msg);
+        logger.log(record);
     }
 
     @Override
     protected void internalInfo(String msg, Throwable cause) {
-        logger.logp(Level.INFO, name, null, msg, cause);
+        LogRecord record = new ESLogRecord(Level.INFO, msg);
+        record.setThrown(cause);
+        logger.log(record);
     }
 
     @Override
     protected void internalWarn(String msg) {
-        logger.logp(Level.WARNING, name, null, msg);
+        LogRecord record = new ESLogRecord(Level.WARNING, msg);
+        logger.log(record);
     }
 
     @Override
     protected void internalWarn(String msg, Throwable cause) {
-        logger.logp(Level.WARNING, name, null, msg, cause);
+        LogRecord record = new ESLogRecord(Level.WARNING, msg);
+        record.setThrown(cause);
+        logger.log(record);
     }
 
     @Override
     protected void internalError(String msg) {
-        logger.logp(Level.SEVERE, name, null, msg);
+        LogRecord record = new ESLogRecord(Level.SEVERE, msg);
+        logger.log(record);
     }
 
     @Override
     protected void internalError(String msg, Throwable cause) {
-        logger.logp(Level.SEVERE, name, null, msg, cause);
+        LogRecord record = new ESLogRecord(Level.SEVERE, msg);
+        record.setThrown(cause);
+        logger.log(record);
     }
 }

--- a/src/main/java/org/elasticsearch/common/logging/jdk/JdkESLoggerFactory.java
+++ b/src/main/java/org/elasticsearch/common/logging/jdk/JdkESLoggerFactory.java
@@ -22,8 +22,6 @@ package org.elasticsearch.common.logging.jdk;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 
-import java.util.logging.LogManager;
-
 /**
  *
  */
@@ -37,6 +35,6 @@ public class JdkESLoggerFactory extends ESLoggerFactory {
     @Override
     protected ESLogger newInstance(String prefix, String name) {
         final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(name);
-        return new JdkESLogger(prefix, name, logger);
+        return new JdkESLogger(prefix, logger);
     }
 }

--- a/src/main/java/org/elasticsearch/common/logging/log4j/Log4jESLogger.java
+++ b/src/main/java/org/elasticsearch/common/logging/log4j/Log4jESLogger.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.logging.support.AbstractESLogger;
 public class Log4jESLogger extends AbstractESLogger {
 
     private final org.apache.log4j.Logger logger;
+    private final String FQCN = AbstractESLogger.class.getName();
 
     public Log4jESLogger(String prefix, Logger logger) {
         super(prefix);
@@ -91,51 +92,51 @@ public class Log4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalTrace(String msg) {
-        logger.trace(msg);
+        logger.log(FQCN, Level.TRACE, msg, null);
     }
 
     @Override
     protected void internalTrace(String msg, Throwable cause) {
-        logger.trace(msg, cause);
+        logger.log(FQCN, Level.TRACE, msg, cause);
     }
 
     @Override
     protected void internalDebug(String msg) {
-        logger.debug(msg);
+        logger.log(FQCN, Level.DEBUG, msg, null);
     }
 
     @Override
     protected void internalDebug(String msg, Throwable cause) {
-        logger.debug(msg, cause);
+        logger.log(FQCN, Level.DEBUG, msg, cause);
     }
 
     @Override
     protected void internalInfo(String msg) {
-        logger.info(msg);
+        logger.log(FQCN, Level.INFO, msg, null);
     }
 
     @Override
     protected void internalInfo(String msg, Throwable cause) {
-        logger.info(msg, cause);
+        logger.log(FQCN, Level.INFO, msg, cause);
     }
 
     @Override
     protected void internalWarn(String msg) {
-        logger.warn(msg);
+        logger.log(FQCN, Level.WARN, msg, null);
     }
 
     @Override
     protected void internalWarn(String msg, Throwable cause) {
-        logger.warn(msg, cause);
+        logger.log(FQCN, Level.WARN, msg, cause);
     }
 
     @Override
     protected void internalError(String msg) {
-        logger.error(msg);
+        logger.log(FQCN, Level.ERROR, msg, null);
     }
 
     @Override
     protected void internalError(String msg, Throwable cause) {
-        logger.error(msg, cause);
+        logger.log(FQCN, Level.ERROR, msg, cause);
     }
 }

--- a/src/main/java/org/elasticsearch/common/logging/slf4j/Slf4jESLogger.java
+++ b/src/main/java/org/elasticsearch/common/logging/slf4j/Slf4jESLogger.java
@@ -29,11 +29,17 @@ import org.slf4j.spi.LocationAwareLogger;
 public class Slf4jESLogger extends AbstractESLogger {
 
     private final Logger logger;
+    private final LocationAwareLogger lALogger;
     private final String FQCN = AbstractESLogger.class.getName();
 
     public Slf4jESLogger(String prefix, Logger logger) {
         super(prefix);
         this.logger = logger;
+        if (logger instanceof LocationAwareLogger) {
+            lALogger = (LocationAwareLogger) logger;
+        } else {
+            lALogger = null;
+        }
     }
 
     @Override
@@ -79,8 +85,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalTrace(String msg) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, null);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, null);
         } else {
             logger.trace(msg);
         }
@@ -88,8 +94,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalTrace(String msg, Throwable cause) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, cause);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, cause);
         } else {
             logger.trace(msg);
         }
@@ -97,8 +103,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalDebug(String msg) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
         } else {
             logger.debug(msg);
         }
@@ -106,8 +112,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalDebug(String msg, Throwable cause) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, cause);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, cause);
         } else {
             logger.debug(msg);
         }
@@ -115,8 +121,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalInfo(String msg) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, null);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, null);
         } else {
             logger.info(msg);
         }
@@ -124,8 +130,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalInfo(String msg, Throwable cause) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, cause);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, cause);
         } else {
             logger.info(msg, cause);
         }
@@ -133,8 +139,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalWarn(String msg) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
         } else {
             logger.warn(msg);
         }
@@ -142,8 +148,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalWarn(String msg, Throwable cause) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, cause);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, cause);
         } else {
             logger.warn(msg);
         }
@@ -151,8 +157,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalError(String msg) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, null);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, null);
         } else {
             logger.error(msg);
         }
@@ -160,8 +166,8 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalError(String msg, Throwable cause) {
-        if (logger instanceof LocationAwareLogger) {
-            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, cause);
+        if (lALogger != null) {
+            lALogger.log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, cause);
         } else {
             logger.error(msg);
         }

--- a/src/main/java/org/elasticsearch/common/logging/slf4j/Slf4jESLogger.java
+++ b/src/main/java/org/elasticsearch/common/logging/slf4j/Slf4jESLogger.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.logging.slf4j;
 
 import org.elasticsearch.common.logging.support.AbstractESLogger;
 import org.slf4j.Logger;
+import org.slf4j.spi.LocationAwareLogger;
 
 /**
  *
@@ -28,6 +29,7 @@ import org.slf4j.Logger;
 public class Slf4jESLogger extends AbstractESLogger {
 
     private final Logger logger;
+    private final String FQCN = AbstractESLogger.class.getName();
 
     public Slf4jESLogger(String prefix, Logger logger) {
         super(prefix);
@@ -77,51 +79,91 @@ public class Slf4jESLogger extends AbstractESLogger {
 
     @Override
     protected void internalTrace(String msg) {
-        logger.trace(msg);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, null);
+        } else {
+            logger.trace(msg);
+        }
     }
 
     @Override
     protected void internalTrace(String msg, Throwable cause) {
-        logger.trace(msg, cause);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.TRACE_INT, msg, null, cause);
+        } else {
+            logger.trace(msg);
+        }
     }
 
     @Override
     protected void internalDebug(String msg) {
-        logger.debug(msg);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, null);
+        } else {
+            logger.debug(msg);
+        }
     }
 
     @Override
     protected void internalDebug(String msg, Throwable cause) {
-        logger.debug(msg, cause);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.DEBUG_INT, msg, null, cause);
+        } else {
+            logger.debug(msg);
+        }
     }
 
     @Override
     protected void internalInfo(String msg) {
-        logger.info(msg);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, null);
+        } else {
+            logger.info(msg);
+        }
     }
 
     @Override
     protected void internalInfo(String msg, Throwable cause) {
-        logger.info(msg, cause);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.INFO_INT, msg, null, cause);
+        } else {
+            logger.info(msg, cause);
+        }
     }
 
     @Override
     protected void internalWarn(String msg) {
-        logger.warn(msg);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, null);
+        } else {
+            logger.warn(msg);
+        }
     }
 
     @Override
     protected void internalWarn(String msg, Throwable cause) {
-        logger.warn(msg, cause);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.WARN_INT, msg, null, cause);
+        } else {
+            logger.warn(msg);
+        }
     }
 
     @Override
     protected void internalError(String msg) {
-        logger.error(msg);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, null);
+        } else {
+            logger.error(msg);
+        }
     }
 
     @Override
     protected void internalError(String msg, Throwable cause) {
-        logger.error(msg, cause);
+        if (logger instanceof LocationAwareLogger) {
+            ((LocationAwareLogger) logger).log(null, FQCN, LocationAwareLogger.ERROR_INT, msg, null, cause);
+        } else {
+            logger.error(msg);
+        }
     }
 }


### PR DESCRIPTION
ESLogger logs wrong class name, method name, line number.

version: 1.0.0

configuration:
  log4j
      conversionPattern: "[%d{ISO8601}][%-5p][%-25c][%C.%M:%L] %m%n"
  slf4j + logback
    <pattern>[%date{ISO8601}][%-5.5level][%-25.25logger][%class{36}.%method:%line] %msg%n</pattern>

ESLogger logs this.(wrong class name!):
  org.elasticsearch.common.logging.log4j.Log4jESLogger.internalInfo:114

ESLogger always logs the class name "Log4jESLogger".
I thought Elasticsearch can avoid it using other log4j/slf4j methods and I changed.
