### PR TITLE
REST Testing framework enhancement

### DIFF
--- a/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/test/README.asciidoc
@@ -221,6 +221,14 @@ Compares two numeric values, eg:
     - lt: { fields._ttl: 10000 }  # the `_ttl` value is less than 10,000
 ....
 
+=== `lte` and `gte`
+
+Compares two numeric values, eg:
+
+....
+    - lte: { fields._ttl: 10000 }  # the `_ttl` value is less than or equal to 10,000
+....
+
 === `length`
 
 This depends on the datatype of the value being examined, eg:

--- a/src/test/java/org/elasticsearch/test/rest/parser/GreaterThanEqualToParser.java
+++ b/src/test/java/org/elasticsearch/test/rest/parser/GreaterThanEqualToParser.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.parser;
+
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.test.rest.section.GreaterThanEqualToAssertion;
+
+import java.io.IOException;
+
+/**
+ * Parser for gte assert sections
+ */
+public class GreaterThanEqualToParser implements RestTestFragmentParser<GreaterThanEqualToAssertion> {
+
+    @Override
+    public GreaterThanEqualToAssertion parse(RestTestSuiteParseContext parseContext) throws IOException, RestTestParseException {
+        Tuple<String,Object> stringObjectTuple = parseContext.parseTuple();
+        if (! (stringObjectTuple.v2() instanceof Comparable) ) {
+            throw new RestTestParseException("gte section can only be used with objects that support natural ordering, found " + stringObjectTuple.v2().getClass().getSimpleName());
+        }
+        return new GreaterThanEqualToAssertion(stringObjectTuple.v1(), stringObjectTuple.v2());
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/parser/LessThanOrEqualToParser.java
+++ b/src/test/java/org/elasticsearch/test/rest/parser/LessThanOrEqualToParser.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.parser;
+
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.test.rest.section.LessThanOrEqualToAssertion;
+
+import java.io.IOException;
+
+/**
+ * Parser for lte assert section
+ */
+public class LessThanOrEqualToParser implements RestTestFragmentParser<LessThanOrEqualToAssertion> {
+
+    @Override
+    public LessThanOrEqualToAssertion parse(RestTestSuiteParseContext parseContext) throws IOException, RestTestParseException {
+        Tuple<String,Object> stringObjectTuple = parseContext.parseTuple();
+        if (! (stringObjectTuple.v2() instanceof Comparable) ) {
+            throw new RestTestParseException("lte section can only be used with objects that support natural ordering, found " + stringObjectTuple.v2().getClass().getSimpleName());
+        }
+        return new LessThanOrEqualToAssertion(stringObjectTuple.v1(), stringObjectTuple.v2());
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/parser/RestTestSuiteParseContext.java
+++ b/src/test/java/org/elasticsearch/test/rest/parser/RestTestSuiteParseContext.java
@@ -44,7 +44,9 @@ public class RestTestSuiteParseContext {
         EXECUTABLE_SECTIONS_PARSERS.put("is_true", new IsTrueParser());
         EXECUTABLE_SECTIONS_PARSERS.put("is_false", new IsFalseParser());
         EXECUTABLE_SECTIONS_PARSERS.put("gt", new GreaterThanParser());
+        EXECUTABLE_SECTIONS_PARSERS.put("gte", new GreaterThanEqualToParser());
         EXECUTABLE_SECTIONS_PARSERS.put("lt", new LessThanParser());
+        EXECUTABLE_SECTIONS_PARSERS.put("lte", new LessThanOrEqualToParser());
         EXECUTABLE_SECTIONS_PARSERS.put("length", new LengthParser());
     }
 

--- a/src/test/java/org/elasticsearch/test/rest/section/GreaterThanEqualToAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/GreaterThanEqualToAssertion.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.section;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Represents a gte assert section:
+ *
+ *   - gte:     { fields._ttl: 0 }
+ */
+public class GreaterThanEqualToAssertion extends Assertion {
+
+    private static final ESLogger logger = Loggers.getLogger(GreaterThanEqualToAssertion.class);
+
+    public GreaterThanEqualToAssertion(String field, Object expectedValue) {
+        super(field, expectedValue);
+    }
+
+    @Override
+    protected void doAssert(Object actualValue, Object expectedValue) {
+        logger.trace("assert that [{}] is greater than or equal to [{}]", actualValue, expectedValue);
+        assertThat(actualValue, instanceOf(Comparable.class));
+        assertThat(expectedValue, instanceOf(Comparable.class));
+        assertThat(errorMessage(), (Comparable)actualValue, greaterThanOrEqualTo((Comparable) expectedValue));
+    }
+
+    private String errorMessage() {
+        return "field [" + getField() + "] is not greater than or equal to [" + getExpectedValue() + "]";
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/section/LessThanOrEqualToAssertion.java
+++ b/src/test/java/org/elasticsearch/test/rest/section/LessThanOrEqualToAssertion.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.section;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Represents a lte assert section:
+ *
+ *   - lte:     { fields._ttl: 0 }
+ */
+public class LessThanOrEqualToAssertion  extends Assertion {
+
+    private static final ESLogger logger = Loggers.getLogger(LessThanOrEqualToAssertion.class);
+
+    public LessThanOrEqualToAssertion(String field, Object expectedValue) {
+        super(field, expectedValue);
+    }
+
+    @Override
+    protected void doAssert(Object actualValue, Object expectedValue) {
+        logger.trace("assert that [{}] is less than or equal to [{}]", actualValue, expectedValue);
+        assertThat(actualValue, instanceOf(Comparable.class));
+        assertThat(expectedValue, instanceOf(Comparable.class));
+        assertThat(errorMessage(), (Comparable)actualValue, lessThanOrEqualTo((Comparable) expectedValue));
+    }
+
+    private String errorMessage() {
+        return "field [" + getField() + "] is not less than or equal to [" + getExpectedValue() + "]";
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/support/Features.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/Features.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public final class Features {
 
-    private static final List<String> SUPPORTED = Lists.newArrayList("regex");
+    private static final List<String> SUPPORTED = Lists.newArrayList("regex", "gtelte");
 
     private Features() {
 


### PR DESCRIPTION
Adding operators 'lte' and 'gte' to our REST test framework. These
operators test for, respectively, less-than-or-equal and
greater-than-or-equal.

Closes #5360 
