### PR TITLE
[TEST] Randomized number of shards used for indices created during tests

### DIFF
--- a/docs/reference/testing/testing-framework.asciidoc
+++ b/docs/reference/testing/testing-framework.asciidoc
@@ -61,9 +61,15 @@ In case you only need to execute a unit test, because your implementation can be
 [[integration-tests]]
 === integration tests
 
-These kind of tests require firing up a whole cluster of nodes, before the tests can actually be run. Compared to unit tests they are obviously way more time consuming, but the test infrastructure tries to minimize the time cost by only restarting the whole cluster, if this is configured explicitely.
+These kind of tests require firing up a whole cluster of nodes, before the tests can actually be run. Compared to unit tests they are obviously way more time consuming, but the test infrastructure tries to minimize the time cost by only restarting the whole cluster, if this is configured explicitly.
 
-The class your tests have to inherit from is `ElasticsearchIntegrationTest`. As soon as you inherit, there is no need for you to start any elasticsearch nodes manually in your test anymore, though you might need to ensure that at least a certain amount of nodes is up running.
+The class your tests have to inherit from is `ElasticsearchIntegrationTest`. As soon as you inherit, there is no need for you to start any elasticsearch nodes manually in your test anymore, though you might need to ensure that at least a certain amount of nodes is up and running.
+
+[[number-of-shards]]
+==== number of shards
+
+The number of shards used for indices created during integration tests is randomized between `1` and `10` unless overwritten upon index creation via index settings.
+Rule of thumb is not to specify the number of shards unless needed, so that each test will use a different one all the time.
 
 [[helper-methods]]
 ==== generic helper methods
@@ -197,7 +203,7 @@ As many elasticsearch tests are checking for a similar output, like the amount o
 
 [horizontal]
 `assertHitCount()`::        Checks hit count of a search or count request
-`assertAcked()`::           Ensure the a request has been ackknowledged by the master
+`assertAcked()`::           Ensure the a request has been acknowledged by the master
 `assertSearchHits()`::      Asserts a search response contains specific ids
 `assertMatchCount()`::      Asserts a matching count from a percolation response
 `assertFirstHit()`::        Asserts the first hit hits the specified matcher
@@ -205,6 +211,7 @@ As many elasticsearch tests are checking for a similar output, like the amount o
 `assertThirdHit()`::        Asserts the third hits hits the specified matcher
 `assertSearchHit()`::       Assert a certain element in a search response hits the specified matcher
 `assertNoFailures()`::      Asserts that no shard failures have occured in the response
+`assertFailures()`::        Asserts that shard failures have happened during a search request
 `assertHighlight()`::       Assert specific highlights matched
 `assertSuggestion()`::      Assert for specific suggestions
 `assertSuggestionSize()`::  Assert for specific suggestion count

--- a/src/test/java/org/elasticsearch/action/termvector/MultiTermVectorsTests.java
+++ b/src/test/java/org/elasticsearch/action/termvector/MultiTermVectorsTests.java
@@ -30,8 +30,9 @@ public class MultiTermVectorsTests extends AbstractTermVectorTests {
     @Test
     public void testDuelESLucene() throws Exception {
         AbstractTermVectorTests.TestFieldSetting[] testFieldSettings = getFieldSettings();
-        createIndexBasedOnFieldSettings(testFieldSettings, -1);
-        AbstractTermVectorTests.TestDoc[] testDocs = generateTestDocs(5, testFieldSettings);
+        createIndexBasedOnFieldSettings("test", testFieldSettings);
+        //we generate as many docs as many shards we have
+        TestDoc[] testDocs = generateTestDocs(getNumShards("test").numPrimaries, testFieldSettings);
 
         DirectoryReader directoryReader = indexDocsWithLucene(testDocs);
         AbstractTermVectorTests.TestConfig[] testConfigs = generateTestConfigs(20, testDocs, testFieldSettings);
@@ -62,6 +63,7 @@ public class MultiTermVectorsTests extends AbstractTermVectorTests {
 
     }
 
+    @Test
     public void testMissingIndexThrowsMissingIndex() throws Exception {
         TermVectorRequestBuilder requestBuilder = client().prepareTermVector("testX", "typeX", Integer.toString(1));
         MultiTermVectorsRequestBuilder mtvBuilder = new MultiTermVectorsRequestBuilder(client());

--- a/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -33,8 +33,6 @@ import org.elasticsearch.cluster.metadata.AliasAction;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.StopWatch;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
@@ -550,16 +548,13 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testIndicesGetAliases() throws Exception {
-        Settings indexSettings = ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 1)
-                .put("index.number_of_replicas", 0)
-                .build();
+
         logger.info("--> creating indices [foobar, test, test123, foobarbaz, bazbar]");
-        assertAcked(prepareCreate("foobar").setSettings(indexSettings));
-        assertAcked(prepareCreate("test").setSettings(indexSettings));
-        assertAcked(prepareCreate("test123").setSettings(indexSettings));
-        assertAcked(prepareCreate("foobarbaz").setSettings(indexSettings));
-        assertAcked(prepareCreate("bazbar").setSettings(indexSettings));
+        createIndex("foobar");
+        createIndex("test");
+        createIndex("test123");
+        createIndex("foobarbaz");
+        createIndex("bazbar");
 
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -51,7 +51,6 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put("discovery.zen.ping_timeout", "200ms")
                 .put("discovery.initial_state_timeout", "500ms")
-                .put("index.number_of_shards", 1)
                 .build();
 
         TimeValue timeout = TimeValue.timeValueMillis(200);

--- a/src/test/java/org/elasticsearch/cluster/SpecificMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/SpecificMasterNodesTests.java
@@ -67,9 +67,9 @@ public class SpecificMasterNodesTests extends ElasticsearchIntegrationTest {
         }
 
         logger.info("--> start master node");
-        final String nextMasterEligableNodeName = cluster().startNode(settingsBuilder().put("node.data", false).put("node.master", true));
-        assertThat(cluster().nonMasterClient().admin().cluster().prepareState().execute().actionGet().getState().nodes().masterNode().name(), equalTo(nextMasterEligableNodeName));
-        assertThat(cluster().masterClient().admin().cluster().prepareState().execute().actionGet().getState().nodes().masterNode().name(), equalTo(nextMasterEligableNodeName));
+        final String nextMasterEligibleNodeName = cluster().startNode(settingsBuilder().put("node.data", false).put("node.master", true));
+        assertThat(cluster().nonMasterClient().admin().cluster().prepareState().execute().actionGet().getState().nodes().masterNode().name(), equalTo(nextMasterEligibleNodeName));
+        assertThat(cluster().masterClient().admin().cluster().prepareState().execute().actionGet().getState().nodes().masterNode().name(), equalTo(nextMasterEligibleNodeName));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class SpecificMasterNodesTests extends ElasticsearchIntegrationTest {
         logger.info("--> start data node / non master node");
         cluster().startNode(settingsBuilder().put("node.data", true).put("node.master", false));
 
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings("number_of_shards", 1).get());
+        createIndex("test");
         assertAcked(client().admin().indices().preparePutMapping("test").setType("_default_").setSource("_timestamp", "enabled=true"));
 
         MappingMetaData defaultMapping = client().admin().cluster().prepareState().get().getState().getMetaData().getIndices().get("test").getMappings().get("_default_");

--- a/src/test/java/org/elasticsearch/cluster/UpdateSettingsValidationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/UpdateSettingsValidationTests.java
@@ -41,16 +41,17 @@ public class UpdateSettingsValidationTests extends ElasticsearchIntegrationTest 
         String node_1 = cluster().startNode(settingsBuilder().put("node.master", false).build());
         String node_2 = cluster().startNode(settingsBuilder().put("node.master", false).build());
 
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 5).put("index.number_of_replicas", 1)).execute().actionGet();
+        createIndex("test");
+        NumShards test = getNumShards("test");
+
         ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth("test").setWaitForEvents(Priority.LANGUID).setWaitForNodes("3").setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
-        assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(10));
+        assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.totalNumShards));
 
         client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put("index.number_of_replicas", 0)).execute().actionGet();
         healthResponse = client().admin().cluster().prepareHealth("test").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
-        assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(5));
+        assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.numPrimaries));
 
         try {
             client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put("index.refresh_interval", "")).execute().actionGet();

--- a/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.SUITE;
@@ -176,12 +177,12 @@ public class AckTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testClusterRerouteAcknowledgement() throws InterruptedException {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder()
-                        .put("number_of_shards", atLeast(cluster().size()))
-                        .put("number_of_replicas", 0)).get();
+        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder()
+                .put(indexSettings())
+                .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+        ));
         ensureGreen();
-
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
 
@@ -207,16 +208,14 @@ public class AckTests extends ElasticsearchIntegrationTest {
             }
             assertThat(found, equalTo(true));
         }
-        //let's wait for the relocation to be completed, otherwise there can be issues with after test checks (mock directory wrapper etc.)
-        waitForRelocation();
     }
 
     @Test
     public void testClusterRerouteNoAcknowledgement() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put("number_of_shards", atLeast(cluster().size()))
-                        .put("number_of_replicas", 0)).get();
+                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
@@ -229,8 +228,8 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteAcknowledgementDryRun() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put("number_of_shards", atLeast(cluster().size()))
-                        .put("number_of_replicas", 0)).get();
+                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
@@ -262,8 +261,8 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteNoAcknowledgementDryRun() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put("number_of_shards", atLeast(cluster().size()))
-                        .put("number_of_replicas", 0)).get();
+                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
@@ -334,7 +333,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
 
         for (Client client : clients()) {
             IndexMetaData indexMetaData = getLocalClusterState(client).metaData().indices().get("test");
-            assertThat(indexMetaData.getState(), equalTo(IndexMetaData.State.CLOSE));
+            assertThat(indexMetaData.getState(), equalTo(State.CLOSE));
         }
     }
 
@@ -358,7 +357,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
 
         for (Client client : clients()) {
             IndexMetaData indexMetaData = getLocalClusterState(client).metaData().indices().get("test");
-            assertThat(indexMetaData.getState(), equalTo(IndexMetaData.State.OPEN));
+            assertThat(indexMetaData.getState(), equalTo(State.OPEN));
         }
     }
 

--- a/src/test/java/org/elasticsearch/cluster/allocation/SimpleAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/SimpleAllocationTests.java
@@ -20,35 +20,44 @@ package org.elasticsearch.cluster.allocation;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.RoutingNode;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SimpleAllocationTests extends ElasticsearchIntegrationTest {
-    
+
+    @Override
+    protected int numberOfShards() {
+        return 3;
+    }
+
+    @Override
+    protected int numberOfReplicas() {
+        return 1;
+    }
+
     /**
      * Test for 
      * https://groups.google.com/d/msg/elasticsearch/y-SY_HyoB-8/EZdfNt9VO44J
      */
     @Test
     public void testSaneAllocation() {
-        prepareCreate("test", 3,
-                        settingsBuilder().put("index.number_of_shards", 3)
-                        .put("index.number_of_replicas", 1))
-                        .execute().actionGet();
-        ensureGreen();            
-        ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        assertAcked(prepareCreate("test", 3));
+        ensureGreen();
+
+         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.routingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.routingNodes()) {
             if (!node.isEmpty()) {
                 assertThat(node.size(), equalTo(2));
             }
         }
-        client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put("index.number_of_replicas", 0)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put(SETTING_NUMBER_OF_REPLICAS, 0)).execute().actionGet();
+        ensureGreen();
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
 
         assertThat(state.routingNodes().unassigned().size(), equalTo(0));
@@ -57,17 +66,13 @@ public class SimpleAllocationTests extends ElasticsearchIntegrationTest {
                 assertThat(node.size(), equalTo(1));
             }
         }
-        
+
         // create another index
-        prepareCreate("test2", 3,
-                        settingsBuilder()
-                        .put("index.number_of_shards", 3)
-                        .put("index.number_of_replicas", 1))
-                        .execute()
-                .actionGet();
-        ensureGreen();            
-        client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put("index.number_of_replicas", 1)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test2", 3));
+        ensureGreen();
+
+        client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put(SETTING_NUMBER_OF_REPLICAS, 1)).execute().actionGet();
+        ensureGreen();
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
 
         assertThat(state.routingNodes().unassigned().size(), equalTo(0));

--- a/src/test/java/org/elasticsearch/count/simple/SimpleCountTests.java
+++ b/src/test/java/org/elasticsearch/count/simple/SimpleCountTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.count.simple;
 
 import org.elasticsearch.action.count.CountResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -31,14 +30,14 @@ import java.util.concurrent.ExecutionException;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
 public class SimpleCountTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testCountRandomPreference() throws InterruptedException, ExecutionException {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", between(1, 3))).get();
+        createIndex("test");
         indexRandom(true, client().prepareIndex("test", "type", "1").setSource("field", "value"),
                 client().prepareIndex("test", "type", "2").setSource("field", "value"),
                 client().prepareIndex("test", "type", "3").setSource("field", "value"),
@@ -56,7 +55,7 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleIpTests() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).execute().actionGet();
+        createIndex("test");
 
         client().admin().indices().preparePutMapping("test").setType("type1")
                 .setSource(XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
@@ -76,7 +75,7 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleIdTests() {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).execute().actionGet();
+        createIndex("test");
 
         client().prepareIndex("test", "type", "XXX1").setSource("field", "value").setRefresh(true).execute().actionGet();
         // id is not indexed, but lets see that we automatically convert to
@@ -96,13 +95,12 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleDateMathTests() throws Exception {
-        prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()).execute().actionGet();
+        createIndex("test");
         client().prepareIndex("test", "type1", "1").setSource("field", "2010-01-05T02:00").execute().actionGet();
         client().prepareIndex("test", "type1", "2").setSource("field", "2010-01-06T02:00").execute().actionGet();
         ensureGreen();
         refresh();
         CountResponse countResponse = client().prepareCount("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d")).execute().actionGet();
-        assertNoFailures(countResponse);
         assertHitCount(countResponse, 2l);
 
         countResponse = client().prepareCount("test").setQuery(QueryBuilders.queryString("field:[2010-01-03||+2d TO 2010-01-04||+2d]")).execute().actionGet();
@@ -111,7 +109,7 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void localDependentDateTests() throws Exception {
-        prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1",
                         jsonBuilder().startObject()
                                 .startObject("type1")
@@ -123,27 +121,24 @@ public class SimpleCountTests extends ElasticsearchIntegrationTest {
                                 .endObject()
                                 .endObject()
                                 .endObject()
-                                .endObject())
-                .execute().actionGet();
+                                .endObject()));
         ensureGreen();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type1", "" + i).setSource("date_field", "Mi, 06 Dez 2000 02:55:00 -0800").execute().actionGet();
             client().prepareIndex("test", "type1", "" + (10 + i)).setSource("date_field", "Do, 07 Dez 2000 02:55:00 -0800").execute().actionGet();
         }
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
         for (int i = 0; i < 10; i++) {
             CountResponse countResponse = client().prepareCount("test")
                     .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Do, 07 Dez 2000 00:00:00 -0800"))
                     .execute().actionGet();
             assertHitCount(countResponse, 10l);
 
-
             countResponse = client().prepareCount("test")
                     .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Fr, 08 Dez 2000 00:00:00 -0800"))
                     .execute().actionGet();
             assertHitCount(countResponse, 20l);
-
         }
     }
 }

--- a/src/test/java/org/elasticsearch/deleteByQuery/DeleteByQueryTests.java
+++ b/src/test/java/org/elasticsearch/deleteByQuery/DeleteByQueryTests.java
@@ -107,12 +107,14 @@ public class DeleteByQueryTests extends ElasticsearchIntegrationTest {
                 .setQuery(QueryBuilders.hasChildQuery("type", QueryBuilders.matchAllQuery()))
                 .execute().actionGet();
 
+        NumShards twitter = getNumShards("twitter");
+
         assertThat(response.status(), equalTo(RestStatus.BAD_REQUEST));
         assertThat(response.getIndex("twitter").getSuccessfulShards(), equalTo(0));
-        assertThat(response.getIndex("twitter").getFailedShards(), equalTo(5));
+        assertThat(response.getIndex("twitter").getFailedShards(), equalTo(twitter.numPrimaries));
         assertThat(response.getIndices().size(), equalTo(1));
-        assertThat(response.getIndices().get("twitter").getFailedShards(), equalTo(5));
-        assertThat(response.getIndices().get("twitter").getFailures().length, equalTo(5));
+        assertThat(response.getIndices().get("twitter").getFailedShards(), equalTo(twitter.numPrimaries));
+        assertThat(response.getIndices().get("twitter").getFailures().length, equalTo(twitter.numPrimaries));
         for (ShardOperationFailedException failure : response.getIndices().get("twitter").getFailures()) {
             assertThat(failure.reason(), containsString("[twitter] [has_child] No mapping for for type [type]"));
             assertThat(failure.status(), equalTo(RestStatus.BAD_REQUEST));

--- a/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
+++ b/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
@@ -201,7 +201,6 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
         assertThat(((Map<String, Object>) response.getGetResult().getSource().get("obj1")).get("field1").toString(), equalTo("value1"));
     }
 
-
     @Test
     public void testExplainWithAlias() throws Exception {
         client().admin().indices().prepareCreate("test")
@@ -223,7 +222,7 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void explainDateRangeInQueryString() {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).get();
+        createIndex("test");
 
         String aMonthAgo = ISODateTimeFormat.yearMonthDay().print(new DateTime(DateTimeZone.UTC).minusMonths(1));
         String aMonthFromNow = ISODateTimeFormat.yearMonthDay().print(new DateTime(DateTimeZone.UTC).plusMonths(1));

--- a/src/test/java/org/elasticsearch/flt/FuzzyLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/flt/FuzzyLikeThisActionTests.java
@@ -24,9 +24,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.fuzzyLikeThisFieldQuery;
 import static org.elasticsearch.index.query.QueryBuilders.fuzzyLikeThisQuery;
@@ -39,13 +36,15 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class FuzzyLikeThisActionTests extends ElasticsearchIntegrationTest {
 
+    @Override
+    protected int numberOfReplicas() {
+        return between(0, 1);
+    }
+
     @Test
     // See issue https://github.com/elasticsearch/elasticsearch/issues/3252
     public void testNumericField() throws Exception {
         assertAcked(prepareCreate("test")
-                .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(1, 5))
-                        .put(SETTING_NUMBER_OF_REPLICAS, between(0, 1)))
                 .addMapping("type", "int_value", "type=integer"));
         ensureGreen();
         client().prepareIndex("test", "type", "1")

--- a/src/test/java/org/elasticsearch/gateway/fs/IndexGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/fs/IndexGatewayTests.java
@@ -70,15 +70,12 @@ public class IndexGatewayTests extends ElasticsearchIntegrationTest {
             if (between(0, 5) == 0) {
                 builder.put("gateway.fs.chunk_size", between(1, 100) + "kb");
             }
-            builder.put("index.number_of_replicas", "1");
-            builder.put("index.number_of_shards", rarely() ? Integer.toString(between(2, 6)) : "1");
             storeType = rarely() ? "ram" : "fs";
             builder.put("index.store.type", storeType);
             settings.set(builder.build());
         }
         return settings.get();
     }
-
 
     protected boolean isPersistentStorage() {
         assertNotNull(storeType);

--- a/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
@@ -96,11 +96,13 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testSimpleOpenClose() throws Exception {
 
         logger.info("--> starting 2 nodes");
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 1).build());
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 1).build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
 
         logger.info("--> creating test index");
-        client().admin().indices().prepareCreate("test").execute().actionGet();
+        createIndex("test");
+
+        NumShards test = getNumShards("test");
 
         logger.info("--> waiting for green status");
         ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().setWaitForNodes("2").execute().actionGet();
@@ -108,8 +110,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
 
         ClusterStateResponse stateResponse = client().admin().cluster().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metaData().index("test").state(), equalTo(IndexMetaData.State.OPEN));
-        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(2));
-        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(4));
+        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(test.numPrimaries));
+        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(test.totalNumShards));
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").execute().actionGet();
@@ -151,8 +153,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
 
         stateResponse = client().admin().cluster().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metaData().index("test").state(), equalTo(IndexMetaData.State.OPEN));
-        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(2));
-        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(4));
+        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(test.numPrimaries));
+        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(test.totalNumShards));
 
         logger.info("--> trying to get the indexed document on the first index");
         GetResponse getResponse = client().prepareGet("test", "type1", "1").execute().actionGet();
@@ -191,8 +193,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
 
         stateResponse = client().admin().cluster().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metaData().index("test").state(), equalTo(IndexMetaData.State.OPEN));
-        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(2));
-        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(4));
+        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(test.numPrimaries));
+        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(test.totalNumShards));
 
         logger.info("--> trying to get the indexed document on the first round (before close and shutdown)");
         getResponse = client().prepareGet("test", "type1", "1").execute().actionGet();
@@ -207,7 +209,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        cluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 1).build());
+        cluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
@@ -216,7 +218,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         cluster().closeNonSharedNodes(false);
 
         logger.info("--> starting 1 master node non data again");
-        cluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 1).build());
+        cluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
 
         logger.info("--> waiting for test index to be created");
         ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setIndices("test").execute().actionGet();
