### PR TITLE
NPE in PluginsService when starting elasticsearch with a wrong user

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -236,15 +236,15 @@ public class FileSystemUtils {
         assert directory != null && logger != null;
 
         if (!directory.exists()) {
-            logger.debug("plugins directory does not exist [{}].", directory.getAbsolutePath());
+            logger.debug("[{}] directory does not exist.", directory.getAbsolutePath());
             return false;
         }
         if (!directory.isDirectory()) {
-            logger.debug("plugins directory is not a directory [{}].", directory.getAbsolutePath());
+            logger.debug("[{}] should be a directory but is not.", directory.getAbsolutePath());
             return false;
         }
         if (!directory.canRead()) {
-            logger.debug("plugins directory is not readable [{}].", directory.getAbsolutePath());
+            logger.debug("[{}] directory is not readable.", directory.getAbsolutePath());
             return false;
         }
         return true;

--- a/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -228,6 +228,28 @@ public class FileSystemUtils {
         }
     }
 
+    /**
+     * Check that a directory exists, is a directory and is readable
+     * by the current user
+     */
+    public static boolean isAccessibleDirectory(File directory, ESLogger logger) {
+        assert directory != null && logger != null;
+
+        if (!directory.exists()) {
+            logger.debug("plugins directory does not exist [{}].", directory.getAbsolutePath());
+            return false;
+        }
+        if (!directory.isDirectory()) {
+            logger.debug("plugins directory is not a directory [{}].", directory.getAbsolutePath());
+            return false;
+        }
+        if (!directory.canRead()) {
+            logger.debug("plugins directory is not readable [{}].", directory.getAbsolutePath());
+            return false;
+        }
+        return true;
+    }
+
     private FileSystemUtils() {
 
     }

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -353,6 +353,11 @@ public class PluginsService extends AbstractComponent {
                 if (logger.isTraceEnabled()) {
                     logger.trace("--- adding plugin [" + pluginFile.getAbsolutePath() + "]");
                 }
+                if (!pluginFile.canRead()) {
+                    logger.debug("plugin directory is not readable [{}].", pluginFile.getAbsolutePath());
+                    continue;
+                }
+
                 try {
                     // add the root
                     addURL.invoke(classLoader, pluginFile.toURI().toURL());

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -437,12 +437,7 @@ public class PluginsService extends AbstractComponent {
         for (File pluginFile : pluginsFile.listFiles()) {
             if (!loadedJvmPlugins.contains(pluginFile.getName())) {
                 File sitePluginDir = new File(pluginFile, "_site");
-                if (sitePluginDir.exists()) {
-                    // Check if _site is readable
-                    if (!isAccessibleDirectory(sitePluginDir, logger)) {
-                        continue;
-                    }
-
+                if (isAccessibleDirectory(sitePluginDir, logger)) {
                     // We have a _site plugin. Let's try to get more information on it
                     String name = pluginFile.getName();
                     String version = PluginInfo.VERSION_NOT_AVAILABLE;

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -342,9 +342,8 @@ public class PluginsService extends AbstractComponent {
             return;
         }
 
-        File[] pluginsFiles = pluginsFile.listFiles();
         if (pluginsFile != null) {
-            for (File pluginFile : pluginsFiles) {
+            for (File pluginFile : pluginsFile.listFiles()) {
                 if (pluginFile.isDirectory()) {
                     if (logger.isTraceEnabled()) {
                         logger.trace("--- adding plugin [" + pluginFile.getAbsolutePath() + "]");

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -44,6 +43,8 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.*;
+
+import static org.elasticsearch.common.io.FileSystemUtils.isAccessibleDirectory;
 
 /**
  *
@@ -318,7 +319,7 @@ public class PluginsService extends AbstractComponent {
 
     private void loadPluginsIntoClassLoader() {
         File pluginsDirectory = environment.pluginsFile();
-        if (!FileSystemUtils.isAccessibleDirectory(pluginsDirectory, logger)) {
+        if (!isAccessibleDirectory(pluginsDirectory, logger)) {
             return;
         }
 
@@ -342,7 +343,7 @@ public class PluginsService extends AbstractComponent {
 
         for (File plugin : pluginsDirectory.listFiles()) {
             // We check that subdirs are directories and readable
-            if (!FileSystemUtils.isAccessibleDirectory(plugin, logger)) {
+            if (!isAccessibleDirectory(plugin, logger)) {
                 continue;
             }
 

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -347,9 +347,7 @@ public class PluginsService extends AbstractComponent {
                 continue;
             }
 
-            if (logger.isTraceEnabled()) {
-                logger.trace("--- adding plugin [{}]", plugin.getAbsolutePath());
-            }
+            logger.trace("--- adding plugin [{}]", plugin.getAbsolutePath());
 
             try {
                 // add the root

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -317,16 +318,7 @@ public class PluginsService extends AbstractComponent {
 
     private void loadPluginsIntoClassLoader() {
         File pluginsDirectory = environment.pluginsFile();
-        if (!pluginsDirectory.exists()) {
-            logger.debug("plugins directory does not exist [{}].", pluginsDirectory.getAbsolutePath());
-            return;
-        }
-        if (!pluginsDirectory.isDirectory()) {
-            logger.debug("plugins directory is not a directory [{}].", pluginsDirectory.getAbsolutePath());
-            return;
-        }
-        if (!pluginsDirectory.canRead()) {
-            logger.debug("plugins directory is not readable [{}].", pluginsDirectory.getAbsolutePath());
+        if (!FileSystemUtils.isAccessibleDirectory(pluginsDirectory, logger)) {
             return;
         }
 
@@ -350,12 +342,7 @@ public class PluginsService extends AbstractComponent {
 
         for (File plugin : pluginsDirectory.listFiles()) {
             // We check that subdirs are directories and readable
-            if (!plugin.isDirectory()) {
-                logger.debug("plugins directory is not a directory [{}].", pluginsDirectory.getAbsolutePath());
-                continue;
-            }
-            if (!plugin.canRead()) {
-                logger.debug("plugin directory is not readable [{}].", plugin.getAbsolutePath());
+            if (!FileSystemUtils.isAccessibleDirectory(plugin, logger)) {
                 continue;
             }
 

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -394,7 +394,7 @@ public class PluginsService extends AbstractComponent {
 
                     // Is it a site plugin as well? Does it have also an embedded _site structure
                     File siteFile = new File(new File(environment.pluginsFile(), plugin.name()), "_site");
-                    boolean isSite = siteFile.exists() && siteFile.isDirectory();
+                    boolean isSite = isAccessibleDirectory(siteFile, logger);
                     if (logger.isTraceEnabled()) {
                         logger.trace("found a jvm plugin [{}], [{}]{}",
                                 plugin.name(), plugin.description(), isSite ? ": with _site structure" : "");
@@ -438,6 +438,11 @@ public class PluginsService extends AbstractComponent {
             if (!loadedJvmPlugins.contains(pluginFile.getName())) {
                 File sitePluginDir = new File(pluginFile, "_site");
                 if (sitePluginDir.exists()) {
+                    // Check if _site is readable
+                    if (!isAccessibleDirectory(sitePluginDir, logger)) {
+                        continue;
+                    }
+
                     // We have a _site plugin. Let's try to get more information on it
                     String name = pluginFile.getName();
                     String version = PluginInfo.VERSION_NOT_AVAILABLE;
@@ -487,7 +492,7 @@ public class PluginsService extends AbstractComponent {
         }
 
         File sitePluginDir = new File(pluginsFile, name + "/_site");
-        return sitePluginDir.exists();
+        return isAccessibleDirectory(sitePluginDir, logger);
     }
 
     private Plugin loadPlugin(String className, Settings settings) {


### PR DESCRIPTION
When starting elasticsearch with a wrong linux user, it could generate a `NullPointerException` when `PluginsService` tries to list available plugins in `./plugins` dir.

To reproduce:
- create a plugins directory with `rwx` rights for root user only
- launch elasticsearch from another account (elasticsearch for example)

It was supposed to be fixed with #4186, but sadly it's not :-(

Closes #5195.
