### PR TITLE
[DOCS] Fix minor error in cluster stats example

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -8,7 +8,7 @@ versions, memory usage, cpu and installed plugins).
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'http://localhost:9200/_cluster/stats?human'
+curl -XGET 'http://localhost:9200/_cluster/stats?human&pretty'
 --------------------------------------------------
 
 Will return, for example:


### PR DESCRIPTION
`?human` doesn't pretty print for me (Elasticsearch 1.0.1)