@@ -232,8 +234,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        cluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 1).build());
-        cluster().startNode(settingsBuilder().put("node.master", false).put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 1).build());
+        cluster().startNode(settingsBuilder().put("node.data", false).put("gateway.type", "local").build());
+        cluster().startNode(settingsBuilder().put("node.master", false).put("gateway.type", "local").build());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();
@@ -250,8 +252,8 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 2 nodes");
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 5).put("index.number_of_replicas", 1).build());
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 5).put("index.number_of_replicas", 1).build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefresh(true).execute().actionGet();
@@ -291,7 +293,6 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testDanglingIndicesAutoImportYes() throws Exception {
         Settings settings = settingsBuilder()
                 .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "yes")
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 1)
                 .build();
         logger.info("--> starting two nodes");
         final String node_1 = cluster().startNode(settings);
@@ -349,7 +350,6 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testDanglingIndicesAutoImportClose() throws Exception {
         Settings settings = settingsBuilder()
                 .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "closed")
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 1)
                 .build();
   
 
@@ -417,7 +417,6 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testDanglingIndicesNoAutoImport() throws Exception {
         Settings settings = settingsBuilder()
                 .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "no")
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 1)
                 .build();
         logger.info("--> starting two nodes");
         final String node_1 = cluster().startNode(settings);
@@ -483,7 +482,6 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
     public void testDanglingIndicesNoAutoImportStillDanglingAndCreatingSameIndex() throws Exception {
         Settings settings = settingsBuilder()
                 .put("gateway.type", "local").put("gateway.local.auto_import_dangled", "no")
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 1)
                 .build();
 
         logger.info("--> starting two nodes");

--- a/src/test/java/org/elasticsearch/gateway/local/QuorumLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/QuorumLocalGatewayTests.java
@@ -40,9 +40,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 /**
  *
@@ -50,28 +48,31 @@ import static org.hamcrest.Matchers.notNullValue;
 @ClusterScope(numNodes=0, scope=Scope.TEST)
 public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
 
+    @Override
+    protected int numberOfReplicas() {
+        return 2;
+    }
+
     @Test
     @Slow
     public void testChangeInitialShardsRecovery() throws Exception {
         logger.info("--> starting 3 nodes");
         final String[] nodes = new String[3];
-        nodes[0] = cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 2).build());
-        nodes[1] = cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 2).build());
-        nodes[2] = cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 2).build());
+        nodes[0] = cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        nodes[1] = cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        nodes[2] = cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+
+        createIndex("test");
+        ensureGreen();
+        NumShards test = getNumShards("test");
 
         logger.info("--> indexing...");
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         //We don't check for failures in the flush response: if we do we might get the following:
         // FlushNotAllowedEngineException[[test][1] recovery is in progress, flush [COMMIT_TRANSLOG] is not allowed]
-        client().admin().indices().prepareFlush().get();
+        flush();
         client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
-        assertNoFailures(client().admin().indices().prepareRefresh().execute().get());
-
-        logger.info("--> running cluster_health (wait for the shards to startup)");
-        ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForActiveShards(6)).actionGet();
-        logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        refresh();
 
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareCount().setQuery(matchAllQuery()).get(), 2l);
@@ -93,7 +94,7 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
         if (randomBoolean()) {
             Thread.sleep(between(1, 400)); // wait a bit and give is a chance to try to allocate
         }
-        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForNodes("1")).actionGet();
+        ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForNodes("1")).actionGet();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.RED));  // nothing allocated yet
         assertThat(awaitBusy(new Predicate<Object>() {
@@ -109,8 +110,8 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
         logger.info("--> change the recovery.initial_shards setting, and make sure its recovered");
         client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put("recovery.initial_shards", 1)).get();
 
-        logger.info("--> running cluster_health (wait for the shards to startup), 2 shards since we only have 1 node");
-        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForYellowStatus().waitForActiveShards(2)).actionGet();
+        logger.info("--> running cluster_health (wait for the shards to startup), primaries only since we only have 1 node");
+        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForYellowStatus().waitForActiveShards(test.numPrimaries)).actionGet();
         logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
@@ -125,23 +126,21 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
     public void testQuorumRecovery() throws Exception {
 
         logger.info("--> starting 3 nodes");
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 2).build());
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 2).build());
-        cluster().startNode(settingsBuilder().put("gateway.type", "local").put("index.number_of_shards", 2).put("index.number_of_replicas", 2).build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+        cluster().startNode(settingsBuilder().put("gateway.type", "local").build());
+
+        createIndex("test");
+        ensureGreen();
+        final NumShards test = getNumShards("test");
 
         logger.info("--> indexing...");
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         //We don't check for failures in the flush response: if we do we might get the following:
         // FlushNotAllowedEngineException[[test][1] recovery is in progress, flush [COMMIT_TRANSLOG] is not allowed]
-        client().admin().indices().prepareFlush().get();
+        flush();
         client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
-        assertNoFailures(client().admin().indices().prepareRefresh().get());
-
-        logger.info("--> running cluster_health (wait for the shards to startup)");
-        ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForActiveShards(6)).actionGet();
-        logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        refresh();
 
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareCount().setQuery(matchAllQuery()).get(), 2l);
@@ -163,7 +162,7 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
                         @Override
                         public boolean apply(Object input) {
                             logger.info("--> running cluster_health (wait for the shards to startup)");
-                            ClusterHealthResponse clusterHealth = activeClient.admin().cluster().health(clusterHealthRequest().waitForYellowStatus().waitForNodes("2").waitForActiveShards(4)).actionGet();
+                            ClusterHealthResponse clusterHealth = activeClient.admin().cluster().health(clusterHealthRequest().waitForYellowStatus().waitForNodes("2").waitForActiveShards(test.numPrimaries * 2)).actionGet();
                             logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
                             return (!clusterHealth.isTimedOut()) && clusterHealth.getStatus() == ClusterHealthStatus.YELLOW;
                         }
@@ -180,10 +179,7 @@ public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
         });
         logger.info("--> all nodes are started back, verifying we got the latest version");
         logger.info("--> running cluster_health (wait for the shards to startup)");
-        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForActiveShards(6)).actionGet();
-        logger.info("--> done cluster_health, status " + clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        ensureGreen();
 
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareCount().setQuery(matchAllQuery()).get(), 3l);

--- a/src/test/java/org/elasticsearch/index/fielddata/FieldDataFilterIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/FieldDataFilterIntegrationTests.java
@@ -32,18 +32,20 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.facet.FacetBuilders.termsFacet;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 public class FieldDataFilterIntegrationTests extends ElasticsearchIntegrationTest {
 
+    @Override
+    protected int numberOfReplicas() {
+        return 0;
+    }
+
     @Test
     public void testRegexpFilter() throws IOException {
-        CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
-                .put("index.number_of_shards", between(1,5))
-                .put("index.number_of_replicas", 0));
+        CreateIndexRequestBuilder builder = prepareCreate("test");
         XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties")
                     .startObject("name")
@@ -82,7 +84,6 @@ public class FieldDataFilterIntegrationTests extends ElasticsearchIntegrationTes
         assertThat(notFilteredFacet.getEntries().size(), Matchers.equalTo(2));
         assertThat(notFilteredFacet.getEntries().get(0).getTerm().string(), Matchers.isOneOf("bacon", "bastards"));
         assertThat(notFilteredFacet.getEntries().get(1).getTerm().string(), Matchers.isOneOf("bacon", "bastards"));
-        
     }
 
 }

--- a/src/test/java/org/elasticsearch/indices/fielddata/breaker/RandomExceptionCircuitBreakerTests.java
+++ b/src/test/java/org/elasticsearch/indices/fielddata/breaker/RandomExceptionCircuitBreakerTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.engine.MockInternalEngine;
 import org.elasticsearch.test.engine.ThrowingAtomicReaderWrapper;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -61,7 +60,7 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
                 .clear().setBreaker(true).execute().actionGet().getNodes()) {
             assertThat("Breaker is not set to 0", node.getBreaker().getEstimated(), equalTo(0L));
         }
-        final int numShards = between(1, 5);
+
         final int numReplicas = randomIntBetween(0, 1);
         String mapping = XContentFactory.jsonBuilder()
                 .startObject()
@@ -107,7 +106,7 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
         }
 
         ImmutableSettings.Builder settings = settingsBuilder()
-                .put("index.number_of_shards", numShards)
+                .put(indexSettings())
                 .put("index.number_of_replicas", numReplicas)
                 .put(MockInternalEngine.READER_WRAPPER_TYPE, RandomExceptionDirectoryReaderWrapper.class.getName())
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)

--- a/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingTests.java
+++ b/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
@@ -50,6 +49,7 @@ import java.util.Map;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
@@ -61,7 +61,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
     public void dynamicUpdates() throws Exception {
         client().admin().indices().prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
+                        settingsBuilder()
                                 .put("index.number_of_shards", 1)
                                 .put("index.number_of_replicas", 0)
                 ).execute().actionGet();
@@ -124,7 +124,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
     public void updateMappingWithoutType() throws Exception {
         client().admin().indices().prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
+                        settingsBuilder()
                                 .put("index.number_of_shards", 1)
                                 .put("index.number_of_replicas", 0)
                 ).addMapping("doc", "{\"doc\":{\"properties\":{\"body\":{\"type\":\"string\"}}}}")
@@ -146,7 +146,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
     public void updateMappingWithoutTypeMultiObjects() throws Exception {
         client().admin().indices().prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
+                        settingsBuilder()
                                 .put("index.number_of_shards", 1)
                                 .put("index.number_of_replicas", 0)
                 ).execute().actionGet();
@@ -168,7 +168,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
+                        settingsBuilder()
                                 .put("index.number_of_shards", 2)
                                 .put("index.number_of_replicas", 0)
                 ).addMapping("type", "{\"type\":{\"properties\":{\"body\":{\"type\":\"string\"}}}}")
@@ -200,7 +200,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
+                        settingsBuilder()
                                 .put("index.number_of_shards", 2)
                                 .put("index.number_of_replicas", 0)
                 ).addMapping("type", "{\"type\":{\"properties\":{\"body\":{\"type\":\"string\"}}}}")
@@ -224,7 +224,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
 
         client().admin().indices().prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
+                        settingsBuilder()
                                 .put("index.number_of_shards", 2)
                                 .put("index.number_of_replicas", 0)
                 ).addMapping("type", "{\"type\":{\"properties\":{\"body\":{\"type\":\"string\"}}}}")
@@ -406,11 +406,7 @@ public class UpdateMappingTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void updateMappingConcurrently() throws Throwable {
-        // Test that we can concurrently update different indexes and types.
-        int shardNo = Math.max(5, cluster().size());
-
-        prepareCreate("test1").setSettings("index.number_of_shards", shardNo).execute().actionGet();
-        prepareCreate("test2").setSettings("index.number_of_shards", shardNo).execute().actionGet();
+        createIndex("test1", "test2");
 
         // This is important. The test assumes all nodes are aware of all indices. Due to initializing shard throttling
         // not all shards are allocated with the initial create index. Wait for it..

--- a/src/test/java/org/elasticsearch/indices/state/SimpleIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/SimpleIndexStateTests.java
@@ -57,10 +57,12 @@ public class SimpleIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> waiting for green status");
         ensureGreen();
 
+        NumShards numShards = getNumShards("test");
+
         ClusterStateResponse stateResponse = client().admin().cluster().prepareState().get();
         assertThat(stateResponse.getState().metaData().index("test").state(), equalTo(IndexMetaData.State.OPEN));
-        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(5));
-        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(10));
+        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(numShards.numPrimaries));
+        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(numShards.totalNumShards));
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
@@ -94,8 +96,9 @@ public class SimpleIndexStateTests extends ElasticsearchIntegrationTest {
 
         stateResponse = client().admin().cluster().prepareState().get();
         assertThat(stateResponse.getState().metaData().index("test").state(), equalTo(IndexMetaData.State.OPEN));
-        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(5));
-        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(10));
+
+        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(numShards.numPrimaries));
+        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(numShards.totalNumShards));
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
@@ -105,8 +108,7 @@ public class SimpleIndexStateTests extends ElasticsearchIntegrationTest {
     public void testFastCloseAfterCreateDoesNotClose() {
         logger.info("--> creating test index that cannot be allocated");
         client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.routing.allocation.include.tag", "no_such_node")
-                .put("index.number_of_replicas", 1).build()).get();
+                .put("index.routing.allocation.include.tag", "no_such_node").build()).get();
 
         ClusterHealthResponse health = client().admin().cluster().prepareHealth("test").setWaitForNodes(">=2").get();
         assertThat(health.isTimedOut(), equalTo(false));
@@ -126,10 +128,12 @@ public class SimpleIndexStateTests extends ElasticsearchIntegrationTest {
         logger.info("--> waiting for green status");
         ensureGreen();
 
+        NumShards numShards = getNumShards("test");
+
         ClusterStateResponse stateResponse = client().admin().cluster().prepareState().get();
         assertThat(stateResponse.getState().metaData().index("test").state(), equalTo(IndexMetaData.State.OPEN));
-        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(5));
-        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(10));
+        assertThat(stateResponse.getState().routingTable().index("test").shards().size(), equalTo(numShards.numPrimaries));
+        assertThat(stateResponse.getState().routingTable().index("test").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(numShards.totalNumShards));
 
         logger.info("--> indexing a simple document");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();

--- a/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Random;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -189,7 +190,9 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSegmentsStats() {
-        prepareCreate("test1", 2).setSettings("index.number_of_shards", 5, "index.number_of_replicas", 1).get();
+        assertAcked(prepareCreate("test1", 2));
+
+        NumShards test1 = getNumShards("test1");
 
         ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
@@ -203,7 +206,7 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
         IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).get();
 
         assertThat(stats.getTotal().getSegments(), notNullValue());
-        assertThat(stats.getTotal().getSegments().getCount(), equalTo(10l));
+        assertThat(stats.getTotal().getSegments().getCount(), equalTo((long)test1.totalNumShards));
         assumeTrue(org.elasticsearch.Version.CURRENT.luceneVersion != Version.LUCENE_46);
         assertThat(stats.getTotal().getSegments().getMemoryInBytes(), greaterThan(0l));
     }

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -37,12 +37,8 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-/**
- *
- */
 @ClusterScope(scope=Scope.TEST, numNodes=1)
 public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest {
-
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
@@ -67,6 +63,12 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
         }
 
         return settingsBuilder.build();
