### PR TITLE
Togglable stacktrace display

### DIFF
--- a/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -23,6 +23,9 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.rest.RestStatus;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 /**
  *
  */
@@ -109,5 +112,12 @@ public final class ExceptionsHelper {
         } else {
             return t.getClass().getSimpleName() + "[" + t.getMessage() + "]";
         }
+    }
+
+    public static String stackTrace(Throwable e) {
+        StringWriter stackTraceStringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stackTraceStringWriter);
+        e.printStackTrace(printWriter);
+        return stackTraceStringWriter.toString();
     }
 }

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -274,6 +274,9 @@ public class Bootstrap {
         } else {
             errorMessage.append("- ").append(ExceptionsHelper.detailedMessage(e, true, 0));
         }
+        if (Loggers.getLogger(Bootstrap.class).isDebugEnabled()) {
+            errorMessage.append("\n").append(ExceptionsHelper.stackTrace(e));
+        }
         return errorMessage.toString();
     }
 }


### PR DESCRIPTION
Make it flaggable with system property whether ES will display 
only Throwable message or full stack trace on startup, as 
suggested by @imotov in #5103 discussion. Defaults to 
displaying stack trace, but it can be suppressed by 
`-Des.suppress-stack-traces=true` .

Closes #5102
