### PR TITLE
PR for plugin isolation

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
@@ -149,7 +149,11 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         } else {
             this.version = VERSION_NOT_AVAILABLE;
         }
-        this.isolation = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
+            this.isolation = in.readBoolean();
+        } else {
+            this.isolation = false;
+        }
     }
 
     @Override
@@ -161,7 +165,9 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         if (out.getVersion().onOrAfter(Version.V_1_0_0_RC2)) {
             out.writeString(version);
         }
-        out.writeBoolean(isolation);
+        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
+            out.writeBoolean(isolation);
+        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
@@ -41,6 +41,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         static final XContentBuilderString JVM = new XContentBuilderString("jvm");
         static final XContentBuilderString SITE = new XContentBuilderString("site");
         static final XContentBuilderString VERSION = new XContentBuilderString("version");
+        static final XContentBuilderString ISOLATION = new XContentBuilderString("isolation");
     }
 
     private String name;
@@ -48,6 +49,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
     private boolean site;
     private boolean jvm;
     private String version;
+    private boolean isolation;
 
     public PluginInfo() {
     }
@@ -60,8 +62,9 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
      * @param site        true if it's a site plugin
      * @param jvm         true if it's a jvm plugin
      * @param version     Version number is applicable (NA otherwise)
+     * @param isolation   true if it's an isolated plugin
      */
-    public PluginInfo(String name, String description, boolean site, boolean jvm, String version) {
+    public PluginInfo(String name, String description, boolean site, boolean jvm, String version, boolean isolation) {
         this.name = name;
         this.description = description;
         this.site = site;
@@ -71,6 +74,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         } else {
             this.version = VERSION_NOT_AVAILABLE;
         }
+        this.isolation = isolation;
     }
 
     /**
@@ -121,6 +125,13 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         return version;
     }
 
+    /**
+     * @return Plugin isolation
+     */
+    public boolean isIsolation() {
+        return isolation;
+    }
+
     public static PluginInfo readPluginInfo(StreamInput in) throws IOException {
         PluginInfo info = new PluginInfo();
         info.readFrom(in);
@@ -138,6 +149,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         } else {
             this.version = VERSION_NOT_AVAILABLE;
         }
+        this.isolation = in.readBoolean();
     }
 
     @Override
@@ -149,6 +161,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         if (out.getVersion().onOrAfter(Version.V_1_0_0_RC2)) {
             out.writeString(version);
         }
+        out.writeBoolean(isolation);
     }
 
     @Override
@@ -162,6 +175,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         }
         builder.field(Fields.JVM, jvm);
         builder.field(Fields.SITE, site);
+        builder.field(Fields.ISOLATION, isolation);
         builder.endObject();
 
         return builder;
@@ -193,6 +207,7 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
         sb.append(", site=").append(site);
         sb.append(", jvm=").append(jvm);
         sb.append(", version='").append(version).append('\'');
