### PR TITLE
Add support for char filters in the analyze API

### DIFF
--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -12,12 +12,15 @@ analyzers:
 curl -XGET 'localhost:9200/_analyze?analyzer=standard' -d 'this is a test'
 --------------------------------------------------
 
-Or by building a custom transient analyzer out of tokenizers and
-filters:
+Or by building a custom transient analyzer out of tokenizers,
+token filters and char filters. Token filters can use the shorter 'filters' parameter name:
 
 [source,js]
 --------------------------------------------------
 curl -XGET 'localhost:9200/_analyze?tokenizer=keyword&filters=lowercase' -d 'this is a test'
+
+curl -XGET 'localhost:9200/_analyze?tokenizer=keyword&token_filters=lowercase&char_filters=html_strip' -d 'this is a <b>test</b>'
+
 --------------------------------------------------
 
 It can also run against a specific index:

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -13,7 +13,8 @@ curl -XGET 'localhost:9200/_analyze?analyzer=standard' -d 'this is a test'
 --------------------------------------------------
 
 Or by building a custom transient analyzer out of tokenizers,
-token filters and char filters. Token filters can use the shorter 'filters' parameter name:
+token filters and char filters. Token filters can use the shorter 'filters'
+parameter name:
 
 [source,js]
 --------------------------------------------------

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.action.admin.indices.analyze;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.custom.SingleCustomOperationRequest;
 import org.elasticsearch.common.Nullable;
@@ -153,11 +154,13 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
                 tokenFilters[i] = in.readString();
             }
         }
-        size = in.readVInt();
-        if (size > 0) {
-            charFilters = new String[size];
-            for (int i = 0; i < size; i++) {
-                charFilters[i] = in.readString();
+        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
+            size = in.readVInt();
+            if (size > 0) {
+                charFilters = new String[size];
+                for (int i = 0; i < size; i++) {
+                    charFilters[i] = in.readString();
+                }
             }
         }
         field = in.readOptionalString();
@@ -178,12 +181,14 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
                 out.writeString(tokenFilter);
             }
         }
-        if (charFilters == null) {
-            out.writeVInt(0);
-        } else {
-            out.writeVInt(charFilters.length);
-            for (String charFilter : charFilters) {
-                out.writeString(charFilter);
+        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
+            if (charFilters == null) {
+                out.writeVInt(0);
+            } else {
+                out.writeVInt(charFilters.length);
+                for (String charFilter : charFilters) {
+                    out.writeString(charFilter);
+                }
             }
         }
         out.writeOptionalString(field);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.indices.analyze;
 
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.custom.SingleCustomOperationRequest;
@@ -107,9 +106,6 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     }
 
     public AnalyzeRequest tokenFilters(String... tokenFilters) {
-        if (tokenFilters == null) {
-            throw new ElasticsearchIllegalArgumentException("token filters must not be null");
-        }
         this.tokenFilters = tokenFilters;
         return this;
     }
@@ -119,9 +115,6 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     }
 
     public AnalyzeRequest charFilters(String... charFilters) {
-        if (charFilters == null) {
-            throw new ElasticsearchIllegalArgumentException("char filters must not be null");
-        }
         this.charFilters = charFilters;
         return this;
     }
@@ -144,6 +137,12 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         ActionRequestValidationException validationException = super.validate();
         if (text == null) {
             validationException = addValidationError("text is missing", validationException);
+        }
+        if (tokenFilters == null) {
+            validationException = addValidationError("token filters must not be null", validationException);
+        }
+        if (charFilters == null) {
+            validationException = addValidationError("char filters must not be null", validationException);
         }
         return validationException;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -44,6 +44,8 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
 
     private String[] tokenFilters;
 
+    private String[] charFilters;
+
     private String field;
 
     AnalyzeRequest() {
@@ -110,6 +112,15 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         return this.tokenFilters;
     }
 
+    public AnalyzeRequest charFilters(String... charFilters) {
+        this.charFilters = charFilters;
+        return this;
+    }
+
+    public String[] charFilters() {
+        return this.charFilters;
+    }
+
     public AnalyzeRequest field(String field) {
         this.field = field;
         return this;
@@ -142,6 +153,13 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
                 tokenFilters[i] = in.readString();
             }
         }
+        size = in.readVInt();
+        if (size > 0) {
+            charFilters = new String[size];
+            for (int i = 0; i < size; i++) {
+                charFilters[i] = in.readString();
+            }
+        }
         field = in.readOptionalString();
     }
 
