### PR TITLE
Fixed multi term queries support in postings highlighter for non top-level queries

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -57,11 +57,19 @@ highlighting using the postings highlighter on it:
 }
 --------------------------------------------------
 
+[NOTE]
 Note that the postings highlighter is meant to perform simple query terms
 highlighting, regardless of their positions. That means that when used for
 instance in combination with a phrase query, it will highlight all the terms
 that the query is composed of, regardless of whether they are actually part of
 a query match, effectively ignoring their positions.
+
+[WARNING]
+The postings highlighter does support highlighting of multi term queries, like
+prefix queries, wildcard queries and so on. On the other hand, this requires
+the queries to be rewritten using a proper
+<<query-dsl-multi-term-rewrite,rewrite method>> that supports multi term
+extraction, which is a potentially expensive operation.
 
 
 ==== Fast vector highlighter


### PR DESCRIPTION
In #4052 we added support for highlighting multi term queries using the postings highlighter. That worked only for top-level queries though, and not for multi term queries that are nested for instance within a bool query, or filtered query, or a constant score query.

The way we can make this work is by walking the query structure and temporarily overriding the query rewrite method with a method that allows for multi terms extraction.

Closes #5127 