+    }
+
+    @Override
+    protected int numberOfShards() {
+        //number of shards won't be set through index settings, the one from the index templates needs to be used
+        return -1;
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/template/template0.json
+++ b/src/test/java/org/elasticsearch/indices/template/template0.json
@@ -1,5 +1,6 @@
 {
     "template" : "foo*",
+    "order" : 10,
     "settings" : {
         "index.number_of_shards": 10,
         "index.number_of_replicas": 0

--- a/src/test/java/org/elasticsearch/indices/template/template1.json
+++ b/src/test/java/org/elasticsearch/indices/template/template1.json
@@ -1,5 +1,6 @@
 {
     "template" : "foo*",
+    "order" : 10,
     "settings" : {
         "number_of_shards": 10,
         "number_of_replicas": 0

--- a/src/test/java/org/elasticsearch/indices/template/template2.json
+++ b/src/test/java/org/elasticsearch/indices/template/template2.json
@@ -1,5 +1,6 @@
 {
     "template" : "foo*",
+    "order" : 10,
     "settings" : {
         "index" : {
             "number_of_shards": 10,

--- a/src/test/java/org/elasticsearch/indices/template/template3.json
+++ b/src/test/java/org/elasticsearch/indices/template/template3.json
@@ -1,6 +1,7 @@
 {
     "mytemplate" : {
         "template" : "foo*",
+        "order" : 10,
         "settings" : {
             "index.number_of_shards": 10,
             "index.number_of_replicas": 0

--- a/src/test/java/org/elasticsearch/indices/template/template4.json
+++ b/src/test/java/org/elasticsearch/indices/template/template4.json
@@ -1,6 +1,7 @@
 {
     "mytemplate" : {
         "template" : "foo*",
+        "order" : 10,
         "settings" : {
             "number_of_shards": 10,
             "number_of_replicas": 0

--- a/src/test/java/org/elasticsearch/indices/template/template5.json
+++ b/src/test/java/org/elasticsearch/indices/template/template5.json
@@ -1,6 +1,7 @@
 {
     "mytemplate" : {
         "template" : "foo*",
+        "order" : 10,
         "settings" : {
             "index" : {
                 "number_of_shards": 10,

--- a/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerTests.java
@@ -46,18 +46,14 @@ import org.junit.Test;
 
 import java.util.Locale;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
-/**
- */
 public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
-
 
     @Test
     public void simpleWarmerTests() {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1))
-                .execute().actionGet();
+        createIndex("test");
         ensureGreen();
 
         PutWarmerResponse putWarmerResponse = client().admin().indices().preparePutWarmer("warmer_1")
@@ -127,9 +123,7 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
                         "}")
                 .execute().actionGet();
 
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1))
-                .execute().actionGet();
+        createIndex("test");
         ensureGreen();
 
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
@@ -143,11 +137,8 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void createIndexWarmer() {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSource("{\n" +
-                        "    \"settings\" : {\n" +
-                        "        \"index.number_of_shards\" : 1\n" +
-                        "    },\n" +
                         "    \"warmers\" : {\n" +
                         "        \"warmer_1\" : {\n" +
                         "            \"types\" : [],\n" +
@@ -158,8 +149,7 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
                         "            }\n" +
                         "        }\n" +
                         "    }\n" +
-                        "}")
-                .execute().actionGet();
+                        "}"));
 
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         IndexWarmersMetaData warmersMetaData = clusterState.metaData().index("test").custom(IndexWarmersMetaData.TYPE);
@@ -208,9 +198,7 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
 
     @Test // issue 3246
     public void ensureThatIndexWarmersCanBeChangedOnRuntime() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1, "index.number_of_replicas", 0))
-                .execute().actionGet();
+        createIndex("test");
         ensureGreen();
 
         PutWarmerResponse putWarmerResponse = client().admin().indices().preparePutWarmer("custom_warmer")
@@ -233,9 +221,7 @@ public class SimpleIndicesWarmerTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void gettingAllWarmersUsingAllAndWildcardsShouldWork() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1, "index.number_of_replicas", 0))
-                .execute().actionGet();
+        createIndex("test");
         ensureGreen();
 
         PutWarmerResponse putWarmerResponse = client().admin().indices().preparePutWarmer("custom_warmer")

--- a/src/test/java/org/elasticsearch/nested/SimpleNestedTests.java
+++ b/src/test/java/org/elasticsearch/nested/SimpleNestedTests.java
@@ -27,8 +27,6 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.FilterBuilders;
@@ -40,7 +38,6 @@ import org.elasticsearch.search.facet.termsstats.TermsStatsFacet;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,8 +45,7 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
 public class SimpleNestedTests extends ElasticsearchIntegrationTest {
@@ -70,7 +66,7 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
                 endObject().
                 endObject().
                 endObject();
-        ElasticsearchAssertions.assertAcked(prepareCreate("test").addMapping("type1", builder));
+        assertAcked(prepareCreate("test").addMapping("type1", builder));
         ensureGreen();
 
         // check on no data, see it works
@@ -195,14 +191,13 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     private void simpleNestedDeleteByQuery(int total, int docToDelete) throws Exception {
 
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.referesh_interval", -1).build())
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder().put(indexSettings()).put("index.referesh_interval", -1).build())
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested")
                         .endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
         ensureGreen();
 
@@ -255,16 +250,15 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     private void noChildrenNestedDeleteByQuery(long total, int docToDelete) throws Exception {
 
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.referesh_interval", -1).build())
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder().put(indexSettings()).put("index.referesh_interval", -1).build())
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested")
                         .endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
 
         for (int i = 0; i < total; i++) {
@@ -293,14 +287,13 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void multiNested() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested").startObject("properties")
                         .startObject("nested2").field("type", "nested").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
         ensureGreen();
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder()
@@ -370,22 +363,23 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFacetsMultiShards() throws Exception {
-        testFacets(3);
+        testFacets(between(2, DEFAULT_MAX_NUM_SHARDS));
     }
 
     private void testFacets(int numberOfShards) throws Exception {
 
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", numberOfShards))
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
+                        .put("index.number_of_shards", numberOfShards))
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested").startObject("properties")
                         .startObject("nested2").field("type", "nested").endObject()
                         .endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder()
                 .startObject()
@@ -405,7 +399,7 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
                 .endArray()
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery())
                 .addFacet(FacetBuilders.termsStatsFacet("facet1").keyField("nested1.nested2.field2_1").valueField("nested1.nested2.field2_2").nested("nested1.nested2"))
@@ -497,19 +491,18 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
     // This IncludeNestedDocsQuery also needs to be aware of the filter from alias
     public void testDeleteNestedDocsWithAlias() throws Exception {
 
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.referesh_interval", -1).build())
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder().put(indexSettings()).put("index.referesh_interval", -1).build())
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested")
                         .endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
         client().admin().indices().prepareAliases()
                 .addAlias("test", "alias1", FilterBuilders.termFilter("field1", "value1")).execute().actionGet();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
@@ -560,15 +553,14 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
     @Test
     public void testExplain() throws Exception {
 
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested")
                         .endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("field1", "value1")
@@ -603,26 +595,22 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleNestedSorting() throws Exception {
-                client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder()
-                        .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 0)
-                        .put("index.refresh_interval", -1)
-                        .build()
-                )
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("nested1")
-                        .field("type", "nested")
-                        .startObject("properties")
-                        .startObject("field1")
-                        .field("type", "long")
-                        .field("store", "yes")
-                        .endObject()
-                        .endObject()
-                        .endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                assertAcked(prepareCreate("test")
+                        .setSettings(settingsBuilder()
+                                .put(indexSettings())
+                                .put("index.refresh_interval", -1))
+                        .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
+                                .startObject("nested1")
+                                .field("type", "nested")
+                                .startObject("properties")
+                                .startObject("field1")
+                                .field("type", "long")
+                                .field("store", "yes")
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject().endObject().endObject()));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("field1", 1)
@@ -657,7 +645,7 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
                 .endObject()
                 .endArray()
                 .endObject()).execute().actionGet();
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setTypes("type1")
@@ -777,20 +765,16 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleNestedSorting_withNestedFilterMissing() throws Exception {
-                client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder()
-                        .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 0)
-                        .put("index.referesh_interval", -1)
-                        .build()
-                )
-                .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
-                        .startObject("nested1")
-                        .field("type", "nested")
-                        .endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                assertAcked(prepareCreate("test")
+                        .setSettings(settingsBuilder()
+                                .put(indexSettings())
+                                .put("index.referesh_interval", -1))
+                        .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
+                                .startObject("nested1")
+                                .field("type", "nested")
+                                .endObject()
+                                .endObject().endObject().endObject()));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("field1", 1)
@@ -819,7 +803,7 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
                 .endArray()
                 .endObject()).execute().actionGet();
         // Doc with missing nested docs if nested filter is used
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
         client().prepareIndex("test", "type1", "3").setSource(jsonBuilder().startObject()
                 .field("field1", 3)
                 .startArray("nested1")
@@ -833,7 +817,7 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
                 .endObject()
                 .endArray()
                 .endObject()).execute().actionGet();
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setTypes("type1")
@@ -866,27 +850,25 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSortNestedWithNestedFilter() throws Exception {
-                client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("type1", XContentFactory.jsonBuilder().startObject()
-                        .startObject("type1")
-                        .startObject("properties")
-                        .startObject("grand_parent_values").field("type", "long").endObject()
-                        .startObject("parent").field("type", "nested")
-                        .startObject("properties")
-                        .startObject("parent_values").field("type", "long").endObject()
-                        .startObject("child").field("type", "nested")
-                        .startObject("properties")
-                        .startObject("child_values").field("type", "long").endObject()
-                        .endObject()
-                        .endObject()
-                        .endObject()
-                        .endObject()
-                        .endObject()
-                        .endObject()
-                        .endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                assertAcked(prepareCreate("test")
+                        .addMapping("type1", XContentFactory.jsonBuilder().startObject()
+                                .startObject("type1")
+                                .startObject("properties")
+                                .startObject("grand_parent_values").field("type", "long").endObject()
+                                .startObject("parent").field("type", "nested")
+                                .startObject("properties")
+                                .startObject("parent_values").field("type", "long").endObject()
+                                .startObject("child").field("type", "nested")
+                                .startObject("properties")
+                                .startObject("child_values").field("type", "long").endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject()));
+        ensureGreen();
 
         // sum: 11
         client().prepareIndex("test", "type1", Integer.toString(1)).setSource(jsonBuilder().startObject()
@@ -983,7 +965,7 @@ public class SimpleNestedTests extends ElasticsearchIntegrationTest {
                 .endObject()
                 .endObject()
                 .endObject()).execute().actionGet();
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         // Without nested filter
         SearchResponse searchResponse = client().prepareSearch()

--- a/src/test/java/org/elasticsearch/percolator/ConcurrentPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/ConcurrentPercolatorTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -51,12 +50,7 @@ public class ConcurrentPercolatorTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleConcurrentPercolator() throws Exception {
-        client().admin().indices().prepareCreate("index").setSettings(
-                ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 0)
-                        .build()
-        ).execute().actionGet();
+        createIndex("index");
         ensureGreen();
 
         final BytesReference onlyField1 = XContentFactory.jsonBuilder().startObject().startObject("doc")
@@ -147,12 +141,7 @@ public class ConcurrentPercolatorTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testConcurrentAddingAndPercolating() throws Exception {
-        client().admin().indices().prepareCreate("index").setSettings(
-                ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 2)
-                        .put("index.number_of_replicas", 1)
-                        .build()
-        ).execute().actionGet();
+        createIndex("index");
         ensureGreen();
         final int numIndexThreads = 3;
         final int numPercolateThreads = 6;
@@ -296,12 +285,7 @@ public class ConcurrentPercolatorTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testConcurrentAddingAndRemovingWhilePercolating() throws Exception {
-        client().admin().indices().prepareCreate("index").setSettings(
-                ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 2)
-                        .put("index.number_of_replicas", 1)
-                        .build()
-        ).execute().actionGet();
+        createIndex("index");
         ensureGreen();
         final int numIndexThreads = 3;
         final int numberPercolateOperation = 100;

--- a/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadTests.java
+++ b/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -44,10 +43,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -310,7 +308,7 @@ public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {
         cluster().ensureAtLeastNumNodes(3);
         logger.info("--> creating test index ...");
         int allowNodes = 2;
-        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder().put("number_of_shards", numShards).put("number_of_replicas", numReplicas).build()));
+        assertAcked(prepareCreate("test").setSettings(settingsBuilder().put(indexSettings()).put("number_of_shards", numShards).put("number_of_replicas", numReplicas).build()));
         final AtomicLong idGenerator = new AtomicLong();
         final AtomicLong indexCounter = new AtomicLong();
         final AtomicBoolean stop = new AtomicBoolean(false);
@@ -364,7 +362,7 @@ public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {
         logger.info("--> indexing threads stopped");
         logger.info("--> bump up number of replicas to 1 and allow all nodes to hold the index");
         allowNodes("test", 3);
-        assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(ImmutableSettings.settingsBuilder().put("number_of_replicas", 1)).get());
+        assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put("number_of_replicas", 1)).get());
         assertThat(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForGreenStatus().execute().actionGet().isTimedOut(), equalTo(false));
 
         logger.info("--> refreshing the index");

--- a/src/test/java/org/elasticsearch/recovery/SimpleRecoveryTests.java
+++ b/src/test/java/org/elasticsearch/recovery/SimpleRecoveryTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.recovery;
 
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -50,30 +48,26 @@ public class SimpleRecoveryTests extends ElasticsearchIntegrationTest {
     public void testSimpleRecovery() throws Exception {
         prepareCreate("test", 1).execute().actionGet(5000);
 
+        NumShards numShards = getNumShards("test");
+
         logger.info("Running Cluster Health");
-        ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForYellowStatus()).actionGet();
-        logger.info("Done Cluster Health, status " + clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
+        ensureYellow();
 
         client().index(indexRequest("test").type("type1").id("1").source(source("1", "test"))).actionGet();
         FlushResponse flushResponse = client().admin().indices().flush(flushRequest("test")).actionGet();
-        assertThat(flushResponse.getTotalShards(), equalTo(10));
-        assertThat(flushResponse.getSuccessfulShards(), equalTo(5));
+        assertThat(flushResponse.getTotalShards(), equalTo(numShards.totalNumShards));
+        assertThat(flushResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
         assertThat(flushResponse.getFailedShards(), equalTo(0));
         client().index(indexRequest("test").type("type1").id("2").source(source("2", "test"))).actionGet();
         RefreshResponse refreshResponse = client().admin().indices().refresh(refreshRequest("test")).actionGet();
-        assertThat(refreshResponse.getTotalShards(), equalTo(10));
-        assertThat(refreshResponse.getSuccessfulShards(), equalTo(5));
+        assertThat(refreshResponse.getTotalShards(), equalTo(numShards.totalNumShards));
+        assertThat(refreshResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
 
         allowNodes("test", 2);
 
         logger.info("Running Cluster Health");
-        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().local(true).waitForNodes(">=2")).actionGet();
-        logger.info("Done Cluster Health, status " + clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        ensureGreen();
 
         GetResponse getResult;
 
@@ -92,10 +86,7 @@ public class SimpleRecoveryTests extends ElasticsearchIntegrationTest {
         allowNodes("test", 3);
         Thread.sleep(200);
         logger.info("Running Cluster Health");
-        clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForGreenStatus().waitForRelocatingShards(0).waitForNodes(">=3")).actionGet();
-        logger.info("Done Cluster Health, status " + clusterHealth.getStatus());
-        assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        ensureGreen();
 
         for (int i = 0; i < 5; i++) {
             getResult = client().get(getRequest("test").type("type1").id("1")).actionGet(1000);

--- a/src/test/java/org/elasticsearch/river/RiverTests.java
+++ b/src/test/java/org/elasticsearch/river/RiverTests.java
@@ -143,6 +143,7 @@ public class RiverTests extends ElasticsearchIntegrationTest {
         IndexResponse indexResponse = client().prepareIndex(RiverIndexName.Conf.DEFAULT_INDEX_NAME, riverName, "_meta")
                 .setSource("type", DummyRiverModule.class.getCanonicalName()).get();
         assertTrue(indexResponse.isCreated());
+        ensureGreen();
     }
 
     private void checkRiverIsStarted(final String riverName) throws InterruptedException {

--- a/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.action.termvector.TermVectorRequest;
 import org.elasticsearch.action.termvector.TermVectorResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Requests;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -38,20 +37,22 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 /**
  *
  */
 public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
-   
-    
+
+    @Override
+    protected int minimumNumberOfShards() {
+        return 2;
+    }
+
     @Test
     public void testSimpleCrudRouting() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
@@ -109,7 +110,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
     @Test
     public void testSimpleSearchRouting() {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
@@ -178,7 +179,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_routing").field("required", true).endObject().endObject().endObject())
                 .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
@@ -236,7 +237,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
                         .endObject().endObject())
                 .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", "0").setRefresh(true).execute().actionGet();
@@ -273,7 +274,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
                         .endObject().endObject())
                 .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareBulk().add(
@@ -304,7 +305,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
                         .endObject().endObject())
                 .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", 0).execute().actionGet();
@@ -331,7 +332,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_routing").field("required", true).endObject().endObject().endObject())
                 .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").get();

--- a/src/test/java/org/elasticsearch/search/StressSearchServiceReaperTest.java
+++ b/src/test/java/org/elasticsearch/search/StressSearchServiceReaperTest.java
@@ -31,19 +31,23 @@ import org.junit.Test;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
-/**
- */
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+@ClusterScope(scope = SUITE)
 public class StressSearchServiceReaperTest extends ElasticsearchIntegrationTest {
-
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         // very frequent checks
         return ImmutableSettings.builder().put(SearchService.KEEPALIVE_INTERVAL_KEY, TimeValue.timeValueMillis(1)).build();
+    }
+
+    @Override
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     @Slow
@@ -54,7 +58,7 @@ public class StressSearchServiceReaperTest extends ElasticsearchIntegrationTest 
         for (int i = 0; i < builders.length; i++) {
             builders[i] = client().prepareIndex("test", "type", "" + i).setSource("f", English.intToEnglish(i));
         }
-        prepareCreate("test").setSettings("number_of_shards", randomIntBetween(1,5), "number_of_replicas", randomIntBetween(0,1)).setSettings();
+        createIndex("test");
         indexRandom(true, builders);
         ensureYellow();
         final int iterations = atLeast(500);

--- a/src/test/java/org/elasticsearch/search/aggregations/CombiTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/CombiTests.java
@@ -23,8 +23,6 @@ import com.carrotsearch.hppc.IntIntMap;
 import com.carrotsearch.hppc.IntIntOpenHashMap;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -46,13 +44,9 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class CombiTests extends ElasticsearchIntegrationTest {
 
-
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     /**

--- a/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
@@ -25,8 +25,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.RangeFilterBuilder;
@@ -51,14 +49,9 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class RandomTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
-
-
 
     // Make sure that unordered, reversed, disjoint and/or overlapping ranges are supported
     // Duel with filters

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -20,8 +20,6 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
@@ -53,11 +51,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     private DateTime date(int month, int day) {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -54,11 +54,8 @@ import static org.hamcrest.core.IsNull.nullValue;
 public class DateRangeTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     private static IndexRequestBuilder indexDoc(int month, int day, int value) throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
@@ -62,11 +62,8 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
     private static final String MULTI_VALUED_FIELD_NAME = "d_values";
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
@@ -50,11 +48,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class FilterTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     int numDocs, numTag1Docs;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -52,11 +50,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class GeoDistanceTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     private IndexRequestBuilder indexCity(String idx, String name, String... latLons) throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -24,8 +24,6 @@ import com.carrotsearch.hppc.cursors.ObjectIntCursor;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoHashUtils;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.GeoBoundingBoxFilterBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -41,20 +39,15 @@ import java.util.Random;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geohashGrid;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-/**
- *
- */
 public class GeoHashGridTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     private IndexRequestBuilder indexCity(String name, String latLon) throws Exception {
@@ -75,9 +68,8 @@ public class GeoHashGridTests extends ElasticsearchIntegrationTest {
 
     @Before
     public void init() throws Exception {
-        prepareCreate("idx")
-                .addMapping("type", "location", "type=geo_point", "city", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        assertAcked(prepareCreate("idx")
+                .addMapping("type", "location", "type=geo_point", "city", "type=string,index=not_analyzed"));
 
         createIndex("idx_unmapped");
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
@@ -49,11 +49,8 @@ public class GlobalTests extends ElasticsearchIntegrationTest {
     int numDocs;
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import com.carrotsearch.hppc.LongOpenHashSet;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -55,11 +53,8 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas",  between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     int numDocs;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
@@ -20,8 +20,6 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4Range;
@@ -50,11 +48,8 @@ import static org.hamcrest.core.IsNull.nullValue;
 public class IPv4RangeTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
     
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
@@ -60,11 +60,8 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
@@ -50,11 +50,8 @@ public class MinDocCountTests extends ElasticsearchIntegrationTest {
     private static final QueryBuilder QUERY = QueryBuilders.termQuery("match", true);
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     private int cardinality;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingTests.java
@@ -20,8 +20,6 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
@@ -46,13 +44,9 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class MissingTests extends ElasticsearchIntegrationTest {
 
-
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     int numDocs, numDocsMissing, numDocsUnmapped;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
@@ -42,6 +42,7 @@ import java.util.List;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -53,11 +54,8 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class NestedTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     int numParents;
@@ -66,10 +64,9 @@ public class NestedTests extends ElasticsearchIntegrationTest {
     @Before
     public void init() throws Exception {
 
-        prepareCreate("idx")
-                .addMapping("type", "nested", "type=nested")
-                .setSettings(indexSettings())
-                .execute().actionGet();
+        assertAcked(prepareCreate("idx")
+                .addMapping("type", "nested", "type=nested"));
+
         List<IndexRequestBuilder> builders = new ArrayList<IndexRequestBuilder>();
 
         numParents = randomIntBetween(3, 10);

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -20,8 +20,6 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -52,11 +50,8 @@ public class RangeTests extends ElasticsearchIntegrationTest {
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     int numDocs;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoHashUtils;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
@@ -42,6 +40,7 @@ import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -54,11 +53,8 @@ import static org.hamcrest.Matchers.equalTo;
 public class ShardReduceTests extends ElasticsearchIntegrationTest {
 
     @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", randomBoolean() ? 1 : randomIntBetween(2, 10))
-                .put("index.number_of_replicas", randomIntBetween(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     private IndexRequestBuilder indexDoc(String date, int value) throws Exception {
@@ -79,10 +75,8 @@ public class ShardReduceTests extends ElasticsearchIntegrationTest {
 
     @Before
     public void init() throws Exception {
-        prepareCreate("idx")
-                .addMapping("type", "nested", "type=nested", "ip", "type=ip", "location", "type=geo_point")
-                .setSettings(indexSettings())
-                .execute().actionGet();
+        assertAcked(prepareCreate("idx")
+                .addMapping("type", "nested", "type=nested", "ip", "type=ip", "location", "type=geo_point"));
 
         indexRandom(true,
                 indexDoc("2014-01-01", 1),

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTermsTests.java
@@ -19,54 +19,22 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import com.google.common.collect.ImmutableMap;
-import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
-/**
- *
- */
-@ClusterScope(scope = Scope.TEST)
-public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
-
-    /**
-     * to properly test the effect/functionality of shard_size, we need to force having 2 shards and also
-     * control the routing such that certain documents will end on each shard. Using "djb" routing hash + ignoring the
-     * doc type when hashing will ensure that docs with routing value "1" will end up in a different shard than docs with
-     * routing value "2".
-     */
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", 2)
-                .put("index.number_of_replicas", 0)
-                .put("cluster.routing.operation.hash.type", "djb")
-                .put("cluster.routing.operation.use_type", "false")
-                .build();
-    }
+public class ShardSizeTermsTests extends ShardSizeTests {
 
     @Test
     public void noShardSize_string() throws Exception {
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -91,9 +59,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_string() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -118,9 +84,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_string_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -145,9 +109,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void noShardSize_long() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -172,9 +134,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_long() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -199,9 +159,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_long_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -226,9 +184,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void noShardSize_double() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -253,9 +209,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_double() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -280,9 +234,7 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_double_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -303,59 +255,4 @@ public class ShardSizeTermsTests extends ElasticsearchIntegrationTest {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
     }
-
-    private void indexData() throws Exception {
-
-        /*
-
-
-        ||          ||           size = 3, shard_size = 5               ||           shard_size = size = 3               ||
-        ||==========||==================================================||===============================================||
-        || shard 1: ||  "1" - 5 | "2" - 4 | "3" - 3 | "4" - 2 | "5" - 1 || "1" - 5 | "3" - 3 | "2" - 4                   ||
-        ||----------||--------------------------------------------------||-----------------------------------------------||
-        || shard 2: ||  "1" - 3 | "2" - 1 | "3" - 5 | "4" - 2 | "5" - 1 || "1" - 3 | "3" - 5 | "4" - 2                   ||
-        ||----------||--------------------------------------------------||-----------------------------------------------||
-        || reduced: ||  "1" - 8 | "2" - 5 | "3" - 8 | "4" - 4 | "5" - 2 ||                                               ||
-        ||          ||                                                  || "1" - 8, "3" - 8, "2" - 4    <= WRONG         ||
-        ||          ||  "1" - 8 | "3" - 8 | "2" - 5     <= CORRECT      ||                                               ||
-
-
-        */
-
-        List<IndexRequestBuilder> indexOps = new ArrayList<IndexRequestBuilder>();
-
-        indexDoc("1", "1", 5, indexOps);
-        indexDoc("1", "2", 4, indexOps);
-        indexDoc("1", "3", 3, indexOps);
-        indexDoc("1", "4", 2, indexOps);
-        indexDoc("1", "5", 1, indexOps);
-
-        // total docs in shard "1" = 15
-
-        indexDoc("2", "1", 3, indexOps);
-        indexDoc("2", "2", 1, indexOps);
-        indexDoc("2", "3", 5, indexOps);
-        indexDoc("2", "4", 2, indexOps);
-        indexDoc("2", "5", 1, indexOps);
-
-        // total docs in shard "2"  = 12
-
-        indexRandom(true, indexOps);
-
-        long totalOnOne = client().prepareSearch("idx").setTypes("type").setRouting("1").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
-        assertThat(totalOnOne, is(15l));
-        long totalOnTwo = client().prepareSearch("idx").setTypes("type").setRouting("2").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
-        assertThat(totalOnTwo, is(12l));
-        ensureSearchable();
-    }
-
-    private void indexDoc(String shard, String key, int times, List<IndexRequestBuilder> indexOps) throws Exception {
-        for (int i = 0; i < times; i++) {
-            indexOps.add(client().prepareIndex("idx", "type").setRouting(shard).setCreate(true).setSource(jsonBuilder()
-                    .startObject()
-                    .field("key", key)
-                    .endObject()));
-        }
-    }
-
 }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTests.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Ignore;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.SUITE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.is;
+
+@Ignore
+@ClusterScope(scope = SUITE)
+public abstract class ShardSizeTests extends ElasticsearchIntegrationTest {
+
+    /**
+     * to properly test the effect/functionality of shard_size, we need to force having 2 shards and also
+     * control the routing such that certain documents will end on each shard. Using "djb" routing hash + ignoring the
+     * doc type when hashing will ensure that docs with routing value "1" will end up in a different shard than docs with
+     * routing value "2".
+     */
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder()
+                .put("cluster.routing.operation.hash.type", "djb")
+                .put("cluster.routing.operation.use_type", "false")
+                .build();
+    }
+
+    @Override
+    protected int numberOfShards() {
+        return 2;
+    }
+
+    @Override
+    protected int numberOfReplicas() {
+        return between(0, 1);
+    }
+
+    protected void createIdx(String keyFieldMapping) {
+        assertAcked(prepareCreate("idx")
+                .addMapping("type", "key", keyFieldMapping));
+    }
+
+    protected void indexData() throws Exception {
+
+        /*
+
+
+        ||          ||           size = 3, shard_size = 5               ||           shard_size = size = 3               ||
+        ||==========||==================================================||===============================================||
+        || shard 1: ||  "1" - 5 | "2" - 4 | "3" - 3 | "4" - 2 | "5" - 1 || "1" - 5 | "3" - 3 | "2" - 4                   ||
+        ||----------||--------------------------------------------------||-----------------------------------------------||
+        || shard 2: ||  "1" - 3 | "2" - 1 | "3" - 5 | "4" - 2 | "5" - 1 || "1" - 3 | "3" - 5 | "4" - 2                   ||
+        ||----------||--------------------------------------------------||-----------------------------------------------||
+        || reduced: ||  "1" - 8 | "2" - 5 | "3" - 8 | "4" - 4 | "5" - 2 ||                                               ||
+        ||          ||                                                  || "1" - 8, "3" - 8, "2" - 4    <= WRONG         ||
+        ||          ||  "1" - 8 | "3" - 8 | "2" - 5     <= CORRECT      ||                                               ||
+
+
+        */
+
+
+        indexDoc("1", "1", 5);
+        indexDoc("1", "2", 4);
+        indexDoc("1", "3", 3);
+        indexDoc("1", "4", 2);
+        indexDoc("1", "5", 1);
+
+        // total docs in shard "1" = 15
+
+        indexDoc("2", "1", 3);
+        indexDoc("2", "2", 1);
+        indexDoc("2", "3", 5);
+        indexDoc("2", "4", 2);
+        indexDoc("2", "5", 1);
+
+        // total docs in shard "2"  = 12
+
+        client().admin().indices().prepareFlush("idx").execute().actionGet();
+        client().admin().indices().prepareRefresh("idx").execute().actionGet();
+
+        long totalOnOne = client().prepareSearch("idx").setTypes("type").setRouting("1").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
+        assertThat(totalOnOne, is(15l));
+        long totalOnTwo = client().prepareSearch("idx").setTypes("type").setRouting("2").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
+        assertThat(totalOnTwo, is(12l));
+    }
+
+    protected void indexDoc(String shard, String key, int times) throws Exception {
+        for (int i = 0; i < times; i++) {
+            client().prepareIndex("idx", "type").setRouting(shard).setCreate(true).setSource(jsonBuilder()
+                    .startObject()
+                    .field("key", key)
+                    .field("value", 1)
+                    .endObject()).execute().actionGet();
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -63,11 +63,8 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     private static final String MULTI_VALUED_FIELD_NAME = "s_values";
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     public static String randomExecutionHint() {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
@@ -19,8 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
 
@@ -33,13 +31,10 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  *
  */
 public abstract class AbstractNumericTests extends ElasticsearchIntegrationTest {
-    
+
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     protected long minValue, maxValue, minValues, maxValues;

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountTests.java
@@ -19,8 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCount;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
@@ -38,11 +36,8 @@ import static org.hamcrest.Matchers.notNullValue;
 public class ValueCountTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     @Before

--- a/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresTests.java
@@ -50,25 +50,27 @@ public class TransportSearchFailuresTests extends ElasticsearchIntegrationTest {
     @Test
     public void testFailedSearchWithWrongQuery() throws Exception {
         logger.info("Start Testing failed search with wrong query");
-        prepareCreate("test", 1, settingsBuilder().put("index.number_of_shards", 3)
+        prepareCreate("test", 1, settingsBuilder().put(indexSettings())
                     .put("index.number_of_replicas", 2)
                     .put("routing.hash.type", "simple")).execute().actionGet();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        ensureYellow();
+
+        NumShards test = getNumShards("test");
 
         for (int i = 0; i < 100; i++) {
             index(client(), Integer.toString(i), "test", i);
         }
         RefreshResponse refreshResponse = client().admin().indices().refresh(refreshRequest("test")).actionGet();
-        assertThat(refreshResponse.getTotalShards(), equalTo(9));
-        assertThat(refreshResponse.getSuccessfulShards(), equalTo(3));
+        assertThat(refreshResponse.getTotalShards(), equalTo(test.totalNumShards));
+        assertThat(refreshResponse.getSuccessfulShards(), equalTo(test.numPrimaries));
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
         for (int i = 0; i < 5; i++) {
             try {
                 SearchResponse searchResponse = client().search(searchRequest("test").source("{ xxx }".getBytes(Charsets.UTF_8))).actionGet();
-                assertThat(searchResponse.getTotalShards(), equalTo(3));
+                assertThat(searchResponse.getTotalShards(), equalTo(test.numPrimaries));
                 assertThat(searchResponse.getSuccessfulShards(), equalTo(0));
-                assertThat(searchResponse.getFailedShards(), equalTo(3));
+                assertThat(searchResponse.getFailedShards(), equalTo(test.numPrimaries));
                 fail("search should fail");
             } catch (ElasticsearchException e) {
                 assertThat(e.unwrapCause(), instanceOf(SearchPhaseExecutionException.class));
@@ -81,23 +83,23 @@ public class TransportSearchFailuresTests extends ElasticsearchIntegrationTest {
 
         logger.info("Running Cluster Health");
         ClusterHealthResponse clusterHealth = client().admin().cluster().health(clusterHealthRequest("test")
-                .waitForYellowStatus().waitForRelocatingShards(0).waitForActiveShards(6)).actionGet();
+                .waitForYellowStatus().waitForRelocatingShards(0).waitForActiveShards(test.numPrimaries * 2)).actionGet();
         logger.info("Done Cluster Health, status " + clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
-        assertThat(clusterHealth.getActiveShards(), equalTo(6));
+        assertThat(clusterHealth.getActiveShards(), equalTo(test.numPrimaries * 2));
 
         refreshResponse = client().admin().indices().refresh(refreshRequest("test")).actionGet();
-        assertThat(refreshResponse.getTotalShards(), equalTo(9));
-        assertThat(refreshResponse.getSuccessfulShards(), equalTo(6));
+        assertThat(refreshResponse.getTotalShards(), equalTo(test.totalNumShards));
+        assertThat(refreshResponse.getSuccessfulShards(), equalTo(test.numPrimaries * 2));
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
 
         for (int i = 0; i < 5; i++) {
             try {
                 SearchResponse searchResponse = client().search(searchRequest("test").source("{ xxx }".getBytes(Charsets.UTF_8))).actionGet();
-                assertThat(searchResponse.getTotalShards(), equalTo(3));
+                assertThat(searchResponse.getTotalShards(), equalTo(test.numPrimaries));
                 assertThat(searchResponse.getSuccessfulShards(), equalTo(0));
-                assertThat(searchResponse.getFailedShards(), equalTo(3));
+                assertThat(searchResponse.getFailedShards(), equalTo(test.numPrimaries));
                 fail("search should fail");
             } catch (ElasticsearchException e) {
                 assertThat(e.unwrapCause(), instanceOf(SearchPhaseExecutionException.class));

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -30,9 +30,8 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.common.Priority;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.mapper.MergeMappingException;
 import org.elasticsearch.index.query.*;
@@ -52,7 +51,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.builder;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
@@ -68,18 +68,16 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void multiLevelChild() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
                 .addMapping("child", "_parent", "type=parent")
-                .addMapping("grandchild", "_parent", "type=child")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .get();
+                .addMapping("grandchild", "_parent", "type=child"));
         ensureGreen();
 
         client().prepareIndex("test", "parent", "p1").setSource("p_field", "p_value1").get();
         client().prepareIndex("test", "child", "c1").setSource("c_field", "c_value1").setParent("p1").get();
         client().prepareIndex("test", "grandchild", "gc1").setSource("gc_field", "gc_value1")
-                .setParent("c1").setRouting("gc1").get();
+                .setParent("c1").setRouting("p1").get();
         refresh();
 
         SearchResponse searchResponse = client()
@@ -125,17 +123,15 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     @Test
     // see #2744
     public void test2744() throws ElasticsearchException, IOException {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("test", "_parent", "type=foo")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .get();
+                .addMapping("test", "_parent", "type=foo"));
         ensureGreen();
 
         // index simple data
         client().prepareIndex("test", "foo", "1").setSource("foo", 1).get();
         client().prepareIndex("test", "test").setSource("foo", 1).setParent("1").get();
-        client().admin().indices().prepareRefresh().get();
+        refresh();
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("test", matchQuery("foo", 1))).execute()
                 .actionGet();
         assertThat(searchResponse.getFailedShards(), equalTo(0));
@@ -146,11 +142,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleChildQuery() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -251,13 +245,8 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testClearIdCacheBug() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .addMapping("parent")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                ).get();
+        assertAcked(prepareCreate("test")
+                .addMapping("parent"));
         ensureGreen();
 
         client().prepareIndex("test", "parent", "p0").setSource("p_field", "p_value0").get();
@@ -281,7 +270,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "child", "c3").setSource("c_field", "blue").setParent("p2").get();
         client().prepareIndex("test", "child", "c4").setSource("c_field", "red").setParent("p2").get();
 
-        client().admin().indices().prepareRefresh().get();
+        refresh();
 
         indicesStatsResponse = client().admin().indices()
                 .prepareStats("test").setFieldData(true).get();
@@ -312,11 +301,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     @Test
     // See: https://github.com/elasticsearch/elasticsearch/issues/3290
     public void testCachingBug_withFqueryFilter() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -330,8 +317,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
             client().prepareIndex("test", "child", Integer.toString(i + 10)).setSource("c_field", i + 10).setParent(Integer.toString(i))
                     .get();
         }
-        client().admin().indices().prepareFlush().get();
-        client().admin().indices().prepareRefresh().get();
+        flushAndRefresh();
 
         for (int i = 0; i < 10; i++) {
             SearchResponse searchResponse = client().prepareSearch("test")
@@ -351,11 +337,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testHasParentFilter() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
         Map<String, Set<String>> parentToChildren = newHashMap();
         // Childless parent
@@ -382,7 +366,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
             }
             assertThat(parentToChildren.get(previousParentId).add(childId), is(true));
         }
-        indexRandom(true, builders.toArray(new IndexRequestBuilder[0]));
+        indexRandom(true, builders.toArray(new IndexRequestBuilder[builders.size()]));
 
         assertThat(parentToChildren.isEmpty(), equalTo(false));
         for (Map.Entry<String, Set<String>> parentToChildrenEntry : parentToChildren.entrySet()) {
@@ -404,11 +388,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleChildQueryWithFlush() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data with flushes, so we have many segments
@@ -425,108 +407,6 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "child", "c4").setSource("c_field", "red").setParent("p2").get();
         client().admin().indices().prepareFlush().get();
         refresh();
-
-        // TOP CHILDREN QUERY
-
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(topChildrenQuery("child", termQuery("c_field", "yellow")))
-                .get();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
-
-        searchResponse = client().prepareSearch("test").setQuery(topChildrenQuery("child", termQuery("c_field", "blue"))).execute()
-                .actionGet();
-        if (searchResponse.getFailedShards() > 0) {
-            logger.warn("Failed shards:");
-            for (ShardSearchFailure shardSearchFailure : searchResponse.getShardFailures()) {
-                logger.warn("-> {}", shardSearchFailure);
-            }
-        }
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
-
-        searchResponse = client().prepareSearch("test").setQuery(topChildrenQuery("child", termQuery("c_field", "red"))).execute()
-                .actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
-        assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
-        assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
-
-        // HAS CHILD QUERY
-
-        searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "yellow"))).execute()
-                .actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
-
-        searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "blue"))).execute()
-                .actionGet();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
-
-        searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "red"))).get();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
-        assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
-        assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
-
-        // HAS CHILD FILTER
-
-        searchResponse = client().prepareSearch("test")
-                .setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "yellow")))).get();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "blue"))))
-                .get();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(hasChildFilter("child", termQuery("c_field", "red"))))
-                .get();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
-        assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
-        assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
-    }
-
-    @Test
-    public void simpleChildQueryWithFlushAnd3Shards() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 3).put("index.number_of_replicas", 0))
-                .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
-        ensureGreen();
-
-        // index simple data with flushes, so we have many segments
-        client().prepareIndex("test", "parent", "p1").setSource("p_field", "p_value1").get();
-        client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "child", "c1").setSource("c_field", "red").setParent("p1").get();
-        client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "child", "c2").setSource("c_field", "yellow").setParent("p1").get();
-        client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "parent", "p2").setSource("p_field", "p_value2").get();
-        client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "child", "c3").setSource("c_field", "blue").setParent("p2").get();
-        client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "child", "c4").setSource("c_field", "red").setParent("p2").get();
-        client().admin().indices().prepareFlush().get();
-
-        client().admin().indices().prepareRefresh().get();
 
         // TOP CHILDREN QUERY
 
@@ -607,11 +487,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testScopedFacet() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -648,11 +526,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeletedParent() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
         // index simple data
         client().prepareIndex("test", "parent", "p1").setSource("p_field", "p_value1").get();
@@ -711,11 +587,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDfsSearchType() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -745,11 +619,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFixAOBEIfTopChildrenIsWrappedInMusNotClause() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -770,11 +642,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testTopChildrenReSearchBug() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
         int numberOfParents = 4;
         int numberOfChildrenPerParent = 123;
@@ -803,16 +673,15 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
         assertNoFailures(searchResponse);
         assertThat(searchResponse.getFailedShards(), equalTo(0));
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
-        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
+        assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p4")));
+        assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p4")));
     }
 
     @Test
     public void testHasChildAndHasParentFailWhenSomeSegmentsDontContainAnyParentOrChildDocs() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         client().prepareIndex("test", "parent", "1").setSource("p_field", 1).get();
@@ -837,11 +706,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testCountApiUsage() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         String parentId = "p1";
@@ -872,11 +739,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testExplainUsage() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         String parentId = "p1";
@@ -970,16 +835,13 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testScoreForParentChildQueries_withFunctionScore() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
                 .addMapping("child", "_parent", "type=parent")
-                .addMapping("child1", "_parent", "type=parent")
-                .get();
+                .addMapping("child1", "_parent", "type=parent"));
         ensureGreen();
 
-        indexRandom(false, createDocBuilders().toArray(new IndexRequestBuilder[0]));
-        refresh();
+        indexRandom(true, createDocBuilders().toArray(new IndexRequestBuilder[0]));
         SearchResponse response = client()
                 .prepareSearch("test")
                 .setQuery(
@@ -1057,11 +919,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     @Test
     // https://github.com/elasticsearch/elasticsearch/issues/2536
     public void testParentChildQueriesCanHandleNoRelevantTypesInIndex() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         SearchResponse response = client().prepareSearch("test")
@@ -1093,11 +953,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testHasChildAndHasParentFilter_withFilter() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         client().prepareIndex("test", "parent", "1").setSource("p_field", 1).get();
@@ -1124,11 +982,13 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleQueryRewrite() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
+                //top_children query needs at least 2 shards for the totalHits to be accurate
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
+                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, between(2, DEFAULT_MAX_NUM_SHARDS)))
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1170,7 +1030,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
             assertThat(searchResponse.getHits().hits()[4].id(), equalTo("c004"));
 
             searchResponse = client().prepareSearch("test").setSearchType(searchType)
-                    .setQuery(topChildrenQuery("child", prefixQuery("c_field", "c"))).addSort("p_field", SortOrder.ASC).setSize(5)
+                    .setQuery(topChildrenQuery("child", prefixQuery("c_field", "c")).factor(10)).addSort("p_field", SortOrder.ASC).setSize(5)
                     .get();
             assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().totalHits(), equalTo(10L));
@@ -1186,11 +1046,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     // See also issue:
     // https://github.com/elasticsearch/elasticsearch/issues/3144
     public void testReIndexingParentAndChildDocuments() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1255,11 +1113,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     // See also issue:
     // https://github.com/elasticsearch/elasticsearch/issues/3203
     public void testHasChildQueryWithMinimumScore() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1283,13 +1139,12 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testParentFieldFilter() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 1)
-                                .put("index.refresh_interval", -1))
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder().put(indexSettings())
+                        .put("index.refresh_interval", -1))
                 .addMapping("parent")
                 .addMapping("child", "_parent", "type=parent")
-                .addMapping("child2", "_parent", "type=parent")
-                .get();
+                .addMapping("child2", "_parent", "type=parent"));
         ensureGreen();
 
         // test term filter
