### PR TITLE
Add tracking of allocated arrays.

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryParsingException;
@@ -69,13 +70,16 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
 
     private final PageCacheRecycler pageCacheRecycler;
 
+    private final BigArrays bigArrays;
+
     @Inject
-    public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler) {
+    public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
         super(settings, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
     }
 
     @Override
@@ -184,7 +188,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
             SearchContext.setCurrent(new DefaultSearchContext(0,
                     new ShardSearchRequest().types(request.types()).nowInMillis(request.nowInMillis()),
                     null, indexShard.acquireSearcher("validate_query"), indexService, indexShard,
-                    scriptService, cacheRecycler, pageCacheRecycler));
+                    scriptService, cacheRecycler, pageCacheRecycler, bigArrays));
             try {
                 ParsedQuery parsedQuery = queryParserService.parseQuery(request.source());
                 valid = true;

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
@@ -70,14 +71,18 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
 
     private final PageCacheRecycler pageCacheRecycler;
 
+    private final BigArrays bigArrays;
+
     @Inject
     public TransportCountAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler) {
+                                IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler,
+                                PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
         super(settings, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
     }
 
     @Override
@@ -168,7 +173,7 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
                         .filteringAliases(request.filteringAliases())
                         .nowInMillis(request.nowInMillis()),
                 shardTarget, indexShard.acquireSearcher("count"), indexService, indexShard,
-                scriptService, cacheRecycler, pageCacheRecycler);
+                scriptService, cacheRecycler, pageCacheRecycler, bigArrays);
         SearchContext.setCurrent(context);
 
         try {

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.Uid;
@@ -66,15 +67,19 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
 
     private final PageCacheRecycler pageCacheRecycler;
 
+    private final BigArrays bigArrays;
+
     @Inject
     public TransportExplainAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                   TransportService transportService, IndicesService indicesService,
-                                  ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler) {
+                                  ScriptService scriptService, CacheRecycler cacheRecycler,
+                                  PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
         super(settings, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
     }
 
     @Override
@@ -118,7 +123,8 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
                         .filteringAliases(request.filteringAlias())
                         .nowInMillis(request.nowInMillis),
                 null, result.searcher(), indexService, indexShard,
-                scriptService, cacheRecycler, pageCacheRecycler
+                scriptService, cacheRecycler, pageCacheRecycler,
+                bigArrays
         );
         SearchContext.setCurrent(context);
 

--- a/src/main/java/org/elasticsearch/common/compress/CompressedIndexInput.java
+++ b/src/main/java/org/elasticsearch/common/compress/CompressedIndexInput.java
@@ -59,7 +59,7 @@ public abstract class CompressedIndexInput<T extends CompressorContext> extends 
         in.seek(metaDataPosition);
         this.totalUncompressedLength = in.readVLong();
         int size = in.readVInt();
-        offsets = BigArrays.newLongArray(size);
+        offsets = BigArrays.NON_RECYCLING_INSTANCE.newLongArray(size);
         for (int i = 0; i < size; i++) {
             offsets.set(i, in.readVLong());
         }

--- a/src/main/java/org/elasticsearch/common/lease/Releasables.java
+++ b/src/main/java/org/elasticsearch/common/lease/Releasables.java
@@ -35,7 +35,7 @@ public enum Releasables {
         throw new RuntimeException(t);
     }
 