@@ -158,6 +176,14 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
             out.writeVInt(tokenFilters.length);
             for (String tokenFilter : tokenFilters) {
                 out.writeString(tokenFilter);
+            }
+        }
+        if (charFilters == null) {
+            out.writeVInt(0);
+        } else {
+            out.writeVInt(charFilters.length);
+            for (String charFilter : charFilters) {
+                out.writeString(charFilter);
             }
         }
         out.writeOptionalString(field);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -107,7 +107,9 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     }
 
     public AnalyzeRequest tokenFilters(String... tokenFilters) {
-        if (tokenFilters == null) throw new ElasticsearchIllegalArgumentException("token filters must not be null");
+        if (tokenFilters == null) {
+            throw new ElasticsearchIllegalArgumentException("token filters must not be null");
+        }
         this.tokenFilters = tokenFilters;
         return this;
     }
@@ -117,7 +119,9 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     }
 
     public AnalyzeRequest charFilters(String... charFilters) {
-        if (charFilters == null) throw new ElasticsearchIllegalArgumentException("char filters must not be null");
+        if (charFilters == null) {
+            throw new ElasticsearchIllegalArgumentException("char filters must not be null");
+        }
         this.charFilters = charFilters;
         return this;
     }
@@ -140,12 +144,6 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         ActionRequestValidationException validationException = super.validate();
         if (text == null) {
             validationException = addValidationError("text is missing", validationException);
-        }
-        if (tokenFilters == null) {
-            validationException = addValidationError("tokenFilters is null", validationException);
-        }
-        if (charFilters == null) {
-            validationException = addValidationError("charFilters is null", validationException);
         }
         return validationException;
     }
@@ -171,9 +169,9 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
         out.writeString(text);
         out.writeOptionalString(analyzer);
         out.writeOptionalString(tokenizer);
-        out.writeStringArrayNullable(tokenFilters);
+        out.writeStringArray(tokenFilters);
         if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
-            out.writeStringArrayNullable(charFilters);
+            out.writeStringArray(charFilters);
         }
         out.writeOptionalString(field);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.action.admin.indices.analyze;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.custom.SingleCustomOperationRequest;
@@ -106,6 +107,7 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     }
 
     public AnalyzeRequest tokenFilters(String... tokenFilters) {
+        if (tokenFilters == null) throw new ElasticsearchIllegalArgumentException("token filters must not be null");
         this.tokenFilters = tokenFilters;
         return this;
     }
@@ -115,6 +117,7 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     }
 
     public AnalyzeRequest charFilters(String... charFilters) {
+        if (charFilters == null) throw new ElasticsearchIllegalArgumentException("char filters must not be null");
         this.charFilters = charFilters;
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -81,6 +81,14 @@ public class AnalyzeRequestBuilder extends SingleCustomOperationRequestBuilder<A
         return this;
     }
 
+    /**
+     * Sets char filters that will be used before the tokenizer.
+     */
+    public AnalyzeRequestBuilder setCharFilters(String... charFilters) {
+        request.charFilters(charFilters);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<AnalyzeResponse> listener) {
         ((IndicesAdminClient) client).analyze(request, listener);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -171,17 +171,17 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
                     if (indexService == null) {
                         TokenFilterFactoryFactory tokenFilterFactoryFactory = indicesAnalysisService.tokenFilterFactoryFactory(tokenFilterName);
                         if (tokenFilterFactoryFactory == null) {
-                            throw new ElasticsearchIllegalArgumentException("failed to find global token filter under [" + request.tokenizer() + "]");
+                            throw new ElasticsearchIllegalArgumentException("failed to find global token filter under [" + tokenFilterName + "]");
                         }
                         tokenFilterFactories[i] = tokenFilterFactoryFactory.create(tokenFilterName, ImmutableSettings.Builder.EMPTY_SETTINGS);
                     } else {
                         tokenFilterFactories[i] = indexService.analysisService().tokenFilter(tokenFilterName);
                         if (tokenFilterFactories[i] == null) {
-                            throw new ElasticsearchIllegalArgumentException("failed to find token filter under [" + request.tokenizer() + "]");
+                            throw new ElasticsearchIllegalArgumentException("failed to find token filter under [" + tokenFilterName + "]");
                         }
                     }
                     if (tokenFilterFactories[i] == null) {
-                        throw new ElasticsearchIllegalArgumentException("failed to find token filter under [" + request.tokenizer() + "]");
+                        throw new ElasticsearchIllegalArgumentException("failed to find token filter under [" + tokenFilterName + "]");
                     }
                 }
             }