@@ -1351,15 +1206,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testHasChildNotBeingCached() throws ElasticsearchException, IOException {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                )
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1395,16 +1244,13 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeleteByQuery_has_child() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 1)
+                        settingsBuilder().put(indexSettings())
                                 .put("index.refresh_interval", "-1")
                 )
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1441,16 +1287,14 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeleteByQuery_has_child_SingleRefresh() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 1)
+                        settingsBuilder()
+                                .put(indexSettings())
                                 .put("index.refresh_interval", "-1")
                 )
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1497,16 +1341,14 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeleteByQuery_has_parent() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 1)
+                        settingsBuilder()
+                                .put(indexSettings())
                                 .put("index.refresh_interval", "-1")
                 )
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1552,17 +1394,11 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     @Test
     // Relates to bug: https://github.com/elasticsearch/elasticsearch/issues/3818
     public void testHasChildQueryOnlyReturnsSingleChildType() {
-        client().admin().indices().prepareCreate("grandissue")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                )
+        assertAcked(prepareCreate("grandissue")
                 .addMapping("grandparent", "name", "type=string")
                 .addMapping("parent", "_parent", "type=grandparent")
                 .addMapping("child_type_one", "_parent", "type=parent")
-                .addMapping("child_type_two", "_parent", "type=parent")
-                .get();
+                .addMapping("child_type_two", "_parent", "type=parent"));
 
         client().prepareIndex("grandissue", "grandparent", "1").setSource("name", "Grandpa").get();
         client().prepareIndex("grandissue", "parent", "2").setParent("1").setSource("name", "Dana").get();
@@ -1611,15 +1447,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void indexChildDocWithNoParentMapping() throws ElasticsearchException, IOException {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                )
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child1")
-                .get();
+                .addMapping("child1"));
         ensureGreen();
 
         client().prepareIndex("test", "parent", "p1").setSource("p_field", "p_value1", "_parent", "bla").get();
@@ -1641,12 +1471,7 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testAddingParentToExistingMapping() throws ElasticsearchException, IOException {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                ).get();
+        createIndex("test");
         ensureGreen();
 
         PutMappingResponse putMappingResponse = client().admin().indices().preparePutMapping("test").setType("child").setSource("number", "type=integer")
@@ -1672,15 +1497,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     @Test
     // The SimpleIdReaderTypeCache#docById method used lget, which can't be used if a map is shared.
     public void testTopChildrenBug_concurrencyIssue() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                )
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -1730,15 +1549,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testHasChildQueryWithNestedInnerObjects() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
-                )
+        assertAcked(prepareCreate("test")
                 .addMapping("parent", "objects", "type=nested")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         client().prepareIndex("test", "parent", "p1")
@@ -1778,11 +1591,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testNamedFilters() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         String parentId = "p1";
@@ -1823,17 +1634,15 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testParentChildQueriesNoParentType() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 1)
-                        .put("index.refresh_interval", -1)
-                        .put("index.number_of_replicas", 0))
-                .get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
+                        .put("index.refresh_interval", -1)));
+        ensureGreen();
 
         String parentId = "p1";
         client().prepareIndex("test", "parent", parentId).setSource("p_field", "1").get();
-        client().admin().indices().prepareRefresh().get();
+        refresh();
 
         try {
             client().prepareSearch("test")
@@ -1892,17 +1701,15 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testAdd_ParentFieldAfterIndexingParentDocButBeforeIndexingChildDoc() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 1)
-                        .put("index.refresh_interval", -1)
-                        .put("index.number_of_replicas", 0))
-                .get();
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
+                        .put("index.refresh_interval", -1)));
         ensureGreen();
 
         String parentId = "p1";
         client().prepareIndex("test", "parent", parentId).setSource("p_field", "1").get();
-        client().admin().indices().prepareRefresh().get();
+        refresh();
         assertAcked(client().admin()
                 .indices()
                 .preparePutMapping("test")
@@ -1951,16 +1758,14 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testParentChildCaching() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder()
-                                .put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
+                        settingsBuilder()
+                                .put(indexSettings())
                                 .put("index.refresh_interval", -1)
                 )
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
         // index simple data
@@ -2004,18 +1809,16 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testParentChildQueriesViaScrollApi() throws Exception {
-        client().admin().indices().prepareCreate("test")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("parent")
-                .addMapping("child", "_parent", "type=parent")
-                .get();
+                .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "parent", "p" + i).setSource("{}").get();
             client().prepareIndex("test", "child", "c" + i).setSource("{}").setParent("p" + i).get();
         }
 
