### PR TITLE
Made SearchContextHighlight.Field class immutable to prevent from unwanted updates

### DIFF
--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -189,6 +189,10 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public void highlight(SearchContextHighlight highlight) {
+        if (highlight != null) {
+            // Enforce highlighting by source, because MemoryIndex doesn't support stored fields.
+            highlight.globalForceSource(true);
+        }
         this.highlight = highlight;
     }
 

--- a/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -64,10 +64,7 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.percolator.QueryCollector.Count;
-import org.elasticsearch.percolator.QueryCollector.Match;
-import org.elasticsearch.percolator.QueryCollector.MatchAndScore;
-import org.elasticsearch.percolator.QueryCollector.MatchAndSort;
+import org.elasticsearch.percolator.QueryCollector.*;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchShardTarget;
@@ -79,7 +76,6 @@ import org.elasticsearch.search.facet.InternalFacet;
 import org.elasticsearch.search.facet.InternalFacets;
 import org.elasticsearch.search.highlight.HighlightField;
 import org.elasticsearch.search.highlight.HighlightPhase;
-import org.elasticsearch.search.highlight.SearchContextHighlight;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortParseElement;
 
@@ -307,11 +303,6 @@ public class PercolatorService extends AbstractComponent {
             // We need to get the actual source from the request body for highlighting, so parse the request body again
             // and only get the doc source.
             if (context.highlight() != null) {
-                // Enforce highlighting by source, because MemoryIndex doesn't support stored fields.
-                for (SearchContextHighlight.Field field : context.highlight().fields()) {
-                    field.forceSource(true);
-                }
-
                 parser.close();
                 currentFieldName = null;
                 parser = XContentFactory.xContent(source).createParser(source);
@@ -370,10 +361,6 @@ public class PercolatorService extends AbstractComponent {
             doc = docMapper.parse(source(parser).type(type).flyweight(true));
 
             if (context.highlight() != null) {
-                // Enforce highlighting by source, because MemoryIndex doesn't support stored fields.
-                for (SearchContextHighlight.Field field : context.highlight().fields()) {
-                    field.forceSource(true);
-                }
                 doc.setSource(fetchedDoc);
             }
         } catch (Throwable e) {

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightUtils.java
@@ -41,7 +41,9 @@ public final class HighlightUtils {
 
     }
 
-    static List<Object> loadFieldValues(FieldMapper<?> mapper, SearchContext searchContext, FetchSubPhase.HitContext hitContext, boolean forceSource) throws IOException {
+    static List<Object> loadFieldValues(SearchContextHighlight.Field field, FieldMapper<?> mapper, SearchContext searchContext, FetchSubPhase.HitContext hitContext) throws IOException {
+        //percolator needs to always load from source, thus it sets the global force source to true
+        boolean forceSource = searchContext.highlight().forceSource(field);
         List<Object> textsToHighlight;
         if (!forceSource && mapper.fieldType().stored()) {
             CustomFieldsVisitor fieldVisitor = new CustomFieldsVisitor(ImmutableSet.of(mapper.names().indexName()), false);

--- a/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -19,31 +19,68 @@
 
 package org.elasticsearch.search.highlight;
 
+import com.google.common.collect.Maps;
 import org.apache.lucene.search.Query;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  *
  */
 public class SearchContextHighlight {
 
-    private final List<Field> fields;
+    private final Map<String, Field> fields;
 
-    public SearchContextHighlight(List<Field> fields) {
-        this.fields = fields;
+    private boolean globalForceSource = false;
+
+    public SearchContextHighlight(Collection<Field> fields) {
+        assert fields != null;
+        this.fields = Maps.newHashMap();
+        for (Field field : fields) {
+            this.fields.put(field.field, field);
+        }
     }
 
-    public List<Field> fields() {
-        return fields;
+    public Collection<Field> fields() {
+        return fields.values();
+    }
+
+    public void globalForceSource(boolean globalForceSource) {
+        this.globalForceSource = globalForceSource;
+    }
+
+    public boolean forceSource(Field field) {
+        if (globalForceSource) {
+            return true;
+        }
+
+        Field _field = fields.get(field.field);
+        return _field == null ? false : _field.fieldOptions.forceSource;
     }
 
     public static class Field {
-        // Fields that default to null or -1 are often set to their real default in HighlighterParseElement#parse
         private final String field;
+        private final FieldOptions fieldOptions;
 
+        Field(String field, FieldOptions fieldOptions) {
+            assert field != null;
+            assert fieldOptions != null;
+            this.field = field;
+            this.fieldOptions = fieldOptions;
+        }
+
+        public String field() {
+            return field;
+        }
+
+        public FieldOptions fieldOptions() {
+            return fieldOptions;
+        }
+    }
+
+    public static class FieldOptions {
+
+        // Field options that default to null or -1 are often set to their real default in HighlighterParseElement#parse
         private int fragmentCharSize = -1;
 
         private int numberOfFragments = -1;
@@ -82,164 +119,236 @@ public class SearchContextHighlight {
 
         private int phraseLimit = -1;
 
-        public Field(String field) {
-            this.field = field;
-        }
-
-        public String field() {
-            return field;
-        }
-
         public int fragmentCharSize() {
             return fragmentCharSize;
-        }
-
-        public void fragmentCharSize(int fragmentCharSize) {
-            this.fragmentCharSize = fragmentCharSize;
         }
 
         public int numberOfFragments() {
             return numberOfFragments;
         }
 
-        public void numberOfFragments(int numberOfFragments) {
-            this.numberOfFragments = numberOfFragments;
-        }
-
         public int fragmentOffset() {
             return fragmentOffset;
-        }
-
-        public void fragmentOffset(int fragmentOffset) {
-            this.fragmentOffset = fragmentOffset;
         }
 
         public String encoder() {
             return encoder;
         }
 
-        public void encoder(String encoder) {
-            this.encoder = encoder;
-        }
-
         public String[] preTags() {
             return preTags;
-        }
-
-        public void preTags(String[] preTags) {
-            this.preTags = preTags;
         }
 
         public String[] postTags() {
             return postTags;
         }
 
-        public void postTags(String[] postTags) {
-            this.postTags = postTags;
-        }
-
         public Boolean scoreOrdered() {
             return scoreOrdered;
-        }
-
-        public void scoreOrdered(boolean scoreOrdered) {
-            this.scoreOrdered = scoreOrdered;
         }
 
         public Boolean highlightFilter() {
             return highlightFilter;
         }
 
-        public void highlightFilter(boolean highlightFilter) {
-            this.highlightFilter = highlightFilter;
-        }
-
         public Boolean requireFieldMatch() {
             return requireFieldMatch;
-        }
-
-        public void requireFieldMatch(boolean requireFieldMatch) {
-            this.requireFieldMatch = requireFieldMatch;
         }
 
         public String highlighterType() {
             return highlighterType;
         }
 
-        public void highlighterType(String type) {
-            this.highlighterType = type;
-        }
-
-        public Boolean forceSource() {
-            return forceSource;
-        }
-
-        public void forceSource(boolean forceSource) {
-            this.forceSource = forceSource;
-        }
-
         public String fragmenter() {
             return fragmenter;
-        }
-
-        public void fragmenter(String fragmenter) {
-            this.fragmenter = fragmenter;
         }
 
         public int boundaryMaxScan() {
             return boundaryMaxScan;
         }
 
-        public void boundaryMaxScan(int boundaryMaxScan) {
-            this.boundaryMaxScan = boundaryMaxScan;
-        }
-
         public Character[] boundaryChars() {
             return boundaryChars;
-        }
-
-        public void boundaryChars(Character[] boundaryChars) {
-            this.boundaryChars = boundaryChars;
         }
 
         public Query highlightQuery() {
             return highlightQuery;
         }
 
-        public void highlightQuery(Query highlightQuery) {
-            this.highlightQuery = highlightQuery;
-        }
-
         public int noMatchSize() {
             return noMatchSize;
-        }
-
-        public void noMatchSize(int noMatchSize) {
-            this.noMatchSize = noMatchSize;
         }
 
         public int phraseLimit() {
             return phraseLimit;
         }
 
-        public void phraseLimit(int phraseLimit) {
-            this.phraseLimit = phraseLimit;
-        }
-
         public Set<String> matchedFields() {
             return matchedFields;
-        }
-
-        public void matchedFields(Set<String> matchedFields) {
-            this.matchedFields = matchedFields;
         }
 
         public Map<String, Object> options() {
             return options;
         }
 
-        public void options(Map<String, Object> options) {
-            this.options = options;
+        static class Builder {
+
+            private final FieldOptions fieldOptions = new FieldOptions();
+
+            Builder fragmentCharSize(int fragmentCharSize) {
+                fieldOptions.fragmentCharSize = fragmentCharSize;
+                return this;
+            }
+
+            Builder numberOfFragments(int numberOfFragments) {
+                fieldOptions.numberOfFragments = numberOfFragments;
+                return this;
+            }
+
+            Builder fragmentOffset(int fragmentOffset) {
+                fieldOptions.fragmentOffset = fragmentOffset;
+                return this;
+            }
+
+            Builder encoder(String encoder) {
+                fieldOptions.encoder = encoder;
+                return this;
+            }
+
+            Builder preTags(String[] preTags) {
+                fieldOptions.preTags = preTags;
+                return this;
+            }
+
+            Builder postTags(String[] postTags) {
+                fieldOptions.postTags = postTags;
+                return this;
+            }
+
+            Builder scoreOrdered(boolean scoreOrdered) {
+                fieldOptions.scoreOrdered = scoreOrdered;
+                return this;
+            }
+
+            Builder highlightFilter(boolean highlightFilter) {
+                fieldOptions.highlightFilter = highlightFilter;
+                return this;
+            }
+
+            Builder requireFieldMatch(boolean requireFieldMatch) {
+                fieldOptions.requireFieldMatch = requireFieldMatch;
+                return this;
+            }
+
+            Builder highlighterType(String type) {
+                fieldOptions.highlighterType = type;
+                return this;
+            }
+
+            Builder forceSource(boolean forceSource) {
+                fieldOptions.forceSource = forceSource;
+                return this;
+            }
+
+            Builder fragmenter(String fragmenter) {
+                fieldOptions.fragmenter = fragmenter;
+                return this;
+            }
+
+            Builder boundaryMaxScan(int boundaryMaxScan) {
+                fieldOptions.boundaryMaxScan = boundaryMaxScan;
+                return this;
+            }
+
+            Builder boundaryChars(Character[] boundaryChars) {
+                fieldOptions.boundaryChars = boundaryChars;
+                return this;
+            }
+
+            Builder highlightQuery(Query highlightQuery) {
+                fieldOptions.highlightQuery = highlightQuery;
+                return this;
+            }
+
+            Builder noMatchSize(int noMatchSize) {
+                fieldOptions.noMatchSize = noMatchSize;
+                return this;
+            }
+
+            Builder phraseLimit(int phraseLimit) {
+                fieldOptions.phraseLimit = phraseLimit;
+                return this;
+            }
+
+            Builder matchedFields(Set<String> matchedFields) {
+                fieldOptions.matchedFields = matchedFields;
+                return this;
+            }
+
+            Builder options(Map<String, Object> options) {
+                fieldOptions.options = options;
+                return this;
+            }
+
+            FieldOptions build() {
+                return fieldOptions;
+            }
+
+            Builder merge(FieldOptions globalOptions) {
+                if (fieldOptions.preTags == null && globalOptions.preTags != null) {
+                    fieldOptions.preTags = Arrays.copyOf(globalOptions.preTags, globalOptions.preTags.length);
+                }
+                if (fieldOptions.postTags == null && globalOptions.postTags != null) {
+                    fieldOptions.postTags = Arrays.copyOf(globalOptions.postTags, globalOptions.postTags.length);
+                }
+                if (fieldOptions.highlightFilter == null) {
+                    fieldOptions.highlightFilter = globalOptions.highlightFilter;
+                }
+                if (fieldOptions.scoreOrdered == null) {
+                    fieldOptions.scoreOrdered = globalOptions.scoreOrdered;
+                }
+                if (fieldOptions.fragmentCharSize == -1) {
+                    fieldOptions.fragmentCharSize = globalOptions.fragmentCharSize;
+                }
+                if (fieldOptions.numberOfFragments == -1) {
+                    fieldOptions.numberOfFragments = globalOptions.numberOfFragments;
+                }
+                if (fieldOptions.encoder == null) {
+                    fieldOptions.encoder = globalOptions.encoder;
+                }
+                if (fieldOptions.requireFieldMatch == null) {
+                    fieldOptions.requireFieldMatch = globalOptions.requireFieldMatch;
+                }
+                if (fieldOptions.boundaryMaxScan == -1) {
+                    fieldOptions.boundaryMaxScan = globalOptions.boundaryMaxScan;
+                }
+                if (fieldOptions.boundaryChars == null && globalOptions.boundaryChars != null) {
+                    fieldOptions.boundaryChars = Arrays.copyOf(globalOptions.boundaryChars, globalOptions.boundaryChars.length);
+                }
+                if (fieldOptions.highlighterType == null) {
+                    fieldOptions.highlighterType = globalOptions.highlighterType;
+                }
+                if (fieldOptions.fragmenter == null) {
+                    fieldOptions.fragmenter = globalOptions.fragmenter;
+                }
+                if ((fieldOptions.options == null || fieldOptions.options.size() == 0) && globalOptions.options != null) {
+                    fieldOptions.options = Maps.newHashMap(globalOptions.options);
+                }
+                if (fieldOptions.highlightQuery == null && globalOptions.highlightQuery != null) {
+                    fieldOptions.highlightQuery = globalOptions.highlightQuery;
+                }
+                if (fieldOptions.noMatchSize == -1) {
+                    fieldOptions.noMatchSize = globalOptions.noMatchSize;
+                }
+                if (fieldOptions.forceSource == null) {
+                    fieldOptions.forceSource = globalOptions.forceSource;
+                }
+                if (fieldOptions.phraseLimit == -1) {
+                    fieldOptions.phraseLimit = globalOptions.phraseLimit;
+                }
+
+                return this;
+            }
         }
     }
 }

--- a/src/test/java/org/elasticsearch/search/highlight/CustomHighlighter.java
+++ b/src/test/java/org/elasticsearch/search/highlight/CustomHighlighter.java
@@ -42,8 +42,8 @@ public class CustomHighlighter implements Highlighter {
         List<Text> responses = Lists.newArrayList();
         responses.add(new StringText("standard response"));
 
-        if (field.options() != null) {
-            for (Map.Entry<String, Object> entry : field.options().entrySet()) {
+        if (field.fieldOptions().options() != null) {
+            for (Map.Entry<String, Object> entry : field.fieldOptions().options().entrySet()) {
                 responses.add(new StringText("field:" + entry.getKey() + ":" + entry.getValue()));
             }
         }


### PR DESCRIPTION
A Field instance can map to multiple actual fields when using wildcard expressions. Each actual field should use the proper highlighter depending on the available data structure (e.g. term_vectors), while we currently select the highlighter for the first field and we keep using the same for all the fields that match the wildcard expression.

Modified also how the PercolateContext sets the forceSource option, in a global manner now rather than per field.

Closes #5175