@@ -194,17 +194,17 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
                     if (indexService == null) {
                         CharFilterFactoryFactory charFilterFactoryFactory = indicesAnalysisService.charFilterFactoryFactory(charFilterName);
                         if (charFilterFactoryFactory == null) {
-                            throw new ElasticsearchIllegalArgumentException("failed to find global char filter under [" + request.tokenizer() + "]");
+                            throw new ElasticsearchIllegalArgumentException("failed to find global char filter under [" + charFilterName + "]");
                         }
                         charFilterFactories[i] = charFilterFactoryFactory.create(charFilterName, ImmutableSettings.Builder.EMPTY_SETTINGS);
                     } else {
                         charFilterFactories[i] = indexService.analysisService().charFilter(charFilterName);
                         if (charFilterFactories[i] == null) {
-                            throw new ElasticsearchIllegalArgumentException("failed to find token char under [" + request.tokenizer() + "]");
+                            throw new ElasticsearchIllegalArgumentException("failed to find token char under [" + charFilterName + "]");
                         }
                     }
                     if (charFilterFactories[i] == null) {
-                        throw new ElasticsearchIllegalArgumentException("failed to find token char under [" + request.tokenizer() + "]");
+                        throw new ElasticsearchIllegalArgumentException("failed to find token char under [" + charFilterName + "]");
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -71,6 +71,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
         analyzeRequest.field(request.param("field"));
         analyzeRequest.tokenizer(request.param("tokenizer"));
         analyzeRequest.tokenFilters(request.paramAsStringArray("token_filters", request.paramAsStringArray("filters", null)));
+        analyzeRequest.charFilters(request.paramAsStringArray("char_filters", null));
         client.admin().indices().analyze(analyzeRequest, new ActionListener<AnalyzeResponse>() {
             @Override
             public void onResponse(AnalyzeResponse response) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -70,8 +70,8 @@ public class RestAnalyzeAction extends BaseRestHandler {
         analyzeRequest.analyzer(request.param("analyzer"));
         analyzeRequest.field(request.param("field"));
         analyzeRequest.tokenizer(request.param("tokenizer"));
-        analyzeRequest.tokenFilters(request.paramAsStringArray("token_filters", request.paramAsStringArray("filters", null)));
-        analyzeRequest.charFilters(request.paramAsStringArray("char_filters", null));
+        analyzeRequest.tokenFilters(request.paramAsStringArray("token_filters", request.paramAsStringArray("filters", analyzeRequest.tokenFilters())));
+        analyzeRequest.charFilters(request.paramAsStringArray("char_filters", analyzeRequest.charFilters()));
         client.admin().indices().analyze(analyzeRequest, new ActionListener<AnalyzeResponse>() {
             @Override
             public void onResponse(AnalyzeResponse response) {

--- a/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionTests.java
@@ -109,6 +109,17 @@ public class AnalyzeActionTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void analyzeWithCharFilter() throws Exception {
+
+        AnalyzeResponse analyzeResponse = client().admin().indices().prepareAnalyze("<h2><b>THIS</b> IS A</h2> <a href=\"#\">TEST</a>").setTokenizer("standard").setCharFilters("html_strip").execute().actionGet();
+        assertThat(analyzeResponse.getTokens().size(), equalTo(4));
+
+        analyzeResponse = client().admin().indices().prepareAnalyze("THIS IS A <b>TEST</b>").setTokenizer("keyword").setTokenFilters("lowercase").setCharFilters("html_strip").execute().actionGet();
+        assertThat(analyzeResponse.getTokens().size(), equalTo(1));
+        assertThat(analyzeResponse.getTokens().get(0).getTerm(), equalTo("this is a test"));
+    }
+
+    @Test
     public void analyzerWithFieldOrTypeTests() throws Exception {
 
         createIndex("test");


### PR DESCRIPTION
Allow char filters to be used in the analyze API. Potentially breaks AnalyzeRequest serialization. The REST action contains the now ambiguous 'filter' parameter, which will denote a 'token_filter', not a 'char_filter'.

One additional item I noticed is the exception message for invalid token filters. To me it appears like an overzealous copy and paste, but should the exception contain the token filter name, not the tokenizer? I can fix this item as well.

Example:
https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java?source=cc#L173
