### PR TITLE
Changing the sorting for terms aggs,

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
@@ -212,8 +212,11 @@ class InternalOrder extends Terms.Order {
                         double v2 = ((MetricsAggregator.MultiValue) aggregator).metric(valueName, ((InternalTerms.Bucket) o2).bucketOrd);
                         // some metrics may return NaN (eg. avg, variance, etc...) in which case we'd like to push all of those to
                         // the bottom
-                        if (v1 == Double.NaN) {
-                            return asc ? 1 : -1;
+                        if (Double.isNaN(v1)) {
+                            return 1;
+                        }
+                        if (Double.isNaN(v2)) {
+                            return -1;
                         }
                         return asc ? Double.compare(v1, v2) : Double.compare(v2, v1);
                     }
@@ -227,8 +230,11 @@ class InternalOrder extends Terms.Order {
                     double v2 = ((MetricsAggregator.SingleValue) aggregator).metric(((InternalTerms.Bucket) o2).bucketOrd);
                     // some metrics may return NaN (eg. avg, variance, etc...) in which case we'd like to push all of those to
                     // the bottom
-                    if (v1 == Double.NaN) {
-                        return asc ? 1 : -1;
+                    if (Double.isNaN(v1)) {
+                        return 1;
+                    }
+                    if (Double.isNaN(v2)) {
+                        return -1;
                     }
                     return asc ? Double.compare(v1, v2) : Double.compare(v2, v1);
                 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
@@ -213,7 +213,7 @@ class InternalOrder extends Terms.Order {
                         // some metrics may return NaN (eg. avg, variance, etc...) in which case we'd like to push all of those to
                         // the bottom
                         if (Double.isNaN(v1)) {
-                            return 1;
+                            return Double.isNaN(v2) ? 0 : 1;
                         }
                         if (Double.isNaN(v2)) {
                             return -1;
@@ -231,7 +231,7 @@ class InternalOrder extends Terms.Order {
                     // some metrics may return NaN (eg. avg, variance, etc...) in which case we'd like to push all of those to
                     // the bottom
                     if (Double.isNaN(v1)) {
-                        return 1;
+                        return Double.isNaN(v2) ? 0 : 1;
                     }
                     if (Double.isNaN(v2)) {
                         return -1;


### PR DESCRIPTION
This pull request fixes the sorting of aggregations as discussed in issue #5236.

It forces the `NaN` values to be pushed to the bottom of the list, no matter if you are sorting asc/desc. This way top lists show the most relevant aggregates in the top. Also it actually does what the comments above it already said it should do.

Closes #5236.