-        client().admin().indices().prepareRefresh().get();
+        refresh();
 
         QueryBuilder[] queries = new QueryBuilder[]{
                 hasChildQuery("child", matchAllQuery()),
@@ -2052,8 +1855,10 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testValidateThatHasChildAndHasParentFilterAreNeverCached() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test")
-                .setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0)
+        assertAcked(prepareCreate("test")
+                .setSettings(builder().put(indexSettings())
+                        //we need 0 replicas here to make sure we always hit the very same shards
+                        .put(SETTING_NUMBER_OF_REPLICAS, 0))
                 .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
 
@@ -2083,6 +1888,9 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
                 .setQuery(QueryBuilders.filteredQuery(matchAllQuery(), FilterBuilders.hasChildFilter("child", matchAllQuery()).cache(true)))
                 .get();
         assertHitCount(searchResponse, 1l);
+
+        statsResponse = client().admin().indices().prepareStats("test").clear().setFilterCache(true).get();
+        assertThat(statsResponse.getIndex("test").getTotal().getFilterCache().getMemorySizeInBytes(), equalTo(initialCacheSize));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.filteredQuery(matchAllQuery(), FilterBuilders.hasParentFilter("parent", matchAllQuery()).cache(true)))

--- a/src/test/java/org/elasticsearch/search/facet/ExtendedFacetsTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/ExtendedFacetsTests.java
@@ -23,8 +23,6 @@ import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -44,21 +42,18 @@ import static org.hamcrest.Matchers.equalTo;
 public class ExtendedFacetsTests extends ElasticsearchIntegrationTest {
 
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", numberOfShards())
-                .put("index.number_of_replicas", 0)
-                .build();
-    }
-
     protected int numberOfShards() {
         return 1;
+    }
+
+    @Override
+    protected int numberOfReplicas() {
+        return 0;
     }
 
     protected int numDocs() {
         return 2500;
     }
-
 
     @Test
     @Slow

--- a/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
@@ -26,11 +26,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.joda.Joda;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.facet.datehistogram.DateHistogramFacet;
@@ -60,6 +57,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.search.facet.FacetBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.*;
 
@@ -69,12 +67,10 @@ import static org.hamcrest.Matchers.*;
 public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
 
     private int numRuns = -1;
+
     @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", 0)
-                .build();
+    protected int numberOfReplicas() {
+        return between(0, 1);
     }
 
     protected int numberOfRuns() {
@@ -133,9 +129,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testBinaryFacet() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("tag", "green")
@@ -175,16 +169,15 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFacetNumeric() throws ElasticsearchException, IOException {
-        prepareCreate("test").addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
+        assertAcked(prepareCreate("test").addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
                 .startObject("byte").field("type", "byte").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("short").field("type", "short").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("integer").field("type", "integer").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("long").field("type", "long").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("float").field("type", "float").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("double").field("type", "double").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
-                .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject().endObject()));
+        ensureGreen();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test", "type", "" + i).setSource(jsonBuilder().startObject()
@@ -306,14 +299,12 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
             assertThat(facet.getOtherCount(), equalTo(90l));
             assertThat(facet.getMissingCount(), equalTo(10l));
         }
-
     }
-
 
     @Test
     @Slow
     public void testConcurrentFacets() throws ElasticsearchException, IOException, InterruptedException, ExecutionException {
-        prepareCreate("test")
+        assertAcked(prepareCreate("test")
         .addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
                 .startObject("byte").field("type", "byte").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("short").field("type", "short").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
@@ -321,9 +312,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("long").field("type", "long").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("float").field("type", "float").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .startObject("double").field("type", "double").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
-                .endObject().endObject().endObject())
-        .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject().endObject()));
+        ensureGreen();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test", "type", "" + i).setSource(jsonBuilder().startObject()
@@ -481,49 +471,48 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     @Slow
     public void testDuelByteFieldDataImpl() throws ElasticsearchException, IOException, InterruptedException, ExecutionException {
-        prepareCreate("test")
-        .addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
-                 .startObject("name_paged")
-                    .field("type", "string")
-                    .startObject("fielddata").field("format", "paged_bytes").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
-                 .endObject()
-                 .startObject("name_fst")
-                    .field("type", "string")
-                    .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
-                 .endObject()
-                 .startObject("name_dv")
-                    .field("type", "string")
-                    .field("index", "no")
-                    .startObject("fielddata").field("format", "doc_values").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
-                 .endObject()
-                 .startObject("name_paged_mv")
-                    .field("type", "string")
-                    .startObject("fielddata").field("format", "paged_bytes").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
-                 .endObject()
-                 .startObject("name_fst_mv")
-                    .field("type", "string")
-                    .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
-                 .endObject()
-                 .startObject("name_dv_mv")
-                    .field("type", "string")
-                    .field("index", "no")
-                    .startObject("fielddata").field("format", "doc_values").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
-                 .endObject()
-                 .startObject("filtered")
-                    .field("type", "string")
-                    .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").startObject("filter")
-                    .startObject("regex").field("pattern", "\\d{1,2}").endObject().endObject()
-                    .endObject()
-                    // only 1 or 2 digits 
-                 .endObject()
-                  .startObject("filtered_mv")
-                    .field("type", "string")
-                    .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").startObject("filter")
-                    .startObject("regex").field("pattern", "\\d{1,2}").endObject().endObject()
-                    .endObject()
-                .endObject().endObject().endObject())
-        .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test")
+                .addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
+                        .startObject("name_paged")
+                        .field("type", "string")
+                        .startObject("fielddata").field("format", "paged_bytes").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
+                        .endObject()
+                        .startObject("name_fst")
+                        .field("type", "string")
+                        .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
+                        .endObject()
+                        .startObject("name_dv")
+                        .field("type", "string")
+                        .field("index", "no")
+                        .startObject("fielddata").field("format", "doc_values").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
+                        .endObject()
+                        .startObject("name_paged_mv")
+                        .field("type", "string")
+                        .startObject("fielddata").field("format", "paged_bytes").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
+                        .endObject()
+                        .startObject("name_fst_mv")
+                        .field("type", "string")
+                        .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
+                        .endObject()
+                        .startObject("name_dv_mv")
+                        .field("type", "string")
+                        .field("index", "no")
+                        .startObject("fielddata").field("format", "doc_values").field("loading", randomBoolean() ? "eager" : "lazy").endObject()
+                        .endObject()
+                        .startObject("filtered")
+                        .field("type", "string")
+                        .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").startObject("filter")
+                       .startObject("regex").field("pattern", "\\d{1,2}").endObject().endObject()
+                        .endObject()
+                                // only 1 or 2 digits 
+                        .endObject()
+                        .startObject("filtered_mv")
+                        .field("type", "string")
+                        .startObject("fielddata").field("format", "fst").field("loading", randomBoolean() ? "eager" : "lazy").startObject("filter")
+                        .startObject("regex").field("pattern", "\\d{1,2}").endObject().endObject()
+                        .endObject()
+                        .endObject().endObject().endObject()));
+        ensureGreen();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test", "type", "" + i).setSource(jsonBuilder().startObject()
@@ -639,9 +628,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testSearchFilter() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("tag", "green")
@@ -689,9 +676,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testFacetsWithSize0() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("stag", "111")
@@ -747,7 +732,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     public void testTermsIndexFacet() throws Exception {
         createIndex("test1");
         createIndex("test2");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test1", "type1").setSource(jsonBuilder().startObject()
                 .field("stag", "111")
@@ -791,7 +776,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testFilterFacets() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("stag", "111")
@@ -804,7 +789,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startArray("tag").value("zzz").value("yyy").endArray()
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         for (int i = 0; i < numberOfRuns(); i++) {
             SearchResponse searchResponse = client().prepareSearch()
@@ -835,7 +820,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testTermsFacetsMissing() throws Exception {
-        prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("bstag").field("type", "byte").endObject()
                         .startObject("shstag").field("type", "short").endObject()
@@ -843,9 +828,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                         .startObject("lstag").field("type", "long").endObject()
                         .startObject("fstag").field("type", "float").endObject()
                         .startObject("dstag").field("type", "double").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                        .endObject().endObject().endObject()));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("stag", "111")
@@ -883,7 +867,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     }
 
     private void testTermsFacets(String executionHint) throws Exception {
-        prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("bstag").field("type", "byte").endObject()
                         .startObject("shstag").field("type", "short").endObject()
@@ -891,9 +875,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                         .startObject("lstag").field("type", "long").endObject()
                         .startObject("fstag").field("type", "float").endObject()
                         .startObject("dstag").field("type", "double").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                        .endObject().endObject().endObject()));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("stag", "111")
@@ -922,7 +905,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startArray("dtag").value(3000.1).value(2000.1).endArray()
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         for (int i = 0; i < numberOfRuns(); i++) {
             SearchResponse searchResponse = client().prepareSearch()
@@ -1293,9 +1276,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testTermFacetWithEqualTermDistribution() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         // at the end of the index, we should have 10 of each `bar`, `foo`, and `baz`
         for (int i = 0; i < 5; i++) {
@@ -1314,7 +1295,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                     .field("text", "baz foo")
                     .endObject()).execute().actionGet();
         }
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         for (int i = 0; i < numberOfRuns(); i++) {
             SearchResponse searchResponse = client().prepareSearch()
@@ -1341,8 +1322,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("num").field("type", "integer").endObject()
                 .startObject("multi_num").field("type", "float").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("num", 1)
@@ -1439,8 +1420,9 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
         String mapping = jsonBuilder().startObject().startObject("type1").startObject("properties")
                 .startObject("num").field("type", "integer").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
+
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("num", 100)
                 .endObject()).execute().actionGet();
@@ -1486,8 +1468,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("multi_num").field("type", "float").endObject()
                 .startObject("date").field("type", "date").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("num", 1055)
@@ -1655,8 +1637,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("multi_value").field("type", "float").endObject()
                 .startObject("date").field("type", "date").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("num", 1055)
@@ -1825,8 +1807,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("date").field("type", "date").endObject()
                 .startObject("date_in_seconds").field("type", "long").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
         DateTimeFormatter parser = Joda.forPattern("dateOptionalTime").parser();
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("date", "2009-03-05T01:01:01")
@@ -1952,8 +1934,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("num").field("type", "integer").endObject()
                 .startObject("date").field("type", "date").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("date", "2009-03-05T23:31:01")
@@ -2019,8 +2001,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("num").field("type", "integer").endObject()
                 .startObject("multi_num").field("type", "float").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("field", "xxx")
@@ -2205,8 +2187,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .startObject("num").field("type", "float").endObject()
                 .startObject("multi_num").field("type", "integer").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
                 .field("lField", 100l)
@@ -2277,8 +2259,8 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
         String mapping = jsonBuilder().startObject().startObject("type1").startObject("properties")
                 .startObject("num").field("type", "float").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        ensureGreen();
 
         for (int i = 0; i < 20; i++) {
             client().prepareIndex("test", "type1", Integer.toString(i)).setSource("num", i % 10).execute().actionGet();
@@ -2310,7 +2292,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testQueryFacet() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         for (int i = 0; i < 20; i++) {
             client().prepareIndex("test", "type1", Integer.toString(i)).setSource("num", i % 10).execute().actionGet();
@@ -2351,7 +2333,7 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
                 .field("field", "xxx")
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         for (int i = 0; i < numberOfRuns(); i++) {
             SearchResponse searchResponse = client().prepareSearch()

--- a/src/test/java/org/elasticsearch/search/facet/terms/ShardSizeTermsFacetTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/terms/ShardSizeTermsFacetTests.java
@@ -20,51 +20,23 @@ package org.elasticsearch.search.facet.terms;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.aggregations.bucket.ShardSizeTests;
 import org.elasticsearch.search.facet.Facets;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.facet.FacetBuilders.termsFacet;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
-/**
- *
- */
-@ClusterScope(scope = Scope.SUITE)
-public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
-
-    /**
-     * to properly test the effect/functionality of shard_size, we need to force having 2 shards and also
-     * control the routing such that certain documents will end on each shard. Using "djb" routing hash + ignoring the
-     * doc type when hashing will ensure that docs with routing value "1" will end up in a different shard than docs with
-     * routing value "2".
-     */
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", 2)
-                .put("index.number_of_replicas", 0)
-                .put("cluster.routing.operation.hash.type", "djb")
-                .put("cluster.routing.operation.use_type", "false")
-                .build();
-    }
+public class ShardSizeTermsFacetTests extends ShardSizeTests {
 
     @Test
     public void noShardSize_string() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -90,9 +62,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_string() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -118,9 +88,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_string_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -146,9 +114,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_string_withExecutionHintMap() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -174,9 +140,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_string_withExecutionHintMap_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -202,9 +166,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void noShardSize_long() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -230,9 +192,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_long() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -258,9 +218,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_long_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -286,9 +244,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void noShardSize_double() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -314,9 +270,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_double() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -342,9 +296,7 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
     @Test
     public void withShardSize_double_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -366,58 +318,4 @@ public class ShardSizeTermsFacetTests extends ElasticsearchIntegrationTest {
             assertThat(entry.getCount(), equalTo(expected.get(entry.getTermAsNumber().intValue())));
         }
     }
-
-    private void indexData() throws Exception {
-
-        /*
-
-
-        ||          ||           size = 3, shard_size = 5               ||           shard_size = size = 3               ||
-        ||==========||==================================================||===============================================||
-        || shard 1: ||  "1" - 5 | "2" - 4 | "3" - 3 | "4" - 2 | "5" - 1 || "1" - 5 | "3" - 3 | "2" - 4                   ||
-        ||----------||--------------------------------------------------||-----------------------------------------------||
-        || shard 2: ||  "1" - 3 | "2" - 1 | "3" - 5 | "4" - 2 | "5" - 1 || "1" - 3 | "3" - 5 | "4" - 2                   ||
-        ||----------||--------------------------------------------------||-----------------------------------------------||
-        || reduced: ||  "1" - 8 | "2" - 5 | "3" - 8 | "4" - 4 | "5" - 2 ||                                               ||
-        ||          ||                                                  || "1" - 8, "3" - 8, "2" - 4    <= WRONG         ||
-        ||          ||  "1" - 8 | "3" - 8 | "2" - 5     <= CORRECT      ||                                               ||
-
-
-        */
-
-
-        indexDoc("1", "1", 5);
-        indexDoc("1", "2", 4);
-        indexDoc("1", "3", 3);
-        indexDoc("1", "4", 2);
-        indexDoc("1", "5", 1);
-
-        // total docs in shard "1" = 15
-
-        indexDoc("2", "1", 3);
-        indexDoc("2", "2", 1);
-        indexDoc("2", "3", 5);
-        indexDoc("2", "4", 2);
-        indexDoc("2", "5", 1);
-
-        // total docs in shard "2"  = 12
-
-        client().admin().indices().prepareFlush("idx").execute().actionGet();
-        client().admin().indices().prepareRefresh("idx").execute().actionGet();
-
-        long totalOnOne = client().prepareSearch("idx").setTypes("type").setRouting("1").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
-        assertThat(totalOnOne, is(15l));
-        long totalOnTwo = client().prepareSearch("idx").setTypes("type").setRouting("2").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
-        assertThat(totalOnTwo, is(12l));
-    }
-
-    private void indexDoc(String shard, String key, int times) throws Exception {
-        for (int i = 0; i < times; i++) {
-            client().prepareIndex("idx", "type").setRouting(shard).setCreate(true).setSource(jsonBuilder()
-                    .startObject()
-                    .field("key", key)
-                    .endObject()).execute().actionGet();
-        }
-    }
-
 }

--- a/src/test/java/org/elasticsearch/search/facet/terms/UnmappedFieldsTermsFacetsTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/terms/UnmappedFieldsTermsFacetsTests.java
@@ -20,9 +20,6 @@ package org.elasticsearch.search.facet.terms;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -32,6 +29,7 @@ import java.util.ArrayList;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.facet.FacetBuilders.termsFacet;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -40,25 +38,13 @@ import static org.hamcrest.Matchers.is;
  */
 public class UnmappedFieldsTermsFacetsTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", numberOfShards())
-                .put("index.number_of_replicas", 0)
-                .build();
-    }
-
-    protected int numberOfShards() {
-        return 5;
-    }
-
     /**
      * Tests the terms facet when faceting on unmapped field
      */
     @Test
     public void testUnmappedField() throws Exception {
         createIndex("idx");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("idx", "type", "" + i).setSource(jsonBuilder().startObject()
@@ -156,8 +142,7 @@ public class UnmappedFieldsTermsFacetsTests extends ElasticsearchIntegrationTest
      */
     @Test
     public void testPartiallyUnmappedField() throws ElasticsearchException, IOException {
-        client().admin().indices().prepareCreate("mapped_idx")
-                .setSettings(indexSettings())
+        assertAcked(prepareCreate("mapped_idx")
                 .addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
                         .startObject("partially_mapped_byte").field("type", "byte").endObject()
                         .startObject("partially_mapped_short").field("type", "short").endObject()
@@ -165,12 +150,11 @@ public class UnmappedFieldsTermsFacetsTests extends ElasticsearchIntegrationTest
                         .startObject("partially_mapped_long").field("type", "long").endObject()
                         .startObject("partially_mapped_float").field("type", "float").endObject()
                         .startObject("partially_mapped_double").field("type", "double").endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                        .endObject().endObject().endObject()));
+        ensureGreen();
 
         createIndex("unmapped_idx");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("mapped_idx", "type", "" + i).setSource(jsonBuilder().startObject()
@@ -284,8 +268,7 @@ public class UnmappedFieldsTermsFacetsTests extends ElasticsearchIntegrationTest
 
     @Test
     public void testMappedYetMissingField() throws IOException {
-        client().admin().indices().prepareCreate("idx")
-                .setSettings(indexSettings())
+        assertAcked(prepareCreate("idx")
                 .addMapping("type", jsonBuilder().startObject()
                         .field("type").startObject()
                         .field("properties").startObject()
@@ -293,9 +276,8 @@ public class UnmappedFieldsTermsFacetsTests extends ElasticsearchIntegrationTest
                         .field("long").startObject().field("type", "long").endObject()
                         .field("double").startObject().field("type", "double").endObject()
                         .endObject()
-                        .endObject())
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                        .endObject()));
+        ensureGreen();
 
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("idx", "type", "" + i).setSource(jsonBuilder().startObject()
@@ -338,7 +320,7 @@ public class UnmappedFieldsTermsFacetsTests extends ElasticsearchIntegrationTest
     @Test
     public void testMultiFields() throws Exception {
         createIndex("idx");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("idx", "type", "" + i).setSource(jsonBuilder().startObject()

--- a/src/test/java/org/elasticsearch/search/facet/termsstats/ShardSizeTermsStatsFacetTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/termsstats/ShardSizeTermsStatsFacetTests.java
@@ -20,51 +20,23 @@ package org.elasticsearch.search.facet.termsstats;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.aggregations.bucket.ShardSizeTests;
 import org.elasticsearch.search.facet.Facets;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.facet.FacetBuilders.termsStatsFacet;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
-/**
- *
- */
-@ClusterScope(scope = Scope.SUITE)
-public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest {
-
-    /**
-     * to properly test the effect/functionality of shard_size, we need to force having 2 shards and also
-     * control the routing such that certain documents will end on each shard. Using "djb" routing hash + ignoring the
-     * doc type when hashing will ensure that docs with routing value "1" will end up in a different shard than docs with
-     * routing value "2".
-     */
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", 2)
-                .put("index.number_of_replicas", 0)
-                .put("cluster.routing.operation.hash.type", "djb")
-                .put("cluster.routing.operation.use_type", "false")
-                .build();
-    }
+public class ShardSizeTermsStatsFacetTests extends ShardSizeTests {
 
     @Test
     public void noShardSize_string() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -90,9 +62,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void noShardSize_string_allTerms() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -120,9 +90,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_string_allTerms() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -150,9 +118,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_string() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -178,9 +144,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_string_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=string,index=not_analyzed")
-                .execute().actionGet();
+        createIdx("type=string,index=not_analyzed");
 
         indexData();
 
@@ -206,9 +170,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void noShardSize_long() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -234,9 +196,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void noShardSize_long_allTerms() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -264,9 +224,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_long_allTerms() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -294,9 +252,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_long() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -322,9 +278,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_long_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=long")
-                .execute().actionGet();
+        createIdx("type=long");
 
         indexData();
 
@@ -350,9 +304,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void noShardSize_double() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -378,9 +330,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void noShardSize_double_allTerms() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -408,9 +358,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_double_allTerms() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -438,9 +386,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_double() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -466,9 +412,7 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
     @Test
     public void withShardSize_double_singleShard() throws Exception {
 
-        client().admin().indices().prepareCreate("idx")
-                .addMapping("type", "key", "type=double")
-                .execute().actionGet();
+        createIdx("type=double");
 
         indexData();
 
@@ -490,59 +434,4 @@ public class ShardSizeTermsStatsFacetTests extends ElasticsearchIntegrationTest 
             assertThat(entry.getCount(), equalTo(expected.get(entry.getTermAsNumber().intValue())));
         }
     }
-
-    private void indexData() throws Exception {
-
-        /*
-
-
-        ||          ||           size = 3, shard_size = 5               ||           shard_size = size = 3               ||
-        ||==========||==================================================||===============================================||
-        || shard 1: ||  "1" - 5 | "2" - 4 | "3" - 3 | "4" - 2 | "5" - 1 || "1" - 5 | "3" - 3 | "2" - 4                   ||
-        ||----------||--------------------------------------------------||-----------------------------------------------||
-        || shard 2: ||  "1" - 3 | "2" - 1 | "3" - 5 | "4" - 2 | "5" - 1 || "1" - 3 | "3" - 5 | "4" - 2                   ||
-        ||----------||--------------------------------------------------||-----------------------------------------------||
-        || reduced: ||  "1" - 8 | "2" - 5 | "3" - 8 | "4" - 4 | "5" - 2 ||                                               ||
-        ||          ||                                                  || "1" - 8, "3" - 8, "2" - 4    <= WRONG         ||
-        ||          ||  "1" - 8 | "3" - 8 | "2" - 5     <= CORRECT      ||                                               ||
-
-
-        */
-
-
-        indexDoc("1", "1", 5);
-        indexDoc("1", "2", 4);
-        indexDoc("1", "3", 3);
-        indexDoc("1", "4", 2);
-        indexDoc("1", "5", 1);
-
-        // total docs in shard "1" = 15
-
-        indexDoc("2", "1", 3);
-        indexDoc("2", "2", 1);
-        indexDoc("2", "3", 5);
-        indexDoc("2", "4", 2);
-        indexDoc("2", "5", 1);
-
-        // total docs in shard "2"  = 12
-
-        client().admin().indices().prepareFlush("idx").execute().actionGet();
-        client().admin().indices().prepareRefresh("idx").execute().actionGet();
-
-        long totalOnOne = client().prepareSearch("idx").setTypes("type").setRouting("1").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
-        assertThat(totalOnOne, is(15l));
-        long totalOnTwo = client().prepareSearch("idx").setTypes("type").setRouting("2").setQuery(matchAllQuery()).execute().actionGet().getHits().getTotalHits();
-        assertThat(totalOnTwo, is(12l));
-    }
-
-    private void indexDoc(String shard, String key, int times) throws Exception {
-        for (int i = 0; i < times; i++) {
-            client().prepareIndex("idx", "type").setRouting(shard).setCreate(true).setSource(jsonBuilder()
-                    .startObject()
-                    .field("key", key)
-                    .field("value", 1)
-                    .endObject()).execute().actionGet();
-        }
-    }
-
 }

--- a/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
@@ -42,8 +42,7 @@ import java.util.List;
 import static org.elasticsearch.client.Requests.indexRequest;
 import static org.elasticsearch.client.Requests.searchRequest;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.*;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
@@ -87,17 +86,16 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         }
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
 
-        indexRandom(false, builders);
-        refresh();
+        indexRandom(true, builders);
 
         // Test Gauss
         List<Float> lonlat = new ArrayList<Float>();
-        lonlat.add(new Float(20));
-        lonlat.add(new Float(11));
+        lonlat.add(20f);
+        lonlat.add(11f);
 
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
-                        searchSource().explain(false).query(termQuery("test", "value"))));
+                        searchSource().explain(false).query(constantScoreQuery(termQuery("test", "value")))));
         SearchResponse sr = response.actionGet();
         SearchHits sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (numDummyDocs + 2)));
