### PR TITLE
Corrected issue with throttle type setting not respected upon updates

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/support/AbstractIndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/support/AbstractIndexStore.java
@@ -45,7 +45,7 @@ public abstract class AbstractIndexStore extends AbstractIndexComponent implemen
     class ApplySettings implements IndexSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            String rateLimitingType = indexSettings.get(INDEX_STORE_THROTTLE_TYPE, AbstractIndexStore.this.rateLimitingType);
+            String rateLimitingType = settings.get(INDEX_STORE_THROTTLE_TYPE, AbstractIndexStore.this.rateLimitingType);
             if (!rateLimitingType.equals(AbstractIndexStore.this.rateLimitingType)) {
                 logger.info("updating index.store.throttle.type from [{}] to [{}]", AbstractIndexStore.this.rateLimitingType, rateLimitingType);
                 if (rateLimitingType.equalsIgnoreCase("node")) {


### PR DESCRIPTION
The setting "index.store.throttle.type" is not able to be updated on a live running instance using a PUT request to _settings
