### PR TITLE
Make _exists_/_missing_ behave consistently with exists/missing.

### DIFF
--- a/src/main/java/org/apache/lucene/queryparser/classic/ExistsFieldQueryExtension.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/ExistsFieldQueryExtension.java
@@ -19,14 +19,10 @@
 
 package org.apache.lucene.queryparser.classic;
 
-import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermRangeFilter;
 import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.ExistsFilterParser;
 import org.elasticsearch.index.query.QueryParseContext;
-
-import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFilter;
 
 /**
  *
@@ -37,23 +33,6 @@ public class ExistsFieldQueryExtension implements FieldQueryExtension {
 
     @Override
     public Query query(QueryParseContext parseContext, String queryText) {
-        String fieldName = queryText;
-        Filter filter = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null) {
-            if (smartNameFieldMappers.hasMapper()) {
-                filter = smartNameFieldMappers.mapper().rangeFilter(null, null, true, true, parseContext);
-            }
-        }
-        if (filter == null) {
-            filter = new TermRangeFilter(fieldName, null, null, true, true);
-        }
-
-        // we always cache this one, really does not change...
-        filter = parseContext.cacheFilter(filter, null);
-
-        filter = wrapSmartNameFilter(filter, smartNameFieldMappers, parseContext);
-
-        return new XConstantScoreQuery(filter);
+        return new XConstantScoreQuery(ExistsFilterParser.newFilter(parseContext, queryText, null));
     }
 }

--- a/src/main/java/org/apache/lucene/queryparser/classic/MissingFieldQueryExtension.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/MissingFieldQueryExtension.java
@@ -19,15 +19,10 @@
 
 package org.apache.lucene.queryparser.classic;
 
-import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermRangeFilter;
-import org.elasticsearch.common.lucene.search.NotFilter;
 import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.MissingFilterParser;
 import org.elasticsearch.index.query.QueryParseContext;
-
-import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFilter;
 
 /**
  *
@@ -38,27 +33,7 @@ public class MissingFieldQueryExtension implements FieldQueryExtension {
 
     @Override
     public Query query(QueryParseContext parseContext, String queryText) {
-        String fieldName = queryText;
-
-        Filter filter = null;
-        MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
-        if (smartNameFieldMappers != null) {
-            if (smartNameFieldMappers.hasMapper()) {
-                filter = smartNameFieldMappers.mapper().rangeFilter(null, null, true, true, parseContext);
-            }
-        }
-        if (filter == null) {
-            filter = new TermRangeFilter(fieldName, null, null, true, true);
-        }
-
-        // we always cache this one, really does not change... (exists)
-        filter = parseContext.cacheFilter(filter, null);
-        filter = new NotFilter(filter);
-        // cache the not filter as well, so it will be faster
-        filter = parseContext.cacheFilter(filter, null);
-
-        filter = wrapSmartNameFilter(filter, smartNameFieldMappers, parseContext);
-
-        return new XConstantScoreQuery(filter);
+        return new XConstantScoreQuery(MissingFilterParser.newFilter(parseContext, queryText,
+                MissingFilterParser.DEFAULT_EXISTENCE_VALUE, MissingFilterParser.DEFAULT_NULL_VALUE, null));
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/ExistsFilterParser.java
@@ -77,6 +77,10 @@ public class ExistsFilterParser implements FilterParser {
             throw new QueryParsingException(parseContext.index(), "exists must be provided with a [field]");
         }
 
+        return newFilter(parseContext, fieldPattern, filterName);
+    }
+
+    public static Filter newFilter(QueryParseContext parseContext, String fieldPattern, String filterName) {
         MapperService.SmartNameObjectMapper smartNameObjectMapper = parseContext.smartObjectMapper(fieldPattern);
         if (smartNameObjectMapper != null && smartNameObjectMapper.hasMapper()) {
             // automatic make the object mapper pattern
@@ -116,4 +120,5 @@ public class ExistsFilterParser implements FilterParser {
         }
         return filter;
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MissingFilterParser.java
@@ -41,6 +41,8 @@ import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameFi
 public class MissingFilterParser implements FilterParser {
 
     public static final String NAME = "missing";
+    public static final boolean DEFAULT_NULL_VALUE = false;
+    public static final boolean DEFAULT_EXISTENCE_VALUE = true;
 
     @Inject
     public MissingFilterParser() {
@@ -57,8 +59,8 @@ public class MissingFilterParser implements FilterParser {
 
         String fieldPattern = null;
         String filterName = null;
-        boolean nullValue = false;
-        boolean existence = true;
+        boolean nullValue = DEFAULT_NULL_VALUE;
+        boolean existence = DEFAULT_EXISTENCE_VALUE;
 
         XContentParser.Token token;
         String currentFieldName = null;
@@ -84,6 +86,10 @@ public class MissingFilterParser implements FilterParser {
             throw new QueryParsingException(parseContext.index(), "missing must be provided with a [field]");
         }
 
+        return newFilter(parseContext, fieldPattern, existence, nullValue, filterName);
+    }
+
+    public static Filter newFilter(QueryParseContext parseContext, String fieldPattern, boolean existence, boolean nullValue, String filterName) {
         if (!existence && !nullValue) {
             throw new QueryParsingException(parseContext.index(), "missing must have either existence, or null_value, or both set to true");
         }


### PR DESCRIPTION
`_exists_` and `_missing_` miss field name expansion that `exists` and
`missing` have, which allows these filters to work on `object` fields.

Close #5142