@@ -105,7 +103,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("loc", lonlat, "1000km")))));
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), gaussDecayFunction("loc", lonlat, "1000km")))));
         sr = response.actionGet();
         sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (numDummyDocs + 2)));
@@ -116,7 +114,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
 
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
-                        searchSource().explain(false).query(termQuery("test", "value"))));
+                        searchSource().explain(false).query(constantScoreQuery(termQuery("test", "value")))));
         sr = response.actionGet();
         sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (numDummyDocs + 2)));
@@ -124,7 +122,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("test", "value"), linearDecayFunction("loc", lonlat, "1000km")))));
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), linearDecayFunction("loc", lonlat, "1000km")))));
         sr = response.actionGet();
         sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (numDummyDocs + 2)));
@@ -135,7 +133,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
 
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
-                        searchSource().explain(false).query(termQuery("test", "value"))));
+                        searchSource().explain(false).query(constantScoreQuery(termQuery("test", "value")))));
         sr = response.actionGet();
         sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (numDummyDocs + 2)));
@@ -143,7 +141,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("test", "value"), exponentialDecayFunction("loc", lonlat, "1000km")))));
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), exponentialDecayFunction("loc", lonlat, "1000km")))));
         sr = response.actionGet();
         sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (numDummyDocs + 2)));
@@ -175,8 +173,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         }
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
 
-        indexRandom(false, builders);
-        refresh();
+        indexRandom(true, builders);
 
         // Test Gauss
 
@@ -257,13 +254,12 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                                 .endObject().endObject()));
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
 
-        indexRandom(false, builders);
-        refresh();
+        indexRandom(true, builders);
 
         // Test Gauss
         List<Float> lonlat = new ArrayList<Float>();
-        lonlat.add(new Float(20));
-        lonlat.add(new Float(11));
+        lonlat.add(20f);
+        lonlat.add(11f);
 
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
@@ -308,8 +304,8 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                                 .endObject()));
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
 
-        indexRandom(false, builders);
-        refresh();
+        indexRandom(true, builders);
+
         GeoPoint point = new GeoPoint(20, 11);
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
@@ -349,8 +345,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                 .setSource(jsonBuilder().startObject().field("test", "value").field("num", 1.0).endObject()));
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
 
-        indexRandom(false, builders);
-        refresh();
+        indexRandom(true, builders);
 
         // function score should return 0.5 for this function
 
@@ -486,11 +481,9 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
 
     }
 
-
     @Test(expected = ElasticsearchIllegalStateException.class)
     public void testExceptionThrownIfScaleRefNotBetween0And1() throws Exception {
         DecayFunctionBuilder gfb = new GaussDecayFunctionBuilder("num1", "2013-05-28", "1d").setDecay(100);
-
     }
 
     @Test
@@ -500,21 +493,20 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                 "type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "string")
                         .endObject().startObject("num1").field("type", "date").endObject().startObject("num2").field("type", "double")
-                        .endObject().endObject().endObject().endObject()));
+                        .endObject().endObject().endObject().endObject())
+        );
+
         ensureYellow();
+
         client().index(
-                indexRequest("test")
-                        .type("type1")
-                        .id("1")
+                indexRequest("test").type("type1").id("1")
                         .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-27").field("num2", "1.0")
                                 .endObject())).actionGet();
         client().index(
                 indexRequest("test").type("type1").id("2")
                         .source(jsonBuilder().startObject().field("test", "value").field("num2", "1.0").endObject())).actionGet();
         client().index(
-                indexRequest("test")
-                        .type("type1")
-                        .id("3")
+                indexRequest("test").type("type1").id("3")
                         .source(jsonBuilder().startObject().field("test", "value").field("num1", "2013-05-30").field("num2", "1.0")
                                 .endObject())).actionGet();
         client().index(
@@ -525,11 +517,12 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
 
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
-                        searchSource().explain(false).query(
-                                functionScoreQuery(termQuery("test", "value")).add(linearDecayFunction("num1", "2013-05-28", "+3d"))
+                        searchSource().explain(true).query(
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value"))).add(linearDecayFunction("num1", "2013-05-28", "+3d"))
                                         .add(linearDecayFunction("num2", "0.0", "1")).scoreMode("multiply"))));
 
         SearchResponse sr = response.actionGet();
+
         assertNoFailures(sr);
         SearchHits sh = sr.getHits();
         assertThat(sh.hits().length, equalTo(4));
@@ -619,8 +612,8 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         IndexRequestBuilder[] builders = indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]);
         indexRandom(true, builders);
         List<Float> lonlat = new ArrayList<Float>();
-        lonlat.add(new Float(100));
-        lonlat.add(new Float(110));
+        lonlat.add(100f);
+        lonlat.add(110f);
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().size(numDocs).query(
@@ -640,9 +633,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         }
         for (int i = 0; i < numDocs - 1; i++) {
             assertThat(scores[i], lessThan(scores[i + 1]));
-
         }
-
     }
 
     @Test(expected = SearchPhaseExecutionException.class)
@@ -659,8 +650,8 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                                 .endObject())).actionGet();
         refresh();
         List<Float> lonlat = new ArrayList<Float>();
-        lonlat.add(new Float(100));
-        lonlat.add(new Float(110));
+        lonlat.add(100f);
+        lonlat.add(110f);
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource()

--- a/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionTests.java
@@ -42,11 +42,10 @@ public class RandomScoreFunctionTests extends ElasticsearchIntegrationTest {
     public void consistentHitsWithSameSeed() throws Exception {
         final int replicas = between(0, 2); // needed for green status!
         cluster().ensureAtLeastNumNodes(replicas + 1);
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(
-                        ImmutableSettings.builder().put("index.number_of_shards", between(2, 5))
-                                .put("index.number_of_replicas", replicas)
-                                .build()));
+                        ImmutableSettings.builder().put(indexSettings())
+                                .put("index.number_of_replicas", replicas)));
         ensureGreen(); // make sure we are done otherwise preference could change?
         int docCount = atLeast(100);
         for (int i = 0; i < docCount; i++) {
@@ -86,7 +85,7 @@ public class RandomScoreFunctionTests extends ElasticsearchIntegrationTest {
     public void distribution() throws Exception {
         int count = 10000;
 
-        prepareCreate("test").execute().actionGet();
+        assertAcked(prepareCreate("test"));
         ensureGreen();
 
         for (int i = 0; i < count; i++) {
@@ -148,7 +147,6 @@ public class RandomScoreFunctionTests extends ElasticsearchIntegrationTest {
         }
 
         System.out.println("mean: " + sum / (double) count);
-
     }
 
 }

--- a/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxTests.java
+++ b/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxTests.java
@@ -20,16 +20,16 @@
 package org.elasticsearch.search.geo;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.geoBoundingBoxFilter;
 import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -40,16 +40,11 @@ public class GeoBoundingBoxTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleBoundingBoxTest() throws Exception {
-        try {
-            client().admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (Exception e) {
-            // ignore
-        }
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location").field("type", "geo_point").field("lat_lon", true).endObject().endObject()
-                .endObject().endObject().string();
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("name", "New York")
@@ -115,16 +110,11 @@ public class GeoBoundingBoxTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void limitsBoundingBoxTest() throws Exception {
-        try {
-            client().admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (Exception e) {
-            // ignore
-        }
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location").field("type", "geo_point").field("lat_lon", true).endObject().endObject()
-                .endObject().endObject().string();
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping).setSettings(settingsBuilder().put("index.number_of_shards", "1")).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .startObject("location").field("lat", 40).field("lon", -20).endObject()
@@ -166,7 +156,7 @@ public class GeoBoundingBoxTests extends ElasticsearchIntegrationTest {
                 .startObject("location").field("lat", -10).field("lon", 170).endObject()
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxFilter("location").topLeft(41, -11).bottomRight(40, 9)))
@@ -223,16 +213,11 @@ public class GeoBoundingBoxTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void limit2BoundingBoxTest() throws Exception {
-        try {
-            client().admin().indices().prepareDelete("test").execute().actionGet();
-        } catch (Exception e) {
-            // ignore
-        }
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location").field("type", "geo_point").field("lat_lon", true).endObject().endObject()
-                .endObject().endObject().string();
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping).setSettings(settingsBuilder().put("index.number_of_shards", "1")).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("userid", 880)

--- a/src/test/java/org/elasticsearch/search/geo/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/geo/GeoDistanceTests.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.search.geo;
 
-import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -38,9 +36,7 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.*;
 import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
@@ -54,12 +50,13 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleDistanceTests() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location").field("type", "geo_point").field("lat_lon", true)
                 .startObject("fielddata").field("format", randomNumericFieldDataFormat()).endObject().endObject().endObject()
-                .endObject().endObject().string();
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        ensureGreen();
+
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("name", "New York")
                 .startObject("location").field("lat", 40.7143528).field("lon", -74.0059731).endObject()
@@ -206,16 +203,13 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDistanceSortingMVFields() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("locations").field("type", "geo_point").field("lat_lon", true)
                 .startObject("fielddata").field("format", randomNumericFieldDataFormat()).endObject().endObject().endObject()
-                .endObject().endObject().string();
-
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("type1", mapping)
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth("test").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test")
+                .addMapping("type1", xContentBuilder));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("names", "New York")
@@ -325,29 +319,21 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).doubleValue(), closeTo(1157.0d, 10d));
         assertThat(((Number) searchResponse.getHits().getAt(3).sortValues()[0]).doubleValue(), closeTo(0d, 10d));
 
-        try {
-            client().prepareSearch("test").setQuery(matchAllQuery())
-                    .addSort(SortBuilders.geoDistanceSort("locations").point(40.7143528, -74.0059731).sortMode("sum"))
-                    .execute().actionGet();
-            fail("Expected error");
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.shardFailures()[0].status(), equalTo(RestStatus.BAD_REQUEST));
-        }
+        assertFailures(client().prepareSearch("test").setQuery(matchAllQuery())
+                .addSort(SortBuilders.geoDistanceSort("locations").point(40.7143528, -74.0059731).sortMode("sum")),
+                RestStatus.BAD_REQUEST,
+                containsString("sort_mode [sum] isn't supported for sorting by geo distance"));
     }
 
     @Test
     // Regression bug: https://github.com/elasticsearch/elasticsearch/issues/2851
     public void testDistanceSortingWithMissingGeoPoint() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("locations").field("type", "geo_point").field("lat_lon", true)
                 .startObject("fielddata").field("format", randomNumericFieldDataFormat()).endObject().endObject().endObject()
-                .endObject().endObject().string();
-
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("type1", mapping)
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth("test").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("names", "Times Square", "Tribeca")
@@ -363,7 +349,7 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
                 .field("names", "Wall Street", "Soho")
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         // Order: Asc
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery())
@@ -394,18 +380,18 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         double target_lat = 32.81;
         double target_long = -117.21;
 
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location").field("type", "geo_point").field("lat_lon", true).endObject().endObject()
-                .endObject().endObject().string();
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+                .endObject().endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        ensureGreen();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("name", "TestPosition")
                 .startObject("location").field("lat", source_lat).field("lon", source_long).endObject()
                 .endObject()).execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse1 = client().prepareSearch().addField("_source").addScriptField("distance", "doc['location'].arcDistance(" + target_lat + "," + target_long + ")").execute().actionGet();
         Double resultDistance1 = searchResponse1.getHits().getHits()[0].getFields().get("distance").getValue();
@@ -438,30 +424,27 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         SearchResponse searchResponse8 = client().prepareSearch().addField("_source").addScriptField("distance", "doc['location'].distanceInMiles(" + target_lat + "," + target_long + ")").execute().actionGet();
         Double resultDistance8 = searchResponse8.getHits().getHits()[0].getFields().get("distance").getValue();
         assertThat(resultDistance8, closeTo(GeoDistance.PLANE.calculate(source_lat, source_long, target_lat, target_long, DistanceUnit.MILES), 0.0001d));