-    private static void release(Iterable<Releasable> releasables, boolean ignoreException) {
+    private static void release(Iterable<? extends Releasable> releasables, boolean ignoreException) {
         Throwable th = null;
         for (Releasable releasable : releasables) {
             if (releasable != null) {
@@ -54,7 +54,7 @@ public enum Releasables {
     }
 
     /** Release the provided {@link Releasable}s. */
-    public static void release(Iterable<Releasable> releasables) {
+    public static void release(Iterable<? extends Releasable> releasables) {
         release(releasables, false);
     }
 

--- a/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 /** Common implementation for array lists that slice data into fixed-size blocks. */
 abstract class AbstractBigArray extends AbstractArray {
 
+    private final PageCacheRecycler recycler;
     private Recycler.V<?>[] cache;
 
     private final int pageShift;
@@ -39,7 +40,8 @@ abstract class AbstractBigArray extends AbstractArray {
     protected long size;
 
     protected AbstractBigArray(int pageSize, PageCacheRecycler recycler, boolean clearOnResize) {
-        super(recycler, clearOnResize);
+        super(clearOnResize);
+        this.recycler = recycler;
         Preconditions.checkArgument(pageSize >= 128, "pageSize must be >= 128");
         Preconditions.checkArgument((pageSize & (pageSize - 1)) == 0, "pageSize must be a power of two");
         this.pageShift = Integer.numberOfTrailingZeros(pageSize);

--- a/src/main/java/org/elasticsearch/common/util/BigArray.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArray.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.util;
 import org.elasticsearch.common.lease.Releasable;
 
 /** Base abstraction of an array. */
-interface BigArray extends Releasable {
+public interface BigArray extends Releasable {
 
     /** Return the length of this array. */
     public long size();

--- a/src/main/java/org/elasticsearch/common/util/BigArraysModule.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArraysModule.java
@@ -19,22 +19,32 @@
 
 package org.elasticsearch.common.util;
 
-import org.elasticsearch.common.lease.Releasable;
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.inject.SpawnModules;
+import org.elasticsearch.common.settings.Settings;
 
-abstract class AbstractArray implements Releasable {
+import static org.elasticsearch.common.inject.Modules.createModule;
 
-    public final boolean clearOnResize;
-    private boolean released = false;
+/**
+ */
+public class BigArraysModule extends AbstractModule implements SpawnModules {
 
-    AbstractArray(boolean clearOnResize) {
-        this.clearOnResize = clearOnResize;
+    public static final String IMPL = "common.util.big_arrays_impl";
+
+    private final Settings settings;
+
+    public BigArraysModule(Settings settings) {
+        this.settings = settings;
     }
 
     @Override
-    public boolean release() {
-        assert !released : "double release";
-        released = true;
-        return true; // nothing to release by default
+    protected void configure() {
     }
 
+    @Override
+    public Iterable<? extends Module> spawnModules() {
+        return ImmutableList.of(createModule(settings.getAsClass(IMPL, DefaultBigArraysModule.class), settings));
+    }
 }

--- a/src/main/java/org/elasticsearch/common/util/DefaultBigArraysModule.java
+++ b/src/main/java/org/elasticsearch/common/util/DefaultBigArraysModule.java
@@ -19,22 +19,21 @@
 
 package org.elasticsearch.common.util;
 
-import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.settings.Settings;
 
-abstract class AbstractArray implements Releasable {
+/**
+ */
+public class DefaultBigArraysModule extends AbstractModule {
 
-    public final boolean clearOnResize;
-    private boolean released = false;
+    private final Settings settings;
 
-    AbstractArray(boolean clearOnResize) {
-        this.clearOnResize = clearOnResize;
+    public DefaultBigArraysModule(Settings settings) {
+        this.settings = settings;
     }
 
     @Override
-    public boolean release() {
-        assert !released : "double release";
-        released = true;
-        return true; // nothing to release by default
+    protected void configure() {
+        bind(BigArrays.class).asEagerSingleton();
     }
-
 }

--- a/src/main/java/org/elasticsearch/common/util/LongHash.java
+++ b/src/main/java/org/elasticsearch/common/util/LongHash.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.util;
 
 import com.carrotsearch.hppc.hash.MurmurHash3;
-import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.lease.Releasables;
 
 /**
@@ -35,14 +34,14 @@ public final class LongHash extends AbstractHash {
     private LongArray keys;
 
     // Constructor with configurable capacity and default maximum load factor.
-    public LongHash(long capacity, PageCacheRecycler recycler) {
-        this(capacity, DEFAULT_MAX_LOAD_FACTOR, recycler);
+    public LongHash(long capacity, BigArrays bigArrays) {
+        this(capacity, DEFAULT_MAX_LOAD_FACTOR, bigArrays);
     }
 
     //Constructor with configurable capacity and load factor.
-    public LongHash(long capacity, float maxLoadFactor, PageCacheRecycler recycler) {
-        super(capacity, maxLoadFactor, recycler);
-        keys = BigArrays.newLongArray(capacity(), recycler, false);
+    public LongHash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
+        super(capacity, maxLoadFactor, bigArrays);
+        keys = bigArrays.newLongArray(capacity(), false);
     }
 
     private static long hash(long value) {
@@ -116,7 +115,7 @@ public final class LongHash extends AbstractHash {
 
     @Override
     protected void resizeKeys(long capacity) {
-        keys = BigArrays.resize(keys, capacity);
+        keys = bigArrays.resize(keys, capacity);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
@@ -95,7 +95,7 @@ public class FSTBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<Scr
         if (needsHashes) {
             if (hashes == null) {
                 BytesRefFSTEnum<Long> fstEnum = new BytesRefFSTEnum<Long>(fst);
-                IntArray hashes = BigArrays.newIntArray(ordinals.getMaxOrd());
+                IntArray hashes = BigArrays.NON_RECYCLING_INSTANCE.newIntArray(ordinals.getMaxOrd());
                 // we don't store an ord 0 in the FST since we could have an empty string in there and FST don't support
                 // empty strings twice. ie. them merge fails for long output.
                 hashes.set(0, new BytesRef().hashCode());

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -94,7 +94,7 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
     private final IntArray getHashes() {
         if (hashes == null) {
             long numberOfValues = termOrdToBytesOffset.size();
-            IntArray hashes = BigArrays.newIntArray(numberOfValues);
+            IntArray hashes = BigArrays.NON_RECYCLING_INSTANCE.newIntArray(numberOfValues);
             BytesRef scratch = new BytesRef();
             for (long i = 0; i < numberOfValues; i++) {
                 bytes.fill(scratch, termOrdToBytesOffset.get(i));

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVAtomicFieldData.java
@@ -85,7 +85,7 @@ abstract class SortedSetDVAtomicFieldData {
             synchronized (this) {
                 if (hashes == null) {
                     final long valueCount = values.getValueCount();
-                    final IntArray hashes = BigArrays.newIntArray(1L + valueCount);
+                    final IntArray hashes = BigArrays.NON_RECYCLING_INSTANCE.newIntArray(1L + valueCount);
                     BytesRef scratch = new BytesRef(16);
                     hashes.set(0, scratch.hashCode());
                     for (long i = 0; i < valueCount; ++i) {

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -51,6 +51,7 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.util.BigArraysModule;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.DiscoveryService;
@@ -151,6 +152,7 @@ public final class InternalNode implements Node {
         modules.add(new Version.Module(version));
         modules.add(new CacheRecyclerModule(settings));
         modules.add(new PageCacheRecyclerModule(settings));
+        modules.add(new BigArraysModule(settings));
         modules.add(new PluginsModule(settings, pluginsService));
         modules.add(new SettingsModule(settings));
         modules.add(new NodeModule(this));

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.HashedBytesRef;
 import org.elasticsearch.common.text.StringText;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
@@ -93,6 +94,7 @@ public class PercolateContext extends SearchContext {
     private final IndexShard indexShard;
     private final CacheRecycler cacheRecycler;
     private final PageCacheRecycler pageCacheRecycler;
+    private final BigArrays bigArrays;
     private final ScriptService scriptService;
     private final ConcurrentMap<HashedBytesRef, Query> percolateQueries;
     private String[] types;
@@ -115,7 +117,7 @@ public class PercolateContext extends SearchContext {
 
     public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
                             IndexService indexService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
-                            ScriptService scriptService) {
+                            BigArrays bigArrays, ScriptService scriptService) {
         this.request = request;
         this.indexShard = indexShard;
         this.indexService = indexService;
@@ -125,6 +127,7 @@ public class PercolateContext extends SearchContext {
         this.types = new String[]{request.documentType()};
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
         this.querySearchResult = new QuerySearchResult(0, searchShardTarget);
         this.engineSearcher = indexShard.acquireSearcher("percolate");
         this.searcher = new ContextIndexSearcher(this, engineSearcher);
@@ -475,6 +478,11 @@ public class PercolateContext extends SearchContext {
     @Override
     public PageCacheRecycler pageCacheRecycler() {
         return pageCacheRecycler;
+    }
+
+    @Override
+    public BigArrays bigArrays() {
+        return bigArrays;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -108,6 +109,8 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
 
     private final PageCacheRecycler pageCacheRecycler;
 
+    private final BigArrays bigArrays;
+
     private final DfsPhase dfsPhase;
 
     private final QueryPhase queryPhase;
@@ -126,7 +129,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
 
     @Inject
     public SearchService(Settings settings, ClusterService clusterService, IndicesService indicesService, IndicesLifecycle indicesLifecycle, IndicesWarmer indicesWarmer, ThreadPool threadPool,
-                         ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, DfsPhase dfsPhase, QueryPhase queryPhase, FetchPhase fetchPhase) {
+                         ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, DfsPhase dfsPhase, QueryPhase queryPhase, FetchPhase fetchPhase) {
         super(settings);
         this.threadPool = threadPool;
         this.clusterService = clusterService;
@@ -135,6 +138,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
         this.dfsPhase = dfsPhase;
         this.queryPhase = queryPhase;
         this.fetchPhase = fetchPhase;
@@ -490,7 +494,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
 
         Engine.Searcher engineSearcher = searcher == null ? indexShard.acquireSearcher("search") : searcher;
-        SearchContext context = new DefaultSearchContext(idGenerator.incrementAndGet(), request, shardTarget, engineSearcher, indexService, indexShard, scriptService, cacheRecycler, pageCacheRecycler);
+        SearchContext context = new DefaultSearchContext(idGenerator.incrementAndGet(), request, shardTarget, engineSearcher, indexService, indexShard, scriptService, cacheRecycler, pageCacheRecycler, bigArrays);
         SearchContext.setCurrent(context);
         try {
             context.scroll(request.scroll());

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.ReaderContextAware;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
@@ -50,6 +51,7 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
     protected final String name;
     protected final Aggregator parent;
     protected final AggregationContext context;
+    protected final BigArrays bigArrays;
     protected final int depth;
     protected final long estimatedBucketCount;
 
@@ -72,6 +74,7 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
         this.parent = parent;
         this.estimatedBucketCount = estimatedBucketsCount;
         this.context = context;
+        this.bigArrays = context.bigArrays();
         this.depth = parent == null ? 0 : 1 + parent.depth();
         this.bucketAggregationMode = bucketAggregationMode;
         assert factories != null : "sub-factories provided to BucketAggregator must not be null, use AggragatorFactories.EMPTY instead";

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -44,7 +43,7 @@ public abstract class BucketsAggregator extends Aggregator {
     public BucketsAggregator(String name, BucketAggregationMode bucketAggregationMode, AggregatorFactories factories,
                              long estimatedBucketsCount, AggregationContext context, Aggregator parent) {
         super(name, bucketAggregationMode, factories, estimatedBucketsCount, context, parent);
-        docCounts = BigArrays.newLongArray(estimatedBucketsCount, context.pageCacheRecycler(), true);
+        docCounts = bigArrays.newLongArray(estimatedBucketsCount, true);
         List<Aggregator> collectables = new ArrayList<Aggregator>(subAggregators.length);
         for (int i = 0; i < subAggregators.length; i++) {
             if (subAggregators[i].shouldCollect()) {
@@ -58,7 +57,7 @@ public abstract class BucketsAggregator extends Aggregator {
      * Utility method to collect the given doc in the given bucket (identified by the bucket ordinal)
      */
     protected final void collectBucket(int doc, long bucketOrd) throws IOException {
-        docCounts = BigArrays.grow(docCounts, bucketOrd + 1);
+        docCounts = bigArrays.grow(docCounts, bucketOrd + 1);
         docCounts.increment(bucketOrd, 1);
         for (int i = 0; i < collectableSugAggregators.length; i++) {
             collectableSugAggregators[i].collect(doc, bucketOrd);
@@ -78,7 +77,7 @@ public abstract class BucketsAggregator extends Aggregator {
      * Utility method to increment the doc counts of the given bucket (identified by the bucket ordinal)
      */
     protected final void incrementBucketDocCount(int inc, long bucketOrd) throws IOException {
-        docCounts = BigArrays.grow(docCounts, bucketOrd + 1);
+        docCounts = bigArrays.grow(docCounts, bucketOrd + 1);
         docCounts.increment(bucketOrd, inc);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -54,7 +54,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
         this.valuesSource = valuesSource;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
-        bucketOrds = new LongHash(INITIAL_CAPACITY,aggregationContext.pageCacheRecycler());
+        bucketOrds = new LongHash(INITIAL_CAPACITY, aggregationContext.bigArrays());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -72,7 +72,7 @@ public class HistogramAggregator extends BucketsAggregator {
         this.minDocCount = minDocCount;
         this.histogramFactory = histogramFactory;
 
-        bucketOrds = new LongHash(initialCapacity, aggregationContext.pageCacheRecycler());
+        bucketOrds = new LongHash(initialCapacity, aggregationContext.bigArrays());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -54,7 +54,7 @@ public class DoubleTermsAggregator extends BucketsAggregator {
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
         this.minDocCount = minDocCount;
-        bucketOrds = new LongHash(estimatedBucketCount, aggregationContext.pageCacheRecycler());
+        bucketOrds = new LongHash(estimatedBucketCount, aggregationContext.bigArrays());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -54,7 +54,7 @@ public class LongTermsAggregator extends BucketsAggregator {
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
         this.minDocCount = minDocCount;
-        bucketOrds = new LongHash(estimatedBucketCount, aggregationContext.pageCacheRecycler());
+        bucketOrds = new LongHash(estimatedBucketCount, aggregationContext.bigArrays());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -68,7 +68,7 @@ public class StringTermsAggregator extends BucketsAggregator {
         this.shardSize = shardSize;
         this.minDocCount = minDocCount;
         this.includeExclude = includeExclude;
-        bucketOrds = new BytesRefHash(estimatedBucketCount, aggregationContext.pageCacheRecycler());
+        bucketOrds = new BytesRefHash(estimatedBucketCount, aggregationContext.bigArrays());
     }
 
     @Override
@@ -278,7 +278,7 @@ public class StringTermsAggregator extends BucketsAggregator {
                 if (ordinalToBucket != null) {
                     ordinalToBucket.release();
                 }
-                ordinalToBucket = BigArrays.newLongArray(BigArrays.overSize(maxOrd), context().pageCacheRecycler(), false);
+                ordinalToBucket = context().bigArrays().newLongArray(BigArrays.overSize(maxOrd), false);
             }
             ordinalToBucket.fill(0, maxOrd, -1L);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.avg;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
@@ -50,8 +49,8 @@ public class AvgAggregator extends MetricsAggregator.SingleValue {
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
-            counts = BigArrays.newLongArray(initialSize, context.pageCacheRecycler(), true);
-            sums = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), true);
+            counts = bigArrays.newLongArray(initialSize, true);
+            sums = bigArrays.newDoubleArray(initialSize, true);
         }
     }
 
@@ -67,8 +66,8 @@ public class AvgAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        counts = BigArrays.grow(counts, owningBucketOrdinal + 1);
-        sums = BigArrays.grow(sums, owningBucketOrdinal + 1);
+        counts = bigArrays.grow(counts, owningBucketOrdinal + 1);
+        sums = bigArrays.grow(sums, owningBucketOrdinal + 1);
 
         final int valueCount = values.setDocument(doc);
         counts.increment(owningBucketOrdinal, valueCount);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.max;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -48,7 +47,7 @@ public class MaxAggregator extends MetricsAggregator.SingleValue {
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
-            maxes = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), false);
+            maxes = bigArrays.newDoubleArray(initialSize, false);
             maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         }
     }
@@ -67,7 +66,7 @@ public class MaxAggregator extends MetricsAggregator.SingleValue {
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
         if (owningBucketOrdinal >= maxes.size()) {
             long from = maxes.size();
-            maxes = BigArrays.grow(maxes, owningBucketOrdinal + 1);
+            maxes = bigArrays.grow(maxes, owningBucketOrdinal + 1);
             maxes.fill(from, maxes.size(), Double.NEGATIVE_INFINITY);
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.min;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -48,7 +47,7 @@ public class MinAggregator extends MetricsAggregator.SingleValue {
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
-            mins = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), false);
+            mins = bigArrays.newDoubleArray(initialSize, false);
             mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         }
     }
@@ -71,7 +70,7 @@ public class MinAggregator extends MetricsAggregator.SingleValue {
 
         if (owningBucketOrdinal >= mins.size()) {
             long from = mins.size();
-            mins = BigArrays.grow(mins, owningBucketOrdinal + 1);
+            mins = bigArrays.grow(mins, owningBucketOrdinal + 1);
             mins.fill(from, mins.size(), Double.POSITIVE_INFINITY);
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -53,11 +53,11 @@ public class StatsAggegator extends MetricsAggregator.MultiValue {
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
-            counts = BigArrays.newLongArray(initialSize, context.pageCacheRecycler(), true);
-            sums = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), true);
-            mins = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), false);
+            counts = bigArrays.newLongArray(initialSize, true);
+            sums = bigArrays.newDoubleArray(initialSize, true);
+            mins = bigArrays.newDoubleArray(initialSize, false);
             mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-            maxes = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), false);
+            maxes = bigArrays.newDoubleArray(initialSize, false);
             maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         }
     }
@@ -77,10 +77,10 @@ public class StatsAggegator extends MetricsAggregator.MultiValue {
         if (owningBucketOrdinal >= counts.size()) {
             final long from = counts.size();
             final long overSize = BigArrays.overSize(owningBucketOrdinal + 1);
-            counts = BigArrays.resize(counts, overSize);
-            sums = BigArrays.resize(sums, overSize);
-            mins = BigArrays.resize(mins, overSize);
-            maxes = BigArrays.resize(maxes, overSize);
+            counts = bigArrays.resize(counts, overSize);
+            sums = bigArrays.resize(sums, overSize);
+            mins = bigArrays.resize(mins, overSize);
+            maxes = bigArrays.resize(maxes, overSize);
             mins.fill(from, overSize, Double.POSITIVE_INFINITY);
             maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -54,13 +54,13 @@ public class ExtendedStatsAggregator extends MetricsAggregator.MultiValue {
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
-            counts = BigArrays.newLongArray(initialSize, context.pageCacheRecycler(), true);
-            sums = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), true);
-            mins = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), false);
+            counts = bigArrays.newLongArray(initialSize, true);
+            sums = bigArrays.newDoubleArray(initialSize, true);
+            mins = bigArrays.newDoubleArray(initialSize, false);
             mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-            maxes = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), false);
+            maxes = bigArrays.newDoubleArray(initialSize, false);
             maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-            sumOfSqrs = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), true);
+            sumOfSqrs = bigArrays.newDoubleArray(initialSize, true);
         }
     }
 
@@ -79,11 +79,11 @@ public class ExtendedStatsAggregator extends MetricsAggregator.MultiValue {
         if (owningBucketOrdinal >= counts.size()) {
             final long from = counts.size();
             final long overSize = BigArrays.overSize(owningBucketOrdinal + 1);
-            counts = BigArrays.resize(counts, overSize);
-            sums = BigArrays.resize(sums, overSize);
-            mins = BigArrays.resize(mins, overSize);
-            maxes = BigArrays.resize(maxes, overSize);
-            sumOfSqrs = BigArrays.resize(sumOfSqrs, overSize);
+            counts = bigArrays.resize(counts, overSize);
+            sums = bigArrays.resize(sums, overSize);
+            mins = bigArrays.resize(mins, overSize);
+            maxes = bigArrays.resize(maxes, overSize);
+            sumOfSqrs = bigArrays.resize(sumOfSqrs, overSize);
             mins.fill(from, overSize, Double.POSITIVE_INFINITY);
             maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.sum;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -48,7 +47,7 @@ public class SumAggregator extends MetricsAggregator.SingleValue {
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
-            sums = BigArrays.newDoubleArray(initialSize, context.pageCacheRecycler(), true);
+            sums = bigArrays.newDoubleArray(initialSize, true);
         }
     }
 
@@ -64,7 +63,7 @@ public class SumAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        sums = BigArrays.grow(sums, owningBucketOrdinal + 1);
+        sums = bigArrays.grow(sums, owningBucketOrdinal + 1);
 
         final int valuesCount = values.setDocument(doc);
         double sum = 0;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.valuecount;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -53,7 +52,7 @@ public class ValueCountAggregator extends MetricsAggregator.SingleValue {
         if (valuesSource != null) {
             // expectedBucketsCount == 0 means it's a top level bucket
             final long initialSize = expectedBucketsCount < 2 ? 1 : expectedBucketsCount;
-            counts = BigArrays.newLongArray(initialSize, context.pageCacheRecycler(), true);
+            counts = bigArrays.newLongArray(initialSize, true);
         }
     }
 
@@ -69,7 +68,7 @@ public class ValueCountAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void collect(int doc, long owningBucketOrdinal) throws IOException {
-        counts = BigArrays.grow(counts, owningBucketOrdinal + 1);
+        counts = bigArrays.grow(counts, owningBucketOrdinal + 1);
         counts.increment(owningBucketOrdinal, values.setDocument(doc));
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.lucene.ReaderContextAware;
 import org.elasticsearch.common.lucene.ScorerAware;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -69,6 +70,10 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
 
     public PageCacheRecycler pageCacheRecycler() {
         return searchContext.pageCacheRecycler();
+    }
+
+    public BigArrays bigArrays() {
+        return searchContext.bigArrays();
     }
 
     public AtomicReaderContext currentReader() {

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
 import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.lucene.search.function.BoostScoreFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
@@ -92,6 +93,8 @@ public class DefaultSearchContext extends SearchContext {
     private final CacheRecycler cacheRecycler;
 
     private final PageCacheRecycler pageCacheRecycler;
+
+    private final BigArrays bigArrays;
 
     private final IndexShard indexShard;
 
@@ -175,7 +178,8 @@ public class DefaultSearchContext extends SearchContext {
 
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
                          Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard,
-                         ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler) {
+                         ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler,
+                         BigArrays bigArrays) {
         this.id = id;
         this.request = request;
         this.searchType = request.searchType();
@@ -184,6 +188,7 @@ public class DefaultSearchContext extends SearchContext {
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
         this.dfsResult = new DfsSearchResult(id, shardTarget);
         this.queryResult = new QuerySearchResult(id, shardTarget);
         this.fetchResult = new FetchSearchResult(id, shardTarget);
@@ -445,6 +450,10 @@ public class DefaultSearchContext extends SearchContext {
 
     public PageCacheRecycler pageCacheRecycler() {
         return pageCacheRecycler;
+    }
+
+    public BigArrays bigArrays() {
+        return bigArrays;
     }
 
     public FilterCache filterCache() {

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.search.AndFilter;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
@@ -674,19 +675,10 @@ public class DefaultSearchContext extends SearchContext {
     @Override
     public void clearReleasables() {
         if (clearables != null) {
-            Throwable th = null;
-            for (Releasable releasable : clearables) {
-                try {
-                    releasable.release();
-                } catch (Throwable t) {
-                    if (th == null) {
-                        th = t;
-                    }
-                }
-            }
-            clearables.clear();
-            if (th != null) {
-                throw new RuntimeException(th);
+            try {
+                Releasables.release(clearables);
+            } finally {
+                clearables.clear();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
@@ -181,6 +182,8 @@ public abstract class SearchContext implements Releasable {
     public abstract CacheRecycler cacheRecycler();
 
     public abstract PageCacheRecycler pageCacheRecycler();
+
+    public abstract BigArrays bigArrays();
 
     public abstract FilterCache filterCache();
 

--- a/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -92,6 +92,22 @@ public class BigArraysTests extends ElasticsearchTestCase {
         array.release();
     }
 
+    public void testFloatArrayGrowth() {
+        final int totalLen = randomIntBetween(1, 1000000);
+        final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
+        FloatArray array = bigArrays.newFloatArray(startLen, randomBoolean());
+        float[] ref = new float[totalLen];
+        for (int i = 0; i < totalLen; ++i) {
+            ref[i] = randomFloat();
+            array = bigArrays.grow(array, i + 1);
+            array.set(i, ref[i]);
+        }
+        for (int i = 0; i < totalLen; ++i) {
+            assertEquals(ref[i], array.get(i), 0.001d);
+        }
+        array.release();
+    }
+
     public void testDoubleArrayGrowth() {
         final int totalLen = randomIntBetween(1, 1000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
@@ -126,6 +142,27 @@ public class BigArraysTests extends ElasticsearchTestCase {
             assertSame(ref[i], array.get(i));
         }
         array.release();
+    }
+
+    public void testFloatArrayFill() {
+        final int len = randomIntBetween(1, 100000);
+        final int fromIndex = randomIntBetween(0, len - 1);
+        final int toIndex = randomBoolean()
+            ? Math.min(fromIndex + randomInt(100), len) // single page
+            : randomIntBetween(fromIndex, len); // likely multiple pages
+        final FloatArray array2 = bigArrays.newFloatArray(len, randomBoolean());
+        final float[] array1 = new float[len];
+        for (int i = 0; i < len; ++i) {
+            array1[i] = randomFloat();
+            array2.set(i, array1[i]);
+        }
+        final float rand = randomFloat();
+        Arrays.fill(array1, fromIndex, toIndex, rand);
+        array2.fill(fromIndex, toIndex, rand);
+        for (int i = 0; i < len; ++i) {
+            assertEquals(array1[i], array2.get(i), 0.001d);
+        }
+        array2.release();
     }
 
     public void testDoubleArrayFill() {

--- a/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -24,24 +24,34 @@ import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
 
 import java.util.Arrays;
 
 public class BigArraysTests extends ElasticsearchTestCase {
 
-    public static PageCacheRecycler randomCacheRecycler() {
-        return randomBoolean() ? null : new MockPageCacheRecycler(ImmutableSettings.EMPTY, new ThreadPool());
+    public static BigArrays randombigArrays() {
+        final PageCacheRecycler recycler = randomBoolean() ? null : new MockPageCacheRecycler(ImmutableSettings.EMPTY, new ThreadPool());
+        return new MockBigArrays(ImmutableSettings.EMPTY, recycler);
+    }
+
+    private BigArrays bigArrays;
+
+    @Before
+    public void init() {
+        bigArrays = randombigArrays();
     }
 
     public void testByteArrayGrowth() {
         final int totalLen = randomIntBetween(1, 4000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
-        ByteArray array = BigArrays.newByteArray(startLen, randomCacheRecycler(), randomBoolean());
+        ByteArray array = bigArrays.newByteArray(startLen, randomBoolean());
         byte[] ref = new byte[totalLen];
         for (int i = 0; i < totalLen; ++i) {
             ref[i] = randomByte();
-            array = BigArrays.grow(array, i + 1);
+            array = bigArrays.grow(array, i + 1);
             array.set(i, ref[i]);
         }
         for (int i = 0; i < totalLen; ++i) {
@@ -53,11 +63,11 @@ public class BigArraysTests extends ElasticsearchTestCase {
     public void testIntArrayGrowth() {
         final int totalLen = randomIntBetween(1, 1000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
-        IntArray array = BigArrays.newIntArray(startLen, randomCacheRecycler(), randomBoolean());
+        IntArray array = bigArrays.newIntArray(startLen, randomBoolean());
         int[] ref = new int[totalLen];
         for (int i = 0; i < totalLen; ++i) {
             ref[i] = randomInt();
-            array = BigArrays.grow(array, i + 1);
+            array = bigArrays.grow(array, i + 1);
             array.set(i, ref[i]);
         }
         for (int i = 0; i < totalLen; ++i) {
@@ -69,11 +79,11 @@ public class BigArraysTests extends ElasticsearchTestCase {
     public void testLongArrayGrowth() {
         final int totalLen = randomIntBetween(1, 1000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
-        LongArray array = BigArrays.newLongArray(startLen, randomCacheRecycler(), randomBoolean());
+        LongArray array = bigArrays.newLongArray(startLen, randomBoolean());
         long[] ref = new long[totalLen];
         for (int i = 0; i < totalLen; ++i) {
             ref[i] = randomLong();
-            array = BigArrays.grow(array, i + 1);
+            array = bigArrays.grow(array, i + 1);
             array.set(i, ref[i]);
         }
         for (int i = 0; i < totalLen; ++i) {
@@ -85,11 +95,11 @@ public class BigArraysTests extends ElasticsearchTestCase {
     public void testDoubleArrayGrowth() {
         final int totalLen = randomIntBetween(1, 1000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
-        DoubleArray array = BigArrays.newDoubleArray(startLen, randomCacheRecycler(), randomBoolean());
+        DoubleArray array = bigArrays.newDoubleArray(startLen, randomBoolean());
         double[] ref = new double[totalLen];
         for (int i = 0; i < totalLen; ++i) {
             ref[i] = randomDouble();
-            array = BigArrays.grow(array, i + 1);
+            array = bigArrays.grow(array, i + 1);
             array.set(i, ref[i]);
         }
         for (int i = 0; i < totalLen; ++i) {
@@ -101,7 +111,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
     public void testObjectArrayGrowth() {
         final int totalLen = randomIntBetween(1, 1000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);
-        ObjectArray<Object> array = BigArrays.newObjectArray(startLen, randomCacheRecycler());
+        ObjectArray<Object> array = bigArrays.newObjectArray(startLen);
         final Object[] pool = new Object[100];
         for (int i = 0; i < pool.length; ++i) {
             pool[i] = new Object();
@@ -109,7 +119,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         Object[] ref = new Object[totalLen];
         for (int i = 0; i < totalLen; ++i) {
             ref[i] = randomFrom(pool);
-            array = BigArrays.grow(array, i + 1);
+            array = bigArrays.grow(array, i + 1);
             array.set(i, ref[i]);
         }
         for (int i = 0; i < totalLen; ++i) {
@@ -124,7 +134,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         final int toIndex = randomBoolean()
             ? Math.min(fromIndex + randomInt(100), len) // single page
             : randomIntBetween(fromIndex, len); // likely multiple pages
-        final DoubleArray array2 = BigArrays.newDoubleArray(len, randomCacheRecycler(), randomBoolean());
+        final DoubleArray array2 = bigArrays.newDoubleArray(len, randomBoolean());
         final double[] array1 = new double[len];
         for (int i = 0; i < len; ++i) {
             array1[i] = randomDouble();
@@ -145,7 +155,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         final int toIndex = randomBoolean()
             ? Math.min(fromIndex + randomInt(100), len) // single page
             : randomIntBetween(fromIndex, len); // likely multiple pages
-        final LongArray array2 = BigArrays.newLongArray(len, randomCacheRecycler(), randomBoolean());
+        final LongArray array2 = bigArrays.newLongArray(len, randomBoolean());
         final long[] array1 = new long[len];
         for (int i = 0; i < len; ++i) {
             array1[i] = randomLong();
@@ -163,7 +173,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
     public void testByteArrayBulkGet() {
         final byte[] array1 = new byte[randomIntBetween(1, 4000000)];
         getRandom().nextBytes(array1);
-        final ByteArray array2 = BigArrays.newByteArray(array1.length, randomCacheRecycler(), randomBoolean());
+        final ByteArray array2 = bigArrays.newByteArray(array1.length, randomBoolean());
         for (int i = 0; i < array1.length; ++i) {
             array2.set(i, array1[i]);
         }
@@ -180,7 +190,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
     public void testByteArrayBulkSet() {
         final byte[] array1 = new byte[randomIntBetween(1, 4000000)];
         getRandom().nextBytes(array1);
-        final ByteArray array2 = BigArrays.newByteArray(array1.length, randomCacheRecycler(), randomBoolean());
+        final ByteArray array2 = bigArrays.newByteArray(array1.length, randomBoolean());
         for (int i = 0; i < array1.length; ) {
             final int len = Math.min(array1.length - i, randomBoolean() ? randomInt(10) : randomInt(3 * BigArrays.BYTE_PAGE_SIZE));
             array2.set(i, array1, i, len);

--- a/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -40,7 +40,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
         }
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
-        hash = new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randomCacheRecycler());
+        hash = new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randombigArrays());
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/common/util/LongHashTests.java
+++ b/src/test/java/org/elasticsearch/common/util/LongHashTests.java
@@ -39,7 +39,7 @@ public class LongHashTests extends ElasticsearchTestCase {
         final long[] idToValue = new long[values.length];
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
-        final LongHash longHash = new LongHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randomCacheRecycler());
+        final LongHash longHash = new LongHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randombigArrays());
         final int iters = randomInt(1000000);
         for (int i = 0; i < iters; ++i) {
             final Long value = randomFrom(values);

--- a/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
@@ -57,6 +57,7 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ElasticsearchLuceneTestCase;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.elasticsearch.test.index.service.StubIndexService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Description;
@@ -333,7 +334,7 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
         final Index index = new Index(indexName);
         final CacheRecycler cacheRecycler = new CacheRecycler(ImmutableSettings.EMPTY);
         final PageCacheRecycler pageCacheRecycler = new PageCacheRecycler(ImmutableSettings.EMPTY, new ThreadPool());
-        final BigArrays bigArrays = new BigArrays(ImmutableSettings.EMPTY, pageCacheRecycler);
+        final BigArrays bigArrays = new MockBigArrays(ImmutableSettings.EMPTY, pageCacheRecycler);
         Settings settings = ImmutableSettings.EMPTY;
         MapperService mapperService = MapperTestUtils.newMapperService(index, settings);
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(index, new DummyCircuitBreakerService());

--- a/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
 import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.cache.filter.weighted.WeightedFilterCache;
 import org.elasticsearch.index.engine.Engine;
@@ -332,6 +333,7 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
         final Index index = new Index(indexName);
         final CacheRecycler cacheRecycler = new CacheRecycler(ImmutableSettings.EMPTY);
         final PageCacheRecycler pageCacheRecycler = new PageCacheRecycler(ImmutableSettings.EMPTY, new ThreadPool());
+        final BigArrays bigArrays = new BigArrays(ImmutableSettings.EMPTY, pageCacheRecycler);
         Settings settings = ImmutableSettings.EMPTY;
         MapperService mapperService = MapperTestUtils.newMapperService(index, settings);
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(index, new DummyCircuitBreakerService());
@@ -346,7 +348,7 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
         NodeSettingsService nodeSettingsService = new NodeSettingsService(settings);
         IndicesFilterCache indicesFilterCache = new IndicesFilterCache(settings, threadPool, cacheRecycler, nodeSettingsService);
         WeightedFilterCache filterCache = new WeightedFilterCache(index, settings, indicesFilterCache);
-        return new TestSearchContext(cacheRecycler, pageCacheRecycler, indexService, filterCache, indexFieldDataService);
+        return new TestSearchContext(cacheRecycler, pageCacheRecycler, bigArrays, indexService, filterCache, indexFieldDataService);
     }
 
 }

--- a/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
 import org.elasticsearch.index.cache.filter.FilterCache;
@@ -66,6 +67,7 @@ public class TestSearchContext extends SearchContext {
 
     final CacheRecycler cacheRecycler;
     final PageCacheRecycler pageCacheRecycler;
+    final BigArrays bigArrays;
     final IndexService indexService;
     final FilterCache filterCache;
     final IndexFieldDataService indexFieldDataService;
@@ -73,9 +75,10 @@ public class TestSearchContext extends SearchContext {
     ContextIndexSearcher searcher;
     int size;
 
-    public TestSearchContext(CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, IndexService indexService, FilterCache filterCache, IndexFieldDataService indexFieldDataService) {
+    public TestSearchContext(CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService, FilterCache filterCache, IndexFieldDataService indexFieldDataService) {
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
+        this.bigArrays = bigArrays;
         this.indexService = indexService;
         this.filterCache = filterCache;
         this.indexFieldDataService = indexFieldDataService;
@@ -84,6 +87,7 @@ public class TestSearchContext extends SearchContext {
     public TestSearchContext() {
         this.cacheRecycler = null;
         this.pageCacheRecycler = null;
+        this.bigArrays = null;
         this.indexService = null;
         this.filterCache = null;
         this.indexFieldDataService = null;
@@ -317,6 +321,11 @@ public class TestSearchContext extends SearchContext {
     @Override
     public PageCacheRecycler pageCacheRecycler() {
         return pageCacheRecycler;
+    }
+
+    @Override
+    public BigArrays bigArrays() {
+        return bigArrays;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -675,6 +676,7 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMissingSubAggregation() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -693,6 +695,7 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByNonMetricsSubAggregation() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -712,6 +715,7 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithUknownMetric() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -732,6 +736,7 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithoutMetric() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -667,6 +668,7 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMissingSubAggregation() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -685,6 +687,7 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByNonMetricsSubAggregation() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -704,6 +707,7 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithUknownMetric() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -724,6 +728,7 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithoutMetric() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -141,6 +142,7 @@ public class NestedTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void onNonNestedField() throws Exception {
+        MockBigArrays.discardNextCheck();
         try {
             client().prepareSearch("idx")
                     .addAggregation(nested("nested").path("value")

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCount;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -835,6 +836,7 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMissingSubAggregation() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -854,6 +856,7 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByNonMetricsSubAggregation() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -874,6 +877,7 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithUknownMetric() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -895,6 +899,7 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithoutMetric() throws Exception {
 
+        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -39,6 +39,7 @@ import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.store.MockDirectoryHelper;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.Closeable;
@@ -124,6 +125,12 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     @After
     public void ensureAllPagesReleased() {
         MockPageCacheRecycler.ensureAllPagesAreReleased();
+    }
+
+    @Before
+    public void resetArrayTracking() {
+        // useful if there are tests that use MockBigArrays but don't inherit from ElasticsearchTestCase
+        MockBigArrays.reset();
     }
 
     @After

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.elasticsearch.test.engine.MockInternalEngine;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.store.MockDirectoryHelper;
@@ -123,6 +124,11 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     @After
     public void ensureAllPagesReleased() {
         MockPageCacheRecycler.ensureAllPagesAreReleased();
+    }
+
+    @After
+    public void ensureAllArraysReleased() {
+        MockBigArrays.ensureAllArraysAreReleased();
     }
 
     public static void ensureAllFilesClosed() throws IOException {

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -46,11 +46,13 @@ import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.BigArraysModule;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.engine.IndexEngineModule;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.search.SearchService;
+import org.elasticsearch.test.cache.recycler.MockBigArraysModule;
 import org.elasticsearch.test.cache.recycler.MockPageCacheRecyclerModule;
 import org.elasticsearch.test.engine.MockEngineModule;
 import org.elasticsearch.test.store.MockFSIndexStoreModule;
@@ -233,6 +235,7 @@ public final class TestCluster implements Iterable<Client> {
             builder.put("index.store.type", MockFSIndexStoreModule.class.getName()); // no RAM dir for now!
             builder.put(IndexEngineModule.EngineSettings.ENGINE_TYPE, MockEngineModule.class.getName());
             builder.put(PageCacheRecyclerModule.CACHE_IMPL, MockPageCacheRecyclerModule.class.getName());
+            builder.put(BigArraysModule.IMPL, MockBigArraysModule.class.getName());
         }
         if (isLocalTransportConfigured()) {
             builder.put(TransportModule.TRANSPORT_TYPE_KEY, AssertingLocalTransportModule.class.getName());

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -1,0 +1,419 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.cache.recycler;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.SeedUtils;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.*;
+
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class MockBigArrays extends BigArrays {
+
+    /**
+     * Tracking allocations is useful when debugging a leak but shouldn't be enabled by default as this would also be very costly
+     * since it creates a new Exception every time a new array is created.
+     */
+    private static final boolean TRACK_ALLOCATIONS = false;
+
+    private static boolean DISCARD = false;
+
+    private static ConcurrentMap<Object, Object> ACQUIRED_ARRAYS = new ConcurrentHashMap<Object, Object>();
+
+    /**
+     * Discard the next check that all arrays should be released. This can be useful if for a specific test, the cost to make
+     * sure the array is released is higher than the cost the user would experience if the array would not be released.
+     */
+    public static void discardNextCheck() {
+        DISCARD = true;
+    }
+
+    public static void ensureAllArraysAreReleased() {
+        try {
+            if (DISCARD) {
+                DISCARD = false;
+            } else if (ACQUIRED_ARRAYS.size() > 0) {
+                final Object cause = ACQUIRED_ARRAYS.entrySet().iterator().next().getValue();
+                throw new RuntimeException(ACQUIRED_ARRAYS.size() + " arrays have not been released", cause instanceof Throwable ? (Throwable) cause : null);
+            }
+        } finally {
+            ACQUIRED_ARRAYS.clear();
+        }
+    }
+
+    private final Random random;
+
+    @Inject
+    public MockBigArrays(Settings settings, PageCacheRecycler recycler) {
+        super(settings, recycler);
+        long seed;
+        try {
+            seed = SeedUtils.parseSeed(RandomizedContext.current().getRunnerSeedAsString());
+        } catch (IllegalStateException e) { // rest tests don't run randomized and have no context
+            seed = 0;
+        }
+        random = new Random(seed);
+    }
+
+    @Override
+    public ByteArray newByteArray(long size, boolean clearOnResize) {
+        final ByteArrayWrapper array = new ByteArrayWrapper(super.newByteArray(size, clearOnResize), clearOnResize);
+        if (!clearOnResize) {
+            array.randomizeContent(0, size);
+        }
+        return array;
+    }
+
+    @Override
+    public ByteArray resize(ByteArray array, long size) {
+        ByteArrayWrapper arr = (ByteArrayWrapper) array;
+        final long originalSize = arr.size();
+        arr.in = super.resize(arr.in, size);
+        if (arr.in instanceof ByteArrayWrapper) {
+            ACQUIRED_ARRAYS.remove(arr);
+            arr = (ByteArrayWrapper) arr.in;
+        }
+        if (!arr.clearOnResize) {
+            arr.randomizeContent(originalSize, size);
+        }
+        return arr;
+    }
+
+    @Override
+    public IntArray newIntArray(long size, boolean clearOnResize) {
+        final IntArrayWrapper array = new IntArrayWrapper(super.newIntArray(size, clearOnResize), clearOnResize);
+        if (!clearOnResize) {
+            array.randomizeContent(0, size);
+        }
+        return array;
+    }
+
+    @Override
+    public IntArray resize(IntArray array, long size) {
+        IntArrayWrapper arr = (IntArrayWrapper) array;
+        final long originalSize = arr.size();
+        arr.in = super.resize(arr.in, size);
+        if (arr.in instanceof IntArrayWrapper) {
+            ACQUIRED_ARRAYS.remove(arr);
+            arr = (IntArrayWrapper) arr.in;
+        }
+        if (!arr.clearOnResize) {
+            arr.randomizeContent(originalSize, size);
+        }
+        return arr;
+    }
+
+    @Override
+    public LongArray newLongArray(long size, boolean clearOnResize) {
+        final LongArrayWrapper array = new LongArrayWrapper(super.newLongArray(size, clearOnResize), clearOnResize);
+        if (!clearOnResize) {
+            array.randomizeContent(0, size);
+        }
+        return array;
+    }
+
+    @Override
+    public LongArray resize(LongArray array, long size) {
+        LongArrayWrapper arr = (LongArrayWrapper) array;
+        final long originalSize = arr.size();
+        arr.in = super.resize(arr.in, size);
+        if (arr.in instanceof LongArrayWrapper) {
+            ACQUIRED_ARRAYS.remove(arr);
+            arr = (LongArrayWrapper) arr.in;
+        }
+        if (!arr.clearOnResize) {
+            arr.randomizeContent(originalSize, size);
+        }
+        return arr;
+    }
+
+    @Override
+    public DoubleArray newDoubleArray(long size, boolean clearOnResize) {
+        final DoubleArrayWrapper array = new DoubleArrayWrapper(super.newDoubleArray(size, clearOnResize), clearOnResize);
+        if (!clearOnResize) {
+            array.randomizeContent(0, size);
+        }
+        return array;
+    }
+
+    @Override
+    public DoubleArray resize(DoubleArray array, long size) {
+        DoubleArrayWrapper arr = (DoubleArrayWrapper) array;
+        final long originalSize = arr.size();
+        arr.in = super.resize(arr.in, size);
+        if (arr.in instanceof DoubleArrayWrapper) {
+            ACQUIRED_ARRAYS.remove(arr);
+            arr = (DoubleArrayWrapper) arr.in;
+        }
+        if (!arr.clearOnResize) {
+            arr.randomizeContent(originalSize, size);
+        }
+        return arr;
+    }
+
+    @Override
+    public <T> ObjectArray<T> newObjectArray(long size) {
+        return new ObjectArrayWrapper<T>(super.<T>newObjectArray(size));
+    }
+
+    @Override
+    public <T> ObjectArray<T> resize(ObjectArray<T> array, long size) {
+        ObjectArrayWrapper<T> arr = (ObjectArrayWrapper<T>) array;
+        arr.in = super.resize(arr.in, size);
+        if (arr.in instanceof ObjectArrayWrapper) {
+            ACQUIRED_ARRAYS.remove(arr);
+            arr = (ObjectArrayWrapper<T>) arr.in;
+        }
+        return arr;
+    }
+
+    private static abstract class AbstractArrayWrapper {
+
+        boolean clearOnResize;
+        boolean released = false;
+
+        AbstractArrayWrapper(boolean clearOnResize) {
+            ACQUIRED_ARRAYS.put(this, TRACK_ALLOCATIONS ? new RuntimeException() : Boolean.TRUE);
+            this.clearOnResize = clearOnResize;
+        }
+
+        protected abstract BigArray getDelegate();
+
+        protected abstract void randomizeContent(long from, long to);
+
+        public long size() {
+            return getDelegate().size();
+        }
+
+        public boolean release() {
+            assert !released;
+            ACQUIRED_ARRAYS.remove(this);
+            randomizeContent(0, size());
+            released = true;
+            return getDelegate().release();
+        }
+
+    }
+
+    private class ByteArrayWrapper extends AbstractArrayWrapper implements ByteArray {
+
+        private ByteArray in;
+
+        ByteArrayWrapper(ByteArray in, boolean clearOnResize) {
+            super(clearOnResize);
+            this.in = in;
+        }
+
+        @Override
+        protected BigArray getDelegate() {
+            return in;
+        }
+
+        @Override
+        protected void randomizeContent(long from, long to) {
+            for (long i = from; i < to; ++i) {
+                set(i, (byte) random.nextInt(1 << 8));
+            }
+        }
+
+        @Override
+        public byte get(long index) {
+            return in.get(index);
+        }
+
+        @Override
+        public byte set(long index, byte value) {
+            return in.set(index, value);
+        }
+
+        @Override
+        public void get(long index, int len, BytesRef ref) {
+            in.get(index, len, ref);
+        }
+
+        @Override
+        public void set(long index, byte[] buf, int offset, int len) {
+            in.set(index, buf, offset, len);
+        }
+
+    }
+
+    private class IntArrayWrapper extends AbstractArrayWrapper implements IntArray {
+
+        private IntArray in;
+
+        IntArrayWrapper(IntArray in, boolean clearOnResize) {
+            super(clearOnResize);
+            this.in = in;
+        }
+
+        @Override
+        protected BigArray getDelegate() {
+            return in;
+        }
+
+        @Override
+        protected void randomizeContent(long from, long to) {
+            for (long i = from; i < to; ++i) {
+                set(i, random.nextInt());
+            }
+        }
+
+        @Override
+        public int get(long index) {
+            return in.get(index);
+        }
+
+        @Override
+        public int set(long index, int value) {
+            return in.set(index, value);
+        }
+
+        @Override
+        public int increment(long index, int inc) {
+            return in.increment(index, inc);
+        }
+
+    }
+
+    private class LongArrayWrapper extends AbstractArrayWrapper implements LongArray {
+
+        private LongArray in;
+
+        LongArrayWrapper(LongArray in, boolean clearOnResize) {
+            super(clearOnResize);
+            this.in = in;
+        }
+
+        @Override
+        protected BigArray getDelegate() {
+            return in;
+        }
+
+        @Override
+        protected void randomizeContent(long from, long to) {
+            for (long i = from; i < to; ++i) {
+                set(i, random.nextLong());
+            }
+        }
+
+        @Override
+        public long get(long index) {
+            return in.get(index);
+        }
+
+        @Override
+        public long set(long index, long value) {
+            return in.set(index, value);
+        }
+
+        @Override
+        public long increment(long index, long inc) {
+            return in.increment(index, inc);
+        }
+
+        @Override
+        public void fill(long fromIndex, long toIndex, long value) {
+            in.fill(fromIndex, toIndex, value);
+        }
+
+    }
+
+    private class DoubleArrayWrapper extends AbstractArrayWrapper implements DoubleArray {
+
+        private DoubleArray in;
+
+        DoubleArrayWrapper(DoubleArray in, boolean clearOnResize) {
+            super(clearOnResize);
+            this.in = in;
+        }
+
+        @Override
+        protected BigArray getDelegate() {
+            return in;
+        }
+
+        @Override
+        protected void randomizeContent(long from, long to) {
+            for (long i = from; i < to; ++i) {
+                set(i, (random.nextDouble() - 0.5) * 1000);
+            }
+        }
+
+        @Override
+        public double get(long index) {
+            return in.get(index);
+        }
+
+        @Override
+        public double set(long index, double value) {
+            return in.set(index, value);
+        }
+
+        @Override
+        public double increment(long index, double inc) {
+            return in.increment(index, inc);
+        }
+
+        @Override
+        public void fill(long fromIndex, long toIndex, double value) {
+            in.fill(fromIndex, toIndex, value);
+        }
+
+    }
+
+    private class ObjectArrayWrapper<T> extends AbstractArrayWrapper implements ObjectArray<T> {
+
+        private ObjectArray<T> in;
+
+        ObjectArrayWrapper(ObjectArray<T> in) {
+            super(false);
+            this.in = in;
+        }
+
+        @Override
+        protected BigArray getDelegate() {
+            return in;
+        }
+
+        @Override
+        public T get(long index) {
+            return in.get(index);
+        }
+
+        @Override
+        public T set(long index, T value) {
+            return in.set(index, value);
+        }
+
+        @Override
+        protected void randomizeContent(long from, long to) {
+            // will be cleared anyway
+        }
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArraysModule.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArraysModule.java
@@ -17,24 +17,16 @@
  * under the License.
  */
 
-package org.elasticsearch.common.util;
+package org.elasticsearch.test.cache.recycler;
 
-import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.util.BigArrays;
 
-abstract class AbstractArray implements Releasable {
-
-    public final boolean clearOnResize;
-    private boolean released = false;
-
-    AbstractArray(boolean clearOnResize) {
-        this.clearOnResize = clearOnResize;
-    }
+public class MockBigArraysModule extends AbstractModule {
 
     @Override
-    public boolean release() {
-        assert !released : "double release";
-        released = true;
-        return true; // nothing to release by default
+    protected void configure() {
+        bind(BigArrays.class).to(MockBigArrays.class).asEagerSingleton();
     }
 
 }


### PR DESCRIPTION
The BigArrays utility class is useful to generate arrays of various sizes: when
small, arrays will be allocated directly on the heap while larger arrays are
going to be paged and to recycle pages through PageCacheRecycler. We already
have tracking for pages but this is not triggered very often since it only
happens on large amounts of data while our tests work on small amounts of data
in order to be fast.

Tracking arrays directly helps make sure that we never forget to release them.

This pull request also improves testing by:
- putting random content in the arrays upon release: this makes sure that
  consumers don't use these arrays anymore when they are released as their
  content may be subject to use for another purpose since pages are recycled
- putting random content in the arrays upon creation and resize when
  `clearOnResize` is `false`.

The major difference with `master` is that the `BigArrays` class is now
instanciable, injected via Guice and usually available through the
`SearchContext`. This way, it can be mocked for tests.
