### PR TITLE
Added support for aliases to index templates

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -27,6 +27,35 @@ Defines a template named template_1, with a template pattern of `te*`.
 The settings and mappings will be applied to any index name that matches
 the `te*` template.
 
+coming[1.1.0]
+
+It is also possible to include aliases in an index template as follows:
+
+[source,js]
+--------------------------------------------------
+curl -XPUT localhost:9200/_template/template_1 -d '
+{
+    "template" : "te*",
+    "settings" : {
+        "number_of_shards" : 1
+    },
+    "aliases" : {
+        "alias1" : {},
+        "alias2" : {
+            "filter" : {
+                "term" : {"user" : "kimchy" }
+            },
+            "routing" : "kimchy"
+        },
+        "{index}-alias" : {} <1>
+    }
+}
+'
+--------------------------------------------------
+
+<1> the `{index}` placeholder within the alias name will be replaced with the
+actual index name that the template gets applied to during index creation.
+
 [float]
 [[delete]]
 === Deleting a Template

--- a/rest-api-spec/test/indices.put_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.put_template/10_basic.yaml
@@ -15,3 +15,27 @@
 
   - match: {test.template: "test-*"}
   - match: {test.settings: {index.number_of_shards: '1', index.number_of_replicas: '0'}}
+
+---
+"Put template with aliases":
+  - do:
+      indices.put_template:
+        name: test
+        body:
+          template: test-*
+          aliases:
+            test_alias: {}
+            test_blias: {routing: b}
+            test_clias: {filter: {term :{user : kimchy}}}
+
+  - do:
+      indices.get_template:
+        name: test
+
+  - match: {test.template: "test-*"}
+  - length: {test.aliases: 3}
+  - is_true: test.aliases.test_alias
+  - match: {test.aliases.test_blias.index_routing: "b"}
+  - match: {test.aliases.test_blias.search_routing: "b"}
+  - match: {test.aliases.test_clias.filter.term.user: "kimchy"}
+

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.action.admin.indices.template.put;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.internal.InternalIndicesAdminClient;
@@ -106,6 +107,49 @@ public class PutIndexTemplateRequestBuilder extends MasterNodeOperationRequestBu
      */
     public PutIndexTemplateRequestBuilder addMapping(String type, String source) {
         request.mapping(type, source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public PutIndexTemplateRequestBuilder setAliases(Map source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public PutIndexTemplateRequestBuilder setAliases(String source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public PutIndexTemplateRequestBuilder setAliases(XContentBuilder source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public PutIndexTemplateRequestBuilder setAliases(BytesReference source) {
+        request.aliases(source);
+        return this;
+    }
+
+    /**
+     * Adds an alias that will be added when the index template gets created.
+     *
+     * @param alias  The alias
+     * @return the request builder
+     */
+    public PutIndexTemplateRequestBuilder addAlias(Alias alias) {
+        request.alias(alias);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -83,6 +83,7 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeOperatio
                 .order(request.order())
                 .settings(request.settings())
                 .mappings(request.mappings())
+                .aliases(request.aliases())
                 .customs(request.customs())
                 .create(request.create())
                 .masterTimeout(request.masterNodeTimeout()),

--- a/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -62,6 +62,10 @@ public class AliasMetaData {
         }
     }
 
+    private AliasMetaData(AliasMetaData aliasMetaData, String alias) {
+        this(alias, aliasMetaData.filter(), aliasMetaData.indexRouting(), aliasMetaData.searchRouting());
+    }
+
     public String alias() {
         return alias;
     }
@@ -110,6 +114,13 @@ public class AliasMetaData {
         return new Builder(alias);
     }
 
+    /**
+     * Creates a new AliasMetaData instance with same content as the given one, but with a different alias name
+     */
+    public static AliasMetaData newAliasMetaData(AliasMetaData aliasMetaData, String newAlias) {
+        return new AliasMetaData(aliasMetaData, newAlias);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -137,7 +148,7 @@ public class AliasMetaData {
 
     public static class Builder {
 
-        private String alias;
+        private final String alias;
 
         private CompressedString filter;
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -31,6 +31,8 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.indices.InvalidAliasNameException;
 
+import java.io.IOException;
+
 /**
  * Validator for an alias, to be used before adding an alias to the index metadata
  * and make sure the alias is valid
@@ -44,7 +46,8 @@ public class AliasValidator extends AbstractComponent {
 
     /**
      * Allows to validate an {@link org.elasticsearch.cluster.metadata.AliasAction} and make sure
-     * it's valid before it gets added to the index metadata
+     * it's valid before it gets added to the index metadata. Doesn't validate the alias filter.
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the alias is not valid
      */
     public void validateAliasAction(AliasAction aliasAction, MetaData metaData) {
         validateAlias(aliasAction.alias(), aliasAction.index(), aliasAction.indexRouting(), metaData);
@@ -52,22 +55,58 @@ public class AliasValidator extends AbstractComponent {
 
     /**
      * Allows to validate an {@link org.elasticsearch.action.admin.indices.alias.Alias} and make sure
-     * it's valid before it gets added to the index metadata
+     * it's valid before it gets added to the index metadata. Doesn't validate the alias filter.
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the alias is not valid
      */
     public void validateAlias(Alias alias, String index, MetaData metaData) {
         validateAlias(alias.name(), index, alias.indexRouting(), metaData);
     }
 
+    /**
+     * Allows to validate an {@link org.elasticsearch.cluster.metadata.AliasMetaData} and make sure
+     * it's valid before it gets added to the index metadata. Doesn't validate the alias filter.
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the alias is not valid
+     */
+    public void validateAliasMetaData(AliasMetaData aliasMetaData, String index, MetaData metaData) {
+        validateAlias(aliasMetaData.alias(), index, aliasMetaData.indexRouting(), metaData);
+    }
+
+    /**
+     * Allows to partially validate an alias, without knowing which index it'll get applied to.
+     * Useful with index templates containing aliases. Checks also that it is possible to parse
+     * the alias filter via {@link org.elasticsearch.common.xcontent.XContentParser},
+     * without validating it as a filter though.
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the alias is not valid
+     */
+    public void validateAliasStandalone(Alias alias) {
+        validateAliasStandalone(alias.name(), alias.indexRouting());
+        if (Strings.hasLength(alias.filter())) {
+            try {
+                XContentParser parser = XContentFactory.xContent(alias.filter()).createParser(alias.filter());
+                parser.mapAndClose();
+            } catch (Throwable e) {
+                throw new ElasticsearchIllegalArgumentException("failed to parse filter for alias [" + alias.name() + "]", e);
+            }
+        }
+    }
+
     private void validateAlias(String alias, String index, String indexRouting, MetaData metaData) {
-        assert metaData != null;
-        if (!Strings.hasText(alias) || !Strings.hasText(index)) {
-            throw new ElasticsearchIllegalArgumentException("index name and alias name are required");
+        validateAliasStandalone(alias, indexRouting);
+
+        if (!Strings.hasText(index)) {
+            throw new ElasticsearchIllegalArgumentException("index name is required");
         }
 
+        assert metaData != null;
         if (metaData.hasIndex(alias)) {
             throw new InvalidAliasNameException(new Index(index), alias, "an index exists with the same name as the alias");
         }
+    }
 
+    private void validateAliasStandalone(String alias, String indexRouting) {
+        if (!Strings.hasText(alias)) {
+            throw new ElasticsearchIllegalArgumentException("alias name is required");
+        }
         if (indexRouting != null && indexRouting.indexOf(',') != -1) {
             throw new ElasticsearchIllegalArgumentException("alias [" + alias + "] has several index routing values associated with it");
         }
@@ -82,13 +121,32 @@ public class AliasValidator extends AbstractComponent {
         assert indexQueryParserService != null;
         try {
             XContentParser parser = XContentFactory.xContent(filter).createParser(filter);
-            try {
-                indexQueryParserService.parseInnerFilter(parser);
-            } finally {
-                parser.close();
-            }
+            validateAliasFilter(parser, indexQueryParserService);
         } catch (Throwable e) {
             throw new ElasticsearchIllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);
+        }
+    }
+
+    /**
+     * Validates an alias filter by parsing it using the
+     * provided {@link org.elasticsearch.index.query.IndexQueryParserService}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the filter is not valid
+     */
+    public void validateAliasFilter(String alias, byte[] filter, IndexQueryParserService indexQueryParserService) {
+        assert indexQueryParserService != null;
+        try {
+            XContentParser parser = XContentFactory.xContent(filter).createParser(filter);
+            validateAliasFilter(parser, indexQueryParserService);
+        } catch (Throwable e) {
+            throw new ElasticsearchIllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);
+        }
+    }
+
+    private void validateAliasFilter(XContentParser parser, IndexQueryParserService indexQueryParserService) throws IOException {
+        try {
+            indexQueryParserService.parseInnerFilter(parser);
+        } finally {
+            parser.close();
         }
     }
 }

--- a/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -92,9 +92,13 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
                         .putAlias(newAliasMetaDataBuilder("alias4").filter(ALIAS_FILTER2)))
                         .put(IndexTemplateMetaData.builder("foo")
                                 .template("bar")
-                                .order(1).settings(settingsBuilder()
+                                .order(1)
+                                .settings(settingsBuilder()
                                         .put("setting1", "value1")
-                                        .put("setting2", "value2")))
+                                        .put("setting2", "value2"))
+                                .putAlias(newAliasMetaDataBuilder("alias-bar1"))
+                                .putAlias(newAliasMetaDataBuilder("alias-bar2").filter("{\"term\":{\"user\":\"kimchy\"}}"))
+                                .putAlias(newAliasMetaDataBuilder("alias-bar3").routing("routing-bar")))
                 .build();
 
         String metaDataSource = MetaData.Builder.toXContent(metaData);
@@ -184,6 +188,13 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
         assertThat(parsedMetaData.templates().get("foo").template(), is("bar"));
         assertThat(parsedMetaData.templates().get("foo").settings().get("index.setting1"), is("value1"));
         assertThat(parsedMetaData.templates().get("foo").settings().getByPrefix("index.").get("setting2"), is("value2"));
+        assertThat(parsedMetaData.templates().get("foo").aliases().size(), equalTo(3));
+        assertThat(parsedMetaData.templates().get("foo").aliases().get("alias-bar1").alias(), equalTo("alias-bar1"));
+        assertThat(parsedMetaData.templates().get("foo").aliases().get("alias-bar2").alias(), equalTo("alias-bar2"));
+        assertThat(parsedMetaData.templates().get("foo").aliases().get("alias-bar2").filter().string(), equalTo("{\"term\":{\"user\":\"kimchy\"}}"));
+        assertThat(parsedMetaData.templates().get("foo").aliases().get("alias-bar3").alias(), equalTo("alias-bar3"));
+        assertThat(parsedMetaData.templates().get("foo").aliases().get("alias-bar3").indexRouting(), equalTo("routing-bar"));
+        assertThat(parsedMetaData.templates().get("foo").aliases().get("alias-bar3").searchRouting(), equalTo("routing-bar"));
     }
 
     private static final String MAPPING_SOURCE1 = "{\"mapping1\":{\"text1\":{\"type\":\"string\"}}}";

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -84,6 +85,9 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
             ClusterStateResponse stateResponse = client().admin().cluster().prepareState().setIndices(indexName).get();
             assertThat(stateResponse.getState().getMetaData().indices().get(indexName).getNumberOfShards(), is(10));
             assertThat(stateResponse.getState().getMetaData().indices().get(indexName).getNumberOfReplicas(), is(0));
+            assertThat(stateResponse.getState().getMetaData().indices().get(indexName).aliases().size(), equalTo(1));
+            String aliasName = indexName + "-alias";
+            assertThat(stateResponse.getState().getMetaData().indices().get(indexName).aliases().get(aliasName).alias(), equalTo(aliasName));
         }
     }
 }

--- a/src/test/java/org/elasticsearch/indices/template/template0.json
+++ b/src/test/java/org/elasticsearch/indices/template/template0.json
@@ -3,5 +3,8 @@
     "settings" : {
         "index.number_of_shards": 10,
         "index.number_of_replicas": 0
-   }
+    },
+    "aliases" : {
+        "{index}-alias" : {}
+    }
 }

--- a/src/test/java/org/elasticsearch/indices/template/template1.json
+++ b/src/test/java/org/elasticsearch/indices/template/template1.json
@@ -3,5 +3,8 @@
     "settings" : {
         "number_of_shards": 10,
         "number_of_replicas": 0
+    },
+    "aliases" : {
+        "{index}-alias" : {}
     }
 }