-
     }
 
     @Test
     public void testDistanceSortingNestedFields() throws Exception {
-                String mapping = XContentFactory.jsonBuilder().startObject().startObject("company")
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("company")
                 .startObject("properties")
                 .startObject("name").field("type", "string").endObject()
                 .startObject("branches")
-                    .field("type", "nested")
-                    .startObject("properties")
-                        .startObject("name").field("type", "string").endObject()
-                        .startObject("location").field("type", "geo_point").field("lat_lon", true)
-                        .startObject("fielddata").field("format", randomNumericFieldDataFormat()).endObject().endObject()
-                    .endObject()
+                .field("type", "nested")
+                .startObject("properties")
+                .startObject("name").field("type", "string").endObject()
+                .startObject("location").field("type", "geo_point").field("lat_lon", true)
+                .startObject("fielddata").field("format", randomNumericFieldDataFormat()).endObject().endObject()
                 .endObject()
                 .endObject()
-                .endObject().endObject().string();
+                .endObject()
+                .endObject().endObject();
 
-        client().admin().indices().prepareCreate("companies")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .addMapping("company", mapping)
-                .execute().actionGet();
-        client().admin().cluster().prepareHealth("companies").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        assertAcked(prepareCreate("companies").addMapping("company", xContentBuilder));
+        ensureGreen();
+
         indexRandom(true, client().prepareIndex("companies", "company", "1").setSource(jsonBuilder().startObject()
                 .field("name", "company 1")
                 .startArray("branches")
@@ -598,14 +581,10 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
         assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).doubleValue(), equalTo(Double.MAX_VALUE));
         assertThat(((Number) searchResponse.getHits().getAt(3).sortValues()[0]).doubleValue(), equalTo(Double.MAX_VALUE));
 
-        try {
-            client().prepareSearch("companies").setQuery(matchAllQuery())
-                    .addSort(SortBuilders.geoDistanceSort("branches.location").point(40.7143528, -74.0059731).sortMode("sum"))
-                    .execute().actionGet();
-            fail("Expected error");
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.shardFailures()[0].status(), equalTo(RestStatus.BAD_REQUEST));
-        }
+        assertFailures(client().prepareSearch("companies").setQuery(matchAllQuery())
+                    .addSort(SortBuilders.geoDistanceSort("branches.location").point(40.7143528, -74.0059731).sortMode("sum")),
+                RestStatus.BAD_REQUEST,
+                containsString("sort_mode [sum] isn't supported for sorting by geo distance"));
     }
     
     /**
@@ -637,12 +616,10 @@ public class GeoDistanceTests extends ElasticsearchIntegrationTest {
                 .startObject()
                     .field("pin", GeoHashUtils.encode(lat, lon))
                 .endObject();
-        
-        ensureYellow();
-        
-        client().admin().indices().prepareCreate("locations").addMapping("location", mapping).execute().actionGet();
+
+        assertAcked(prepareCreate("locations").addMapping("location", mapping));
         client().prepareIndex("locations", "location", "1").setCreate(true).setSource(source).execute().actionGet();
-        client().admin().indices().prepareRefresh("locations").execute().actionGet();
+        refresh();
         client().prepareGet("locations", "location", "1").execute().actionGet();
 
         SearchResponse result = client().prepareSearch("locations")

--- a/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -24,9 +24,9 @@ import com.google.common.collect.Iterables;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.*;
-import org.elasticsearch.client.Requests;
-import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -48,14 +48,15 @@ import java.util.Map;
 
 import static org.elasticsearch.action.search.SearchType.QUERY_THEN_FETCH;
 import static org.elasticsearch.client.Requests.searchRequest;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.FilterBuilders.*;
+import static org.elasticsearch.index.query.FilterBuilders.missingFilter;
+import static org.elasticsearch.index.query.FilterBuilders.typeFilter;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.highlight;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -66,9 +67,8 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     // see #3486
     public void testHighTermFrequencyDoc() throws ElasticsearchException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test")
-                .addMapping("test", "name", "type=string,term_vector=with_positions_offsets,store=" + (randomBoolean() ? "yes" : "no"))
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", between(1, 5))));
+        assertAcked(prepareCreate("test")
+                .addMapping("test", "name", "type=string,term_vector=with_positions_offsets,store=" + (randomBoolean() ? "yes" : "no")));
         ensureYellow();
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 6000; i++) {
@@ -105,8 +105,8 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                         .endObject()
                         .endObject()
                         .endObject())
-                .setSettings(ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 1)
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
                         .put("analysis.tokenizer.autocomplete.max_gram", 20)
                         .put("analysis.tokenizer.autocomplete.min_gram", 1)
                         .put("analysis.tokenizer.autocomplete.token_chars", "letter,digit")
@@ -147,8 +147,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         assertAcked(prepareCreate("test")
                 .addMapping("test", "body", "type=string,index_analyzer=custom_analyzer,search_analyzer=custom_analyzer,term_vector=with_positions_offsets")
                 .setSettings(
-                        ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)
-                                .put("index.number_of_replicas", 0)
+                        settingsBuilder().put(indexSettings())
                                 .put("analysis.filter.wordDelimiter.type", "word_delimiter")
                                 .put("analysis.filter.wordDelimiter.type.split_on_numerics", false)
                                 .put("analysis.filter.wordDelimiter.generate_word_parts", true)
@@ -174,12 +173,12 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testNgramHighlightingPreLucene42() throws ElasticsearchException, IOException {
 
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("test",
                         "name", "type=string,index_analyzer=name_index_analyzer,search_analyzer=name_search_analyzer," + randomStoreField() + "term_vector=with_positions_offsets",
                         "name2", "type=string,index_analyzer=name2_index_analyzer,search_analyzer=name_search_analyzer," + randomStoreField() + "term_vector=with_positions_offsets")
-                .setSettings(ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 2)
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
                         .put("analysis.filter.my_ngram.max_gram", 20)
                         .put("analysis.filter.my_ngram.version", "4.1")
                         .put("analysis.filter.my_ngram.min_gram", 1)
@@ -203,38 +202,50 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         refresh();
 
         SearchResponse search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica m"))).addHighlightedField("name").get();
-        assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
-        assertHighlight(search, 1, "name", 0, equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>"));
+        assertHighlight(search, 0, "name", 0, anyOf(equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"),
+                equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>")));
+        assertHighlight(search, 1, "name", 0, anyOf(equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"),
+                equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>")));
 
         search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica ma"))).addHighlightedField("name").get();
-        assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
-        assertHighlight(search, 1, "name", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
+        assertHighlight(search, 0, "name", 0, anyOf(equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
+        assertHighlight(search, 1, "name", 0, anyOf(equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
 
         search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name", "logica"))).addHighlightedField("name").get();
-        assertHighlight(search, 0, "name", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
+        assertHighlight(search, 0, "name", 0, anyOf(equalTo("<em>logica</em>cmg ehemals avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
+        assertHighlight(search, 0, "name", 0, anyOf(equalTo("<em>logica</em>cmg ehemals avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
 
         search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica m"))).addHighlightedField("name2").get();
-        assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"));
-        assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>"));
+        assertHighlight(search, 0, "name2", 0, anyOf(equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"),
+                equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>")));
+        assertHighlight(search, 1, "name2", 0, anyOf(equalTo("<em>logica</em>c<em>m</em>g ehe<em>m</em>als avinci - the know how co<em>m</em>pany"),
+                equalTo("avinci, unilog avinci, <em>logica</em>c<em>m</em>g, <em>logica</em>")));
 
         search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica ma"))).addHighlightedField("name2").get();
-        assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"));
-        assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
+        assertHighlight(search, 0, "name2", 0, anyOf(equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
+        assertHighlight(search, 1, "name2", 0, anyOf(equalTo("<em>logica</em>cmg ehe<em>ma</em>ls avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
 
         search = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("name2", "logica"))).addHighlightedField("name2").get();
-        assertHighlight(search, 0, "name2", 0, equalTo("<em>logica</em>cmg ehemals avinci - the know how company"));
-        assertHighlight(search, 1, "name2", 0, equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>"));
-
+        assertHighlight(search, 0, "name2", 0, anyOf(equalTo("<em>logica</em>cmg ehemals avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
+        assertHighlight(search, 1, "name2", 0, anyOf(equalTo("<em>logica</em>cmg ehemals avinci - the know how company"),
+                equalTo("avinci, unilog avinci, <em>logica</em>cmg, <em>logica</em>")));
     }
     
     @Test
     public void testNgramHighlighting() throws ElasticsearchException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("test",
                         "name", "type=string,index_analyzer=name_index_analyzer,search_analyzer=name_search_analyzer,term_vector=with_positions_offsets",
                         "name2", "type=string,index_analyzer=name2_index_analyzer,search_analyzer=name_search_analyzer,term_vector=with_positions_offsets")
-                .setSettings(ImmutableSettings.settingsBuilder()
-                        .put("index.number_of_shards", 2)
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
                         .put("analysis.filter.my_ngram.max_gram", 20)
                         .put("analysis.filter.my_ngram.min_gram", 1)
                         .put("analysis.filter.my_ngram.type", "ngram")
@@ -272,7 +283,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     
     @Test
     public void testEnsureNoNegativeOffsets() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1",
                         "no_long_term", "type=string,term_vector=with_positions_offsets",
                         "long_term", "type=string,term_vector=with_positions_offsets"));
@@ -306,7 +317,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     
     @Test
     public void testSourceLookupHighlightingUsingPlainHighlighter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         // we don't store title and don't use term vector, now lets see if it works...
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "no").endObject()
@@ -346,7 +357,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSourceLookupHighlightingUsingFastVectorHighlighter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         // we don't store title, now lets see if it works...
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").endObject()
@@ -386,7 +397,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSourceLookupHighlightingUsingPostingsHighlighter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         // we don't store title, now lets see if it works...
                         .startObject("title").field("type", "string").field("store", "no").field("index_options", "offsets").endObject()
@@ -438,7 +449,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testHighlightIssue1994() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=no", "titleTV", "type=string,store=no,term_vector=with_positions_offsets"));
         ensureYellow();
 
@@ -522,9 +533,8 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testForceSourceWithSourceDisabled() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1")
-                        //just to make sure that we hit the stored fields rather than the _source
                         .startObject("_source").field("enabled", false).endObject()
                         .startObject("properties")
                         .startObject("field1").field("type", "string").field("store", "yes").field("index_options", "offsets")
@@ -544,43 +554,35 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .get();
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
-        searchResponse = client().prepareSearch("test")
+        assertFailures(client().prepareSearch("test")
                 .setQuery(termQuery("field1", "quick"))
-                .addHighlightedField(new Field("field1").preTags("<xxx>").postTags("</xxx>").highlighterType("plain").forceSource(true))
-                .get();
-        assertThat(searchResponse.getFailedShards(), equalTo(1));
-        assertThat(searchResponse.getShardFailures().length, equalTo(1));
-        assertThat(searchResponse.getShardFailures()[0].reason(), containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
+                .addHighlightedField(new Field("field1").preTags("<xxx>").postTags("</xxx>").highlighterType("plain").forceSource(true)),
+                RestStatus.BAD_REQUEST,
+                containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
 
-        searchResponse = client().prepareSearch("test")
+        assertFailures(client().prepareSearch("test")
                 .setQuery(termQuery("field1", "quick"))
-                .addHighlightedField(new Field("field1").preTags("<xxx>").postTags("</xxx>").highlighterType("fvh").forceSource(true))
-                .get();
-        assertThat(searchResponse.getFailedShards(), equalTo(1));
-        assertThat(searchResponse.getShardFailures().length, equalTo(1));
-        assertThat(searchResponse.getShardFailures()[0].reason(), containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
+                .addHighlightedField(new Field("field1").preTags("<xxx>").postTags("</xxx>").highlighterType("fvh").forceSource(true)),
+                RestStatus.BAD_REQUEST,
+                containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
 
-        searchResponse = client().prepareSearch("test")
+        assertFailures(client().prepareSearch("test")
                 .setQuery(termQuery("field1", "quick"))
-                .addHighlightedField(new Field("field1").preTags("<xxx>").postTags("</xxx>").highlighterType("postings").forceSource(true))
-                .get();
-        assertThat(searchResponse.getFailedShards(), equalTo(1));
-        assertThat(searchResponse.getShardFailures().length, equalTo(1));
-        assertThat(searchResponse.getShardFailures()[0].reason(), containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
+                .addHighlightedField(new Field("field1").preTags("<xxx>").postTags("</xxx>").highlighterType("postings").forceSource(true)),
+                RestStatus.BAD_REQUEST,
+                containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
 
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(termQuery("field1", "quick"))
                 .highlight(highlight().forceSource(true).field("field1"));
-        searchResponse = client().search(Requests.searchRequest("test").source(searchSource)).get();
-        assertThat(searchResponse.getFailedShards(), equalTo(1));
-        assertThat(searchResponse.getShardFailures().length, equalTo(1));
-        assertThat(searchResponse.getShardFailures()[0].reason(), containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
+        assertFailures(client().prepareSearch("test").setSource(searchSource.buildAsBytes()),
+                RestStatus.BAD_REQUEST,
+                containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
 
         searchSource = SearchSourceBuilder.searchSource().query(termQuery("field1", "quick"))
                 .highlight(highlight().forceSource(true).field("field*"));
-        searchResponse = client().search(Requests.searchRequest("test").source(searchSource)).get();
-        assertThat(searchResponse.getFailedShards(), equalTo(1));
-        assertThat(searchResponse.getShardFailures().length, equalTo(1));
-        assertThat(searchResponse.getShardFailures()[0].reason(), matches("source is forced for fields \\[field\\d, field\\d\\] but type \\[type1\\] has disabled _source"));
+        assertFailures(client().prepareSearch("test").setSource(searchSource.buildAsBytes()),
+                RestStatus.BAD_REQUEST,
+                matches("source is forced for fields \\[field\\d, field\\d\\] but type \\[type1\\] has disabled _source"));
     }
 
     @Test
@@ -654,7 +656,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFastVectorHighlighter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
@@ -710,7 +712,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
      */
     @Test(timeout=120000)
     public void testFVHManyMatches() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
 
         // Index one megabyte of "t   " over and over and over again
@@ -739,7 +741,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     }
 
     private void checkMatchedFieldsCase(boolean requireFieldMatch) throws Exception {
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
             .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties")
                     .startObject("foo")
@@ -774,7 +776,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                             .endObject()
                         .endObject()
                     .endObject()
-                .endObject()).execute().actionGet();
+                .endObject()));
         ensureGreen();
 
         index("test", "type1", "1",
@@ -882,15 +884,14 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         assertHighlight(resp, 0, "foo", 0, equalTo("<em>weird</em>"));
         assertHighlight(resp, 0, "bar", 0, equalTo("<em>resul</em>t"));
 
-        //But be careful.  It'll blow up if there is a result paste the end of the field.
-        resp = req.setQuery(queryString("result").field("foo").field("foo.plain").field("bar").field("bar.plain")).get();
-        assertThat("Expected ShardFailures", resp.getShardFailures().length, greaterThan(0));
+        assertFailures(req.setQuery(queryString("result").field("foo").field("foo.plain").field("bar").field("bar.plain")),
+                 RestStatus.INTERNAL_SERVER_ERROR, containsString("String index out of range"));
     }
 
     @Test
     @Slow
     public void testFastVectorHighlighterManyDocs() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
 
         int COUNT = between(20, 100);
@@ -949,7 +950,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSameContent() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets"));
         ensureYellow();
 
@@ -972,7 +973,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFastVectorHighlighterOffsetParameter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets").get());
         ensureYellow();
 
@@ -996,7 +997,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testEscapeHtml() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=yes"));
         ensureYellow();
 
@@ -1020,7 +1021,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testEscapeHtml_vector() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets"));
         ensureYellow();
 
@@ -1044,7 +1045,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testMultiMapperVectorWithStore() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "with_positions_offsets").field("analyzer", "classic").endObject()
@@ -1075,7 +1076,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testMultiMapperVectorFromSource() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "with_positions_offsets").field("analyzer", "classic").endObject()
@@ -1108,7 +1109,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testMultiMapperNoVectorWithStore() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "yes").field("term_vector", "no").field("analyzer", "classic").endObject()
@@ -1141,7 +1142,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testMultiMapperNoVectorFromSource() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "no").field("term_vector", "no").field("analyzer", "classic").endObject()
@@ -1173,7 +1174,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFastVectorHighlighterShouldFailIfNoTermVectors() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=yes,term_vector=no"));
         ensureGreen();
 
@@ -1190,30 +1191,24 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .get();
         assertNoFailures(search);
 
-        search = client().prepareSearch()
+        assertFailures(client().prepareSearch()
                 .setQuery(matchPhraseQuery("title", "this is a test"))
                 .addHighlightedField("title", 50, 1, 10)
-                .setHighlighterType("fast-vector-highlighter")
-                .execute().actionGet();
-        assertThat(search.getFailedShards(), equalTo(2));
-        for (ShardSearchFailure shardSearchFailure : search.getShardFailures()) {
-            assertThat(shardSearchFailure.reason(), containsString("the field [title] should be indexed with term vector with position offsets to be used with fast vector highlighter"));
-        }
+                .setHighlighterType("fast-vector-highlighter"),
+                RestStatus.BAD_REQUEST,
+                containsString("the field [title] should be indexed with term vector with position offsets to be used with fast vector highlighter"));
 
-        search = client().prepareSearch()
+        assertFailures(client().prepareSearch()
                 .setQuery(matchPhraseQuery("title", "this is a test"))
                 .addHighlightedField("tit*", 50, 1, 10)
-                .setHighlighterType("fast-vector-highlighter")
-                .execute().actionGet();
-        assertThat(search.getFailedShards(), equalTo(2));
-        for (ShardSearchFailure shardSearchFailure : search.getShardFailures()) {
-            assertThat(shardSearchFailure.reason(), containsString("the field [title] should be indexed with term vector with position offsets to be used with fast vector highlighter"));
-        }
+                .setHighlighterType("fast-vector-highlighter"),
+                RestStatus.BAD_REQUEST,
+                containsString("the field [title] should be indexed with term vector with position offsets to be used with fast vector highlighter"));
     }
 
     @Test
     public void testDisableFastVectorHighlighter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string,store=yes,term_vector=with_positions_offsets,analyzer=classic"));
         ensureGreen();
 
@@ -1259,8 +1254,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFSHHighlightAllMvFragments() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "tags", "type=string,term_vector=with_positions_offsets"));
         ensureGreen();
         client().prepareIndex("test", "type1", "1")
@@ -1298,7 +1292,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     
     @Test
     public void testBoostingQueryTermVector() throws ElasticsearchException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog")
                 .get();
@@ -1338,7 +1332,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testCommonTermsTermVector() throws ElasticsearchException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
@@ -1355,13 +1349,14 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPhrasePrefix() throws ElasticsearchException, IOException {
-        Builder builder = ImmutableSettings.builder();
-        builder.put("index.analysis.analyzer.synonym.tokenizer", "whitespace");
-        builder.putArray("index.analysis.analyzer.synonym.filter", "synonym", "lowercase");
-        builder.put("index.analysis.filter.synonym.type", "synonym");
-        builder.putArray("index.analysis.filter.synonym.synonyms", "quick => fast");
+        Builder builder = settingsBuilder()
+                .put(indexSettings())
+                .put("index.analysis.analyzer.synonym.tokenizer", "whitespace")
+                .putArray("index.analysis.analyzer.synonym.filter", "synonym", "lowercase")
+                .put("index.analysis.filter.synonym.type", "synonym")
+                .putArray("index.analysis.filter.synonym.synonyms", "quick => fast");
 
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(builder.build()).addMapping("type1", type1TermVectorMapping())
+        assertAcked(prepareCreate("test").setSettings(builder.build()).addMapping("type1", type1TermVectorMapping())
                 .addMapping("type2", "_all", "store=yes,termVector=with_positions_offsets",
                         "field4", "type=string,term_vector=with_positions_offsets,analyzer=synonym",
                         "field3", "type=string,analyzer=synonym"));
@@ -1375,23 +1370,21 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         logger.info("--> highlighting and searching on field0");
         SearchSourceBuilder source = searchSource()
                 .query(matchPhrasePrefixQuery("field0", "quick bro"))
-                .from(0).size(60).explain(true)
                 .highlight(highlight().field("field0").order("score").preTags("<x>").postTags("</x>"));
 
-        SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
+        SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 
         assertHighlight(searchResponse, 0, "field0", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
 
         logger.info("--> highlighting and searching on field1");
         source = searchSource()
                 .query(matchPhrasePrefixQuery("field1", "quick bro"))
-                .from(0).size(60).explain(true)
                 .highlight(highlight().field("field1").order("score").preTags("<x>").postTags("</x>"));
 
-        searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
+        searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 
-        assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <x>quick browse</x> button is a fancy thing, right bro?"));
-        assertHighlight(searchResponse, 1, "field1", 0, 1, equalTo("The <x>quick brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field1", 0, 1, anyOf(equalTo("The <x>quick browse</x> button is a fancy thing, right bro?"), equalTo("The <x>quick brown</x> fox jumps over the lazy dog")));
+        assertHighlight(searchResponse, 1, "field1", 0, 1, anyOf(equalTo("The <x>quick browse</x> button is a fancy thing, right bro?"), equalTo("The <x>quick brown</x> fox jumps over the lazy dog")));
 
         // with synonyms
         client().prepareIndex("test", "type2", "0")
@@ -1402,33 +1395,32 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .setSource("field4", "a quick fast blue car").get();
         refresh();
 
-        source = searchSource().postFilter(typeFilter("type2")).query(matchPhrasePrefixQuery("field3", "fast bro")).from(0).size(60).explain(true)
+        source = searchSource().postFilter(typeFilter("type2")).query(matchPhrasePrefixQuery("field3", "fast bro"))
                 .highlight(highlight().field("field3").order("score").preTags("<x>").postTags("</x>"));
 
-        searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
+        searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 
         assertHighlight(searchResponse, 0, "field3", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
 
         logger.info("--> highlighting and searching on field4");
-        source = searchSource().postFilter(typeFilter("type2")).query(matchPhrasePrefixQuery("field4", "the fast bro")).from(0).size(60).explain(true)
+        source = searchSource().postFilter(typeFilter("type2")).query(matchPhrasePrefixQuery("field4", "the fast bro"))
                 .highlight(highlight().field("field4").order("score").preTags("<x>").postTags("</x>"));
-        searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
+        searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 
-        assertHighlight(searchResponse, 0, "field4", 0, 1, equalTo("<x>The quick browse</x> button is a fancy thing, right bro?"));
-        assertHighlight(searchResponse, 1, "field4", 0, 1, equalTo("<x>The quick brown</x> fox jumps over the lazy dog"));
+        assertHighlight(searchResponse, 0, "field4", 0, 1, anyOf(equalTo("<x>The quick browse</x> button is a fancy thing, right bro?"), equalTo("<x>The quick brown</x> fox jumps over the lazy dog")));
+        assertHighlight(searchResponse, 1, "field4", 0, 1, anyOf(equalTo("<x>The quick browse</x> button is a fancy thing, right bro?"), equalTo("<x>The quick brown</x> fox jumps over the lazy dog")));
 
         logger.info("--> highlighting and searching on field4");
-        source = searchSource().postFilter(typeFilter("type2")).query(matchPhrasePrefixQuery("field4", "a fast quick blue ca")).from(0).size(60).explain(true)
+        source = searchSource().postFilter(typeFilter("type2")).query(matchPhrasePrefixQuery("field4", "a fast quick blue ca"))
                 .highlight(highlight().field("field4").order("score").preTags("<x>").postTags("</x>"));
-        searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
+        searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 
         assertHighlight(searchResponse, 0, "field4", 0, 1, equalTo("<x>a quick fast blue car</x>"));
     }
 
     @Test
     public void testPlainHighlightDifferentFragmenter() throws Exception {
-        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "tags", "type=string"));
         ensureGreen();
         client().prepareIndex("test", "type1", "1")
@@ -1453,15 +1445,12 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
         assertHighlight(response, 0, "tags", 0, equalTo("this is a really <em>long</em> <em>tag</em> i would like to highlight"));
         assertHighlight(response, 0, "tags", 1, 2, equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
 
-        try {
-            client().prepareSearch("test")
+        assertFailures(client().prepareSearch("test")
                     .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQueryBuilder.Type.PHRASE))
                     .addHighlightedField(new HighlightBuilder.Field("tags")
-                            .fragmentSize(-1).numOfFragments(2).fragmenter("invalid")).get();
-            fail("Shouldn't get here");
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.shardFailures()[0].status(), equalTo(RestStatus.BAD_REQUEST));
-        }
+                            .fragmentSize(-1).numOfFragments(2).fragmenter("invalid")),
+                    RestStatus.BAD_REQUEST,
+                    containsString("unknown fragmenter option [invalid] for the field [tags]"));
     }
 
     @Test
@@ -1483,7 +1472,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFastVectorHighlighterMultipleFields() {
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "field1", "type=string,term_vectors=with_positions_offsets", "field2", "type=string,term_vectors=with_positions_offsets"));
         ensureGreen();
 
@@ -1501,8 +1490,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testMissingStoredField() throws Exception {
-        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "highlight_field", "type=string,store=yes"));
         ensureGreen();
         client().prepareIndex("test", "type1", "1")
@@ -1551,7 +1539,8 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     // https://github.com/elasticsearch/elasticsearch/issues/3200
     public void testResetTwice() throws Exception {
         assertAcked(prepareCreate("test")
-                .setSettings(ImmutableSettings.builder()
+                .setSettings(settingsBuilder()
+                        .put(indexSettings())
                         .put("analysis.analyzer.my_analyzer.type", "pattern")
                         .put("analysis.analyzer.my_analyzer.pattern", "\\s+")
                         .build())
@@ -1903,7 +1892,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighter() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
@@ -1959,7 +1948,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterMultipleFields() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get());
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get());
         ensureGreen();
 
         index("test", "type1", "1", "field1", "The <b>quick<b> brown fox. Second sentence.", "field2", "The <b>slow<b> brown fox. Second sentence.");
@@ -1976,7 +1965,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterNumberOfFragments() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1", "1")
@@ -2027,7 +2016,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterRequireFieldMatch() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
@@ -2096,7 +2085,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .startObject("field2").field("type", "string").field("index_options", "offsets").field("term_vector", "with_positions_offsets").endObject()
                 .endObject()
                 .endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", mapping));
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
         ensureGreen();
         client().prepareIndex("test", "type1")
                 .setSource("field1", "The quick brown fox jumps over",
@@ -2121,7 +2110,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterOrderByScore() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1")
@@ -2160,7 +2149,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterEscapeHtml() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "title", "type=string," + randomStoreField() + "index_options=offsets"));
         ensureYellow();
 
@@ -2183,7 +2172,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterMultiMapperWithStore() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1")
                         //just to make sure that we hit the stored fields rather than the _source
                         .startObject("_source").field("enabled", false).endObject()
@@ -2220,7 +2209,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterMultiMapperFromSource() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "multi_field").startObject("fields")
                         .startObject("title").field("type", "string").field("store", "no").field("index_options", "offsets").field("analyzer", "classic").endObject()
@@ -2250,7 +2239,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterShouldFailIfNoOffsets() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 2))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("title").field("type", "string").field("store", "yes").field("index_options", "docs").endObject()
                         .endObject().endObject().endObject()));
@@ -2269,42 +2258,33 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .get();
         assertNoFailures(search);
 
-        search = client().prepareSearch()
+        assertFailures(client().prepareSearch()
                 .setQuery(matchQuery("title", "this is a test"))
                 .addHighlightedField("title")
-                .setHighlighterType("postings-highlighter")
-                .get();
-        assertThat(search.getFailedShards(), equalTo(2));
-        for (ShardSearchFailure shardSearchFailure : search.getShardFailures()) {
-            assertThat(shardSearchFailure.reason(), containsString("the field [title] should be indexed with positions and offsets in the postings list to be used with postings highlighter"));
-        }
+                .setHighlighterType("postings-highlighter"),
+                RestStatus.BAD_REQUEST,
+                containsString("the field [title] should be indexed with positions and offsets in the postings list to be used with postings highlighter"));
 
