### PR TITLE
Source filtering with wildcards broken when given multiple patterns

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -172,7 +172,7 @@ public class XContentMapValues {
                     if (include.charAt(0) == '*') {
                         if (Regex.simpleMatch(include, path)) {
                             exactIncludeMatch = true;
-                            continue;
+                            break;
                         }
                         pathIsPrefixOfAnInclude = true;
                         continue;
@@ -180,7 +180,7 @@ public class XContentMapValues {
                     if (include.startsWith(path)) {
                         if (include.length() == path.length()) {
                             exactIncludeMatch = true;
-                            continue;
+                            break;
                         } else if (include.length() > path.length() && include.charAt(path.length()) == '.') {
                             // include might may match deeper paths. Dive deeper.
                             pathIsPrefixOfAnInclude = true;
@@ -189,7 +189,7 @@ public class XContentMapValues {
                     }
                     if (Regex.simpleMatch(include, path)) {
                         exactIncludeMatch = true;
-                        continue;
+                        break;
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -172,24 +172,24 @@ public class XContentMapValues {
                     if (include.charAt(0) == '*') {
                         if (Regex.simpleMatch(include, path)) {
                             exactIncludeMatch = true;
-                            break;
+                            continue;
                         }
                         pathIsPrefixOfAnInclude = true;
-                        break;
+                        continue;
                     }
                     if (include.startsWith(path)) {
                         if (include.length() == path.length()) {
                             exactIncludeMatch = true;
-                            break;
+                            continue;
                         } else if (include.length() > path.length() && include.charAt(path.length()) == '.') {
                             // include might may match deeper paths. Dive deeper.
                             pathIsPrefixOfAnInclude = true;
-                            break;
+                            continue;
                         }
                     }
                     if (Regex.simpleMatch(include, path)) {
                         exactIncludeMatch = true;
-                        break;
+                        continue;
                     }
                 }
             }

--- a/src/test/java/org/elasticsearch/search/source/SourceFetchingTests.java
+++ b/src/test/java/org/elasticsearch/search/source/SourceFetchingTests.java
@@ -98,5 +98,9 @@ public class SourceFetchingTests extends ElasticsearchIntegrationTest {
         assertThat(response.getHits().getAt(0).getSource().size(), equalTo(1));
         assertThat((String) response.getHits().getAt(0).getSource().get("field"), equalTo("value"));
 
+        response = client().prepareSearch("test").setFetchSource(new String[]{"field.notexisting.*","field"}, null).get();
+        assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
+        assertThat(response.getHits().getAt(0).getSource().size(), equalTo(1));
+        assertThat((String) response.getHits().getAt(0).getSource().get("field"), equalTo("value"));
     }
 }

--- a/src/test/java/org/elasticsearch/search/source/SourceFetchingTests.java
+++ b/src/test/java/org/elasticsearch/search/source/SourceFetchingTests.java
@@ -81,5 +81,22 @@ public class SourceFetchingTests extends ElasticsearchIntegrationTest {
 
     }
 
+    /**
+     * Test Case for #5132: Source filtering with wildcards broken when given multiple patterns
+     * https://github.com/elasticsearch/elasticsearch/issues/5132
+     */
+    @Test
+    public void testSourceWithWildcardFiltering() {
+        createIndex("test");
+        ensureGreen();
 
+        client().prepareIndex("test", "type1", "1").setSource("field", "value").get();
+        refresh();
+
+        SearchResponse response = client().prepareSearch("test").setFetchSource(new String[]{"*.notexisting","field"}, null).get();
+        assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
+        assertThat(response.getHits().getAt(0).getSource().size(), equalTo(1));
+        assertThat((String) response.getHits().getAt(0).getSource().get("field"), equalTo("value"));
+
+    }
 }


### PR DESCRIPTION
```
curl -XPUT 'http://localhost:9200/twitter/tweet/1' -d '{
    "user" : "kimchy",
    "post_date" : "2009-11-15T14:12:12",
    "message" : "trying out Elasticsearch", "retweeted": false
}'
```

No source fields delivered:

```
curl -XGET 'http://localhost:9200/twitter/tweet/1?_source=*.id,retweeted&pretty=yes'
```

`retweeted` returned:

```
curl -XGET 'http://localhost:9200/twitter/tweet/1?_source=retweeted,*.id&pretty=yes'
```

Closes #5132.