+        sb.append(", isolation='").append(isolation);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/org/elasticsearch/plugins/PluginClassLoader.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginClassLoader.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+
+public class PluginClassLoader extends URLClassLoader {
+
+    private final ClassLoader system;
+    private final URL url;
+
+    PluginClassLoader(URL[] urls, ClassLoader parent) throws IOException {
+        super(urls, parent);
+        url = (urls != null && urls.length > 0 ? urls[0] : null);
+
+        ClassLoader sys = getSystemClassLoader();
+        while (sys.getParent() != null) {
+            sys = sys.getParent();
+        }
+
+        system = sys;
+    }
+
+    // load first from system class loader then fall back to this one
+    @Override
+    protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+            // check system class loader (jvm & bootclasspath)
+            if (system != null) {
+                try {
+                    c = system.loadClass(name);
+                } catch (ClassNotFoundException ignored) {
+                }
+            }
+            if (c == null) {
+                try {
+                    // check plugin classloader
+                    c = findClass(name);
+                } catch (ClassNotFoundException e) {
+                    // fall back to parent
+                    c = super.loadClass(name, resolve);
+                }
+            }
+        }
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        // apply same rules frmo loadClass
+        URL url = null;
+        if (system != null) {
+            url = system.getResource(name);
+        }
+        if (url == null) {
+            url = findResource(name);
+            if (url == null) {
+                url = super.getResource(name);
+            }
+        }
+        return url;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        List<URL> urls = Lists.newArrayList();
+        if (system != null) {
+            urls.addAll(Collections.list(system.getResources(name)));
+        }
+        urls.addAll(Collections.list(findResources(name)));
+
+        ClassLoader parent = getParent();
+        if (parent != null) {
+            urls.addAll(Collections.list(parent.getResources(name)));
+        }
+
+        return Collections.enumeration(urls);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.US, "PluginClassLoader for url [%s], classpath [%s], systemCL [%s]", url, Arrays.toString(getURLs()), system);
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginUtils.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginUtils.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import com.google.common.collect.Lists;
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+abstract class PluginUtils {
+
+    @SuppressWarnings("unchecked")
+    static Plugin loadPlugin(String className, Settings settings, ClassLoader classLoader) {
+        try {
+            Class<? extends Plugin> pluginClass = (Class<? extends Plugin>) classLoader.loadClass(className);
+            try {
+                return pluginClass.getConstructor(Settings.class).newInstance(settings);
+            } catch (NoSuchMethodException e) {
+                try {
+                    return pluginClass.newInstance();
+                } catch (Exception e1) {
+                    throw new ElasticsearchException("No constructor for [" + pluginClass + "]. A plugin class must " +
+                            "have either an empty default constructor or a single argument constructor accepting a " +
+                            "Settings instance");
+                }
+            }
+
+        } catch (Exception e) {
+            throw new ElasticsearchException("Failed to load plugin class [" + className + "]", e);
+        }
+    }
+
+    static List<File> pluginClassPathAsFiles(File pluginFolder) throws IOException {
+        List<File> cpFiles = Lists.newArrayList();
+        cpFiles.add(pluginFolder);
+
+        List<File> libFiles = Lists.newArrayList();
+        File[] files = pluginFolder.listFiles();
+        if (files != null) {
+            Collections.addAll(libFiles, files);
+        }
+        File libLocation = new File(pluginFolder, "lib");
+        if (libLocation.exists() && libLocation.isDirectory()) {
+            files = libLocation.listFiles();
+            if (files != null) {
+                Collections.addAll(libFiles, files);
+            }
+        }
+
+        // if there are jars in it, add it as well
+        for (File libFile : libFiles) {
+            if (libFile.getName().endsWith(".jar") || libFile.getName().endsWith(".zip")) {
+                cpFiles.add(libFile);
+            }
+        }
+
+        return cpFiles;
+    }
+
+    static boolean lookupIsolation(List<URL> pluginProperties, boolean defaultIsolation) throws IOException {
+        Properties props = new Properties();
+        InputStream is = null;
+        for (URL prop : pluginProperties) {
+            try {
+                props.load(prop.openStream());
+                return Booleans.parseBoolean(props.getProperty("isolation"), defaultIsolation);
+            } finally {
+                IOUtils.closeWhileHandlingException(is);
+            }
+        }
+        return defaultIsolation;
+    }
+
+    static List<URL> lookupPluginProperties(List<File> pluginClassPath) throws Exception {
+        if (pluginClassPath.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<URL> found = Lists.newArrayList();
+
+        for (File file : pluginClassPath) {
+            String toString = file.getName();
+            if (toString.endsWith(".jar") || toString.endsWith(".zip")) {
+                JarFile jar = new JarFile(file);
+                try {
+                    JarEntry jarEntry = jar.getJarEntry("es-plugin.properties");
+                    if (jarEntry != null) {
+                        found.add(new URL("jar:" + file.toURI().toString() + "!/es.plugin.properties"));
+                    }
+                } finally {
+                    IOUtils.closeWhileHandlingException(jar);
+                }
+            }
+            else {
+                File props = new File(file, "es-plugin.properties");
+                if (props.exists() && props.canRead()) {
+                    found.add(props.toURI().toURL());
+                }
+            }
+        }
+
+        return found;
+    }
+
+    static URL[] convertFileToUrl(List<File> pluginClassPath) throws IOException {
+        URL[] urls = new URL[pluginClassPath.size()];
+        for (int i = 0; i < urls.length; i++) {
+            urls[i] = pluginClassPath.get(i).toURI().toURL();
+        }
+        return urls;
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/PluginUtils.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginUtils.java
@@ -35,7 +35,9 @@ import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-abstract class PluginUtils {
+public final class PluginUtils {
+
+    private PluginUtils() {}
 
     @SuppressWarnings("unchecked")
     static Plugin loadPlugin(String className, Settings settings, ClassLoader classLoader) {

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -323,7 +323,7 @@ public class PluginsService extends AbstractComponent {
 
         List<Tuple<PluginInfo, Plugin>> pluginData = Lists.newArrayList();
 
-        Boolean defaultIsolation = settings.getAsBoolean("plugin.isolation", Boolean.TRUE);
+        boolean defaultIsolation = settings.getAsBoolean("plugins.isolation", Boolean.TRUE);
         ClassLoader esClassLoader = settings.getClassLoader();
         Method addURL = null;
         boolean discoveredAddUrl = false;
@@ -338,7 +338,7 @@ public class PluginsService extends AbstractComponent {
                         // check isolation
                         List<File> pluginClassPath = PluginUtils.pluginClassPathAsFiles(pluginRoot);
                         List<URL> pluginProperties = PluginUtils.lookupPluginProperties(pluginClassPath);
-                        boolean isolated = PluginUtils.lookupIsolation(pluginProperties, defaultIsolation.booleanValue());
+                        boolean isolated = PluginUtils.lookupIsolation(pluginProperties, defaultIsolation);
 
                         if (isolated) {
                             logger.trace("--- creating isolated space for plugin [" + pluginRoot.getAbsolutePath() + "]");

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -38,13 +38,10 @@ import org.elasticsearch.index.CloseableIndexComponent;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.*;
-
-import static org.elasticsearch.common.io.FileSystemUtils.isAccessibleDirectory;
 
 /**
  *
@@ -89,8 +86,8 @@ public class PluginsService extends AbstractComponent {
         // first we load all the default plugins from the settings
         String[] defaultPluginsClasses = settings.getAsArray("plugin.types");
         for (String pluginClass : defaultPluginsClasses) {
-            Plugin plugin = loadPlugin(pluginClass, settings);
-            PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), hasSite(plugin.name()), true, PluginInfo.VERSION_NOT_AVAILABLE);
+            Plugin plugin = PluginUtils.loadPlugin(pluginClass, settings, settings.getClassLoader());
+            PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), hasSite(plugin.name()), true, PluginInfo.VERSION_NOT_AVAILABLE, false);
             if (logger.isTraceEnabled()) {
                 logger.trace("plugin loaded from settings [{}]", pluginInfo);
             }
@@ -98,8 +95,7 @@ public class PluginsService extends AbstractComponent {
         }
 
         // now, find all the ones that are in the classpath
-        loadPluginsIntoClassLoader();
-        tupleBuilder.addAll(loadPluginsFromClasspath(settings));
+        tupleBuilder.addAll(loadPlugins());
         this.plugins = tupleBuilder.build();
 
         // We need to build a List of jvm and site plugins for checking mandatory plugins
@@ -317,103 +313,111 @@ public class PluginsService extends AbstractComponent {
         return cachedPluginsInfo;
     }
 
-    private void loadPluginsIntoClassLoader() {
-        File pluginsDirectory = environment.pluginsFile();
-        if (!isAccessibleDirectory(pluginsDirectory, logger)) {
-            return;
+    private List<Tuple<PluginInfo,Plugin>> loadPlugins() {
+        File pluginsFile = environment.pluginsFile();
+        if (!pluginsFile.exists()) {
+            return Collections.emptyList();
+        }
+        if (!pluginsFile.isDirectory()) {
+            return Collections.emptyList();
         }
 
-        ClassLoader classLoader = settings.getClassLoader();
-        Class classLoaderClass = classLoader.getClass();
+        List<Tuple<PluginInfo, Plugin>> pluginData = Lists.newArrayList();
+
+        Boolean defaultIsolation = settings.getAsBoolean("plugin.isolation", Boolean.TRUE);
+        ClassLoader esClassLoader = settings.getClassLoader();
         Method addURL = null;
-        while (!classLoaderClass.equals(Object.class)) {
-            try {
-                addURL = classLoaderClass.getDeclaredMethod("addURL", URL.class);
-                addURL.setAccessible(true);
-                break;
-            } catch (NoSuchMethodException e) {
-                // no method, try the parent
-                classLoaderClass = classLoaderClass.getSuperclass();
-            }
-        }
-        if (addURL == null) {
-            logger.debug("failed to find addURL method on classLoader [" + classLoader + "] to add methods");
-            return;
-        }
+        boolean discoveredAddUrl = false;
 
-        for (File plugin : pluginsDirectory.listFiles()) {
-            // We check that subdirs are directories and readable
-            if (!isAccessibleDirectory(plugin, logger)) {
-                continue;
-            }
+        File[] pluginsFiles = pluginsFile.listFiles();
 
-            logger.trace("--- adding plugin [{}]", plugin.getAbsolutePath());
+        if (pluginsFiles != null) {
+            for (File pluginRoot : pluginsFiles) {
+                if (pluginRoot.isDirectory()) {
+                    try {
+                        logger.trace("--- adding plugin [" + pluginRoot.getAbsolutePath() + "]");
+                        // check isolation
+                        List<File> pluginClassPath = PluginUtils.pluginClassPathAsFiles(pluginRoot);
+                        List<URL> pluginProperties = PluginUtils.lookupPluginProperties(pluginClassPath);
+                        boolean isolated = PluginUtils.lookupIsolation(pluginProperties, defaultIsolation.booleanValue());
 
-            try {
-                // add the root
-                addURL.invoke(classLoader, plugin.toURI().toURL());
-                // gather files to add
-                List<File> libFiles = Lists.newArrayList();
-                if (plugin.listFiles() != null) {
-                    libFiles.addAll(Arrays.asList(plugin.listFiles()));
-                }
-                File libLocation = new File(plugin, "lib");
-                if (libLocation.exists() && libLocation.isDirectory() && libLocation.listFiles() != null) {
-                    libFiles.addAll(Arrays.asList(libLocation.listFiles()));
-                }
+                        if (isolated) {
+                            logger.trace("--- creating isolated space for plugin [" + pluginRoot.getAbsolutePath() + "]");
+                            PluginClassLoader pcl = new PluginClassLoader(PluginUtils.convertFileToUrl(pluginClassPath), esClassLoader);
+                            pluginData.addAll(loadPlugin(pluginClassPath, pluginProperties, pcl, true));
+                        }
+                        else {
+                            if (!discoveredAddUrl) {
+                                discoveredAddUrl = true;
+                                Class<?> esClassLoaderClass = esClassLoader.getClass();
 
-                // if there are jars in it, add it as well
-                for (File libFile : libFiles) {
-                    if (!(libFile.getName().endsWith(".jar") || libFile.getName().endsWith(".zip"))) {
-                        continue;
+                                while (!esClassLoaderClass.equals(Object.class)) {
+                                    try {
+                                        addURL = esClassLoaderClass.getDeclaredMethod("addURL", URL.class);
+                                        addURL.setAccessible(true);
+                                        break;
+                                    } catch (NoSuchMethodException e) {
+                                        // no method, try the parent
+                                        esClassLoaderClass = esClassLoaderClass.getSuperclass();
+                                    }
+                                }
+                            }
+
+                            if (addURL == null) {
+                                logger.debug("failed to find addURL method on classLoader [" + esClassLoader + "] to add methods");
+                            }
+                            else {
+                                for (File file : pluginClassPath) {
+                                    addURL.invoke(esClassLoader, file.toURI().toURL());
+                                }
+                                pluginData.addAll(loadPlugin(pluginClassPath, pluginProperties, esClassLoader, false));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        logger.warn("failed to add plugin [" + pluginRoot.getAbsolutePath() + "]", e);
                     }
-                    addURL.invoke(classLoader, libFile.toURI().toURL());
                 }
-            } catch (Throwable e) {
-                logger.warn("failed to add plugin [" + plugin + "]", e);
             }
+        } else {
+            logger.debug("failed to list plugins from {}. Check your right access.", pluginsFile.getAbsolutePath());
         }
+
+        return pluginData;
     }
 
-    private ImmutableList<Tuple<PluginInfo,Plugin>> loadPluginsFromClasspath(Settings settings) {
-        ImmutableList.Builder<Tuple<PluginInfo, Plugin>> plugins = ImmutableList.builder();
+    private Collection<? extends Tuple<PluginInfo, Plugin>> loadPlugin(List<File> pluginClassPath, List<URL> properties, ClassLoader classLoader, boolean isolation) throws Exception {
+        List<Tuple<PluginInfo, Plugin>> plugins = Lists.newArrayList();
 
-        // Trying JVM plugins: looking for es-plugin.properties files
-        try {
-            Enumeration<URL> pluginUrls = settings.getClassLoader().getResources(ES_PLUGIN_PROPERTIES);
-            while (pluginUrls.hasMoreElements()) {
-                URL pluginUrl = pluginUrls.nextElement();
-                Properties pluginProps = new Properties();
-                InputStream is = null;
-                try {
-                    is = pluginUrl.openStream();
-                    pluginProps.load(is);
-                    String pluginClassName = pluginProps.getProperty("plugin");
-                    String pluginVersion = pluginProps.getProperty("version", PluginInfo.VERSION_NOT_AVAILABLE);
-                    Plugin plugin = loadPlugin(pluginClassName, settings);
+        Enumeration<URL> entries = Collections.enumeration(properties);
+        while (entries.hasMoreElements()) {
+            URL pluginUrl = entries.nextElement();
+            Properties pluginProps = new Properties();
+            InputStream is = null;
+            try {
+                is = pluginUrl.openStream();
+                pluginProps.load(is);
+                String pluginClassName = pluginProps.getProperty("plugin");
+                String pluginVersion = pluginProps.getProperty("version", PluginInfo.VERSION_NOT_AVAILABLE);
+                Plugin plugin = PluginUtils.loadPlugin(pluginClassName, settings, classLoader);
 
-                    // Is it a site plugin as well? Does it have also an embedded _site structure
-                    File siteFile = new File(new File(environment.pluginsFile(), plugin.name()), "_site");
-                    boolean isSite = isAccessibleDirectory(siteFile, logger);
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("found a jvm plugin [{}], [{}]{}",
-                                plugin.name(), plugin.description(), isSite ? ": with _site structure" : "");
-                    }
-
-                    PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), isSite, true, pluginVersion);
-
-                    plugins.add(new Tuple<PluginInfo, Plugin>(pluginInfo, plugin));
-                } catch (Throwable e) {
-                    logger.warn("failed to load plugin from [" + pluginUrl + "]", e);
-                } finally {
-                    IOUtils.closeWhileHandlingException(is);
+                // Is it a site plugin as well? Does it have also an embedded _site structure
+                File siteFile = new File(new File(environment.pluginsFile(), plugin.name()), "_site");
+                boolean isSite = siteFile.exists() && siteFile.isDirectory();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("found a jvm plugin [{}], [{}]{}",
+                            plugin.name(), plugin.description(), isSite ? ": with _site structure" : "");
                 }
+
+                PluginInfo pluginInfo = new PluginInfo(plugin.name(), plugin.description(), isSite, true, pluginVersion, isolation);
+                plugins.add(new Tuple<PluginInfo, Plugin>(pluginInfo, plugin));
+            } catch (Throwable e) {
+                logger.warn("failed to load plugin from [" + pluginUrl + "]", e);
+            } finally {
+                IOUtils.closeWhileHandlingException(is);
             }
-        } catch (IOException e) {
-            logger.warn("failed to find jvm plugins from classpath", e);
         }
 
-        return plugins.build();
+        return plugins;
     }
 
     private ImmutableList<Tuple<PluginInfo,Plugin>> loadSitePlugins() {
@@ -437,7 +441,7 @@ public class PluginsService extends AbstractComponent {
         for (File pluginFile : pluginsFile.listFiles()) {
             if (!loadedJvmPlugins.contains(pluginFile.getName())) {
                 File sitePluginDir = new File(pluginFile, "_site");
-                if (isAccessibleDirectory(sitePluginDir, logger)) {
+                if (sitePluginDir.exists()) {
                     // We have a _site plugin. Let's try to get more information on it
                     String name = pluginFile.getName();
                     String version = PluginInfo.VERSION_NOT_AVAILABLE;
@@ -466,7 +470,7 @@ public class PluginsService extends AbstractComponent {
                         logger.trace("found a site plugin name [{}], version [{}], description [{}]",
                                 name, version, description);
                     }
-                    sitePlugins.add(new Tuple<PluginInfo, Plugin>(new PluginInfo(name, description, true, false, version), null));
+                    sitePlugins.add(new Tuple<PluginInfo, Plugin>(new PluginInfo(name, description, true, false, version, false), null));
                 }
             }
         }
@@ -487,29 +491,6 @@ public class PluginsService extends AbstractComponent {
         }
 
         File sitePluginDir = new File(pluginsFile, name + "/_site");
-        return isAccessibleDirectory(sitePluginDir, logger);
-    }
-
-    private Plugin loadPlugin(String className, Settings settings) {
-        try {
-            Class<? extends Plugin> pluginClass = (Class<? extends Plugin>) settings.getClassLoader().loadClass(className);
-            Plugin plugin;
-            try {
-                plugin = pluginClass.getConstructor(Settings.class).newInstance(settings);
-            } catch (NoSuchMethodException e) {
-                try {
-                    plugin = pluginClass.getConstructor().newInstance();
-                } catch (NoSuchMethodException e1) {
-                    throw new ElasticsearchException("No constructor for [" + pluginClass + "]. A plugin class must " +
-                            "have either an empty default constructor or a single argument constructor accepting a " +
-                            "Settings instance");
-                }
-            }
-
-            return plugin;
-
-        } catch (Throwable e) {
-            throw new ElasticsearchException("Failed to load plugin class [" + className + "]", e);
-        }
+        return sitePluginDir.exists();
     }
 }

--- a/src/test/java/org/elasticsearch/plugins/IsolatedPluginTests.java
+++ b/src/test/java/org/elasticsearch/plugins/IsolatedPluginTests.java
@@ -41,7 +41,9 @@ import java.util.Properties;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
-@ClusterScope(scope = Scope.TEST, numNodes = 0, transportClientRatio = 0.0)
+// NB: the tests uses System Properties to pass the information from different plugins (loaded in separate CLs) to the test.
+// hence the use of try/finally blocks to clean these up after the test has been executed as otherwise the test framework will trigger a failure
+@ClusterScope(scope = Scope.TEST, numNodes = 1)
 public class IsolatedPluginTests extends ElasticsearchIntegrationTest {
 
     private static final Settings SETTINGS;

--- a/src/test/java/org/elasticsearch/plugins/IsolatedPluginTests.java
+++ b/src/test/java/org/elasticsearch/plugins/IsolatedPluginTests.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugins;
+
+import com.google.common.io.Files;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+@ClusterScope(scope = Scope.TEST, numNodes = 0, transportClientRatio = 0.0)
+public class IsolatedPluginTests extends ElasticsearchIntegrationTest {
+
+    private static final Settings SETTINGS;
+    private static final File PLUGIN_DIR;
+    private Properties props;
+
+    static {
+        PLUGIN_DIR = Files.createTempDir();
+
+        SETTINGS = ImmutableSettings.settingsBuilder()
+                .put("discovery.zen.ping.multicast.enabled", false)
+                .put("force.http.enabled", true)
+                .put("plugin.isolation", true)
+                .put("path.plugins", PLUGIN_DIR.getAbsolutePath())
+                .build();
+    }
+
+    @Before
+    public void beforeTest() throws Exception {
+        props = new Properties();
+        props.putAll(System.getProperties());
+
+        logger.info("Installing plugins into folder {}", PLUGIN_DIR);
+        FileSystemUtils.mkdirs(PLUGIN_DIR);
+
+        // copy plugin
+        copyPlugin(new File(PLUGIN_DIR, "plugin-v1"));
+        copyPlugin(new File(PLUGIN_DIR, "plugin-v2"));
+    }
+
+    private void copyPlugin(File p1) throws IOException {
+        FileSystemUtils.mkdirs(p1);
+        // copy plugin
+        File dir = new File(p1, "org/elasticsearch/plugins/isolation/");
+        FileSystemUtils.mkdirs(dir);
+        copyFile(getClass().getResourceAsStream("isolation/DummyClass.class"), new File(dir, "DummyClass.class"));
+        copyFile(getClass().getResourceAsStream("isolation/IsolatedPlugin.class"), new File(dir, "IsolatedPlugin.class"));
+        copyFile(getClass().getResourceAsStream("isolation/es-plugin.properties"), new File(p1, "es-plugin.properties"));
+    }
+
+    private void copyFile(InputStream source, File out) throws IOException {
+        out.createNewFile();
+        Streams.copy(source, new FileOutputStream(out));
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        FileSystemUtils.deleteRecursively(PLUGIN_DIR);
+    }
+
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return SETTINGS;
+    }
+
+    @Test
+    public void testPluginNumberOfIsolatedInstances() throws Exception {
+        try {
+            NodesInfoResponse nodesInfoResponse = client().admin().cluster().prepareNodesInfo().clear().setPlugins(true).get();
+            assertThat(nodesInfoResponse.getNodes().length, equalTo(1));
+            assertThat(nodesInfoResponse.getNodes()[0].getPlugins().getInfos(), notNullValue());
+            assertThat(nodesInfoResponse.getNodes()[0].getPlugins().getInfos().size(), equalTo(2));
+        } finally {
+            System.setProperties(props);
+        }
+    }
+
+    @Test
+    public void testIsolatedPluginProperties() throws Exception {
+        try {
+            cluster().client();
+            Properties p = System.getProperties();
+            assertThat(p.getProperty("es.test.isolated.plugin.count"), equalTo("2"));
+            String prop = p.getProperty("es.test.isolated.plugin.instantiated.hashes");
+            String[] hashes = Strings.delimitedListToStringArray(prop, " ");
+            // 2 plugins plus trailing space
+            assertThat(hashes.length, equalTo(3));
+            assertThat(p.getProperty("es.test.isolated.plugin.instantiated"), equalTo(hashes[1]));
+        } finally {
+            System.setProperties(props);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/plugins/PluginClassLoaderTest.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginClassLoaderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugins;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.*;
+
+
+public class PluginClassLoaderTest {
+
+    private static final String NAME = "es.test.isolated.plugin.name";
+    private static final String INSTANCE = "es.test.isolated.plugin.instantiated";
+    private static final String READ = "es.test.isolated.plugin.read.name";
+
+    private URL root;
+    private String clazz = getClass().getName().replace('.', '/').concat(".class");
+    private ClassLoader parent;
+
+    @Before
+    public void before() throws Exception {
+        System.getProperties().setProperty(READ, "");
+        System.getProperties().setProperty(NAME, "");
+        System.getProperties().setProperty(INSTANCE, "");
+
+        parent = getClass().getClassLoader();
+        URL url = parent.getResource(clazz);
+        root = new URL(url.toString().substring(0, url.toString().indexOf(clazz)));
+    }
+
+    @Test
+    public void testClassSpaceIsolationEvenWhenPointingToSameClass() throws Exception {
+
+        PluginClassLoader space1 = new PluginClassLoader(new URL[] { root }, null);
+        Properties props = System.getProperties();
+        assertThat(props.getProperty(READ), is(""));
+        props.setProperty(NAME, "one");
+        Class<?> class1 = Class.forName("org.elasticsearch.plugins.isolation.DummyClass", true, space1);
+        assertThat(props.getProperty(READ), is("one"));
+
+        String instance1 = props.getProperty(INSTANCE);
+
+        PluginClassLoader space2 = new PluginClassLoader(new URL[] { root }, null);
+        props.setProperty(NAME, "two");
+        Class<?> class2 = Class.forName("org.elasticsearch.plugins.isolation.DummyClass", true, space2);
+        assertThat(props.getProperty(READ), is("two"));
+
+        String instance2 = props.getProperty(INSTANCE);
+        assertThat(instance1, not(instance2));
+        assertNotSame(class1, class2);
+    }
+
+    @Test
+    public void testDelegateToParentIfResourcesNotFoundLocally() throws Exception {
+
+        PluginClassLoader space1 = new PluginClassLoader(new URL[] {}, null);
+        assertNull(space1.getResource(clazz));
+
+        PluginClassLoader space2 = new PluginClassLoader(new URL[] {}, parent);
+        assertNotNull(parent.getResource(clazz));
+        assertNotNull(space2.getResource(clazz));
+    }
+
+    @Test
+    public void testIgnoreClassesInParentIfFoundLocally() throws Exception {
+        ClassLoader parent = getClass().getClassLoader();
+
+        PluginClassLoader space1 = new PluginClassLoader(new URL[] { root }, parent);
+
+        Properties props = System.getProperties();
+        assertThat(props.getProperty(READ), is(""));
+        props.setProperty(NAME, "one");
+
+        String before = props.getProperty(NAME);
+        Class parentClass = Class.forName("org.elasticsearch.plugins.isolation.DummyClass", true, parent);
+        props.setProperty(NAME, "one");
+        Class class1 = Class.forName("org.elasticsearch.plugins.isolation.DummyClass", true, space1);
+        assertThat(props.getProperty(READ), is(before));
+        assertThat(class1, is(not(parentClass)));
+    }
+}

--- a/src/test/java/org/elasticsearch/plugins/isolation/DummyClass.java
+++ b/src/test/java/org/elasticsearch/plugins/isolation/DummyClass.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugins.isolation;
+
+import java.util.Properties;
+
+public class DummyClass {
+
+    static final String name;
+
+    static {
+        Properties sysProps = System.getProperties();
+        // make sure to get a string even when dealing with null
+        name = "" + sysProps.getProperty("es.test.isolated.plugin.name");
+        sysProps.setProperty("es.test.isolated.plugin.instantiated", "" + DummyClass.class.hashCode());
+        Integer count = Integer.getInteger("es.test.isolated.plugin.count");
+        if (count == null) {
+            count = Integer.valueOf(0);
+        }
+
+        count = count + 1;
+
+        sysProps.setProperty("es.test.isolated.plugin.count", count.toString());
+
+        String prop = sysProps.getProperty("es.test.isolated.plugin.instantiated.hashes");
+        if (prop == null) {
+            prop = "";
+        }
+
+        prop = prop + DummyClass.class.hashCode() + " ";
+        sysProps.setProperty("es.test.isolated.plugin.instantiated.hashes", prop);
+        sysProps.setProperty("es.test.isolated.plugin.read.name",  name);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/plugins/isolation/IsolatedPlugin.java
+++ b/src/test/java/org/elasticsearch/plugins/isolation/IsolatedPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugins.isolation;
+
+import org.elasticsearch.plugins.AbstractPlugin;
+
+public class IsolatedPlugin extends AbstractPlugin {
+
+    private final DummyClass dummy;
+
+    public IsolatedPlugin() {
+        dummy = new DummyClass();
+    }
+
+    @Override
+    public String name() {
+        return dummy.name;
+    }
+
+    @Override
+    public String description() {
+        return "IsolatedPlugin "  + hashCode();
+    }
+}

--- a/src/test/resources/org/elasticsearch/plugins/isolation/es-plugin.properties
+++ b/src/test/resources/org/elasticsearch/plugins/isolation/es-plugin.properties
@@ -1,0 +1,1 @@
+plugin=org.elasticsearch.plugins.isolation.IsolatedPlugin


### PR DESCRIPTION
first draft of plugin isolation

the classpath semantics (for finding es-plugin.properties) are respected without going through the CL (can have side-effects)
CL unit tests
Plugin integration tests
class loader isolation sanity checks
