### PR TITLE
Changed the caching of FieldDataSource in aggs to be based on field name...

### DIFF
--- a/src/test/java/org/elasticsearch/search/aggregations/CombiTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/CombiTests.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import com.carrotsearch.hppc.IntIntMap;
+import com.carrotsearch.hppc.IntIntOpenHashMap;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.aggregations.bucket.missing.Missing;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ *
+ */
+public class CombiTests extends ElasticsearchIntegrationTest {
+
+
+    @Override
+    public Settings indexSettings() {
+        return ImmutableSettings.builder()
+                .put("index.number_of_shards", between(1, 5))
+                .put("index.number_of_replicas", between(0, 1))
+                .build();
+    }
+
+    /**
+     * Making sure that if there are multiple aggregations, working on the same field, yet require different
+     * value source type, they can all still work. It used to fail as we used to cache the ValueSource by the
+     * field name. If the cached value source was of type "bytes" and another aggregation on the field required to see
+     * it as "numeric", it didn't work. Now we cache the Value Sources by a custom key (field name + ValueSource type)
+     * so there's no conflict there.
+     */
+    @Test
+    public void multipleAggs_OnSameField_WithDifferentRequiredValueSourceType() throws Exception {
+
+        createIndex("idx");
+        IndexRequestBuilder[] builders = new IndexRequestBuilder[randomInt(30)];
+        IntIntMap values = new IntIntOpenHashMap();
+        long missingValues = 0;
+        for (int i = 0; i < builders.length; i++) {
+            String name = "name_" + randomIntBetween(1, 10);
+            if (rarely()) {
+                missingValues++;
+                builders[i] = client().prepareIndex("idx", "type").setSource(jsonBuilder()
+                        .startObject()
+                        .field("name", name)
+                        .endObject());
+            } else {
+                int value = randomIntBetween(1, 10);
+                values.put(value, values.getOrDefault(value, 0) + 1);
+                builders[i] = client().prepareIndex("idx", "type").setSource(jsonBuilder()
+                        .startObject()
+                        .field("name", name)
+                        .field("value", value)
+                        .endObject());
+            }
+        }
+        indexRandom(true, builders);
+        ensureSearchable();
+
+
+        SearchResponse response = client().prepareSearch("idx")
+                .addAggregation(missing("missing_values").field("value"))
+                .addAggregation(terms("values").field("value"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Aggregations aggs = response.getAggregations();
+
+        Missing missing = aggs.get("missing_values");
+        assertNotNull(missing);
+        assertThat(missing.getDocCount(), equalTo(missingValues));
+
+        Terms terms = aggs.get("values");
+        assertNotNull(terms);
+        Collection<Terms.Bucket> buckets = terms.getBuckets();
+        assertThat(buckets.size(), equalTo(values.size()));
+        for (Terms.Bucket bucket : buckets) {
+            values.remove(bucket.getKeyAsNumber().intValue());
+        }
+        assertTrue(values.isEmpty());
+    }
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
@@ -42,7 +42,10 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-/** Additional tests that aim at testing more complex aggregation trees on larger random datasets, so that things like the growth of dynamic arrays is tested. */
+/**
+ * Additional tests that aim at testing more complex aggregation trees on larger random datasets, so that things like
+ * the growth of dynamic arrays is tested.
+ */
 public class RandomTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -115,7 +115,7 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
                         .size(0))
                 .execute().actionGet();
 
-        assertSearchResponse(response);System.out.println(response);
+        assertSearchResponse(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());


### PR DESCRIPTION
... + required Value Source type as a combi key (used to be only field name). This fixes a problem where multiple aggregations where defined on the same field, yet require different types of value sources.

Closes #5190
