### PR TITLE
Add a char_filter cutting the field into sentences

### DIFF
--- a/docs/reference/analysis/charfilters.asciidoc
+++ b/docs/reference/analysis/charfilters.asciidoc
@@ -14,3 +14,5 @@ include::charfilters/mapping-charfilter.asciidoc[]
 include::charfilters/htmlstrip-charfilter.asciidoc[]
 
 include::charfilters/pattern-replace-charfilter.asciidoc[]
+
+include::charfilters/sentence-charfilter.asciidoc[]

--- a/docs/reference/analysis/charfilters/sentence-charfilter.asciidoc
+++ b/docs/reference/analysis/charfilters/sentence-charfilter.asciidoc
@@ -1,0 +1,47 @@
+[[analysis-sentence-charfilter]]
+=== Sentence Char Filter
+
+A char filter of type `sentence` chops the string into the first few
+sentences.
+
+Here is a sample configuration:
+
+[source,js]
+--------------------------------------------------
+{
+    "index" : {
+        "analysis" : {
+            "char_filter" : {
+                "my_mapping" : {
+                    "type" : "sentence"
+                }
+            },
+            "analyzer" : {
+                "custom_with_char_filter" : {
+                    "tokenizer" : "standard",
+                    "char_filter" : ["sentence"]
+                },
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+Here are the configuration attributes:
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Attribute |Description
+|`sentences` |The number of sentences to keep.  Defaults to `1`.
+
+|`locale` |Locale to use for sentence splitting.  Defaults to `en_us`.
+
+|`ananlyzed_chars` |Maximum number of characters to check for sentences.
+Defaults to `1024`.  If all requested sentences don't fit into this many
+characters then all characters up until the last word break before this
+many characters are passed to the analyzer.
+|=======================================================================
+
+*Note:* All boundaries in this filter are made by Java's BreakIterator,
+including the word boundary when there are insufficient analyzed_chars
+for the requested number of sentences.

--- a/src/main/java/org/elasticsearch/index/analysis/SentenceCharFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SentenceCharFilter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.CharFilter;
+import org.apache.lucene.analysis.util.CharArrayIterator;
+import org.elasticsearch.common.io.FastCharArrayReader;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.text.BreakIterator;
+import java.util.Locale;
+
+public class SentenceCharFilter extends CharFilter {
+    public static CharFilter build(Reader input, Locale locale, int sentences, int analyzedChars) throws IOException {
+        char[] cbuf = new char[analyzedChars];
+        final int limit = input.read(cbuf);
+        CharArrayIterator charIterator = CharArrayIterator.newSentenceInstance();
+        charIterator.setText(cbuf, 0, limit);
+
+        // Input was empty so we can't do anything with it.  Wrapping it in a SentenceCharfilter will turn it into an
+        // empty CharFilter.
+        if (limit < 0) {
+            return new SentenceCharFilter(input);
+        }
+
+        BreakIterator iterator = BreakIterator.getSentenceInstance(locale);
+        iterator.setText(charIterator);
+        iterator.first();
+        int boundary = iterator.next(sentences);
+        if (boundary == BreakIterator.DONE) {
+            // We didn't analyze enough chars to find the sentences so just return what we can.
+            boundary = limit;
+        }
+        if (boundary != analyzedChars) {
+            // Sentences inside the limit so return the boundary.  Success.
+            return new SentenceCharFilter(new FastCharArrayReader(cbuf, 0, boundary));
+        }
+
+        // Sentences not inside the limit so break on the last word in case we chopped a word.
+        charIterator = CharArrayIterator.newWordInstance();
+        charIterator.setText(cbuf, 0, limit);
+        iterator = BreakIterator.getWordInstance(locale);
+        iterator.setText(charIterator);
+        iterator.last();
+        boundary = iterator.previous();
+        // Note that the boundary could be 0 if there are not word breaks in the text.  That is OK because we'd prefer
+        // nothing over a broken word.
+        return new SentenceCharFilter(new FastCharArrayReader(cbuf, 0, boundary));
+    }
+
+    private SentenceCharFilter(Reader input) {
+        super(input);
+    }
+
+    @Override
+    protected int correct(int currentOff) {
+        return currentOff;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        return input.read(cbuf, off, len);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/SentenceCharFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SentenceCharFilterFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.LocaleUtils;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Locale;
+
+@AnalysisSettingsRequired
+public class SentenceCharFilterFactory extends AbstractCharFilterFactory {
+    /**
+     * Default number of characters to analyze.  Picked because the average first sentence length on English Wikipedia's
+     * content articles is 286 characters with a standard deviation of 367.  1020 would get two standard deviations
+     * worth of articles so we round up to 1024.
+     */
+    public static final int DEFAULT_ANALYZED_CHARS = 1024;
+    private final Locale locale;
+    private final int sentences;
+    private final int analyzedChars;
+
+    @Inject
+    public SentenceCharFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name);
+
+        locale = LocaleUtils.parse(settings.get("locale", "en_us"));
+        sentences = settings.getAsInt("sentences", 1);
+        analyzedChars = settings.getAsInt("analyzed_chars", DEFAULT_ANALYZED_CHARS);
+    }
+
+    @Override
+    public Reader create(Reader tokenStream) {
+        try {
+            return SentenceCharFilter.build(tokenStream, locale, sentences, analyzedChars);
+        } catch (IOException e) {
+            throw new ElasticsearchException("Error building sentence filter.", e);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/analysis/SentenceCharFilterTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/SentenceCharFilterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.util._TestUtil;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.EnvironmentModule;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNameModule;
+import org.elasticsearch.index.settings.IndexSettingsModule;
+import org.elasticsearch.indices.analysis.IndicesAnalysisModule;
+import org.elasticsearch.indices.analysis.IndicesAnalysisService;
+import org.elasticsearch.test.ElasticsearchTokenStreamTestCase;
+import org.junit.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+
+public class SentenceCharFilterTest extends ElasticsearchTokenStreamTestCase {
+    @Test
+    public void sentenceCharFilter() throws Exception {
+        Index index = new Index("test");
+        Settings settings = settingsBuilder()
+                .put("index.analysis.char_filter.first_sentence.type", "sentence")
+                .put("index.analysis.char_filter.first_sentence.sentences", "1")
+                .put("index.analysis.char_filter.first_two_sentences.type", "sentence")
+                .put("index.analysis.char_filter.first_two_sentences.sentences", "2")
+                .put("index.analysis.char_filter.first_sentence.sentences", "1")
+                .put("index.analysis.char_filter.short_sentence.type", "sentence")
+                .put("index.analysis.char_filter.short_sentence.analyzed_chars", "10")
+                .put("index.analysis.analyzer.one_sentence.tokenizer", "standard")
+                .put("index.analysis.analyzer.one_sentence.char_filter", "first_sentence")
+                .put("index.analysis.analyzer.two_sentences.tokenizer", "standard")
+                .put("index.analysis.analyzer.two_sentences.char_filter", "first_two_sentences")
+                .put("index.analysis.analyzer.short_sentence.tokenizer", "standard")
+                .put("index.analysis.analyzer.short_sentence.char_filter", "short_sentence")
+                .build();
+        Injector parentInjector = new ModulesBuilder().add(new SettingsModule(settings), new EnvironmentModule(new Environment(settings)), new IndicesAnalysisModule()).createInjector();
+        Injector injector = new ModulesBuilder().add(
+                new IndexSettingsModule(index, settings),
+                new IndexNameModule(index),
+                new AnalysisModule(settings, parentInjector.getInstance(IndicesAnalysisService.class)))
+                .createChildInjector(parentInjector);
+
+        AnalysisService analysisService = injector.getInstance(AnalysisService.class);
+
+        NamedAnalyzer oneSentence = analysisService.analyzer("one_sentence");
+        NamedAnalyzer twoSentences = analysisService.analyzer("two_sentences");
+        NamedAnalyzer shortSentence = analysisService.analyzer("short_sentence");
+
+        // One sentence
+        assertTokenStreamContents(oneSentence.tokenStream("test", "The quick brown fox jumped."),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(twoSentences.tokenStream("test", "The quick brown fox jumped."),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+
+        // Two sentences
+        assertTokenStreamContents(oneSentence.tokenStream("test", "The quick brown fox jumped.  Then came down."),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(twoSentences.tokenStream("test", "The quick brown fox jumped.  Then came down."),
+                new String[]{"The", "quick", "brown", "fox", "jumped", "Then", "came", "down"});
+
+        // Three Sentences
+        assertTokenStreamContents(oneSentence.tokenStream("test", "The quick brown fox jumped.  Then came down.  The cow jumped over the moon."),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(twoSentences.tokenStream("test", "The quick brown fox jumped.  Then came down.  The cow jumped over the moon."),
+                new String[]{"The", "quick", "brown", "fox", "jumped", "Then", "came", "down"});
+
+        // Empty
+        assertTokenStreamContents(oneSentence.tokenStream("test", ""),
+                new String[]{});
+        assertTokenStreamContents(twoSentences.tokenStream("test", ""),
+                new String[]{});
+
+        // Incomplete sentences
+        assertTokenStreamContents(oneSentence.tokenStream("test", "The quick brown fox jumped"),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(twoSentences.tokenStream("test", "The quick brown fox jumped"),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(oneSentence.tokenStream("test", "The quick brown fox jumped.  Then came down"),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(twoSentences.tokenStream("test", "The quick brown fox jumped.  Then came down"),
+                new String[]{"The", "quick", "brown", "fox", "jumped", "Then", "came", "down"});
+
+        // String longer then analyzed chars
+        StringBuilder tooLong = new StringBuilder("The quick brown fox jumped.  Then came down.  Capitalletter ");
+        while (tooLong.length() < SentenceCharFilterFactory.DEFAULT_ANALYZED_CHARS) {
+            tooLong.append(_TestUtil.randomAnalysisString(random(), SentenceCharFilterFactory.DEFAULT_ANALYZED_CHARS * 2, true));
+        }
+        assertTokenStreamContents(oneSentence.tokenStream("test", tooLong.toString()),
+                new String[]{"The", "quick", "brown", "fox", "jumped"});
+        assertTokenStreamContents(twoSentences.tokenStream("test", tooLong.toString()),
+                new String[]{"The", "quick", "brown", "fox", "jumped", "Then", "came", "down"});
+
+        // First sentence longer then analyzed chars
+        assertTokenStreamContents(shortSentence.tokenStream("test", "The quick brown fox jumped."), new String[]{"The", "quick"});
+        assertTokenStreamContents(shortSentence.tokenStream("test", "The quickest brown fox jumped."), new String[]{"The"});
+        //                                            Only analyze up to -----^ (inclusive)
+
+        // Super degenerate case: one word for all analyzed chars
+        assertTokenStreamContents(shortSentence.tokenStream("test", "Thequickestbrownfoxjumped."), new String[]{});
+    }
+
+}


### PR DESCRIPTION
Adds a char_filter that cuts the field down to the configured number of
sentences.  Defaults to just the first sentence.

There is some impedence between the incoming Reader and the CharacterIterator
that has to be passed to the BreakIterator.  We copy a configurable number
of characters into a character array and shove those into the BreakIterator
via Lucene's CharArrayIterator rather than try anything fancy.  Hopefully
this is fine from a performance perspective.

Closes #5377
