### PR TITLE
Upgrade randomized-testing to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
-            <version>2.0.15</version>
+            <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -356,7 +356,7 @@
             <plugin>
                 <groupId>com.carrotsearch.randomizedtesting</groupId>
                 <artifactId>junit4-maven-plugin</artifactId>
-                <version>2.0.15</version>
+                <version>2.1.1</version>
                 <executions>
                     <execution>
                         <id>tests</id>

--- a/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
+++ b/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
@@ -362,4 +362,16 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
     public String getTestName() {
         return threadAndTestNameRule.testMethodName;
     }
+
+    /**
+     * Returns a random value greater or equal to <code>min</code>. The value
+     * picked is affected by {@link #isNightly()} and {@link #multiplier()}.
+     * The upper bound is calculated based on <code>min</code>: <code>min + (min / 2)</code>
+     *
+     * @see #scaledRandomIntBetween(int, int)
+     */
+    public static int atLeast(int min) {
+        if (min < 0) throw new IllegalArgumentException("atLeast requires non-negative argument: " + min);
+        return scaledRandomIntBetween(min, (int)Math.min(Integer.MAX_VALUE, (long)min + (min / 2)));
+    }
 }


### PR DESCRIPTION
Note that the standard `atLeast` implementation has now Integer.MAX_VALUE as upper bound, thus it behaves differently from what we expect in our tests, as we never expect the upper bound to be that high.
Added our own `atLeast` to `AbstractRandomizedTest` so that it has the expected behaviour with a reasonable upper bound.
See https://github.com/carrotsearch/randomizedtesting/issues/131
