### PR TITLE
Packaging: Log stdout output into file

### DIFF
--- a/src/deb/default/elasticsearch
+++ b/src/deb/default/elasticsearch
@@ -25,6 +25,9 @@
 # Elasticsearch log directory
 #LOG_DIR=/var/log/elasticsearch
 
+# stdout log file
+#STDOUT_LOG_FILE=/var/log/elasticsearch/elasticsearch-stdout.log
+
 # Elasticsearch data directory
 #DATA_DIR=/var/lib/elasticsearch
 

--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -78,6 +78,9 @@ MAX_OPEN_FILES=65535
 # Elasticsearch log directory
 LOG_DIR=/var/log/$NAME
 
+# stdout log file
+STDOUT_LOG_FILE=/var/log/elasticsearch/elasticsearch-stdout.log
+
 # Elasticsearch data directory
 DATA_DIR=/var/lib/$NAME
 
@@ -147,6 +150,7 @@ case "$1" in
 	# Prepare environment
 	mkdir -p "$LOG_DIR" "$DATA_DIR" "$WORK_DIR" && chown "$ES_USER":"$ES_GROUP" "$LOG_DIR" "$DATA_DIR" "$WORK_DIR"
 	touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
+	touch "$STDOUT_LOG_FILE" && chown "$ES_USER":"$ES_GROUP" "$STDOUT_LOG_FILE"
 
 	if [ -n "$MAX_OPEN_FILES" ]; then
 		ulimit -n $MAX_OPEN_FILES
@@ -161,7 +165,7 @@ case "$1" in
 	fi
 
 	# Start Daemon
-	start-stop-daemon --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	start-stop-daemon --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec /bin/bash -- -c "$DAEMON $DAEMON_OPTS > $STDOUT_LOG_FILE 2>&1"
 	log_end_msg $?
 	;;		
   stop)

--- a/src/rpm/init.d/elasticsearch
+++ b/src/rpm/init.d/elasticsearch
@@ -85,7 +85,7 @@ start() {
     fi
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-    daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
+    daemon --user $ES_USER --pidfile $pidfile "$exec > $STDOUT_LOG_FILE 2>&1" -p $pidfile -d -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/src/rpm/sysconfig/elasticsearch
+++ b/src/rpm/sysconfig/elasticsearch
@@ -25,6 +25,9 @@ MAX_MAP_COUNT=262144
 # Elasticsearch log directory
 LOG_DIR=/var/log/elasticsearch
 
+# stdout log file
+STDOUT_LOG_FILE=/var/log/elasticsearch/elasticsearch-stdout.log
+
 # Elasticsearch data directory
 DATA_DIR=/var/lib/elasticsearch
 

--- a/src/rpm/systemd/elasticsearch.service
+++ b/src/rpm/systemd/elasticsearch.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Starts and stops a single elasticsearch instance on this system
+Description=Elasticsearch
 Documentation=http://www.elasticsearch.org
 
 [Service]
@@ -15,6 +15,9 @@ LimitNOFILE=65535
 #LimitMEMLOCK=infinity
 # Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)
 TimeoutStopSec=20
+# Use journalctl to read possible error messages when the service is started
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Until stdout was ignored during start up of our packages. This could
result in problems when specyfying something like an invalid heap size
(2gb instead of 2g) as this was not logged anywhere.

For init.d style startup, errors are now logged into
/var/log/elasticsearch/elasticsearch-stdout.log

For systemd startup, one can now use journalctl to see these errors.

This PR is based on #4429 (which only supported the debian package)