-        search = client().prepareSearch()
+
+
+        assertFailures(client().prepareSearch()
                 .setQuery(matchQuery("title", "this is a test"))
                 .addHighlightedField("title")
-                .setHighlighterType("postings")
-                .get();
+                .setHighlighterType("postings"),
+                RestStatus.BAD_REQUEST,
+                containsString("the field [title] should be indexed with positions and offsets in the postings list to be used with postings highlighter"));
 
-        assertThat(search.getFailedShards(), equalTo(2));
-        for (ShardSearchFailure shardSearchFailure : search.getShardFailures()) {
-            assertThat(shardSearchFailure.reason(), containsString("the field [title] should be indexed with positions and offsets in the postings list to be used with postings highlighter"));
-        }
-
-        search = client().prepareSearch()
+        assertFailures(client().prepareSearch()
                 .setQuery(matchQuery("title", "this is a test"))
                 .addHighlightedField("tit*")
-                .setHighlighterType("postings")
-                .get();
-
-        assertThat(search.getFailedShards(), equalTo(2));
-        for (ShardSearchFailure shardSearchFailure : search.getShardFailures()) {
-            assertThat(shardSearchFailure.reason(), containsString("the field [title] should be indexed with positions and offsets in the postings list to be used with postings highlighter"));
-        }
+                .setHighlighterType("postings"),
+                RestStatus.BAD_REQUEST,
+                containsString("the field [title] should be indexed with positions and offsets in the postings list to be used with postings highlighter"));
     }
 
     @Test
     public void testPostingsHighlighterBoostingQuery() throws ElasticsearchException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.")
                 .get();
@@ -2321,7 +2301,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterCommonTermsQuery() throws ElasticsearchException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2350,7 +2330,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterPrefixQuery() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2368,7 +2348,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterFuzzyQuery() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2384,7 +2364,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterRegexpQuery() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2402,7 +2382,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterWildcardQuery() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2428,7 +2408,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterTermRangeQuery() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "aaab").get();
@@ -2444,7 +2424,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPostingsHighlighterQueryString() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.").get();
@@ -2463,7 +2443,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testPostingsHighlighterRegexpQueryWithinConstantScoreQuery() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "The photography word will get highlighted").get();
@@ -2482,7 +2462,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testPostingsHighlighterMultiTermQueryMultipleLevels() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "The photography word will get highlighted").get();
@@ -2504,7 +2484,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testPostingsHighlighterPrefixQueryWithinBooleanQuery() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "The photography word will get highlighted").get();
@@ -2523,7 +2503,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     public void testPostingsHighlighterQueryStringWithinFilteredQuery() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "The photography word will get highlighted").get();
@@ -2542,7 +2522,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
     @Test
     @Slow
     public void testPostingsHighlighterManyDocs() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
         int COUNT = between(20, 100);
@@ -2590,7 +2570,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test //https://github.com/elasticsearch/elasticsearch/issues/4116
     public void testPostingsHighlighterCustomIndexName() {
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
             .addMapping("type1", "field1", "type=string,index_options=offsets,index_name=my_field"));
         ensureGreen();
 
@@ -2613,7 +2593,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFastVectorHighlighterCustomIndexName() {
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "field1", "type=string,term_vector=with_positions_offsets,index_name=my_field"));
         ensureGreen();
 
@@ -2636,7 +2616,7 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPlainHighlighterCustomIndexName() {
-        assertAcked(client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", "field1", "type=string,index_name=my_field"));
         ensureGreen();
 
@@ -2659,13 +2639,13 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testFastVectorHighlighterPhraseBoost() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
         phraseBoostTestCase("fvh");
     }
 
     @Test
     public void testPostingsHighlighterPhraseBoost() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         phraseBoostTestCase("postings");
     }
 

--- a/src/test/java/org/elasticsearch/search/preference/SearchPreferenceTests.java
+++ b/src/test/java/org/elasticsearch/search/preference/SearchPreferenceTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
@@ -38,11 +37,11 @@ public class SearchPreferenceTests extends ElasticsearchIntegrationTest {
     @Test // see #2896
     public void testStopOneNodePreferenceWithRedState() throws InterruptedException {
         client().admin().indices().prepareCreate("test").setSettings(settingsBuilder().put("index.number_of_shards", cluster().size()+2).put("index.number_of_replicas", 0)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type1", ""+i).setSource("field1", "value1").execute().actionGet();
         }
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
         cluster().stopRandomNode();
         client().admin().cluster().prepareHealth().setWaitForStatus(ClusterHealthStatus.RED).execute().actionGet();
         String[] preferences = new String[] {"_primary", "_local", "_primary_first", "_only_local", "_prefer_node:somenode", "_prefer_node:server2"};
@@ -55,15 +54,14 @@ public class SearchPreferenceTests extends ElasticsearchIntegrationTest {
             assertThat(pref, searchResponse.getFailedShards(), greaterThanOrEqualTo(0));
         }
     }
-    
 
     @Test
     public void noPreferenceRandom() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 1)).execute().actionGet();
+        createIndex("test");
         ensureGreen();
         
         client().prepareIndex("test", "type1").setSource("field1", "value1").execute().actionGet();
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         final Client client = cluster().smartClient();
         SearchResponse searchResponse = client.prepareSearch("test").setQuery(matchAllQuery()).execute().actionGet();
@@ -77,10 +75,10 @@ public class SearchPreferenceTests extends ElasticsearchIntegrationTest {
     @Test
     public void simplePreferenceTests() throws Exception {
         createIndex("test");
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        ensureGreen();
 
         client().prepareIndex("test", "type1").setSource("field1", "value1").execute().actionGet();
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_local").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));

--- a/src/test/java/org/elasticsearch/search/query/MultiMatchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/MultiMatchQueryTests.java
@@ -52,6 +52,7 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
     @Before
     public void init() throws Exception {
         CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
+                .put(indexSettings())
                 .put(SETTING_NUMBER_OF_SHARDS, 1)
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
                 .put("index.analysis.analyzer.perfect_match.type", "custom")

--- a/src/test/java/org/elasticsearch/search/scan/SearchScanScrollingTests.java
+++ b/src/test/java/org/elasticsearch/search/scan/SearchScanScrollingTests.java
@@ -22,10 +22,10 @@ package org.elasticsearch.search.scan;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
 
 import java.util.Set;
 
@@ -36,12 +36,13 @@ import static org.hamcrest.Matchers.greaterThan;
 
 public class SearchScanScrollingTests extends ElasticsearchIntegrationTest {
 
+    @Test
     public void testRandomized() throws Exception {
-        testScroll(between(1, 4), atLeast(100), between(1, 300), getRandom().nextBoolean(), getRandom().nextBoolean());
+        testScroll(atLeast(100), between(1, 300), getRandom().nextBoolean(), getRandom().nextBoolean());
     }
 
-    private void testScroll(int numberOfShards, long numberOfDocs, int size, boolean unbalanced, boolean trackScores) throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", numberOfShards)).get();
+    private void testScroll(long numberOfDocs, int size, boolean unbalanced, boolean trackScores) throws Exception {
+        createIndex("test");
         ensureGreen();
 
         Set<String> ids = Sets.newHashSet();

--- a/src/test/java/org/elasticsearch/search/scan/SearchScanTests.java
+++ b/src/test/java/org/elasticsearch/search/scan/SearchScanTests.java
@@ -24,8 +24,6 @@ import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -42,8 +40,8 @@ public class SearchScanTests extends ElasticsearchIntegrationTest {
     @Test
     @Slow 
     public void testNarrowingQuery() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", between(1,5))).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        createIndex("test");
+        ensureGreen();
 
         Set<String> ids = Sets.newHashSet();
         Set<String> expectedIds = Sets.newHashSet();

--- a/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -28,8 +28,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -59,14 +57,6 @@ import static org.hamcrest.Matchers.*;
  *
  */
 public class SimpleSortTests extends ElasticsearchIntegrationTest {
-
-    @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", 3)
-                .put("index.number_of_replicas", 0)
-                .build();
-    }
 
     @Test
     public void testTrackScores() throws Exception {
@@ -110,10 +100,8 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
     }
 
     public void testRandomSorting() throws ElasticsearchException, IOException, InterruptedException, ExecutionException {
-        int numberOfShards = between(1, 10);
         Random random = getRandom();
-        prepareCreate("test")
-                .setSettings(ImmutableSettings.builder().put("index.number_of_shards", numberOfShards).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type",
                         XContentFactory.jsonBuilder()
                                 .startObject()
@@ -129,7 +117,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                                 .endObject()
                                 .endObject()
                                 .endObject()
-                                .endObject()).execute().actionGet();
+                                .endObject()));
         ensureGreen();
 
         TreeMap<BytesRef, String> sparseBytes = new TreeMap<BytesRef, String>();
@@ -238,7 +226,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testScoreSortDirection() throws Exception {
-        prepareCreate("test").setSettings(ImmutableSettings.builder().put("index.number_of_shards", 1)).execute().actionGet();
+        createIndex("test");
         ensureGreen();
 
         client().prepareIndex("test", "type", "1").setSource("field", 2).execute().actionGet();
@@ -270,7 +258,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testScoreSortDirection_withFunctionScore() throws Exception {
-        prepareCreate("test").setSettings(ImmutableSettings.builder().put("index.number_of_shards", 1)).execute().actionGet();
+        createIndex("test");
         ensureGreen();
 
         client().prepareIndex("test", "type", "1").setSource("field", 2).execute().actionGet();
@@ -301,7 +289,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testIssue2986() {
-        prepareCreate("test").setSettings(indexSettings()).execute().actionGet();
+        createIndex("test");
 
         client().prepareIndex("test", "post", "1").setSource("{\"field1\":\"value1\"}").execute().actionGet();
         client().prepareIndex("test", "post", "2").setSource("{\"field1\":\"value2\"}").execute().actionGet();
@@ -322,7 +310,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
             } catch (Exception e) {
                 // ignore
             }
-            prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", i).put("index.number_of_replicas", 0)).execute().actionGet();
+            createIndex("test");
             ensureGreen();
             client().prepareIndex("test", "type", "1").setSource("tag", "alpha").execute().actionGet();
             refresh();
@@ -352,10 +340,8 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSimpleSorts() throws Exception {
-        final int numberOfShards = between(1, 10);
         Random random = getRandom();
-        prepareCreate("test")
-                .setSettings(ImmutableSettings.builder().put("index.number_of_shards", numberOfShards).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("str_value").field("type", "string").field("index", "not_analyzed").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("boolean_value").field("type", "boolean").endObject()
@@ -365,8 +351,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                         .startObject("long_value").field("type", "long").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("float_value").field("type", "float").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("double_value").field("type", "double").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
         ensureGreen();
         List<IndexRequestBuilder> builders = new ArrayList<IndexRequestBuilder>();
         for (int i = 0; i < 10; i++) {
@@ -673,7 +658,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                 .startObject("svalue").field("type", "string").endObject()
                 .startObject("gvalue").field("type", "geo_point").endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").setSettings(indexSettings()).addMapping("type1", mapping).execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
@@ -763,7 +748,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
         String mapping = jsonBuilder().startObject().startObject("type1").startObject("properties")
                 .startObject("svalue").field("type", "string").field("index", "not_analyzed").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                 .endObject().endObject().endObject().string();
-        prepareCreate("test").setSettings(indexSettings()).addMapping("type1", mapping).execute().actionGet();
+        assertAcked(prepareCreate("test").addMapping("type1", mapping));
         ensureGreen();
 
         client().prepareIndex("test", "type1").setSource(jsonBuilder().startObject()
@@ -851,7 +836,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSortMissingNumbers() throws Exception {
-        prepareCreate("test").addMapping("type1",
+        assertAcked(prepareCreate("test").addMapping("type1",
                 XContentFactory.jsonBuilder()
                         .startObject()
                         .startObject("type1")
@@ -869,7 +854,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                         .field("type", "float")
                         .endObject()
                         .endObject()
-                        .endObject()).execute().actionGet();
+                        .endObject()));
         ensureGreen();
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("id", "1")
@@ -929,7 +914,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSortMissingStrings() throws ElasticsearchException, IOException {
-        prepareCreate("test").addMapping("type1",
+        assertAcked(prepareCreate("test").addMapping("type1",
                 XContentFactory.jsonBuilder()
                         .startObject()
                         .startObject("type1")
@@ -940,7 +925,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                         .endObject()
                         .endObject()
                         .endObject()
-                        .endObject()).execute().actionGet();
+                        .endObject()));
         ensureGreen();
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("id", "1")
@@ -1048,8 +1033,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSortMVField() throws Exception {
-        prepareCreate("test")
-                .setSettings(ImmutableSettings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("long_values").field("type", "long").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("int_values").field("type", "integer").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
@@ -1058,9 +1042,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                         .startObject("float_values").field("type", "float").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("double_values").field("type", "double").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("string_values").field("type", "string").field("index", "not_analyzed").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
-        ensureGreen();
+                        .endObject().endObject().endObject()));
         ensureGreen();
 
         client().prepareIndex("test", "type1", Integer.toString(1)).setSource(jsonBuilder().startObject()
@@ -1366,12 +1348,10 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSortOnRareField() throws ElasticsearchException, IOException {
-        prepareCreate("test")
-                .setSettings(ImmutableSettings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        assertAcked(prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("string_values").field("type", "string").field("index", "not_analyzed").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
-                        .endObject().endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject().endObject()));
         ensureGreen();
         client().prepareIndex("test", "type1", Integer.toString(1)).setSource(jsonBuilder().startObject()
                 .array("string_values", "01", "05", "10", "08")
@@ -1471,13 +1451,12 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
     public void testSortMetaField() throws Exception {
         final boolean idDocValues = maybeDocValues();
         final boolean timestampDocValues = maybeDocValues();
-        prepareCreate("test")
+        assertAcked(prepareCreate("test")
             .addMapping("typ", XContentFactory.jsonBuilder().startObject().startObject("typ")
                         .startObject("_uid").startObject("fielddata").field("format", maybeDocValues() ? "doc_values" : null).endObject().endObject()
                         .startObject("_id").field("index", !idDocValues || randomBoolean() ? "not_analyzed" : "no").startObject("fielddata").field("format", idDocValues ? "doc_values" : null).endObject().endObject()
                         .startObject("_timestamp").field("enabled", true).field("store", true).field("index", !timestampDocValues || randomBoolean() ? "not_analyzed" : "no").startObject("fielddata").field("format", timestampDocValues ? "doc_values" : null).endObject().endObject()
-                        .endObject().endObject())
-                .execute().actionGet();
+                        .endObject().endObject()));
         ensureGreen();
         final int numDocs = atLeast(10);
         IndexRequestBuilder[] indexReqs = new IndexRequestBuilder[numDocs];

--- a/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
+++ b/src/test/java/org/elasticsearch/search/timeout/SearchTimeoutTests.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.search.timeout;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
@@ -34,14 +32,6 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class SearchTimeoutTests extends ElasticsearchIntegrationTest {
     
-    @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", 2)
-                .put("index.number_of_replicas", 0)
-                .build();
-    }
-
     @Test
     public void simpleTimeoutTest() throws Exception {
         createIndex("test");
@@ -49,7 +39,7 @@ public class SearchTimeoutTests extends ElasticsearchIntegrationTest {
         for (int i = 0; i < 10; i++) {
             client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value").execute().actionGet();
         }
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setTimeout("10ms")

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -53,8 +53,6 @@ import java.io.File;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
-/**
- */
 public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
     @Override
@@ -153,6 +151,8 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         logger.info("--> create index with foo type");
         assertAcked(prepareCreate("test-idx", 2, ImmutableSettings.builder().put("refresh_interval", 10)));
 
+        NumShards numShards = getNumShards("test-idx");
+
         assertAcked(client().admin().indices().preparePutMapping("test-idx").setType("foo").setSource("baz", "type=string"));
         ensureGreen();
 
@@ -163,7 +163,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         logger.info("--> delete the index and recreate it with bar type");
         wipeIndices("test-idx");
-        assertAcked(prepareCreate("test-idx", 2, ImmutableSettings.builder().put("refresh_interval", 5)));
+        assertAcked(prepareCreate("test-idx", 2, ImmutableSettings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numShards.numPrimaries).put("refresh_interval", 5)));
         assertAcked(client().admin().indices().preparePutMapping("test-idx").setType("bar").setSource("baz", "type=string"));
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
@@ -51,8 +51,8 @@ public class UpdateByNativeScriptTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatUpdateUsingNativeScriptWorks() throws Exception {
-        prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build()).get();
-        ensureGreen();
+        createIndex("test");
+        ensureYellow();
 
         index("test", "type", "1", "text", "value");
 

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.validate;
 import com.google.common.base.Charsets;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -39,6 +38,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.elasticsearch.index.query.QueryBuilders.queryString;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
 
@@ -49,9 +49,8 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleValidateQuery() throws Exception {
-
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        createIndex("test");
+        ensureGreen();
         client().admin().indices().preparePutMapping("test").setType("type1")
                 .setSource(XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("foo").field("type", "string").endObject()
@@ -59,7 +58,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         .endObject().endObject().endObject())
                 .execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         assertThat(client().admin().indices().prepareValidateQuery("test").setSource("foo".getBytes(Charsets.UTF_8)).execute().actionGet().isValid(), equalTo(false));
         assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.queryString("_id:1")).execute().actionGet().isValid(), equalTo(true));
@@ -75,9 +74,8 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void explainValidateQuery() throws Exception {
-
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        createIndex("test");
+        ensureGreen();
         client().admin().indices().preparePutMapping("test").setType("type1")
                 .setSource(XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("foo").field("type", "string").endObject()
@@ -95,8 +93,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         .endObject().endObject())
                 .execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
-
+        refresh();
 
         ValidateQueryResponse response;
         response = client().admin().indices().prepareValidateQuery("test")
@@ -191,11 +188,8 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void explainValidateQueryTwoNodes() throws IOException {
-
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
-                .put("index.number_of_shards", 1)
-                .put("index.number_of_replicas", 0)).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        createIndex("test");
+        ensureGreen();
         client().admin().indices().preparePutMapping("test").setType("type1")
                 .setSource(XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties")
                         .startObject("foo").field("type", "string").endObject()
@@ -205,10 +199,8 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
                         .endObject().endObject().endObject())
                 .execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
-
-        
         for (Client client : cluster()) {
             ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
                     .setSource("foo".getBytes(Charsets.UTF_8))
@@ -235,7 +227,9 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
 
     @Test //https://github.com/elasticsearch/elasticsearch/issues/3629
     public void explainDateRangeInQueryString() {
-        client().admin().indices().prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_shards", 1)).get();
+        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.settingsBuilder()
+                .put(indexSettings())
+                .put("index.number_of_shards", 1)));
 
         String aMonthAgo = ISODateTimeFormat.yearMonthDay().print(new DateTime(DateTimeZone.UTC).minusMonths(1));
         String aMonthFromNow = ISODateTimeFormat.yearMonthDay().print(new DateTime(DateTimeZone.UTC).plusMonths(1));


### PR DESCRIPTION
Introduced two levels of randomization for the number of shards (between 1 and 10) when running tests:

1) through the existing random index template, which now sets a random number of shards that is shared across all the indices created in the same test method unless overwritten

2) through `createIndex` and `prepareCreate` methods, similar to what happens using the `indexSettings` method, which changes for every `createIndex` or `prepareCreate` unless overwritten (overwrites index template for what concerns the number of shards)

Added the following facilities to deal with the random number of shards:
- `getNumShards` to retrieve the number of shards of a given existing index, useful when doing comparisons based on the number of shards and we can avoid specifying a static number. The method returns an object containing the number of primaries, number of replicas and the expected total number of shards for the existing index
- added `assertFailures` that checks that a shard failure happened during a search request, either partial failure or total (all shards failed). Checks also the error code and the error message related to the failure. This is needed as without knowing the number of shards upfront, when simulating errors we can run into either partial (search returns partial results and failures) or total failures (search returns an error)
- added common methods similar to `indexSettings`, to be used in combination with `createIndex` and `prepareCreate` method and explicitly control the second level of randomization: `numberOfShards`, `minimumNumberOfShards` and `maximumNumberOfShards`. Added also `numberOfReplicas` despite the number of replicas is not randomized (default not specified but can be overwritten by tests)

Tests that specified the number of shards have been reviewed:
- removed number_of_shards in node settings, ignored anyway as it would be overwritten by both mechanisms above
- remove specific number of shards when not needed
- removed manual shards randomization where present, replaced with ordinary one that's now available
- adapted tests that didn't need a specific number of shards to the new random behaviour
- fixed a couple of test bugs (e.g. 3 levels parent child test could only work on a single shard as the routing key used for grand-children wasn't correct)
- also done some cleanup, shared code through shard size facets and aggs tests and used common methods like `assertAcked`, `ensureGreen`, `refresh`, `flush` and `refreshAndFlush` where possible
