### PR TITLE
[DOCS] add Elasticsearch Image Plugin

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -279,5 +279,6 @@ bin/plugin --install mobz/elasticsearch-head --timeout 0
 * https://github.com/endgameinc/elasticsearch-term-plugin[Terms Component Plugin] (by Endgame Inc.)
 * http://tlrx.github.com/elasticsearch-view-plugin[Elasticsearch View Plugin] (by Tanguy Leroux)
 * https://github.com/sonian/elasticsearch-zookeeper[ZooKeeper Discovery Plugin] (by Sonian Inc.)
+* https://github.com/kzwang/elasticsearch-image[Elasticsearch Image Plugin] (by Kevin Wang)
 
 


### PR DESCRIPTION
add Elasticsearch Image Plugin to Plugins page

https://github.com/kzwang/elasticsearch-image