--- a/src/test/java/org/elasticsearch/indices/template/template2.json
+++ b/src/test/java/org/elasticsearch/indices/template/template2.json
@@ -5,5 +5,8 @@
             "number_of_shards": 10,
             "number_of_replicas": 0
         }
+    },
+    "aliases" : {
+        "{index}-alias" : {}
     }
 }

--- a/src/test/java/org/elasticsearch/indices/template/template3.json
+++ b/src/test/java/org/elasticsearch/indices/template/template3.json
@@ -4,6 +4,9 @@
         "settings" : {
             "index.number_of_shards": 10,
             "index.number_of_replicas": 0
+        },
+        "aliases" : {
+            "{index}-alias" : {}
         }
     }
 }

--- a/src/test/java/org/elasticsearch/indices/template/template4.json
+++ b/src/test/java/org/elasticsearch/indices/template/template4.json
@@ -4,6 +4,9 @@
         "settings" : {
             "number_of_shards": 10,
             "number_of_replicas": 0
+        },
+        "aliases" : {
+            "{index}-alias" : {}
         }
     }
 }

--- a/src/test/java/org/elasticsearch/indices/template/template5.json
+++ b/src/test/java/org/elasticsearch/indices/template/template5.json
@@ -6,6 +6,9 @@
                 "number_of_shards": 10,
                 "number_of_replicas": 0
             }
+        },
+        "aliases" : {
+            "{index}-alias" : {}
         }
     }
 }


### PR DESCRIPTION
This PR finalizes the work that has been done in #2739 towards adding support for aliases to index templates.

Aliases can now be specified when creating an index template as follows:

```
curl -XPUT localhost:9200/_template/template_1 -d '
{
    "template" : "te*",
    "settings" : {
        "number_of_shards" : 1
    },
    "aliases" : {
        "alias1" : {},
        "alias2" : {
            "filter" : {
                "term" : {"user" : "kimchy" }
            },
            "routing" : "kimchy"
        },
        "{index}-alias" : {}
    }
}
'
```

The `{index}` placeholder within the alias name will be replaced with the actual index name that the template gets applied to during index creation.

Closes #1825
