### PR TITLE
Upgrade to Spatial4j 0.4.1 and JTS 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,14 +146,14 @@
         <dependency>
             <groupId>com.spatial4j</groupId>
             <artifactId>spatial4j</artifactId>
-            <version>0.3</version>
+            <version>0.4.1</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
-            <version>1.12</version>
+            <version>1.13</version>
             <scope>compile</scope>
             <optional>true</optional>
             <exclusions>

--- a/src/main/java/org/elasticsearch/common/geo/builders/BaseLineStringBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BaseLineStringBuilder.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import com.spatial4j.core.shape.ShapeCollection;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -64,7 +64,7 @@ public abstract class BaseLineStringBuilder<E extends BaseLineStringBuilder<E>> 
         } else {
             geometry = FACTORY.createLineString(coordinates);
         }
-        return new JtsGeometry(geometry, SPATIAL_CONTEXT, !wrapdateline);
+        return jtsGeometry(geometry);
     }
 
     protected static ArrayList<LineString> decompose(GeometryFactory factory, Coordinate[] coordinates, ArrayList<LineString> strings) {

--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -149,8 +148,7 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
 
     @Override
     public Shape build() {
-        Geometry geometry = buildGeometry(FACTORY, wrapdateline);
-        return new JtsGeometry(geometry, SPATIAL_CONTEXT, !wrapdateline);
+        return jtsGeometry(buildGeometry(FACTORY, wrapdateline));
     }
 
     protected XContentBuilder coordinatesArray(XContentBuilder builder, Params params) throws IOException {

--- a/src/main/java/org/elasticsearch/common/geo/builders/MultiLineStringBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/MultiLineStringBuilder.java
@@ -97,7 +97,7 @@ public class MultiLineStringBuilder extends ShapeBuilder {
             }
             geometry = FACTORY.createMultiLineString(lineStrings);
         }
-        return new JtsGeometry(geometry, SPATIAL_CONTEXT, true);
+        return jtsGeometry(geometry);
     }
 
     public static class InternalLineStringBuilder extends BaseLineStringBuilder<InternalLineStringBuilder> {

--- a/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
@@ -19,13 +19,15 @@
 
 package org.elasticsearch.common.geo.builders;
 
+import com.spatial4j.core.shape.Point;
 import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.jts.JtsGeometry;
+import com.spatial4j.core.shape.ShapeCollection;
 import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.MultiPoint;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MultiPointBuilder extends PointCollection<MultiPointBuilder> {
 
@@ -43,8 +45,13 @@ public class MultiPointBuilder extends PointCollection<MultiPointBuilder> {
 
     @Override
     public Shape build() {
-        MultiPoint geometry = FACTORY.createMultiPoint(points.toArray(new Coordinate[points.size()]));
-        return new JtsGeometry(geometry, SPATIAL_CONTEXT, true);
+        //Could wrap JtsGeometry but probably slower due to conversions to/from JTS in relate()
+        //MultiPoint geometry = FACTORY.createMultiPoint(points.toArray(new Coordinate[points.size()]));
+        List<Point> shapes = new ArrayList<Point>(points.size());
+        for (Coordinate coord : points) {
+            shapes.add(SPATIAL_CONTEXT.makePoint(coord.x, coord.y));
+        }
+        return new ShapeCollection<Point>(shapes, SPATIAL_CONTEXT);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchGeoAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchGeoAssertions.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.test.hamcrest;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.spatial4j.core.shape.Shape;
+import com.spatial4j.core.shape.ShapeCollection;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
 import com.vividsolutions.jts.geom.*;
@@ -169,6 +171,13 @@ public class ElasticsearchGeoAssertions {
         assertEquals(g1.getGeom(), g2.getGeom());
     }
 
+    public static void assertEquals(ShapeCollection s1, ShapeCollection s2) {
+        Assert.assertEquals(s1.size(), s2.size());
+        for (int i = 0; i < s1.size(); i++) {
+            assertEquals(s1.get(i), s2.get(i));
+        }
+    }
+
     public static void assertEquals(Shape s1, Shape s2) {
         if(s1 instanceof JtsGeometry && s2 instanceof JtsGeometry) {
             assertEquals((JtsGeometry) s1, (JtsGeometry) s2);
@@ -176,8 +185,13 @@ public class ElasticsearchGeoAssertions {
             JtsPoint p1 = (JtsPoint) s1;
             JtsPoint p2 = (JtsPoint) s2;
             Assert.assertEquals(p1, p2);
+        } else if (s1 instanceof ShapeCollection && s2 instanceof ShapeCollection) {
+            assertEquals((ShapeCollection)s1, (ShapeCollection)s2);
         } else {
-            throw new RuntimeException("equality of shape types not supported [" + s1.getClass().getName() + " and " + s2.getClass().getName() + "]");
+            //We want to know the type of the shape because we test shape equality in a special way...
+            //... in particular we test that one ring is equivalent to another ring even if the points are rotated or reversed.
+            throw new RuntimeException(
+                    "equality of shape types not supported [" + s1.getClass().getName() + " and " + s2.getClass().getName() + "]");
         }
     }
 


### PR DESCRIPTION
This fixes #5279

The main think irking me is that ElasticSearch uses a global hard-coded instance of JtsSpatialContext.GEO as _the_ one and only SpatialContext as a static final in ShapeBuilder.SPATIAL_CONTEXT.  That wasn't what I had in mind when I (or was it Ryan or Chris, I forget) devised SpatialContext concept.  If you look at JtsSpatialContextFactory (or don't even use JTS, look at SpatialContextFactory) you'll see a bunch of options that trigger various behavior.  The most important one is "geo" (aka geodetic or geodesic, synonyms) which is a boolean that chooses between a latitude-longitude spherical world model or a flat plane (Euclidean geometry).  It's not quite clear to me at this time how ElasticSearch users that want a flat world model and who pre-project their data are using this.
