### PR TITLE
Implemented update by paths in order to overwrite document fields instead of merge

### DIFF
--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -125,8 +125,8 @@ public class UpdateHelper extends AbstractComponent {
         String routing = getResult.getFields().containsKey(RoutingFieldMapper.NAME) ? getResult.field(RoutingFieldMapper.NAME).getValue().toString() : null;
         String parent = getResult.getFields().containsKey(ParentFieldMapper.NAME) ? getResult.field(ParentFieldMapper.NAME).getValue().toString() : null;
 
-        if (request.script() == null && request.doc() != null) {
-            IndexRequest indexRequest = request.doc();
+        if (request.script() == null && (request.doc() != null || request.pathsRequest() != null)) {
+            IndexRequest indexRequest = request.pathsRequest() != null ? request.pathsRequest() : request.doc();
             updatedSourceAsMap = sourceAndContent.v2();
             if (indexRequest.ttl() > 0) {
                 ttl = indexRequest.ttl();
@@ -138,7 +138,11 @@ public class UpdateHelper extends AbstractComponent {
             if (indexRequest.parent() != null) {
                 parent = indexRequest.parent();
             }
-            XContentHelper.update(updatedSourceAsMap, indexRequest.sourceAsMap());
+            if (request.docAsPaths() || request.pathsRequest() != null) {
+                XContentHelper.updatePaths(updatedSourceAsMap, indexRequest.sourceAsMap());
+            } else {
+                XContentHelper.update(updatedSourceAsMap, indexRequest.sourceAsMap());
+            }
         } else {
             Map<String, Object> ctx = new HashMap<String, Object>(2);
             ctx.put("_source", sourceAndContent.v2());

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -336,6 +336,40 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
         return this;
     }
 
+
+    public UpdateRequestBuilder setPaths(XContentBuilder source) throws Exception {
+        request.paths(source);
+        return this;
+    }
+
+    public UpdateRequestBuilder setPaths(byte[] source) throws Exception {
+        request.paths(source);
+        return this;
+    }
+
+    public UpdateRequestBuilder setPaths(byte[] source, int offset, int length) throws Exception {
+        request.paths(source, offset, length);
+        return this;
+    }
+
+    public UpdateRequestBuilder setPaths(BytesReference source) throws Exception {
+        request.paths(source);
+        return this;
+    }
+
+    public UpdateRequestBuilder setPaths(String source) throws Exception {
+        request.paths(source);
+        return this;
+    }
+
+    /**
+     * Sets whether the specified doc parameter should be used as paths document.
+     */
+    public UpdateRequestBuilder setDocAsPaths(boolean docAsPaths) {
+        request.docAsPaths(docAsPaths);
+        return this;
+    }
+
     @Override
     protected void doExecute(ActionListener<UpdateResponse> listener) {
         ((Client) client).update(request, listener);

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.common.xcontent;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -33,6 +35,7 @@ import org.elasticsearch.common.io.stream.BytesStreamInput;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -198,6 +201,34 @@ public class XContentHelper {
                     // update the field
                     source.put(changesEntry.getKey(), changesEntry.getValue());
                 }
+            }
+        }
+    }
+
+    /**
+     * Overwrite given values on the source. If the value is a map,
+     * it will not be merged but overwritten. The keys of the changes map representing a path of
+     * the source map tree.
+     * If the path doesn't exists, a new tree will be inserted.
+     */
+    public static void updatePaths(Map<String, Object> source, Map<String, Object> changes) {
+        for (Map.Entry<String, Object> changesEntry : changes.entrySet()) {
+            if (changesEntry.getKey().contains(".")) {
+                // sub-path detected, dive recursive to the wanted tree element
+                List<String> path = Splitter.on(".").splitToList(changesEntry.getKey());
+                String currentKey = path.get(0);
+                if (!source.containsKey(currentKey)) {
+                    // insert parent tree element
+                    source.put(currentKey, new HashMap<String, Object>());
+                }
+                Map<String, Object> subChanges = new HashMap<>();
+                subChanges.put(Joiner.on(".").join(path.subList(1, path.size())),
+                        changesEntry.getValue());
+                updatePaths((Map<String, Object>) source.get(currentKey), subChanges);
+            } else {
+                // overwrite or insert the field
+                source.put(changesEntry.getKey(), changesEntry.getValue());
+
             }
         }
     }

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -70,6 +70,7 @@ public class RestUpdateAction extends BaseRestHandler {
             updateRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
         updateRequest.docAsUpsert(request.paramAsBoolean("doc_as_upsert", updateRequest.docAsUpsert()));
+        updateRequest.docAsPaths(request.paramAsBoolean("doc_as_paths", updateRequest.docAsPaths()));
         updateRequest.script(request.param("script"));
         updateRequest.scriptLang(request.param("lang"));
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
@@ -103,6 +104,17 @@ public class RestUpdateAction extends BaseRestHandler {
                     }
                     upsertRequest.version(RestActions.parseVersion(request));
                     upsertRequest.versionType(VersionType.fromString(request.param("version_type"), upsertRequest.versionType()));
+                }
+                IndexRequest pathsRequest = updateRequest.pathsRequest();
+                if (pathsRequest != null) {
+                    pathsRequest.routing(request.param("routing"));
+                    pathsRequest.parent(request.param("parent")); // order is important, set it after routing, so it will set the routing
+                    pathsRequest.timestamp(request.param("timestamp"));
+                    if (request.hasParam("ttl")) {
+                        pathsRequest.ttl(request.paramAsTime("ttl", null).millis());
+                    }
+                    pathsRequest.version(RestActions.parseVersion(request));
+                    pathsRequest.versionType(VersionType.fromString(request.param("version_type"), pathsRequest.versionType()));
                 }
                 IndexRequest doc = updateRequest.doc();
                 if (doc != null) {


### PR DESCRIPTION
We've implemented a new feature for overwriting doc fields instead of merging values in.
This is done by defining the paths to sub-fields instead of submitting an updated doc.
It gives us the opportunity to overwrite a complete object by a new one, and so deleting unwanted keys.
This is maybe most useful when using dynamic mapping on object fields.
## Demonstration Example (Documentation):
### Create an index

``` shell
curl -XPUT 'http://localhost:9200/twitter'
```
### Create a document mapping with a field of type `object`

``` shell
curl -XPUT 'http://localhost:9200/twitter/tweet/_mapping' -d '{
    "tweet" : {
        "properties" : {
            "person" : {
                "type" : "object",
                "properties" : {
                    "name" : {"type" : "object"},
                    "sid" : {"type" : "string", "index" : "not_analyzed"}
                }
            },
            "message" : {"type" : "string"}
        }
    }
}'
```
### Index a document

``` shell
curl -XPUT 'http://localhost:9200/twitter/tweet/1' -d '{
    "person" : {
        "name" : {
            "first_name" : "Shay",
            "last_name" : "Banon",
            "nick_name": "kimchy"
        },
        "sid" : "12345"
    },
    "message" : "This is a tweet!"
}'
```
### Update the document in order to delete the `person.name.nick_name` field
#### Can be done by submitting the paths by using the `paths` key

``` shell
curl -XPOST 'http://localhost:9200/twitter/tweet/1/_update' -d '{
    "paths" : {
        "person.name" : {
            "first_name" : "Shay",
            "last_name" : "Banon"
        }
    }
}'
```
#### Validate the updated document (`nick_name` removed)

``` shell
 curl -XGET 'http://localhost:9200/twitter/tweet/1' 
{
    "_index" : "twitter",
    "_type" : "tweet",
    "_id" : "1",
    "_version" : 2,
    "exists" : true,
    "_source" : {
        "person" : {
            "name" : {
                "first_name" : "Shay",
                "last_name" : "Banon"
            },
            "sid" : "12345"
        },
        "message" : "This is a tweet!"
    }
} 
```
#### Same can be achieved by using `doc` in conjunction with `doc_as_paths=true`

``` shell
curl -XPOST 'http://localhost:9200/twitter/tweet/1/_update' -d '{
    "doc" : {
        "person.name" : {
            "first_name" : "Shay"
        }
    },
    "doc_as_paths" : true
}'
```
#### Validate the updated document (now `last_name` is removed)

``` shell
 curl -XGET 'http://localhost:9200/twitter/tweet/1' 
{
    "_index" : "twitter",
    "_type" : "tweet",
    "_id" : "1",
    "_version" : 3,
    "exists" : true,
    "_source" : {
        "person" : {
            "name" : {
                "first_name" : "Shay"
            },
            "sid" : "12345"
        },
        "message" : "This is a tweet!"
    }
} 
```

Of course `paths` can also be used to update non-objects.
