### PR TITLE
[TEST] Randomized number of replicas used for indices created during tests

### DIFF
--- a/src/test/java/org/elasticsearch/cluster/ClusterHealthTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterHealthTests.java
@@ -21,14 +21,12 @@ package org.elasticsearch.cluster;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class ClusterHealthTests extends ElasticsearchIntegrationTest {
-
 
     @Test
     public void testHealth() {
@@ -39,18 +37,16 @@ public class ClusterHealthTests extends ElasticsearchIntegrationTest {
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
 
         logger.info("--> running cluster wide health");
-        healthResponse = client().admin().cluster().prepareHealth().setWaitForYellowStatus().setTimeout("10s").execute().actionGet();
+        healthResponse = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
 
         logger.info("--> Creating index test1 with zero replicas");
-        client().admin().indices().prepareCreate("test1")
-                .setSettings(ImmutableSettings.settingsBuilder().put("index.number_of_replicas", 0))
-                .execute().actionGet();
+        createIndex("test1");
 
         logger.info("--> running cluster health on an index that does exists");
-        healthResponse = client().admin().cluster().prepareHealth("test1").setWaitForYellowStatus().setTimeout("10s").execute().actionGet();
+        healthResponse = client().admin().cluster().prepareHealth("test1").setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));

--- a/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
@@ -106,7 +106,7 @@ public class AckClusterUpdateSettingsTests extends ElasticsearchIntegrationTest 
     public void testClusterUpdateSettingsNoAcknowledgement() {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put("number_of_shards", between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put("number_of_shards", between(cluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put("number_of_replicas", 0)).get();
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -179,7 +179,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteAcknowledgement() throws InterruptedException {
         assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder()
                 .put(indexSettings())
-                .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                .put(SETTING_NUMBER_OF_SHARDS, between(cluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
         ));
         ensureGreen();
@@ -214,7 +214,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteNoAcknowledgement() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
@@ -228,7 +228,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteAcknowledgementDryRun() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
@@ -261,7 +261,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteNoAcknowledgementDryRun() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().size(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/cluster/allocation/AwarenessAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/AwarenessAllocationTests.java
@@ -50,6 +50,11 @@ public class AwarenessAllocationTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(AwarenessAllocationTests.class);
 
+    @Override
+    protected int numberOfReplicas() {
+        return 1;
+    }
+
     @Test
     public void testSimpleAwareness() throws Exception {
         Settings commonSettings = ImmutableSettings.settingsBuilder()
@@ -70,8 +75,7 @@ public class AwarenessAllocationTests extends ElasticsearchIntegrationTest {
         //no replicas will be allocated as both indices end up on a single node
         final int totalPrimaries = test1.numPrimaries + test2.numPrimaries;
 
-        ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-        assertThat(health.isTimedOut(), equalTo(false));
+        ensureGreen();
 
         logger.info("--> starting 1 node on a different rack");
         final String node3 = cluster().startNode(ImmutableSettings.settingsBuilder().put(commonSettings).put("node.rack_id", "rack_2").build());
@@ -144,7 +148,6 @@ public class AwarenessAllocationTests extends ElasticsearchIntegrationTest {
                 .put("cluster.routing.allocation.awareness.force.zone.values", "a,b")
                 .put("cluster.routing.allocation.awareness.attributes", "zone")
                 .build();
-
 
         logger.info("--> starting 2 nodes on zones 'a' & 'b'");
         String A_0 = cluster().startNode(ImmutableSettings.settingsBuilder().put(commonSettings).put("node.zone", "a").build());

--- a/src/test/java/org/elasticsearch/cluster/allocation/SimpleAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/SimpleAllocationTests.java
@@ -49,7 +49,7 @@ public class SimpleAllocationTests extends ElasticsearchIntegrationTest {
         assertAcked(prepareCreate("test", 3));
         ensureGreen();
 
-         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.routingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.routingNodes()) {
             if (!node.isEmpty()) {

--- a/src/test/java/org/elasticsearch/flt/FuzzyLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/flt/FuzzyLikeThisActionTests.java
@@ -36,11 +36,6 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class FuzzyLikeThisActionTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     @Test
     // See issue https://github.com/elasticsearch/elasticsearch/issues/3252
     public void testNumericField() throws Exception {

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsTests.java
@@ -72,7 +72,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSpecifiedIndexUnavailable() throws Exception {
-        assertAcked(prepareCreate("test1"));
+        createIndex("test1");
         ensureYellow();
 
         // Verify defaults
@@ -180,7 +180,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSpecifiedIndexUnavailable_snapshotRestore() throws Exception {
-        assertAcked(prepareCreate("test1"));
+        createIndex("test1");
         ensureYellow();
 
         PutRepositoryResponse putRepositoryResponse = client().admin().cluster().preparePutRepository("dummy-repo")
@@ -344,7 +344,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testWildcardBehaviour_snapshotRestore() throws Exception {
-        assertAcked(prepareCreate("foobar"));
+        createIndex("foobar");
         ensureYellow();
 
         PutRepositoryResponse putRepositoryResponse = client().admin().cluster().preparePutRepository("dummy-repo")
@@ -373,7 +373,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testAllMissing_lenient() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test1"));
+        createIndex("test1");
         client().prepareIndex("test1", "type", "1").setSource("k", "v").setRefresh(true).execute().actionGet();
         SearchResponse response = client().prepareSearch("test2")
                 .setIndicesOptions(IndicesOptions.lenient())
@@ -396,7 +396,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testAllMissing_strict() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test1"));
+        createIndex("test1");
         ensureYellow();
         try {
             client().prepareSearch("test2")
@@ -421,8 +421,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
     @Test
     // For now don't handle closed indices
     public void testCloseApi_specifiedIndices() throws Exception {
-        assertAcked(prepareCreate("test1"));
-        assertAcked(prepareCreate("test2"));
+        createIndex("test1", "test2");
         ensureYellow();
         verify(search("test1", "test2"), false);
         verify(count("test1", "test2"), false);
@@ -448,10 +447,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testCloseApi_wildcards() throws Exception {
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
 
         verify(client().admin().indices().prepareClose("bar*"), false);
@@ -468,7 +464,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDeleteIndex() throws Exception {
-        assertAcked(prepareCreate("foobar"));
+        createIndex("foobar");
         ensureYellow();
 
         verify(client().admin().indices().prepareDelete("foo"), true);
@@ -481,10 +477,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
     public void testDeleteIndex_wildcard() throws Exception {
         verify(client().admin().indices().prepareDelete("_all"), false);
 
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
 
         verify(client().admin().indices().prepareDelete("foo*"), false);
@@ -541,7 +534,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPutWarmer() throws Exception {
-        assertAcked(prepareCreate("foobar"));
+        createIndex("foobar");
         ensureYellow();
         verify(client().admin().indices().preparePutWarmer("warmer1").setSearchRequest(client().prepareSearch().setIndices("foobar").setQuery(QueryBuilders.matchAllQuery())), false);
         assertThat(client().admin().indices().prepareGetWarmers("foobar").setWarmers("warmer1").get().getWarmers().size(), equalTo(1));
@@ -550,11 +543,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
     
     @Test
     public void testPutWarmer_wildcard() throws Exception {
-        
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
 
         verify(client().admin().indices().preparePutWarmer("warmer1").setSearchRequest(client().prepareSearch().setIndices("foo*").setQuery(QueryBuilders.matchAllQuery())), false);
@@ -575,7 +564,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPutAlias() throws Exception {
-        assertAcked(prepareCreate("foobar"));
+        createIndex("foobar");
         ensureYellow();
         verify(client().admin().indices().prepareAliases().addAlias("foobar", "foobar_alias"), false);
         assertThat(client().admin().indices().prepareAliasesExist("foobar_alias").setIndices("foobar").get().exists(), equalTo(true));
@@ -584,11 +573,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
     
     @Test
     public void testPutAlias_wildcard() throws Exception {
-        
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
 
         verify(client().admin().indices().prepareAliases().addAlias("foo*", "foobar_alias"), false);
@@ -686,10 +671,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         assertThat(client().admin().indices().prepareExists("foo*").setIndicesOptions(IndicesOptions.fromOptions(false, true, true, false)).get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("_all").get().isExists(), equalTo(false));
 
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
 
         assertThat(client().admin().indices().prepareExists("foo*").get().isExists(), equalTo(true));
@@ -704,10 +686,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(client().admin().indices().preparePutMapping("foo").setType("type1").setSource("field", "type=string"), true);
         verify(client().admin().indices().preparePutMapping("_all").setType("type1").setSource("field", "type=string"), true);
 
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
 
         verify(client().admin().indices().preparePutMapping("foo").setType("type1").setSource("field", "type=string"), false);
@@ -739,10 +718,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(client().admin().indices().prepareUpdateSettings("foo").setSettings(ImmutableSettings.builder().put("a", "b")), true);
         verify(client().admin().indices().prepareUpdateSettings("_all").setSettings(ImmutableSettings.builder().put("a", "b")), true);
 
-        assertAcked(prepareCreate("foo"));
-        assertAcked(prepareCreate("foobar"));
-        assertAcked(prepareCreate("bar"));
-        assertAcked(prepareCreate("barbaz"));
+        createIndex("foo", "foobar", "bar", "barbaz");
         ensureYellow();
         assertAcked(client().admin().indices().prepareClose("_all").get());
 

--- a/src/test/java/org/elasticsearch/indices/fielddata/breaker/RandomExceptionCircuitBreakerTests.java
+++ b/src/test/java/org/elasticsearch/indices/fielddata/breaker/RandomExceptionCircuitBreakerTests.java
@@ -61,7 +61,6 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
             assertThat("Breaker is not set to 0", node.getBreaker().getEstimated(), equalTo(0L));
         }
 
-        final int numReplicas = randomIntBetween(0, 1);
         String mapping = XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("type")
@@ -107,7 +106,6 @@ public class RandomExceptionCircuitBreakerTests extends ElasticsearchIntegration
 
         ImmutableSettings.Builder settings = settingsBuilder()
                 .put(indexSettings())
-                .put("index.number_of_replicas", numReplicas)
                 .put(MockInternalEngine.READER_WRAPPER_TYPE, RandomExceptionDirectoryReaderWrapper.class.getName())
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)

--- a/src/test/java/org/elasticsearch/indices/mapping/ConcurrentDynamicTemplateTests.java
+++ b/src/test/java/org/elasticsearch/indices/mapping/ConcurrentDynamicTemplateTests.java
@@ -40,11 +40,6 @@ public class ConcurrentDynamicTemplateTests extends ElasticsearchIntegrationTest
 
     private final String mappingType = "test-mapping";
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     @Test // see #3544
     public void testConcurrentDynamicMapping() throws Exception {
         final String fieldName = "field";

--- a/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsTests.java
+++ b/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsTests.java
@@ -37,11 +37,6 @@ import static org.hamcrest.Matchers.*;
  */
 public class SimpleGetFieldMappingsTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     @Test
     public void getMappingsWhereThereAreNone() {
         createIndex("index");

--- a/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasTests.java
+++ b/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasTests.java
@@ -33,10 +33,12 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 
-/**
- *
- */
 public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected int maximumNumberOfReplicas() {
+        return 1;
+    }
 
     @Test
     public void simpleUpdateNumberOfReplicasTests() throws Exception {
@@ -51,7 +53,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(clusterHealth.getIndices().get("test").getActivePrimaryShards(), equalTo(numShards.numPrimaries));
-        assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
+        assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(numShards.numReplicas));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.totalNumShards));
 
         for (int i = 0; i < 10; i++) {

--- a/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
@@ -20,14 +20,12 @@
 package org.elasticsearch.indices.stats;
 
 import org.apache.lucene.util.Version;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -40,49 +38,50 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Random;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
-/**
- *
- */
 @ClusterScope(scope = Scope.SUITE, numNodes = 2)
 public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void simpleStats() throws Exception {
-        // rely on 1 replica for this tests
-        createIndex("test1");
-        createIndex("test2");
-
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-        assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
+        createIndex("test1", "test2");
+        ensureGreen();
 
         client().prepareIndex("test1", "type1", Integer.toString(1)).setSource("field", "value").execute().actionGet();
         client().prepareIndex("test1", "type2", Integer.toString(1)).setSource("field", "value").execute().actionGet();
         client().prepareIndex("test2", "type", Integer.toString(1)).setSource("field", "value").execute().actionGet();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
+
+        NumShards test1 = getNumShards("test1");
+        long test1ExpectedWrites = 2 * test1.dataCopies;
+        NumShards test2 = getNumShards("test2");
+        long test2ExpectedWrites = test2.dataCopies;
+        long totalExpectedWrites = test1ExpectedWrites + test2ExpectedWrites;
 
         IndicesStatsResponse stats = client().admin().indices().prepareStats().execute().actionGet();
         assertThat(stats.getPrimaries().getDocs().getCount(), equalTo(3l));
-        assertThat(stats.getTotal().getDocs().getCount(), equalTo(6l));
+        assertThat(stats.getTotal().getDocs().getCount(), equalTo(totalExpectedWrites));
         assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexCount(), equalTo(3l));
-        assertThat(stats.getTotal().getIndexing().getTotal().getIndexCount(), equalTo(6l));
+        assertThat(stats.getTotal().getIndexing().getTotal().getIndexCount(), equalTo(totalExpectedWrites));
         assertThat(stats.getTotal().getStore(), notNullValue());
         assertThat(stats.getTotal().getMerge(), notNullValue());
         assertThat(stats.getTotal().getFlush(), notNullValue());
         assertThat(stats.getTotal().getRefresh(), notNullValue());
 
         assertThat(stats.getIndex("test1").getPrimaries().getDocs().getCount(), equalTo(2l));
-        assertThat(stats.getIndex("test1").getTotal().getDocs().getCount(), equalTo(4l));
+        assertThat(stats.getIndex("test1").getTotal().getDocs().getCount(), equalTo(test1ExpectedWrites));
         assertThat(stats.getIndex("test1").getPrimaries().getStore(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getMerge(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getFlush(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getRefresh(), notNullValue());
 
         assertThat(stats.getIndex("test2").getPrimaries().getDocs().getCount(), equalTo(1l));
-        assertThat(stats.getIndex("test2").getTotal().getDocs().getCount(), equalTo(2l));
+        assertThat(stats.getIndex("test2").getTotal().getDocs().getCount(), equalTo(test2ExpectedWrites));
 
         // make sure that number of requests in progress is 0
         assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getIndexCurrent(), equalTo(0l));
@@ -151,11 +150,9 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testMergeStats() {
-        // rely on 1 replica for this tests
         createIndex("test1");
 
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
-        assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
+        ensureGreen();
 
         // clear all
         IndicesStatsResponse stats = client().admin().indices().prepareStats()
@@ -190,12 +187,10 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSegmentsStats() {
-        assertAcked(prepareCreate("test1", 2));
+        assertAcked(prepareCreate("test1", 2, settingsBuilder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))));
+        ensureGreen();
 
         NumShards test1 = getNumShards("test1");
-
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
-        assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         for (int i = 0; i < 20; i++) {
             index("test1", "type1", Integer.toString(i), "field", "value");
@@ -217,8 +212,7 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
         createIndex("test1");
         createIndex("test2");
 
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
-        assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
+        ensureGreen();
 
         client().prepareIndex("test1", "type1", Integer.toString(1)).setSource("field", "value").execute().actionGet();
         client().prepareIndex("test1", "type2", Integer.toString(1)).setSource("field", "value").execute().actionGet();

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -71,6 +71,12 @@ public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest 
         return -1;
     }
 
+    @Override
+    protected int numberOfReplicas() {
+        //number of replicas won't be set through index settings, the one from the index templates needs to be used
+        return -1;
+    }
+
     @Test
     public void testThatLoadingTemplateFromFileWorks() throws Exception {
         final int iters = atLeast(5);

--- a/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
@@ -29,6 +29,8 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import static org.elasticsearch.client.Requests.*;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisFieldQuery;
@@ -177,10 +179,9 @@ public class MoreLikeThisActionTests extends ElasticsearchIntegrationTest {
                 .startObject("properties")
                 .endObject()
                 .endObject().endObject().string();
-        prepareCreate("foo", 2, ImmutableSettings.builder().put("index.number_of_replicas", 0)
-                .put("index.number_of_shards", 2))
-                .addMapping("bar", mapping)
-                .execute().actionGet();
+        assertAcked(prepareCreate("foo", 2,
+                ImmutableSettings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).put(SETTING_NUMBER_OF_REPLICAS, 0))
+                .addMapping("bar", mapping));
         ensureGreen();
 
         client().prepareIndex("foo", "bar", "1")

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -557,7 +557,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         IndicesStatsResponse indicesResponse = client().admin().indices().prepareStats("test").execute().actionGet();
         assertThat(indicesResponse.getTotal().getPercolate().getCount(), equalTo((long) numShards.numPrimaries));
         assertThat(indicesResponse.getTotal().getPercolate().getCurrent(), equalTo(0l));
-        assertThat(indicesResponse.getTotal().getPercolate().getNumQueries(), equalTo(2l)); // One primary and replica
+        assertThat(indicesResponse.getTotal().getPercolate().getNumQueries(), equalTo((long)numShards.dataCopies)); //number of copies
         assertThat(indicesResponse.getTotal().getPercolate().getMemorySizeInBytes(), greaterThan(0l));
 
         NodesStatsResponse nodesResponse = client().admin().cluster().prepareNodesStats().execute().actionGet();
@@ -577,9 +577,9 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("1"));
 
         indicesResponse = client().admin().indices().prepareStats().setPercolate(true).execute().actionGet();
-        assertThat(indicesResponse.getTotal().getPercolate().getCount(), equalTo((long) numShards.numPrimaries *2));
+        assertThat(indicesResponse.getTotal().getPercolate().getCount(), equalTo((long) numShards.numPrimaries * 2));
         assertThat(indicesResponse.getTotal().getPercolate().getCurrent(), equalTo(0l));
-        assertThat(indicesResponse.getTotal().getPercolate().getNumQueries(), equalTo(2l));
+        assertThat(indicesResponse.getTotal().getPercolate().getNumQueries(), equalTo((long)numShards.dataCopies)); //number of copies
         assertThat(indicesResponse.getTotal().getPercolate().getMemorySizeInBytes(), greaterThan(0l));
 
         percolateCount = 0;

--- a/src/test/java/org/elasticsearch/percolator/TTLPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/TTLPercolatorTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.percolator;
 
+import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.percolate.PercolateResponse;
@@ -29,6 +30,8 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -54,11 +57,11 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testPercolatingWithTimeToLive() throws Exception {
-        Client client = client();
+        final Client client = client();
         client.admin().indices().prepareDelete("_all").execute().actionGet();
         ensureGreen();
 
-        String precolatorMapping = XContentFactory.jsonBuilder().startObject().startObject(PercolatorService.TYPE_NAME)
+        String percolatorMapping = XContentFactory.jsonBuilder().startObject().startObject(PercolatorService.TYPE_NAME)
                 .startObject("_ttl").field("enabled", true).endObject()
                 .startObject("_timestamp").field("enabled", true).endObject()
                 .endObject().endObject().string();
@@ -70,10 +73,12 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
 
         client.admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping(PercolatorService.TYPE_NAME, precolatorMapping)
+                .addMapping(PercolatorService.TYPE_NAME, percolatorMapping)
                 .addMapping("type1", typeMapping)
                 .execute().actionGet();
         ensureGreen();
+
+        final NumShards test = getNumShards("test");
 
         long ttl = 1500;
         long now = System.currentTimeMillis();
@@ -90,7 +95,7 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
         IndicesStatsResponse response = client.admin().indices().prepareStats("test")
                 .clear().setIndexing(true)
                 .execute().actionGet();
-        assertThat(response.getIndices().get("test").getTotal().getIndexing().getTotal().getIndexCount(), equalTo(2l));
+        assertThat(response.getIndices().get("test").getTotal().getIndexing().getTotal().getIndexCount(), equalTo((long)test.dataCopies));
 
         PercolateResponse percolateResponse = client.preparePercolate()
                 .setIndices("test").setDocumentType("type1")
@@ -110,7 +115,7 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
                     .clear().setIndexing(true)
                     .execute().actionGet();
             long currentDeleteCount = response.getIndices().get("test").getTotal().getIndexing().getTotal().getDeleteCount();
-            assertThat(currentDeleteCount, equalTo(2l));
+            assertThat(currentDeleteCount, equalTo((long)test.dataCopies));
             return;
         }
 
@@ -123,16 +128,14 @@ public class TTLPercolatorTests extends ElasticsearchIntegrationTest {
 
         // See comment in SimpleTTLTests
         logger.info("Checking if the ttl purger has run");
-        long currentDeleteCount;
-        do {
-            response = client.admin().indices().prepareStats("test")
-                    .clear().setIndexing(true)
-                    .execute().actionGet();
-            // This returns the number of delete operations stats (not Lucene delete count)
-            currentDeleteCount = response.getIndices().get("test").getTotal().getIndexing().getTotal().getDeleteCount();
-        }
-        while (currentDeleteCount < 2); // TTL deletes one doc, but it is indexed in the primary shard and replica shard.
-        assertThat(currentDeleteCount, equalTo(2l));
+        assertThat(awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                IndicesStatsResponse indicesStatsResponse = client.admin().indices().prepareStats("test").clear().setIndexing(true).get();
+                // TTL deletes one doc, but it is indexed in the primary shard and replica shards
+                return indicesStatsResponse.getIndices().get("test").getTotal().getIndexing().getTotal().getDeleteCount() == test.dataCopies;
+            }
+        }, 5, TimeUnit.SECONDS), equalTo(true));
 
         percolateResponse = client.preparePercolate()
                 .setIndices("test").setDocumentType("type1")

--- a/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
+++ b/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
@@ -45,7 +45,11 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
             logger.info("cluster health request timed out:\n{}", clusterHealth);
             fail("cluster health request timed out");
         }
+    }
 
+    @Override
+    protected int numberOfReplicas() {
+        return 1;
     }
 
     @Test
@@ -59,7 +63,7 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
             client().prepareIndex("test", "type1", Long.toString(i))
                     .setSource(MapBuilder.<String, Object>newMapBuilder().put("test", "value" + i).map()).execute().actionGet();
         }
-        client().admin().indices().prepareFlush().execute().actionGet();
+        flush();
         for (int i = 1000; i < 2000; i++) {
             client().prepareIndex("test", "type1", Long.toString(i))
                     .setSource(MapBuilder.<String, Object>newMapBuilder().put("test", "value" + i).map()).execute().actionGet();
@@ -79,7 +83,7 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForGreenStatus().setWaitForRelocatingShards(0).setWaitForNodes("5"));
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareCount().setQuery(matchAllQuery()).get(), 2000l);
         }
@@ -92,8 +96,7 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForGreenStatus().setWaitForRelocatingShards(0).setWaitForNodes("3"));
 
-
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareCount().setQuery(matchAllQuery()).get(), 2000l);
         }
@@ -106,7 +109,7 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForYellowStatus().setWaitForRelocatingShards(0).setWaitForNodes("1"));
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareCount().setQuery(matchAllQuery()).get(), 2000l);
         }

--- a/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadTests.java
+++ b/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadTests.java
@@ -43,15 +43,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 
-/**
- *
- */
 public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(RecoveryWhileUnderLoadTests.class);
@@ -60,7 +58,7 @@ public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {
     @Slow
     public void recoverWhileUnderLoadAllocateBackupsTest() throws Exception {
         logger.info("--> creating test index ...");
-        assertAcked(prepareCreate("test", 1));
+        assertAcked(prepareCreate("test", 1, settingsBuilder().put(SETTING_NUMBER_OF_REPLICAS, 1)));
 
         final AtomicLong idGenerator = new AtomicLong();
         final AtomicLong indexCounter = new AtomicLong();
@@ -137,7 +135,7 @@ public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {
     @Slow
     public void recoverWhileUnderLoadAllocateBackupsRelocatePrimariesTest() throws Exception {
         logger.info("--> creating test index ...");
-        assertAcked(prepareCreate("test", 1));
+        assertAcked(prepareCreate("test", 1, settingsBuilder().put(SETTING_NUMBER_OF_REPLICAS, 1)));
 
         final AtomicLong idGenerator = new AtomicLong();
         final AtomicLong indexCounter = new AtomicLong();
@@ -211,7 +209,7 @@ public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {
     @Slow
     public void recoverWhileUnderLoadWithNodeShutdown() throws Exception {
         logger.info("--> creating test index ...");
-        assertAcked(prepareCreate("test", 2));
+        assertAcked(prepareCreate("test", 2, settingsBuilder().put(SETTING_NUMBER_OF_REPLICAS, 1)));
 
         final AtomicLong idGenerator = new AtomicLong();
         final AtomicLong indexCounter = new AtomicLong();

--- a/src/test/java/org/elasticsearch/recovery/SimpleRecoveryTests.java
+++ b/src/test/java/org/elasticsearch/recovery/SimpleRecoveryTests.java
@@ -28,25 +28,29 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import static org.elasticsearch.client.Requests.*;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
-/**
- *
- */
 public class SimpleRecoveryTests extends ElasticsearchIntegrationTest {
 
     @Override
     public Settings indexSettings() {
-        return recoverySettings();
+        return settingsBuilder().put(super.indexSettings()).put(recoverySettings()).build();
     }
-    
+
     protected Settings recoverySettings() {
         return ImmutableSettings.Builder.EMPTY_SETTINGS;
     }
 
+    @Override
+    protected int maximumNumberOfReplicas() {
+        return 1;
+    }
+
     @Test
     public void testSimpleRecovery() throws Exception {
-        prepareCreate("test", 1).execute().actionGet(5000);
+        assertAcked(prepareCreate("test", 1).execute().actionGet(5000));
 
         NumShards numShards = getNumShards("test");
 

--- a/src/test/java/org/elasticsearch/search/StressSearchServiceReaperTest.java
+++ b/src/test/java/org/elasticsearch/search/StressSearchServiceReaperTest.java
@@ -45,11 +45,6 @@ public class StressSearchServiceReaperTest extends ElasticsearchIntegrationTest 
         return ImmutableSettings.builder().put(SearchService.KEEPALIVE_INTERVAL_KEY, TimeValue.timeValueMillis(1)).build();
     }
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     @Slow
     @Test // see issue #5165 - this test fails each time without the fix in pull #5170
     public void testStressReaper() throws ExecutionException, InterruptedException {

--- a/src/test/java/org/elasticsearch/search/aggregations/CombiTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/CombiTests.java
@@ -44,11 +44,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class CombiTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     /**
      * Making sure that if there are multiple aggregations, working on the same field, yet require different
      * value source type, they can all still work. It used to fail as we used to cache the ValueSource by the

--- a/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
@@ -48,11 +48,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class RandomTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     // Make sure that unordered, reversed, disjoint and/or overlapping ranges are supported
     // Duel with filters
     public void testRandomRanges() throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -53,11 +53,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class DateHistogramTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     private DateTime date(int month, int day) {
         return new DateTime(2012, month, day, 0, 0, DateTimeZone.UTC);
     }

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -20,8 +20,6 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRange;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder;
@@ -52,11 +50,6 @@ import static org.hamcrest.core.IsNull.nullValue;
  *
  */
 public class DateRangeTests extends ElasticsearchIntegrationTest {
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     private static IndexRequestBuilder indexDoc(int month, int day, int value) throws Exception {
         return client().prepareIndex("idx", "type").setSource(jsonBuilder()

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
@@ -60,11 +58,6 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
     private static final int NUM_DOCS = 5; // TODO: randomize the size?
     private static final String SINGLE_VALUED_FIELD_NAME = "d_value";
     private static final String MULTI_VALUED_FIELD_NAME = "d_values";
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     @Before
     public void init() throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterTests.java
@@ -47,11 +47,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class FilterTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     int numDocs, numTag1Docs;
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceTests.java
@@ -49,11 +49,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class GeoDistanceTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     private IndexRequestBuilder indexCity(String idx, String name, String... latLons) throws Exception {
         XContentBuilder source = jsonBuilder().startObject().field("city", name);
         source.startArray("location");

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -45,11 +45,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class GeoHashGridTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     private IndexRequestBuilder indexCity(String name, String latLon) throws Exception {
         XContentBuilder source = jsonBuilder().startObject().field("city", name);
         if (latLon != null) {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
@@ -47,11 +45,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class GlobalTests extends ElasticsearchIntegrationTest {
 
     int numDocs;
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     @Before
     public void init() throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramTests.java
@@ -52,11 +52,6 @@ public class HistogramTests extends ElasticsearchIntegrationTest {
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     int numDocs;
     int interval;
     int numValueBuckets, numValuesBuckets;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/IPv4RangeTests.java
@@ -47,11 +47,6 @@ import static org.hamcrest.core.IsNull.nullValue;
  */
 public class IPv4RangeTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-    
     @Before
     public void init() throws Exception {
         prepareCreate("idx")

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -58,11 +56,6 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
     private static final int NUM_DOCS = 5; // TODO randomize the size?
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     @Before
     public void init() throws Exception {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountTests.java
@@ -25,8 +25,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
@@ -48,11 +46,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 public class MinDocCountTests extends ElasticsearchIntegrationTest {
 
     private static final QueryBuilder QUERY = QueryBuilders.termQuery("match", true);
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     private int cardinality;
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingTests.java
@@ -44,11 +44,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  */
 public class MissingTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     int numDocs, numDocsMissing, numDocsUnmapped;
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/NaNSortingTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/NaNSortingTests.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Comparators;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -39,14 +37,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 public class NaNSortingTests extends ElasticsearchIntegrationTest {
-
-    @Override
-    public Settings indexSettings() {
-        return ImmutableSettings.builder()
-                .put("index.number_of_shards", between(1, 5))
-                .put("index.number_of_replicas", between(0, 1))
-                .build();
-    }
 
     private enum SubAggregation {
         AVG("avg") {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.nested.Nested;
@@ -52,11 +50,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
  *
  */
 public class NestedTests extends ElasticsearchIntegrationTest {
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     int numParents;
     int[] numChildren;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -49,11 +49,6 @@ public class RangeTests extends ElasticsearchIntegrationTest {
     private static final String SINGLE_VALUED_FIELD_NAME = "l_value";
     private static final String MULTI_VALUED_FIELD_NAME = "l_values";
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     int numDocs;
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceTests.java
@@ -52,11 +52,6 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class ShardReduceTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     private IndexRequestBuilder indexDoc(String date, int value) throws Exception {
         return client().prepareIndex("idx", "type").setSource(jsonBuilder()
                 .startObject()

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTests.java
@@ -54,11 +54,6 @@ public abstract class ShardSizeTests extends ElasticsearchIntegrationTest {
         return 2;
     }
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     protected void createIdx(String keyFieldMapping) {
         assertAcked(prepareCreate("idx")
                 .addMapping("type", "key", keyFieldMapping));

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -22,8 +22,6 @@ import com.google.common.base.Strings;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
@@ -61,11 +59,6 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
 
     private static final String SINGLE_VALUED_FIELD_NAME = "s_value";
     private static final String MULTI_VALUED_FIELD_NAME = "s_values";
-
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
 
     public static String randomExecutionHint() {
         return randomFrom(Arrays.asList(null, TermsAggregatorFactory.EXECUTION_HINT_VALUE_MAP, TermsAggregatorFactory.EXECUTION_HINT_VALUE_ORDINALS));

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
@@ -32,11 +32,6 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  */
 public abstract class AbstractNumericTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     protected long minValue, maxValue, minValues, maxValues;
 
     @Before

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountTests.java
@@ -35,11 +35,6 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class ValueCountTests extends ElasticsearchIntegrationTest {
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     @Before
     public void init() throws Exception {
         createIndex("idx");

--- a/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsTests.java
@@ -46,6 +46,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTest {
     
@@ -85,14 +86,13 @@ public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTes
         
         Builder settings = settingsBuilder()
         .put(indexSettings())
-        .put("index.number_of_replicas", randomIntBetween(0, 1))
         .put(MockDirectoryHelper.RANDOM_IO_EXCEPTION_RATE, exceptionRate)
         .put(MockDirectoryHelper.RANDOM_IO_EXCEPTION_RATE_ON_OPEN, exceptionOnOpenRate)
         .put(MockDirectoryHelper.CHECK_INDEX_ON_CLOSE, true);
         logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(settings)
-                .addMapping("type", mapping).execute().actionGet();
+                .addMapping("type", mapping));
         ClusterHealthResponse clusterHealthResponse = client().admin().cluster()
                 .health(Requests.clusterHealthRequest().waitForYellowStatus().timeout(TimeValue.timeValueSeconds(5))).get(); // it's OK to timeout here 
         final int numDocs;
@@ -184,15 +184,14 @@ public class SearchWithRandomExceptionsTests extends ElasticsearchIntegrationTes
 
         Builder settings = settingsBuilder()
                 .put(indexSettings())
-                .put("index.number_of_replicas", randomIntBetween(0, 1))
                 .put(MockInternalEngine.READER_WRAPPER_TYPE, RandomExceptionDirectoryReaderWrapper.class.getName())
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
                 .put(MockInternalEngine.WRAP_READER_RATIO, 1.0d);
         logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
-        client().admin().indices().prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .setSettings(settings)
-                .addMapping("type", mapping).execute().actionGet();
+                .addMapping("type", mapping));
         ensureSearchable();
         final int numDocs = between(10, 100);
         long numCreated = 0;

--- a/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/SimpleFacetsTests.java
@@ -68,11 +68,6 @@ public class SimpleFacetsTests extends ElasticsearchIntegrationTest {
 
     private int numRuns = -1;
 
-    @Override
-    protected int numberOfReplicas() {
-        return between(0, 1);
-    }
-
     protected int numberOfRuns() {
         if (numRuns == -1) {
             numRuns = atLeast(3);

--- a/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.functionscore;
 
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.hamcrest.CoreMatchers;
@@ -40,12 +39,7 @@ public class RandomScoreFunctionTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void consistentHitsWithSameSeed() throws Exception {
-        final int replicas = between(0, 2); // needed for green status!
-        cluster().ensureAtLeastNumNodes(replicas + 1);
-        assertAcked(prepareCreate("test")
-                .setSettings(
-                        ImmutableSettings.builder().put(indexSettings())
-                                .put("index.number_of_replicas", replicas)));
+        createIndex("test");
         ensureGreen(); // make sure we are done otherwise preference could change?
         int docCount = atLeast(100);
         for (int i = 0; i < docCount; i++) {

--- a/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
+++ b/src/test/java/org/elasticsearch/search/rescore/QueryRescorerTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.search.rescore.RescoreBuilder.QueryRescorer;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
@@ -531,20 +530,18 @@ public class QueryRescorerTests extends ElasticsearchIntegrationTest {
     }
 
     private int indexRandomNumbers(String analyzer, int shards) throws Exception {
-        Builder builder = ImmutableSettings.settingsBuilder().put(indexSettings()).put(SETTING_NUMBER_OF_REPLICAS, between(0, 1));
+        Builder builder = ImmutableSettings.settingsBuilder().put(indexSettings());
 
         if (shards > 0) {
             builder.put(SETTING_NUMBER_OF_SHARDS, shards);
         }
 
-        client().admin()
-                .indices()
-                .prepareCreate("test")
+        assertAcked(prepareCreate("test")
                 .addMapping(
                         "type1",
                         jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("field1")
                                 .field("analyzer", analyzer).field("type", "string").endObject().endObject().endObject().endObject())
-                .setSettings(builder).get();
+                .setSettings(builder));
         int numDocs = atLeast(100);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {

--- a/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchTests.java
@@ -72,11 +72,6 @@ public class CompletionSuggestSearchTests extends ElasticsearchIntegrationTest {
     private final String FIELD = RandomStrings.randomAsciiOfLength(getRandom(), 10).toLowerCase(Locale.ROOT);
     private final CompletionMappingBuilder completionMappingBuilder = new CompletionMappingBuilder();
 
-    @Override
-    protected int numberOfReplicas() {
-        return  between(0, cluster().size() - 1);
-    }
-
     @Test
     public void testSimple() throws Exception {
         createIndexAndMapping(completionMappingBuilder);

--- a/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
@@ -59,9 +59,7 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test // see #3196
     public void testSuggestAcrossMultipleIndices() throws IOException {
-        assertAcked(prepareCreate("test").setSettings(
-                settingsBuilder().put(indexSettings())
-                        .put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))));
+        createIndex("test");
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -76,9 +74,7 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
                 .field("text");
         logger.info("--> run suggestions with one index");
         searchSuggest( termSuggest);
-        assertAcked(prepareCreate("test_1").setSettings(
-                settingsBuilder().put(indexSettings())
-                        .put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))));
+        createIndex("test_1");
         ensureGreen();
 
         index("test_1", "type1", "1", "text", "ab cd");
@@ -100,10 +96,7 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
                 .startObject("text").field("type", "string").field("analyzer", "keyword").endObject()
                 .endObject()
                 .endObject().endObject();
-        assertAcked(prepareCreate("test_2").setSettings(
-                settingsBuilder().put(indexSettings())
-                .put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))
-                ).addMapping("type1", mapping));
+        assertAcked(prepareCreate("test_2").addMapping("type1", mapping));
         ensureGreen();
 
         index("test_2", "type1", "1", "text", "ab cd");
@@ -237,7 +230,6 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
     public void testUnmappedField() throws IOException, InterruptedException, ExecutionException {
         CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
                 .put(indexSettings())
-                .put(SETTING_NUMBER_OF_REPLICAS, between(0, cluster().size() - 1))
                 .put("index.analysis.analyzer.biword.tokenizer", "standard")
                 .putArray("index.analysis.analyzer.biword.filter", "shingler", "lowercase")
                 .put("index.analysis.filter.shingler.type", "shingle")
@@ -774,7 +766,6 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
     public void testShardFailures() throws IOException, InterruptedException {
         CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
                 .put(indexSettings())
-                .put(SETTING_NUMBER_OF_REPLICAS, between(0, cluster().size() - 1))
                 .put("index.analysis.analyzer.suggest.tokenizer", "standard")
                 .putArray("index.analysis.analyzer.suggest.filter", "standard", "lowercase", "shingler")
                 .put("index.analysis.filter.shingler.type", "shingle")
@@ -880,7 +871,6 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
 
         CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
                 .put(indexSettings())
-                .put(SETTING_NUMBER_OF_REPLICAS, between(0, cluster().size() - 1))
                 .put("index.analysis.analyzer.body.tokenizer", "standard")
                 .putArray("index.analysis.analyzer.body.filter", "lowercase", "my_shingle")
                 .put("index.analysis.filter.my_shingle.type", "shingle")

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -835,7 +835,6 @@ public final class TestCluster implements Iterable<Client> {
         }
     }
 
-
     /**
      * Stops the current master node forcefully
      */
@@ -1029,13 +1028,26 @@ public final class TestCluster implements Iterable<Client> {
             dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataLocations()));
         }
         nodes.put(nodeAndClient.name, nodeAndClient);
-
     }
 
     public void closeNonSharedNodes(boolean wipeData) {
         reset(random, wipeData, transportClientRatio);
     }
 
+    public int dataNodes() {
+        return dataNodeAndClients().size();
+    }
+
+    private Collection<NodeAndClient> dataNodeAndClients() {
+        return Collections2.filter(nodes.values(), new DataNodePredicate());
+    }
+
+    private static final class DataNodePredicate implements Predicate<NodeAndClient> {
+        @Override
+        public boolean apply(NodeAndClient nodeAndClient) {
+            return nodeAndClient.node.settings().getAsBoolean("node.data", true);
+        }
+    }
 
     private static final class MasterNodePredicate implements Predicate<NodeAndClient> {
         private final String masterNodeName;

--- a/src/test/java/org/elasticsearch/versioning/ConcurrentDocumentOperationTests.java
+++ b/src/test/java/org/elasticsearch/versioning/ConcurrentDocumentOperationTests.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -41,9 +42,8 @@ public class ConcurrentDocumentOperationTests extends ElasticsearchIntegrationTe
     public void concurrentOperationOnSameDocTest() throws Exception {
 
         logger.info("--> create an index with 1 shard and max replicas based on nodes");
-        client().admin().indices().prepareCreate("test")
-                .setSettings(settingsBuilder().put("index.number_of_shards", 1).put("index.number_of_replicas", cluster().size()-1))
-                .execute().actionGet();
+        assertAcked(prepareCreate("test")
+                .setSettings(settingsBuilder().put(indexSettings()).put("index.number_of_shards", 1)));
 
         logger.info("execute concurrent updates on the same doc");
         int numberOfUpdates = 100;


### PR DESCRIPTION
Introduced two levels of randomization for the number of replicas when running tests:

1) through the existing random index template, which now sets a random number of replicas that can either be 0 or 1 that is shared across all the indices created in the same test method unless overwritten

2)  through createIndex and prepareCreate methods, between 0 and the number of data nodes available, similar to what happens using the indexSettings method, which changes for every createIndex or prepareCreate unless overwritten (overwrites index template for what concerns the number of replicas)

Added the following facilities to deal with the random number of replicas:
- made it possible to retrieve how many data nodes are available in the `TestCluster`
- added common methods similar to indexSettings, to be used in combination with createIndex and prepareCreate method and explicitly control the second level of randomization: numberOfReplicas, minimumNumberOfReplicas and maximumNumberOfReplicas

Tests that specified the number of replicas have been reviewed:
- removed manual replicas randomization where present, replaced with ordinary one that's now available
- adapted tests that didn't need a specific number of replicas to the new random behaviour
- also done some more cleanup, used common methods like assertAcked, ensureGreen, refresh, flush and refreshAndFlush where possible
