### PR TITLE
Add MemoryIndex reuse when percolating doc with nested type

### DIFF
--- a/src/main/java/org/elasticsearch/percolator/PercolatorIndex.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorIndex.java
@@ -21,7 +21,9 @@ package org.elasticsearch.percolator;
 
 import org.elasticsearch.index.mapper.ParsedDocument;
 
-
+/**
+ * Abstraction on how to index the percolator document.
+ */
 interface PercolatorIndex {
 
     /**
@@ -31,10 +33,5 @@ interface PercolatorIndex {
      * @param document Document that is percolated. Can contain several documents.
      * */
     void prepare(PercolateContext context, ParsedDocument document);
-
-    /**
-     * Release resources
-     * */
-    void clean();
 
 }


### PR DESCRIPTION
Also make use of the thread local memory reuse for a document being percolated with nested objects. 
The memory index will only be reused for the root doc, since most of the times that will be the biggest document.
