### PR TITLE
Benchmark: Benchmark API

### DIFF
--- a/docs/reference/indices/benchmark.asciidoc
+++ b/docs/reference/indices/benchmark.asciidoc
@@ -1,0 +1,259 @@
+[[search-benchmark]]
+== Benchmark
+
+.Experimental!
+[IMPORTANT]
+=====
+This feature is marked as experimental, and may be subject to change in the
+future. If you use this feature, please let us know your experience with it!
+=====
+
+The benchmark API provides a standard mechanism for submitting queries and
+measuring their performance relative to one another.
+
+[IMPORTANT]
+=====
+To be eligible to run benchmarks nodes must be started with: *es.node.bench=true*. This is just a way to mark certain nodes as "executors". Searches will still be distributed out to the cluster in the normal manner. This is primarily a defensive measure to prevent production nodes from being flooded with potentially many requests. Typically one would start a single node with this setting and sumbmit benchmark requests to it.
+=====
+
+[source,bash]
+--------------------------------------------------
+$ ./bin/elasticsearch -Des.node.bench=true
+--------------------------------------------------
+
+Benchmarking a search request is as simple as executing the following command:
+
+[source,js]
+--------------------------------------------------
+$ curl -XPUT 'localhost:9200/_bench/?pretty=true' -d
+'{
+    "name": "my_benchmark",
+    "competitors": [ {
+        "name": "my_competitor",
+        "requests": [ {
+            "query": {
+                "match": { "_all": "a*" }
+            }
+        } ]
+    } ]
+}'
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+  "status" : "complete",
+  "competitors" : {
+    "my_competitor" : {
+      "summary" : {
+        "nodes" : [ "localhost" ],
+        "total_iterations" : 5,
+        "completed_iterations" : 5,
+        "total_queries" : 1000,
+        "concurrency" : 5,
+        "multiplier" : 100,
+        "avg_warmup_time" : 43.0,
+        "statistics" : {
+          "min" : 1,
+          "max" : 10,
+          "mean" : 4.19,
+          "qps" : 238.663,
+          "std_dev" : 1.938,
+          "millis_per_hit" : 1.064,
+          "percentile_10" : 2,
+          "percentile_25" : 3,
+          "percentile_50" : 4,
+          "percentile_75" : 5,
+          "percentile_90" : 7,
+          "percentile_99" : 10
+        },
+        "slowest" : [ {
+          "node" : "localhost",
+          "max_time" : 15,
+          "avg_time" : 4,
+          "request":{"query":{"match":{"_all":"a*"}}}
+        } ]
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+A 'competitor' defines one or more search requests to execute along with parameters that describe how the search(es) should be run. 
+Multiple competitors may be submitted as a group in which case they will execute one after the other. This makes it easy to compare various
+competing alternatives side-by-side.
+
+There are several parameters which may be set at the competition level:
+[horizontal]
+`name`::            Unique name for the competition
+`iterations`::      Number of times to run the competitors
+`concurrency`::     Within each iteration use this level of parallelism
+`multiplier`::      Within each iteration run the query this many times
+`warmup`::          Perform warmup of query
+`num_slowest`::     Record N slowest queries
+`search_type`::     Type of search, e.g. "query_then_fetch", "dfs_query_then_fetch", "count" 
+`requests`::        Query DSL describing search requests
+`clear_caches`::    Whether caches should be cleared on each iteration, and if so, how
+`indices`::         Array of indices (and optional types) to search, e.g. ["my_index_1/my_type_1", "my_index_2", "my_index_3/my_type_3"]
+
+Cache clearing parameters:
+[horizontal]
+`clear_caches`::                Set to 'false' to disable cache clearing completely
+`clear_caches.filter`::         Whether to clear the filter cache
+`clear_caches.field_data`::     Whether to clear the field data cache
+`clear_caches.id`::             Whether to clear the id cache
+`clear_caches.recycler`::       Whether to clear the recycler cache
+`clear_caches.fields`::         Array of fields to clear
+`clear_caches.filter_keys`::    Array of filter keys to clear
+
+Global parameters:
+[horizontal]
+`name`::                    Unique name for the benchmark
+`num_executor_nodes`::      Number of cluster nodes from which to submit and time benchmarks. Allows user to run a benchmark simultaneously on one or more nodes and compare timings. Note that this does not control how many nodes a search request will actually execute on. Defaults to: 1.
+`percentiles`::             Array of percentile values to report. Defaults to: [10, 25, 50, 75, 90, 99]
+
+Additionally, the following competition-level parameters may be set globally: iteration, concurrency, multiplier, warmup, and clear_caches.
+
+Using these parameters it is possible to describe precisely how to execute a benchmark under various conditions. In the following example we run a filtered query against two different indices using two different search types.
+
+[source,js]
+--------------------------------------------------
+$ curl -XPUT 'localhost:9200/_bench/?pretty=true' -d
+{
+    "name": "my_benchmark",
+    "num_executor_nodes": 1,
+    "percentiles" : [ 25, 50, 75 ],
+    "iterations": 5,
+    "multiplier": 1000,
+    "concurrency": 5,
+    "num_slowest": 0,
+    "warmup": true,
+    "clear_caches": false,
+
+    "requests": [ {
+        "query" : {
+            "filtered" : {
+                "query" : { "match" : { "_all" : "*" } },
+                "filter" : {
+                    "and" : [ { "term" : { "title" : "Spain" } },
+                              { "term" : { "title" : "rain" } },
+                              { "term" : { "title" : "plain" } } ]
+                }
+            }
+        }
+    } ],
+
+    "competitors": [ {
+        "name": "competitor_1",
+        "search_type": "query_then_fetch",
+        "indices": [ "my_index_1" ],
+        "clear_caches" : {
+            "filter" : true,
+            "field_data" : true,
+            "id" : true,
+            "recycler" : true,
+            "fields": ["title"]
+        }
+    }, {
+        "name": "competitor_2",
+        "search_type": "dfs_query_then_fetch",
+        "indices": [ "my_index_2" ],
+        "clear_caches" : {
+            "filter" : true,
+            "field_data" : true,
+            "id" : true,
+            "recycler" : true,
+            "fields": ["title"]
+        }
+    } ]
+}
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+  "status" : "complete",
+  "competitors" : {
+    "competitor_1" : {
+      "summary" : {
+        "nodes" : [ "localhost" ],
+        "total_iterations" : 5,
+        "completed_iterations" : 5,
+        "total_queries" : 5000,
+        "concurrency" : 5,
+        "multiplier" : 1000,
+        "avg_warmup_time" : 54.0,
+        "statistics" : {
+          "min" : 0,
+          "max" : 3,
+          "mean" : 0.533,
+          "qps" : 1872.659,
+          "std_dev" : 0.528,
+          "millis_per_hit" : 0.0,
+          "percentile_25" : 0.0,
+          "percentile_50" : 1.0,
+          "percentile_75" : 1.0
+        },
+        "slowest" : [ ]
+      }
+    },
+    "competitor_2" : {
+      "summary" : {
+        "nodes" : [ "localhost" ],
+        "total_iterations" : 5,
+        "completed_iterations" : 5,
+        "total_queries" : 5000,
+        "concurrency" : 5,
+        "multiplier" : 1000,
+        "avg_warmup_time" : 4.0,
+        "statistics" : {
+          "min" : 0,
+          "max" : 4,
+          "mean" : 0.487,
+          "qps" : 2049.180,
+          "std_dev" : 0.545,
+          "millis_per_hit" : 0.0,
+          "percentile_25" : 0.0,
+          "percentile_50" : 0.0,
+          "percentile_75" : 1.0
+        },
+        "slowest" : [ ]
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+In some cases it may be desirable to view the progress of a long-running benchmark and optionally terminate it early. To view all active benchmarks use:
+
+[source,js]
+--------------------------------------------------
+$ curl -XGET 'localhost:9200/_bench?pretty'
+--------------------------------------------------
+
+This would display run-time statistics in the same format as the sample output above.
+
+To abort a long-running benchmark use the 'abort' endpoint:
+
+[source,js]
+--------------------------------------------------
+$ curl -XPOST 'localhost:9200/_bench/abort/my_benchmark?pretty'
+--------------------------------------------------
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+    "aborted_benchmarks" : [
+        "node" "localhost",
+        "benchmark_name", "my_benchmark",
+        "aborted", true
+    ]
+}
+--------------------------------------------------
+

--- a/rest-api-spec/api/bench.json
+++ b/rest-api-spec/api/bench.json
@@ -1,0 +1,39 @@
+{
+    "bench" : {
+        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html",
+        "methods": ["GET", "PUT", "POST"],
+        "url": {
+            "path": "/_bench",
+            "paths": [
+                "/_bench",
+                "/{index}/_bench",
+                "/{index}/{type}/_bench",
+                "/_bench/abort/{name}"
+            ],
+            "parts": {
+                "index": {
+                    "type" : "list",
+                    "description" : "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"
+                },
+                "type": {
+                    "type" : "string",
+                    "required" : true,
+                    "description" : "The name of the document type"
+                }
+            },
+            "params": {
+                "wait_for_completion": {
+                    "type": "boolean",
+                    "description": "Specify whether the caller will wait for the benchmark to complete or return immediately after submission (default: true)"
+                },
+                "verbose": {
+                    "type": "boolean",
+                    "description": "Specify whether to return verbose statistics about each iteration (default: false)"
+                }
+            },
+            "body": {
+                "description": "The search definition using the Query DSL"
+            }
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -119,6 +119,7 @@ import org.elasticsearch.action.admin.indices.warmer.get.GetWarmersAction;
 import org.elasticsearch.action.admin.indices.warmer.get.TransportGetWarmersAction;
 import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerAction;
 import org.elasticsearch.action.admin.indices.warmer.put.TransportPutWarmerAction;
+import org.elasticsearch.action.bench.*;
 import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.bulk.TransportShardBulkAction;
@@ -284,6 +285,9 @@ public class ActionModule extends AbstractModule {
         registerAction(ExplainAction.INSTANCE, TransportExplainAction.class);
         registerAction(ClearScrollAction.INSTANCE, TransportClearScrollAction.class);
         registerAction(RecoveryAction.INSTANCE, TransportRecoveryAction.class);
+        registerAction(BenchmarkAction.INSTANCE, TransportBenchmarkAction.class);
+        registerAction(AbortBenchmarkAction.INSTANCE, TransportAbortBenchmarkAction.class);
+        registerAction(BenchmarkStatusAction.INSTANCE, TransportBenchmarkStatusAction.class);
 
         // register Name -> GenericAction Map that can be injected to instances.
         MapBinder<String, GenericAction> actionsBinder

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkAction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.Client;
+
+/**
+ * Abort benchmark action
+ */
+public class AbortBenchmarkAction extends Action<AbortBenchmarkRequest, AbortBenchmarkResponse, AbortBenchmarkRequestBuilder> {
+
+    public static final AbortBenchmarkAction INSTANCE = new AbortBenchmarkAction();
+    public static final String NAME = "benchmark/abort";
+
+    private AbortBenchmarkAction() {
+        super(NAME);
+    }
+
+    @Override
+    public AbortBenchmarkResponse newResponse() {
+        return new AbortBenchmarkResponse();
+    }
+
+    @Override
+    public AbortBenchmarkRequestBuilder newRequestBuilder(Client client) {
+        return new AbortBenchmarkRequestBuilder(client);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkNodeResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkNodeResponse.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+
+/**
+ * Node-level response for the status of a benchmark abort request
+ */
+public class AbortBenchmarkNodeResponse extends ActionResponse implements Streamable, ToXContent {
+
+    private String benchmarkName;
+    private String nodeName;
+    private String errorMessage;
+
+    public AbortBenchmarkNodeResponse() { }
+
+    public AbortBenchmarkNodeResponse(String benchmarkName, String nodeName) {
+        this.benchmarkName = benchmarkName;
+        this.nodeName = nodeName;
+    }
+
+    public AbortBenchmarkNodeResponse(String benchmarkName, String nodeName, boolean aborted, String errorMessage) {
+        this.benchmarkName = benchmarkName;
+        this.nodeName = nodeName;
+        this.errorMessage = errorMessage;
+    }
+
+    public void nodeName(String nodeName) {
+        this.nodeName = nodeName;
+    }
+
+    public String nodeName() {
+        return nodeName;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.NODE, nodeName);
+        builder.field(Fields.NAME, benchmarkName);
+        builder.field(Fields.ERRMSG, errorMessage);
+        return builder;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readString();
+        nodeName = in.readString();
+        errorMessage = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(benchmarkName);
+        out.writeString(nodeName);
+        out.writeString(errorMessage);
+    }
+
+    static final class Fields {
+        static final XContentBuilderString NODE = new XContentBuilderString("node");
+        static final XContentBuilderString NAME = new XContentBuilderString("benchmark_name");
+        static final XContentBuilderString ERRMSG = new XContentBuilderString("error_message");
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * A request to abort a specified benchmark
+ */
+public class AbortBenchmarkRequest extends AcknowledgedRequest {
+    private String benchmarkName;
+
+    public AbortBenchmarkRequest() { }
+
+    public AbortBenchmarkRequest(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public void benchmarkName(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public String benchmarkName() {
+        return benchmarkName;
+    }
+    @Override
+    public ActionRequestValidationException validate() {
+        if (benchmarkName == null) {
+            return ValidateActions.addValidationError("benchmarkName must not be null", null);
+        }
+        return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readString();
+        readTimeout(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(benchmarkName);
+        writeTimeout(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequestBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.internal.InternalClient;
+
+/**
+ * Request builder for aborting a benchmark
+ */
+public class AbortBenchmarkRequestBuilder extends ActionRequestBuilder<AbortBenchmarkRequest, AbortBenchmarkResponse, AbortBenchmarkRequestBuilder> {
+
+    public AbortBenchmarkRequestBuilder(Client client) {
+        super((InternalClient) client, new AbortBenchmarkRequest());
+    }
+
+    public AbortBenchmarkRequestBuilder setBenchmarkName(String benchmarkName) {
+        request.benchmarkName(benchmarkName);
+        return this;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<AbortBenchmarkResponse> listener) {
+        ((Client) client).abortBench(request, listener);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkResponse.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Response for a benchmark abort request
+ */
+public class AbortBenchmarkResponse extends ActionResponse implements Streamable, ToXContent {
+
+    private String benchmarkName;
+    private String errorMessage;
+    private List<AbortBenchmarkNodeResponse> nodeResponses = new ArrayList<>();
+
+    AbortBenchmarkResponse() {
+        super();
+    }
+
+    AbortBenchmarkResponse(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    AbortBenchmarkResponse(String benchmarkName, String errorMessage) {
+        this.benchmarkName = benchmarkName;
+        this.errorMessage = errorMessage;
+    }
+
+    public void addNodeResponse(AbortBenchmarkNodeResponse nodeResponse) {
+        nodeResponses.add(nodeResponse);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readString();
+        errorMessage = in.readString();
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            AbortBenchmarkNodeResponse nodeResponse = new AbortBenchmarkNodeResponse();
+            nodeResponse.readFrom(in);
+            nodeResponses.add(nodeResponse);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(benchmarkName);
+        out.writeString(errorMessage);
+        out.writeVInt(nodeResponses.size());
+        for (AbortBenchmarkNodeResponse nodeResponse : nodeResponses) {
+            nodeResponse.writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (errorMessage != null && !errorMessage.isEmpty()) {
+            builder.field(Fields.ERROR, errorMessage);
+        }
+        if (nodeResponses.size() > 0) {
+            builder.startArray(Fields.ABORTED);
+            for (AbortBenchmarkNodeResponse nodeResponse : nodeResponses) {
+                nodeResponse.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString ERROR = new XContentBuilderString("error");
+        static final XContentBuilderString ABORTED = new XContentBuilderString("aborted_benchmarks");
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkAction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+
+/**
+ * Benchmark action
+ */
+public class BenchmarkAction extends Action<BenchmarkRequest, BenchmarkResponse, BenchmarkRequestBuilder> {
+
+    public static final BenchmarkAction INSTANCE = new BenchmarkAction();
+    public static final String NAME = "benchmark/start";
+
+    private BenchmarkAction() {
+        super(NAME);
+    }
+
+    @Override
+    public BenchmarkResponse newResponse() {
+        return new BenchmarkResponse();
+    }
+
+    @Override
+    public BenchmarkRequestBuilder newRequestBuilder(Client client) {
+        return new BenchmarkRequestBuilder(client, Strings.EMPTY_ARRAY);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkCompetitor.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkCompetitor.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+
+/**
+ * A benchmark competitor describes how to run a search benchmark. Multiple competitors may be
+ * submitted in a single benchmark request, with their results compared.
+ *
+ * Competitors are executed in two loops. The outer loop is the iteration loop. The number of times
+ * this runs is controlled by the 'iterations' variable.
+ *
+ * The inner loop is the multiplier loop. This is controlled by the 'multiplier' variable.
+ *
+ * The level of concurrency pertains to the number of simultaneous searches that may be executed within
+ * the inner multiplier loop. Iterations are never run concurrently; they run serially.
+ */
+public class BenchmarkCompetitor implements Streamable {
+
+    private String name;
+    private BenchmarkSettings settings = new BenchmarkSettings();
+
+    /**
+     * Constructs a competition across the given indices
+     * @param indices   Indices
+     */
+    BenchmarkCompetitor(String... indices) {
+        settings.indices(indices);
+    }
+
+    /**
+     * Constructs a competition
+     */
+    BenchmarkCompetitor() { }
+
+    ActionRequestValidationException validate(ActionRequestValidationException validationException) {
+        if (name == null) {
+            validationException = ValidateActions.addValidationError("name must not be null", validationException);
+        }
+        if (settings.concurrency() < 1) {
+            validationException = ValidateActions.addValidationError("concurrent requests must be >= 1 but was [" + settings.concurrency() + "]", validationException);
+        }
+        if (settings.iterations() < 1) {
+            validationException = ValidateActions.addValidationError("iterations must be >= 1 but was [" + settings.iterations() + "]", validationException);
+        }
+        if (settings.multiplier() < 1) {
+            validationException = ValidateActions.addValidationError("multiplier must be >= 1 but was [" + settings.multiplier() + "]", validationException);
+        }
+        if (settings.numSlowest() < 0) {
+            validationException = ValidateActions.addValidationError("numSlowest must be >= 0 but was [" + settings.numSlowest() + "]", validationException);
+        }
+        if (settings.searchType() == null) {
+            validationException = ValidateActions.addValidationError("searchType must not be null", validationException);
+        }
+        return validationException;
+    }
+
+    /**
+     * Gets the user-supplied name
+     * @return  Name
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Sets the user-supplied name
+     * @param name  Name
+     */
+    public void name(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the benchmark settings
+     * @return  Settings
+     */
+    public BenchmarkSettings settings() {
+        return settings;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        name = in.readString();
+        settings = in.readOptionalStreamable(new BenchmarkSettings());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeOptionalStreamable(settings);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkCompetitorBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkCompetitorBuilder.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.bench.BenchmarkSettings.ClearCachesSettings;
+
+/**
+ * Builder for a benchmark competitor
+ */
+public class BenchmarkCompetitorBuilder {
+
+    private final BenchmarkCompetitor competitor;
+
+    /**
+     * Constructs a new competitor builder to run a competition on the given indices
+     * @param indices   Indices to run against
+     */
+    public BenchmarkCompetitorBuilder(String... indices) {
+        competitor = new BenchmarkCompetitor(indices);
+    }
+
+    /**
+     * If true, competition will run a 'warmup' round. This is to prevent timings from a cold start.
+     * @param warmup    Whether to do a warmup
+     * @return          this
+     */
+    public BenchmarkCompetitorBuilder setWarmup(boolean warmup) {
+        competitor.settings().warmup(warmup, true);
+        return this;
+    }
+
+    /**
+     * Sets the list if indices to execute against
+     * @param indices   Indices to run against
+     * @return          this
+     */
+    public BenchmarkCompetitorBuilder setIndices(String... indices) {
+        competitor.settings().indices(indices);
+        return this;
+    }
+
+    /**
+     * Sets the types of the indices to execute against
+     * @param types     Types of indices
+     * @return          this
+     */
+    public BenchmarkCompetitorBuilder setTypes(String... types) {
+        competitor.settings().types(types);
+        return this;
+    }
+
+    /**
+     * Whether a competitor is allowed to clear index caches. If true, and if a
+     * ClearCachesSettings has been set, the competitor will
+     * submit an index cache clear action at the top of each iteration.
+     * @param   allowCacheClearing  If true, allow caches to be cleared
+     * @return  this
+     */
+    public BenchmarkCompetitorBuilder setAllowCacheClearing(boolean allowCacheClearing) {
+        competitor.settings().allowCacheClearing(allowCacheClearing);
+        return this;
+    }
+
+    /**
+     * Describes how an index cache clear request should be executed.
+     * @param clearCachesSettings   Description of how to clear caches
+     * @return                      this
+     */
+    public BenchmarkCompetitorBuilder setClearCachesSettings(ClearCachesSettings clearCachesSettings) {
+        competitor.settings().clearCachesSettings(clearCachesSettings, true);
+        return this;
+    }
+
+    /**
+     * Sets the concurrency level with which to run the competition. This determines the number of
+     * actively executing searches which the competition will run in parallel.
+     * @param concurrency   Number of searches to run concurrently
+     * @return              this
+     */
+    public BenchmarkCompetitorBuilder setConcurrency(int concurrency) {
+        competitor.settings().concurrency(concurrency, true);
+        return this;
+    }
+
+    /**
+     * Adds a search request to the competition
+     * @param searchRequest     Search request
+     * @return                  this
+     */
+    public BenchmarkCompetitorBuilder addSearchRequest(SearchRequest... searchRequest) {
+        competitor.settings().addSearchRequest(searchRequest);
+        return this;
+    }
+
+    /**
+     * Sets the number of times to run each competition
+     * @param iters     Number of times to run the competition
+     * @return          this
+     */
+    public BenchmarkCompetitorBuilder setIterations(int iters) {
+        competitor.settings().iterations(iters, true);
+        return this;
+    }
+
+    /**
+     * A 'multiplier' for each iteration. This specifies how many times to execute
+     * the search requests within each iteration. The resulting number of total searches
+     * executed will be: iterations X multiplier. Setting a higher multiplier will
+     * smooth out results and dampen the effect of outliers.
+     * @param multiplier    Iteration multiplier
+     * @return              this
+     */
+    public BenchmarkCompetitorBuilder setMultiplier(int multiplier) {
+        competitor.settings().multiplier(multiplier, true);
+        return this;
+    }
+
+    /**
+     * Sets the number of slowest requests to report
+     * @param numSlowest    Number of slow requests to report
+     * @return              this
+     */
+    public BenchmarkCompetitorBuilder setNumSlowest(int numSlowest) {
+        competitor.settings().numSlowest(numSlowest, true);
+        return this;
+    }
+
+    /**
+     * Builds a competitor
+     * @return  A new competitor
+     */
+    public BenchmarkCompetitor build() {
+        return competitor;
+    }
+
+    /**
+     * Sets the type of search to execute
+     * @param searchType    Search type
+     * @return              this
+     */
+    public BenchmarkCompetitorBuilder setSearchType(SearchType searchType) {
+        competitor.settings().searchType(searchType, true);
+        return this;
+    }
+
+    /**
+     * Sets the user-supplied name to the competitor
+     * @param name  Name
+     * @return      this
+     */
+    public BenchmarkCompetitorBuilder setName(String name) {
+        competitor.name(name);
+        return this;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkExecutor.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkExecutor.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.apache.lucene.util.PriorityQueue;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import com.google.common.collect.UnmodifiableIterator;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * Handles execution, listing, and aborting of benchmarks
+ */
+public class BenchmarkExecutor {
+
+    private static final ESLogger logger = Loggers.getLogger(BenchmarkExecutor.class);
+
+    private final Client client;
+    private String nodeName;
+    private final ClusterService clusterService;
+    private volatile ImmutableOpenMap<String, BenchmarkState> activeBenchmarks = ImmutableOpenMap.of();
+    private final Object lock = new Object();
+
+    public BenchmarkExecutor(Client client, ClusterService clusterService) {
+        this.client = client;
+        this.clusterService = clusterService;
+    }
+
+    private static class BenchmarkState {
+        final String id;
+        final StoppableSemaphore semaphore;
+        final BenchmarkResponse response;
+
+        BenchmarkState(BenchmarkRequest request, BenchmarkResponse response, StoppableSemaphore semaphore) {
+            this.id = request.benchmarkName();
+            this.response = response;
+            this.semaphore = semaphore;
+        }
+    }
+
+    /**
+     * Aborts a benchmark with the given id
+     *
+     * @param benchmarkId   The benchmark to abort
+     * @return              Abort response
+     */
+    public AbortBenchmarkNodeResponse abortBenchmark(String benchmarkId) {
+        if (!activeBenchmarks.containsKey(benchmarkId)) {
+            return new AbortBenchmarkNodeResponse(benchmarkId, nodeName, false, "Benchmark with id [" + benchmarkId + "] not found");
+        }
+        BenchmarkState state = activeBenchmarks.get(benchmarkId);
+        if (state == null) {
+            throw new ElasticsearchException("Benchmark with id [" + benchmarkId + "] is missing");
+        }
+        state.semaphore.stop();
+        return new AbortBenchmarkNodeResponse(benchmarkId, nodeName);
+    }
+
+    /**
+     * Reports status of all active benchmarks
+     *
+     * @return  Benchmark status response
+     */
+    public BenchmarkStatusNodeResponse benchmarkStatus() {
+
+        BenchmarkStatusNodeResponse response = new BenchmarkStatusNodeResponse();
+        final ImmutableOpenMap<String, BenchmarkState> activeBenchmarks = this.activeBenchmarks;
+        UnmodifiableIterator<String> iter = activeBenchmarks.keysIt();
+        while (iter.hasNext()) {
+            String id = iter.next();
+            BenchmarkState state = activeBenchmarks.get(id);
+            response.addBenchResponse(state.response);
+        }
+        return response;
+    }
+
+    /**
+     * Submits a search benchmark for execution
+     *
+     * @param request                   A benchmark request
+     * @return                          Summary response of executed benchmark
+     * @throws ElasticsearchException
+     */
+    public BenchmarkResponse benchmark(BenchmarkRequest request) throws ElasticsearchException {
+
+        final StoppableSemaphore semaphore = new StoppableSemaphore(1);
+        final Map<String, CompetitionResult> competitionResults = new HashMap<String, CompetitionResult>();
+        final BenchmarkResponse benchmarkResponse = new BenchmarkResponse(request.benchmarkName(), competitionResults);
+
+        if (this.nodeName == null) {
+            this.nodeName = clusterService.localNode().name();
+        }
+
+        synchronized (lock) {
+            if (activeBenchmarks.containsKey(request.benchmarkName())) {
+                throw new ElasticsearchException("Benchmark with id [" + request.benchmarkName() + "] is already running");
+            }
+
+            activeBenchmarks = ImmutableOpenMap.builder(activeBenchmarks).fPut(
+                    request.benchmarkName(), new BenchmarkState(request, benchmarkResponse, semaphore)).build();
+        }
+
+        try {
+            final List<String> errorMessages = new ArrayList<>();
+
+            try {
+                for (BenchmarkCompetitor competitor : request.competitors()) {
+                    final BenchmarkSettings settings = competitor.settings();
+                    final int iterations = settings.iterations();
+                    logger.debug("Executing [{}] iterations for benchmark [{}][{}] ", iterations, request.benchmarkName(), competitor.name());
+
+                    final List<CompetitionIteration> competitionIterations = new ArrayList<>(iterations);
+                    final CompetitionResult competitionResult =
+                            new CompetitionResult(competitor.name(), settings.concurrency(), settings.multiplier(), request.percentiles());
+                    final CompetitionNodeResult competitionNodeResult =
+                            new CompetitionNodeResult(competitor.name(), nodeName, iterations, competitionIterations);
+
+                    competitionResult.addCompetitionNodeResult(competitionNodeResult);
+                    benchmarkResponse.competitionResults.put(competitor.name(), competitionResult);
+
+                    final List<SearchRequest> searchRequests = competitor.settings().searchRequests();
+
+                    if (settings.warmup()) {
+                        final long beforeWarmup = System.nanoTime();
+                        final List<String> warmUpErrors = warmUp(competitor, searchRequests, semaphore);
+                        final long afterWarmup = System.nanoTime();
+                        competitionNodeResult.warmUpTime(TimeUnit.MILLISECONDS.convert(afterWarmup - beforeWarmup, TimeUnit.NANOSECONDS));
+                        if (!warmUpErrors.isEmpty()) {
+                            competitionNodeResult.failures(warmUpErrors.toArray(Strings.EMPTY_ARRAY));
+                            continue;
+                        }
+                    }
+
+                    final int requestsPerRound = settings.multiplier() * searchRequests.size();
+                    final long[] timeBuckets = new long[requestsPerRound];
+                    final long[] docBuckets = new long[requestsPerRound];
+
+                    for (int i = 0; i < iterations; i++) {
+                        if (settings.allowCacheClearing() && settings.clearCaches() != null) {
+                            try {
+                                client.admin().indices().clearCache(settings.clearCaches()).get();
+                            } catch (ExecutionException e) {
+                                throw new ElasticsearchException("Failed to clear caches before benchmark round", e);
+                            }
+                        }
+
+                        // Run the iteration
+                        CompetitionIteration ci = runIteration(competitor, searchRequests, timeBuckets, docBuckets, errorMessages, semaphore);
+                        ci.percentiles(request.percentiles());
+
+                        if (errorMessages.isEmpty()) {
+                            competitionIterations.add(ci);
+                            competitionNodeResult.incrementCompletedIterations();
+                        } else {
+                            competitionNodeResult.failures(errorMessages.toArray(Strings.EMPTY_ARRAY));
+                            return benchmarkResponse;
+                        }
+                    }
+
+                    competitionNodeResult.totalExecutedQueries(settings.multiplier() * searchRequests.size() * iterations);
+                }
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                benchmarkResponse.state(BenchmarkResponse.State.ABORTED);
+            }
+            benchmarkResponse.state(BenchmarkResponse.State.COMPLETE);
+            return benchmarkResponse;
+        } finally {
+            synchronized (lock) {
+                if (!activeBenchmarks.containsKey(request.benchmarkName())) {
+                    throw new ElasticsearchException("Benchmark with id [" + request.benchmarkName() + "] is missing");
+                }
+                semaphore.stop();
+                activeBenchmarks = ImmutableOpenMap.builder(activeBenchmarks).fRemove(request.benchmarkName()).build();
+            }
+        }
+    }
+
+    private List<String> warmUp(BenchmarkCompetitor competitor, List<SearchRequest> searchRequests, StoppableSemaphore stoppableSemaphore)
+            throws InterruptedException {
+        final StoppableSemaphore semaphore = stoppableSemaphore.reset(competitor.settings().concurrency());
+        final CountDownLatch totalCount = new CountDownLatch(searchRequests.size());
+        final CopyOnWriteArrayList<String> errorMessages = new CopyOnWriteArrayList<String>();
+
+        for (SearchRequest searchRequest : searchRequests) {
+            semaphore.acquire();
+            client.search(searchRequest, new BoundsManagingActionListener<SearchResponse>(semaphore, totalCount, errorMessages) { } );
+        }
+        totalCount.await();
+        return errorMessages;
+    }
+
+    private CompetitionIteration runIteration(BenchmarkCompetitor competitor, List<SearchRequest> searchRequests,
+                                              final long[] timeBuckets, final long[] docBuckets, List<String> errors,
+                                              StoppableSemaphore stoppableSemaphore) throws InterruptedException {
+
+        assert timeBuckets.length == competitor.settings().multiplier() * searchRequests.size();
+        assert docBuckets.length == competitor.settings().multiplier() * searchRequests.size();
+
+        final StoppableSemaphore semaphore = stoppableSemaphore.reset(competitor.settings().concurrency());
+
+        Arrays.fill(timeBuckets, -1);   // wipe CPU cache     ;)
+        Arrays.fill(docBuckets, -1);    // wipe CPU cache     ;)
+
+        int id = 0;
+        final CountDownLatch totalCount = new CountDownLatch(timeBuckets.length);
+        final CopyOnWriteArrayList<String> errorMessages = new CopyOnWriteArrayList<String>();
+        final long beforeRun = System.nanoTime();
+
+        for (int i = 0; i < competitor.settings().multiplier(); i++) {
+            for (SearchRequest searchRequest : searchRequests) {
+                StatisticCollectionActionListener statsListener =
+                        new StatisticCollectionActionListener(semaphore, timeBuckets, docBuckets, id++, totalCount, errorMessages);
+                semaphore.acquire();
+                client.search(searchRequest, statsListener);
+            }
+        }
+        totalCount.await();
+        assert id == timeBuckets.length;
+        final long afterRun = System.nanoTime();
+        if (!errorMessages.isEmpty()) {
+            errors.addAll(errorMessages);
+            return null;
+        }
+
+        assert assertBuckets(timeBuckets); // make sure they are all set
+        assert assertBuckets(docBuckets);  // make sure they are all set
+
+        final long totalTime = TimeUnit.MILLISECONDS.convert(afterRun - beforeRun, TimeUnit.NANOSECONDS);
+
+        CompetitionIterationData iterationData = new CompetitionIterationData(timeBuckets);
+        long sumDocs = new CompetitionIterationData(docBuckets).sum();
+
+        CompetitionIteration.SlowRequest[] topN =
+                competitor.settings().numSlowest() > 0 ? getTopN(timeBuckets, searchRequests,
+                        competitor.settings().multiplier(), competitor.settings().numSlowest()) : null;
+        CompetitionIteration round =
+                new CompetitionIteration(topN, totalTime, timeBuckets.length, sumDocs, iterationData);
+
+        return round;
+    }
+
+    private CompetitionIteration.SlowRequest[] getTopN(long[] buckets, List<SearchRequest> requests, int multiplier, int topN) {
+
+        final int numRequests = requests.size();
+        // collect the top N
+        final PriorityQueue<IndexAndTime> topNQueue = new PriorityQueue<IndexAndTime>(topN) {
+            @Override
+            protected boolean lessThan(IndexAndTime a, IndexAndTime b) {
+                return a.avgTime < b.avgTime;
+            }
+        };
+        assert multiplier > 0;
+        for (int i = 0; i < numRequests; i++) {
+            long sum = 0;
+            long max = Long.MIN_VALUE;
+            for (int j = 0; j < multiplier; j++) {
+                final int base = (numRequests * j);
+                sum += buckets[i + base];
+                max = Math.max(buckets[i + base], max);
+            }
+            final long avg = sum / multiplier;
+            if (topNQueue.size() < topN) {
+                topNQueue.add(new IndexAndTime(i, max, avg));
+            } else if (topNQueue.top().avgTime < max) {
+                topNQueue.top().update(i, max, avg);
+                topNQueue.updateTop();
+
+            }
+        }
+
+        final CompetitionIteration.SlowRequest[] slowRequests = new CompetitionIteration.SlowRequest[topNQueue.size()];
+        int i = topNQueue.size() - 1;
+
+        while (topNQueue.size() > 0) {
+            IndexAndTime pop = topNQueue.pop();
+            CompetitionIteration.SlowRequest slow =
+                    new CompetitionIteration.SlowRequest(pop.avgTime, pop.maxTime, requests.get(pop.index));
+            slowRequests[i--] = slow;
+        }
+
+        return slowRequests;
+    }
+
+    private static class IndexAndTime {
+        int index;
+        long maxTime;
+        long avgTime;
+
+        public IndexAndTime(int index, long maxTime, long avgTime) {
+            this.index = index;
+            this.maxTime = maxTime;
+            this.avgTime = avgTime;
+        }
+
+        public void update(int index, long maxTime, long avgTime) {
+            this.index = index;
+            this.maxTime = maxTime;
+            this.avgTime = avgTime;
+        }
+    }
+
+    private static abstract class BoundsManagingActionListener<Response> implements ActionListener<Response> {
+
+        private final StoppableSemaphore semaphore;
+        private final CountDownLatch latch;
+        private final CopyOnWriteArrayList<String> errorMessages;
+
+        public BoundsManagingActionListener(StoppableSemaphore semaphore, CountDownLatch latch, CopyOnWriteArrayList<String> errorMessages) {
+            this.semaphore = semaphore;
+            this.latch = latch;
+            this.errorMessages = errorMessages;
+        }
+
+        private void manage() {
+            try {
+                semaphore.release();
+            } finally {
+                latch.countDown();
+            }
+        }
+
+        public void onResponse(Response response) {
+            manage();
+        }
+
+        public void onFailure(Throwable e) {
+            manage();
+            if (errorMessages.size() < 5) {
+                logger.error("Failed to execute benchmark [{}]", e.getMessage(), e);
+                e = ExceptionsHelper.unwrapCause(e);
+                errorMessages.add(e.getLocalizedMessage());
+            }
+        }
+    }
+
+    private static class StatisticCollectionActionListener extends BoundsManagingActionListener<SearchResponse> {
+
+        private final long[] timeBuckets;
+        private final int bucketId;
+        private final long[] docBuckets;
+
+        public StatisticCollectionActionListener(StoppableSemaphore semaphore, long[] timeBuckets, long[] docs, int bucketId,
+                                                 CountDownLatch totalCount, CopyOnWriteArrayList<String> errorMessages) {
+            super(semaphore, totalCount, errorMessages);
+            this.bucketId = bucketId;
+            this.timeBuckets = timeBuckets;
+            this.docBuckets = docs;
+        }
+
+        @Override
+        public void onResponse(SearchResponse searchResponse) {
+            super.onResponse(searchResponse);
+            timeBuckets[bucketId] = searchResponse.getTookInMillis();
+            if (searchResponse.getHits() != null) {
+                docBuckets[bucketId] = searchResponse.getHits().getTotalHits();
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            timeBuckets[bucketId] = -1;
+            docBuckets[bucketId] = -1;
+            super.onFailure(e);
+        }
+    }
+
+    private final static class StoppableSemaphore {
+        private Semaphore semaphore;
+        private volatile boolean stopped = false;
+
+        public StoppableSemaphore(int concurrency) {
+            semaphore = new Semaphore(concurrency);
+        }
+
+        public StoppableSemaphore reset(int concurrency) {
+            semaphore = new Semaphore(concurrency);
+            return this;
+        }
+
+        public void acquire() throws InterruptedException {
+            if (stopped) {
+                throw new InterruptedException("Benchmark Interrupted");
+            }
+            semaphore.acquire();
+        }
+
+        public void release() {
+            semaphore.release();
+        }
+
+        public void stop() {
+            stopped = true;
+        }
+    }
+
+    private final boolean assertBuckets(long[] buckets) { // assert only
+        for (int i = 0; i < buckets.length; i++) {
+            assert buckets[i] >= 0 : "Bucket value was negative: " + buckets[i];
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkModule.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.common.inject.AbstractModule;
+
+/**
+ * Benchmark module
+ */
+public class BenchmarkModule extends AbstractModule  {
+
+    @Override
+    protected void configure() {
+        bind(BenchmarkService.class).asEagerSingleton();
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkRequest.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A benchmark request contains one or more competitors, which are descriptions of how to
+ * perform an individual benchmark. Each competitor has its own settings such as concurrency,
+ * number of iterations to perform, and what type of search to perform.
+ */
+public class BenchmarkRequest extends MasterNodeOperationRequest<BenchmarkRequest> {
+
+    private String benchmarkName;
+    private double[] percentiles;
+    private boolean verbose;
+    private int numExecutorNodes = 1;   // How many nodes to run the benchmark on
+
+    // Global settings which can be overwritten at the competitor level
+    private BenchmarkSettings settings = new BenchmarkSettings();
+    private List<BenchmarkCompetitor> competitors = new ArrayList<>();
+
+    /**
+     * Constructs a benchmark request
+     */
+    public BenchmarkRequest() { }
+
+    /**
+     * Constructs a benchmark request
+     */
+    public BenchmarkRequest(String... indices) {
+        settings().indices(indices);
+    }
+
+    /**
+     * Validate benchmark request
+     *
+     * @return  Null if benchmark request is OK, exception otherwise
+     */
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (benchmarkName == null) {
+            validationException = ValidateActions.addValidationError("benchmarkName must not be null", validationException);
+        }
+        if (competitors.isEmpty()) {
+            validationException = ValidateActions.addValidationError("competitors must not be empty", validationException);
+        }
+        if (numExecutorNodes <= 0) {
+            validationException = ValidateActions.addValidationError("num_executors must not be less than 1", validationException);
+        }
+        for (BenchmarkCompetitor competitor : competitors) {
+            validationException = competitor.validate(validationException);
+            if (validationException != null) {
+                break;
+            }
+        }
+        return validationException;
+    }
+
+    /**
+     * Cascade top-level benchmark settings to individual competitors while taking care
+     * not to overwrite any settings which the competitors specifically set.
+     */
+    public void cascadeGlobalSettings() {
+        for (BenchmarkCompetitor competitor : competitors) {
+            competitor.settings().merge(settings);
+            if (competitor.settings().searchRequests().isEmpty()) {
+                for (SearchRequest defaultSearchRequest : settings.searchRequests()) {
+                    SearchRequest copy = new SearchRequest();
+                    if (defaultSearchRequest.indices() != null) {
+                        copy.indices(defaultSearchRequest.indices());
+                    }
+                    copy.types(defaultSearchRequest.types());
+                    copy.searchType(defaultSearchRequest.searchType());
+                    copy.source(defaultSearchRequest.source(), true);
+                    copy.extraSource(defaultSearchRequest.extraSource(), true);
+                    copy.routing(defaultSearchRequest.routing());
+                    copy.preference(defaultSearchRequest.preference());
+                    competitor.settings().addSearchRequest(copy);
+                }
+            }
+        }
+    }
+
+    /**
+     * Apply late binding for certain settings. Indices and types passed will override previously
+     * set values. Cache clear requests cannot be constructed until we know the final set of
+     * indices so do this last.
+     *
+     * @param indices   List of indices to execute on
+     * @param types     List of types to execute on
+     */
+    public void applyLateBoundSettings(String[] indices, String[] types) {
+        if (indices != null && indices.length > 0) {
+            settings.indices(indices);
+        }
+        if (types != null && types.length > 0) {
+            settings.types(types);
+        }
+        for (SearchRequest searchRequest : settings.searchRequests()) {
+            if (indices != null && indices.length > 0) {
+                searchRequest.indices(indices);
+            }
+            if (types != null && types.length > 0) {
+                searchRequest.types(types);
+            }
+            if (settings.clearCachesSettings() != null) {
+                settings.buildClearCachesRequestFromSettings();
+            }
+        }
+        for (BenchmarkCompetitor competitor : competitors) {
+            if (indices != null && indices.length > 0) {
+                competitor.settings().indices(indices);
+                competitor.settings().types(null);
+            }
+            if (types != null && types.length > 0) {
+                competitor.settings().types(types);
+            }
+            competitor.settings().buildSearchRequestsFromSettings();
+            if (competitor.settings().clearCachesSettings() != null) {
+                competitor.settings().buildClearCachesRequestFromSettings();
+            }
+        }
+    }
+
+    /**
+     * Gets the benchmark settings
+     * @return  Settings
+     */
+    public BenchmarkSettings settings() {
+        return settings;
+    }
+
+    /**
+     * Gets the number of nodes in the cluster to execute on.
+     * @return  Number of nodes
+     */
+    public int numExecutorNodes() {
+        return numExecutorNodes;
+    }
+
+    /**
+     * Sets the number of nodes in the cluster to execute the benchmark on. We will attempt to
+     * execute on this many eligible nodes, but will not fail if fewer nodes are available.
+     * @param numExecutorNodes  Number of nodes
+     */
+    public void numExecutorNodes(int numExecutorNodes) {
+        this.numExecutorNodes = numExecutorNodes;
+    }
+
+    /**
+     * Gets the name of the benchmark
+     * @return  Benchmark name
+     */
+    public String benchmarkName() {
+        return benchmarkName;
+    }
+
+    /**
+     * Sets the name of the benchmark
+     * @param benchmarkId   Benchmark name
+     */
+    public void benchmarkName(String benchmarkId) {
+        this.benchmarkName = benchmarkId;
+    }
+
+    /**
+     * Whether to report detailed statistics
+     * @return  True if verbose on
+     */
+    public boolean verbose() {
+        return verbose;
+    }
+
+    /**
+     * Whether to report detailed statistics
+     * @param verbose   True/false
+     */
+    public void verbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    /**
+     * Gets the list of percentiles to report
+     * @return The list of percentiles to report
+     */
+    public double[] percentiles() {
+        return percentiles;
+    }
+
+    /**
+     * Sets the list of percentiles to report
+     * @param percentiles   The list of percentiles to report
+     */
+    public void percentiles(double[] percentiles) {
+        this.percentiles = percentiles;
+    }
+
+    /**
+     * Gets the list of benchmark competitions
+     * @return  Competitions
+     */
+    public List<BenchmarkCompetitor> competitors() {
+        return competitors;
+    }
+
+    /**
+     * Add a benchmark competition
+     * @param competitor    Competition
+     */
+    public void addCompetitor(BenchmarkCompetitor competitor) {
+        this.competitors.add(competitor);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readString();
+        numExecutorNodes = in.readVInt();
+        verbose = in.readBoolean();
+        percentiles = in.readDoubleArray();
+        int size = in.readVInt();
+        competitors.clear();
+        for (int i = 0; i < size; i++) {
+            BenchmarkCompetitor competitor = new BenchmarkCompetitor();
+            competitor.readFrom(in);
+            competitors.add(competitor);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(benchmarkName);
+        out.writeVInt(numExecutorNodes);
+        out.writeBoolean(verbose);
+        if (percentiles != null) {
+            out.writeDoubleArray(percentiles);
+        } else {
+            out.writeVInt(0);
+        }
+        out.writeVInt(competitors.size());
+        for (BenchmarkCompetitor competitor : competitors) {
+            competitor.writeTo(out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkRequestBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.internal.InternalClient;
+
+/**
+ * Request builder for benchmarks
+ */
+public class BenchmarkRequestBuilder extends ActionRequestBuilder<BenchmarkRequest, BenchmarkResponse, BenchmarkRequestBuilder> {
+
+    public BenchmarkRequestBuilder(Client client, String[] indices) {
+        super((InternalClient) client, new BenchmarkRequest(indices));
+    }
+
+    public BenchmarkRequestBuilder(Client client) {
+        super((InternalClient) client, new BenchmarkRequest());
+    }
+
+    public BenchmarkRequestBuilder setAllowCacheClearing(boolean allowCacheClearing) {
+        request.settings().allowCacheClearing(allowCacheClearing);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setClearCachesSettings(BenchmarkSettings.ClearCachesSettings clearCachesSettings) {
+        request.settings().clearCachesSettings(clearCachesSettings, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder addSearchRequest(SearchRequest... searchRequest) {
+        request.settings().addSearchRequest(searchRequest);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder addCompetitor(BenchmarkCompetitor competitor) {
+        request.addCompetitor(competitor);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder addCompetitor(BenchmarkCompetitorBuilder competitorBuilder) {
+        return addCompetitor(competitorBuilder.build());
+    }
+
+    public BenchmarkRequestBuilder setNumExecutorNodes(int numExecutorNodes) {
+        request.numExecutorNodes(numExecutorNodes);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setIterations(int iterations) {
+        request.settings().iterations(iterations, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setConcurrency(int concurrency) {
+        request.settings().concurrency(concurrency, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setMultiplier(int multiplier) {
+        request.settings().multiplier(multiplier, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setNumSlowest(int numSlowest) {
+        request.settings().numSlowest(numSlowest, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setWarmup(boolean warmup) {
+        request.settings().warmup(warmup, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setBenchmarkId(String benchmarkId) {
+        request.benchmarkName(benchmarkId);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setSearchType(SearchType searchType) {
+        request.settings().searchType(searchType, false);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setVerbose(boolean verbose) {
+        request.verbose(verbose);
+        return this;
+    }
+
+    public BenchmarkRequestBuilder setPercentiles(double[] percentiles) {
+        request.percentiles(percentiles);
+        return this;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<BenchmarkResponse> listener) {
+        ((Client) client).bench(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Benchmark response.
+ *
+ * A benchmark response will contain a mapping of names to results for each competition.
+ */
+public class BenchmarkResponse extends ActionResponse implements Streamable, ToXContent {
+
+    private String benchmarkName;
+    private State state = State.RUNNING;
+    private boolean verbose;
+
+    Map<String, CompetitionResult> competitionResults;
+
+    public BenchmarkResponse() {
+        competitionResults = new HashMap<String, CompetitionResult>();
+    }
+
+    public BenchmarkResponse(String benchmarkName, Map<String, CompetitionResult> competitionResults) {
+        this.benchmarkName = benchmarkName;
+        this.competitionResults = competitionResults;
+    }
+
+    /**
+     * Benchmarks can be in one of: RUNNING, COMPLETE, or ABORTED.
+     */
+    public static enum State {
+        RUNNING((byte) 0),
+        COMPLETE((byte) 1),
+        ABORTED((byte) 2);
+
+        private final byte id;
+        private static final State[] STATES = new State[State.values().length];
+
+        static {
+            for (State state : State.values()) {
+                assert state.id() < STATES.length && state.id() >= 0;
+                STATES[state.id] = state;
+            }
+        }
+
+        State(byte id) {
+            this.id = id;
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public static State fromId(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id >= STATES.length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return STATES[id];
+        }
+    }
+
+    public String benchmarkName() {
+        return benchmarkName;
+    }
+
+    public void benchmarkName(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public State state() {
+        return state;
+    }
+
+    public void state(State state) {
+        this.state = state;
+    }
+
+    public Map<String, CompetitionResult> competitionResults() {
+        return competitionResults;
+    }
+
+    public boolean isAborted() {
+        return state == State.ABORTED;
+    }
+
+    public boolean hasFailures() {
+        for (CompetitionResult result : competitionResults.values()) {
+            if (result.hasFailures()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean verbose() {
+        return verbose;
+    }
+
+    public void verbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.STATUS, state.toString().toLowerCase(Locale.ROOT));
+        builder.startObject(Fields.COMPETITORS);
+        if (competitionResults != null) {
+            for (Map.Entry<String, CompetitionResult> entry : competitionResults.entrySet()) {
+                entry.getValue().verbose(verbose);
+                entry.getValue().toXContent(builder, params);
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readString();
+        state = State.fromId(in.readByte());
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            String s = in.readString();
+            CompetitionResult cr = new CompetitionResult();
+            cr.readFrom(in);
+            competitionResults.put(s, cr);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(benchmarkName);
+        out.writeByte(state.id());
+        out.write(competitionResults.size());
+        for (Map.Entry<String, CompetitionResult> entry : competitionResults.entrySet()) {
+            out.writeString(entry.getKey());
+            entry.getValue().writeTo(out);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+            builder.startObject();
+            toXContent(builder, EMPTY_PARAMS);
+            builder.endObject();
+            return builder.string();
+        } catch (IOException e) {
+            return "{ \"error\" : \"" + e.getMessage() + "\"}";
+        }
+    }
+
+    static final class Fields {
+        static final XContentBuilderString STATUS = new XContentBuilderString("status");
+        static final XContentBuilderString INDEX = new XContentBuilderString("index");
+        static final XContentBuilderString COMPETITORS = new XContentBuilderString("competitors");
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -1,0 +1,720 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ProcessedClusterStateUpdateTask;
+import org.elasticsearch.cluster.TimeoutClusterStateUpdateTask;
+import org.elasticsearch.cluster.metadata.BenchmarkMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * Service component for running benchmarks
+ */
+public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkService> {
+
+    private final ThreadPool threadPool;
+    private final ClusterService clusterService;
+    private final TransportService transportService;
+    private final BenchmarkExecutor executor;
+
+    /**
+     * Constructs a service component for running benchmarks
+     *
+     * @param settings          Settings
+     * @param clusterService    Cluster service
+     * @param threadPool        Thread pool
+     * @param client            Client
+     * @param transportService  Transport service
+     */
+    @Inject
+    public BenchmarkService(Settings settings, ClusterService clusterService, ThreadPool threadPool,
+                            Client client, TransportService transportService) {
+        super(settings);
+        this.threadPool = threadPool;
+        this.executor = new BenchmarkExecutor(client, clusterService);
+        this.clusterService = clusterService;
+        this.transportService = transportService;
+        transportService.registerHandler(BenchExecutionHandler.ACTION, new BenchExecutionHandler());
+        transportService.registerHandler(AbortExecutionHandler.ACTION, new AbortExecutionHandler());
+        transportService.registerHandler(StatusExecutionHandler.ACTION, new StatusExecutionHandler());
+    }
+
+    @Override
+    protected void doStart() throws ElasticsearchException { }
+
+    @Override
+    protected void doStop() throws ElasticsearchException { }
+
+    @Override
+    protected void doClose() throws ElasticsearchException { }
+
+    /**
+     * Lists actively running benchmarks on the cluster
+     *
+     * @param request   Status request
+     * @param listener  Response listener
+     */
+    public void listBenchmarks(final BenchmarkStatusRequest request, final ActionListener<BenchmarkStatusResponse> listener) {
+
+        DiscoveryNodes nodes = clusterService.state().nodes();
+        int nodeCount = 0;
+        for (DiscoveryNode node : nodes) {
+            if (isBenchmarkNode(node)) {
+                nodeCount++;
+            }
+        }
+
+        BenchmarkStatusAsyncHandler async = new BenchmarkStatusAsyncHandler(nodeCount, request, listener);
+        for (DiscoveryNode node : nodes) {
+            if (isBenchmarkNode(node)) {
+                transportService.sendRequest(node, StatusExecutionHandler.ACTION, new NodeStatusRequest(request), async);
+            }
+        }
+    }
+
+    /**
+     * Aborts actively running benchmarks on the cluster
+     *
+     * @param id        Benchmark id to abort
+     * @param listener  Response listener
+     */
+    public void abortBenchmark(final String id, final ActionListener<AbortBenchmarkResponse> listener) {
+
+        BenchmarkStateListener benchmarkStateListener = new BenchmarkStateListener() {
+            @Override
+            public void onResponse(final ClusterState newState, final BenchmarkMetaData.Entry entry) {
+                if (entry != null) {
+                    threadPool.executor(ThreadPool.Names.GENERIC).execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            final ImmutableOpenMap<String, DiscoveryNode> nodes = newState.nodes().nodes();
+                            BenchmarkAbortAsyncHandler async = new BenchmarkAbortAsyncHandler(entry.nodes().length, id, listener);
+                            for (String nodeId : entry.nodes()) {
+                                final DiscoveryNode node = nodes.get(nodeId);
+                                if (node != null) {
+                                    transportService.sendRequest(node, AbortExecutionHandler.ACTION, new NodeAbortRequest(id), async);
+                                } else {
+                                    logger.debug("Node for ID [" + nodeId + "] not found in cluster state - skipping");
+                                }
+                            }
+                        }
+                    });
+                } else {
+                    listener.onResponse(new AbortBenchmarkResponse(id, "Benchmark with id [" + id + "] not found"));
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                listener.onFailure(t);
+            }
+        };
+
+        clusterService.submitStateUpdateTask("abort_benchmark", new AbortBenchmarkTask(id, benchmarkStateListener));
+    }
+
+    /**
+     * Executes benchmarks on the cluster
+     *
+     * @param request   Benchmark request
+     * @param listener  Response listener
+     */
+    public void startBenchmark(final BenchmarkRequest request, final ActionListener<BenchmarkResponse> listener) {
+
+        final BenchmarkStateListener benchListener = new BenchmarkStateListener() {
+            @Override
+            public void onResponse(final ClusterState newState, final BenchmarkMetaData.Entry entry) {
+                threadPool.executor(ThreadPool.Names.GENERIC).execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        final ImmutableOpenMap<String, DiscoveryNode> nodes = newState.nodes().nodes();
+                        final BenchmarkSearchAsyncHandler async = new BenchmarkSearchAsyncHandler(entry.nodes().length, request, listener);
+                        for (String nodeId : entry.nodes()) {
+                            final DiscoveryNode node = nodes.get(nodeId);
+                            if (node == null) {
+                                async.handleExceptionInternal(
+                                        new ElasticsearchIllegalStateException("Node for ID [" + nodeId + "] not found in cluster state - skipping"));
+                            }
+                            transportService.sendRequest(node, BenchExecutionHandler.ACTION, new NodeBenchRequest(request), async);
+                        }
+                    }
+                });
+            }
+            @Override
+            public void onFailure(Throwable t) {
+                listener.onFailure(t);
+            }
+        };
+
+        clusterService.submitStateUpdateTask("start_benchmark", new StartBenchmarkTask(request, benchListener));
+    }
+
+    private void finishBenchmark(final BenchmarkResponse benchmarkResponse, final String benchmarkId, final ActionListener<BenchmarkResponse> listener) {
+
+        clusterService.submitStateUpdateTask("finish_benchmark", new FinishBenchmarkTask("finish_benchmark", benchmarkId, new BenchmarkStateListener() {
+            @Override
+            public void onResponse(ClusterState newClusterState, BenchmarkMetaData.Entry changed) {
+                listener.onResponse(benchmarkResponse);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                listener.onFailure(t);
+            }
+        }, !benchmarkResponse.isAborted() && !benchmarkResponse.hasFailures()));
+    }
+
+    private final boolean isBenchmarkNode(DiscoveryNode node) {
+        ImmutableMap<String, String> attributes = node.getAttributes();
+        if (attributes.containsKey("bench")) {
+            String bench = attributes.get("bench");
+            return Boolean.parseBoolean(bench);
+        }
+        return false;
+    }
+
+    private List<DiscoveryNode> findNodes(BenchmarkRequest request) {
+        final int numNodes = request.numExecutorNodes();
+        final DiscoveryNodes nodes = clusterService.state().nodes();
+        DiscoveryNode localNode = nodes.localNode();
+        List<DiscoveryNode> benchmarkNodes = new ArrayList<DiscoveryNode>();
+        if (isBenchmarkNode(localNode)) {
+            benchmarkNodes.add(localNode);
+        }
+        for (DiscoveryNode node : nodes) {
+            if (benchmarkNodes.size() >= numNodes) {
+                return benchmarkNodes;
+            }
+            if (node != localNode && isBenchmarkNode(node)) {
+                benchmarkNodes.add(node);
+            }
+        }
+        return benchmarkNodes;
+    }
+
+    private class BenchExecutionHandler extends BaseTransportRequestHandler<NodeBenchRequest> {
+
+        static final String ACTION = "benchmark/executor/start";
+
+        @Override
+        public NodeBenchRequest newInstance() {
+            return new NodeBenchRequest();
+        }
+
+        @Override
+        public void messageReceived(NodeBenchRequest request, TransportChannel channel) throws Exception {
+            BenchmarkResponse response = executor.benchmark(request.request);
+            channel.sendResponse(response);
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.BENCH;
+        }
+    }
+
+    private class StatusExecutionHandler extends BaseTransportRequestHandler<NodeStatusRequest> {
+
+        static final String ACTION = "benchmark/executor/status";
+
+        @Override
+        public NodeStatusRequest newInstance() {
+            return new NodeStatusRequest();
+        }
+
+        @Override
+        public void messageReceived(NodeStatusRequest request, TransportChannel channel) throws Exception {
+            BenchmarkStatusNodeResponse nodeResponse = executor.benchmarkStatus();
+            nodeResponse.nodeName(clusterService.localNode().name());
+            channel.sendResponse(nodeResponse);
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.BENCH;
+        }
+    }
+
+    private class AbortExecutionHandler extends BaseTransportRequestHandler<NodeAbortRequest> {
+
+        static final String ACTION = "benchmark/executor/abort";
+
+        @Override
+        public NodeAbortRequest newInstance() {
+            return new NodeAbortRequest();
+        }
+
+        @Override
+        public void messageReceived(NodeAbortRequest request, TransportChannel channel) throws Exception {
+            AbortBenchmarkNodeResponse nodeResponse = executor.abortBenchmark(request.benchmarkId);
+            nodeResponse.nodeName(clusterService.localNode().name());
+            channel.sendResponse(nodeResponse);
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.BENCH;
+        }
+    }
+
+    public static class NodeAbortRequest extends TransportRequest {
+        private String benchmarkId;
+
+        public NodeAbortRequest(String benchmarkId) {
+            this.benchmarkId = benchmarkId;
+        }
+
+        public NodeAbortRequest() {
+            this(null);
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            benchmarkId = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(benchmarkId);
+        }
+    }
+
+    public static class NodeStatusRequest extends TransportRequest {
+
+        final BenchmarkStatusRequest request;
+
+        public NodeStatusRequest(BenchmarkStatusRequest request) {
+            this.request = request;
+        }
+
+        public NodeStatusRequest() {
+            this(new BenchmarkStatusRequest());
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            request.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+
+    public static class NodeBenchRequest extends TransportRequest {
+        final BenchmarkRequest request;
+
+        public NodeBenchRequest(BenchmarkRequest request) {
+            this.request = request;
+        }
+
+        public NodeBenchRequest() {
+            this(new BenchmarkRequest());
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            request.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+
+    private abstract class CountDownAsyncHandler<T extends TransportResponse> implements TransportResponseHandler<T> {
+
+        protected final CountDown countDown;
+        protected final CopyOnWriteArrayList<T> responses = new CopyOnWriteArrayList<T>();
+        protected final CopyOnWriteArrayList<Throwable> failures = new CopyOnWriteArrayList<Throwable>();
+
+        protected CountDownAsyncHandler(int size) {
+            countDown = new CountDown(size);
+        }
+
+        public abstract T newInstance();
+        protected abstract void sendResponse();
+
+        @Override
+        public void handleResponse(T t) {
+            responses.add(t);
+            if (countDown.countDown()) {
+                sendResponse();
+            }
+        }
+
+        @Override
+        public void handleException(TransportException t) {
+            failures.add(t);
+            if (countDown.countDown()) {
+                sendResponse();
+            }
+        }
+
+        public String executor() {
+            return ThreadPool.Names.SAME;
+        }
+    }
+
+    private class BenchmarkAbortAsyncHandler extends CountDownAsyncHandler<AbortBenchmarkNodeResponse> {
+
+        private final String benchmarkName;
+        private final ActionListener<AbortBenchmarkResponse> listener;
+
+        public BenchmarkAbortAsyncHandler(int size, String benchmarkName, ActionListener<AbortBenchmarkResponse> listener) {
+            super(size);
+            this.benchmarkName = benchmarkName;
+            this.listener = listener;
+        }
+
+        @Override
+        public AbortBenchmarkNodeResponse newInstance() {
+            return new AbortBenchmarkNodeResponse();
+        }
+
+        @Override
+        protected void sendResponse() {
+            AbortBenchmarkResponse abortResponse = new AbortBenchmarkResponse(benchmarkName);
+            // Merge all node responses into a single response
+            for (AbortBenchmarkNodeResponse nodeResponse : responses) {
+                abortResponse.addNodeResponse(nodeResponse);
+            }
+            listener.onResponse(abortResponse);
+        }
+    }
+
+    private class BenchmarkStatusAsyncHandler extends CountDownAsyncHandler<BenchmarkStatusNodeResponse> {
+
+        private final BenchmarkStatusRequest request;
+        private final ActionListener<BenchmarkStatusResponse> listener;
+
+        public BenchmarkStatusAsyncHandler(int nodeCount, final BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+            super(nodeCount);
+            this.request = request;
+            this.listener = listener;
+        }
+
+        @Override
+        public BenchmarkStatusNodeResponse newInstance() {
+            return new BenchmarkStatusNodeResponse();
+        }
+
+        @Override
+        protected void sendResponse() {
+            BenchmarkStatusResponse consolidatedResponse = new BenchmarkStatusResponse();
+            Map<String, List<BenchmarkResponse>> nameNodeResponseMap = new HashMap<>();
+
+            // Group node responses by benchmark name
+            for (BenchmarkStatusNodeResponse nodeResponse : responses) {
+                for (BenchmarkResponse benchmarkResponse : nodeResponse.benchResponses()) {
+                    List<BenchmarkResponse> benchmarkResponses = nameNodeResponseMap.get(benchmarkResponse.benchmarkName());
+                    if (benchmarkResponses == null) {
+                        benchmarkResponses = new ArrayList<>();
+                        nameNodeResponseMap.put(benchmarkResponse.benchmarkName(), benchmarkResponses);
+                    }
+                    benchmarkResponses.add(benchmarkResponse);
+                }
+            }
+
+            for (Map.Entry<String, List<BenchmarkResponse>> entry : nameNodeResponseMap.entrySet()) {
+                BenchmarkResponse consolidated = consolidateBenchmarkResponses(entry.getValue());
+                consolidatedResponse.addBenchResponse(consolidated);
+            }
+
+            listener.onResponse(consolidatedResponse);
+        }
+    }
+
+    private BenchmarkResponse consolidateBenchmarkResponses(List<BenchmarkResponse> responses) {
+        BenchmarkResponse response = new BenchmarkResponse();
+
+        // Merge node responses into a single consolidated response
+        for (BenchmarkResponse r : responses) {
+            for (Map.Entry<String, CompetitionResult> entry : r.competitionResults.entrySet()) {
+                if (!response.competitionResults.containsKey(entry.getKey())) {
+                    response.competitionResults.put(entry.getKey(),
+                            new CompetitionResult(
+                                    entry.getKey(), entry.getValue().concurrency(), entry.getValue().multiplier(),
+                                    false, entry.getValue().percentiles()));
+                }
+                CompetitionResult cr = response.competitionResults.get(entry.getKey());
+                cr.nodeResults().addAll(entry.getValue().nodeResults());
+            }
+
+            if (response.benchmarkName() == null) {
+                response.benchmarkName(r.benchmarkName());
+            }
+            assert response.benchmarkName().equals(r.benchmarkName());
+        }
+
+        return response;
+    }
+
+    private class BenchmarkSearchAsyncHandler extends CountDownAsyncHandler<BenchmarkResponse> {
+
+        private final ActionListener<BenchmarkResponse> listener;
+        private final BenchmarkRequest request;
+
+        public BenchmarkSearchAsyncHandler(int size, BenchmarkRequest request, ActionListener<BenchmarkResponse> listener) {
+            super(size);
+            this.listener = listener;
+            this.request = request;
+        }
+
+        @Override
+        public BenchmarkResponse newInstance() {
+            return new BenchmarkResponse();
+        }
+
+        @Override
+        protected void sendResponse() {
+            BenchmarkResponse response = consolidateBenchmarkResponses(responses);
+            response.benchmarkName(request.benchmarkName());
+            response.verbose(request.verbose());
+            response.state(BenchmarkResponse.State.COMPLETE);
+            finishBenchmark(response, request.benchmarkName(), listener);
+        }
+
+        public void handleExceptionInternal(Throwable t) {
+            failures.add(t);
+            if (countDown.countDown()) {
+                sendResponse();
+            }
+        }
+    }
+
+    public static interface BenchmarkStateListener {
+
+        void onResponse(ClusterState newClusterState, BenchmarkMetaData.Entry changed);
+
+        void onFailure(Throwable t);
+    }
+
+    public final class StartBenchmarkTask extends BenchmarkStateChangeAction<BenchmarkRequest> {
+
+        private final BenchmarkStateListener stateListener;
+        private BenchmarkMetaData.Entry newBenchmark = null;
+
+        public StartBenchmarkTask(BenchmarkRequest request, BenchmarkStateListener stateListener) {
+            super(request);
+            this.stateListener = stateListener;
+        }
+
+        @Override
+        public ClusterState execute(ClusterState currentState) {
+            MetaData metaData = currentState.getMetaData();
+            BenchmarkMetaData bmd = metaData.custom(BenchmarkMetaData.TYPE);
+            MetaData.Builder mdBuilder = MetaData.builder(metaData);
+            ImmutableList.Builder<BenchmarkMetaData.Entry> builder = ImmutableList.builder();
+
+            if (bmd != null) {
+                for (BenchmarkMetaData.Entry entry : bmd.entries()) {
+                    if (request.benchmarkName().equals(entry.benchmarkId())){
+                        if (entry.state() != BenchmarkMetaData.State.SUCCESS && entry.state() != BenchmarkMetaData.State.FAILED) {
+                            throw new ElasticsearchException("A benchmark with ID [" + request.benchmarkName() + "] is already running in state [" + entry.state() + "]");
+                        }
+                        // just drop the entry it it has finished successfully or it failed!
+                    } else {
+                        builder.add(entry);
+                    }
+                }
+            }
+            logger.debug("Starting benchmark for ID [{}]", request.benchmarkName());
+            List<DiscoveryNode> nodes = findNodes(request);
+            String[] nodeIds = new String[nodes.size()];
+            int i = 0;
+            for (DiscoveryNode node : nodes) {
+                nodeIds[i++] = node.getId();
+            }
+            newBenchmark = new BenchmarkMetaData.Entry(request.benchmarkName(), BenchmarkMetaData.State.STARTED, nodeIds);
+            bmd = new BenchmarkMetaData(builder.add(newBenchmark).build());
+            mdBuilder.putCustom(BenchmarkMetaData.TYPE, bmd);
+            return ClusterState.builder(currentState).metaData(mdBuilder).build();
+        }
+
+        @Override
+        public void onFailure(String source, Throwable t) {
+            logger.warn("failed to start benchmark: [{}]", t, request.benchmarkName());
+            newBenchmark = null;
+            stateListener.onFailure(t);
+        }
+
+        @Override
+        public void clusterStateProcessed(String source, ClusterState oldState, final ClusterState newState) {
+            if (newBenchmark != null) {
+                stateListener.onResponse(newState, newBenchmark);
+            }
+        }
+
+        @Override
+        public TimeValue timeout() {
+            return request.masterNodeTimeout();
+        }
+    }
+
+    public final class FinishBenchmarkTask extends UpdateBenchmarkStateTask {
+
+        private final boolean success;
+
+        public FinishBenchmarkTask(String reason, String benchmarkId, BenchmarkStateListener listener, boolean success) {
+            super(reason, benchmarkId, listener);
+            this.success = success;
+        }
+
+        @Override
+        protected BenchmarkMetaData.Entry process(BenchmarkMetaData.Entry entry) {
+            BenchmarkMetaData.State state = entry.state();
+            assert state == BenchmarkMetaData.State.STARTED || state == BenchmarkMetaData.State.ABORTED :  "Expected state: STARTED or ABORTED but was: " + entry.state();
+            if (success) {
+                return new BenchmarkMetaData.Entry(entry, BenchmarkMetaData.State.SUCCESS);
+            } else {
+                return new BenchmarkMetaData.Entry(entry, BenchmarkMetaData.State.FAILED);
+            }
+        }
+    }
+
+    public final class AbortBenchmarkTask extends UpdateBenchmarkStateTask {
+        public AbortBenchmarkTask(String benchmarkId, BenchmarkStateListener listener) {
+            super("abort_benchmark", benchmarkId, listener);
+        }
+
+        @Override
+        protected BenchmarkMetaData.Entry process(BenchmarkMetaData.Entry entry) {
+            BenchmarkMetaData.State state = entry.state();
+            if (state != BenchmarkMetaData.State.STARTED) {
+                throw new ElasticsearchIllegalStateException("Can't abort benchmark for id: [" + benchmarkId + "] - illegal state [" + state + "]");
+            }
+            return new BenchmarkMetaData.Entry(entry, BenchmarkMetaData.State.ABORTED);
+        }
+    }
+
+    public abstract class UpdateBenchmarkStateTask implements ProcessedClusterStateUpdateTask {
+
+        private final String reason;
+        protected final String benchmarkId;
+        private final BenchmarkStateListener listener;
+        private BenchmarkMetaData.Entry instance;
+
+        protected UpdateBenchmarkStateTask(String reason, String benchmarkId, BenchmarkStateListener listener) {
+            this.reason = reason;
+            this.listener = listener;
+            this.benchmarkId = benchmarkId;
+        }
+
+        @Override
+        public ClusterState execute(ClusterState currentState) {
+            MetaData metaData = currentState.getMetaData();
+            BenchmarkMetaData bmd = metaData.custom(BenchmarkMetaData.TYPE);
+            MetaData.Builder mdBuilder = MetaData.builder(metaData);
+            if (bmd != null && !bmd.entries().isEmpty()) {
+                ImmutableList.Builder<BenchmarkMetaData.Entry> builder = new ImmutableList.Builder<BenchmarkMetaData.Entry>();
+                boolean found = false;
+                for (BenchmarkMetaData.Entry e : bmd.entries()) {
+                    if (benchmarkId == null || e.benchmarkId().equals(benchmarkId)) {
+                        e = process(e);
+                        if (benchmarkId != null) {
+                            assert instance == null : "Illegal state more than one benchmark with he same id [" + benchmarkId + "]";
+                            instance = e;
+                        }
+                        found = true;
+                    }
+
+                    // Don't keep finished benchmarks around in cluster state
+                    if (e != null && (e.state() != BenchmarkMetaData.State.SUCCESS &&
+                            e.state() != BenchmarkMetaData.State.ABORTED &&
+                            e.state() != BenchmarkMetaData.State.FAILED)) {
+                        builder.add(e);
+                    }
+                }
+                if (!found) {
+                    throw new ElasticsearchException("No Benchmark found for id: [" + benchmarkId + "]");
+                }
+                bmd = new BenchmarkMetaData(builder.build());
+            }
+            if (bmd != null) {
+                mdBuilder.putCustom(BenchmarkMetaData.TYPE, bmd);
+            }
+            return ClusterState.builder(currentState).metaData(mdBuilder).build();
+        }
+
+        protected abstract BenchmarkMetaData.Entry process(BenchmarkMetaData.Entry entry);
+
+        @Override
+        public void onFailure(String source, Throwable t) {
+            logger.warn("Failed updating benchmark state for ID [{}] triggered by: [{}]", t, benchmarkId, reason);
+            listener.onFailure(t);
+        }
+
+        @Override
+        public void clusterStateProcessed(String source, ClusterState oldState, final ClusterState newState) {
+            listener.onResponse(newState, instance);
+        }
+
+        public String reason() {
+            return reason;
+        }
+    }
+
+    public abstract class BenchmarkStateChangeAction<R extends MasterNodeOperationRequest> implements TimeoutClusterStateUpdateTask {
+        protected final R request;
+
+        public BenchmarkStateChangeAction(R request) {
+            this.request = request;
+        }
+
+        @Override
+        public TimeValue timeout() {
+            return request.masterNodeTimeout();
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkSettings.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkSettings.java
@@ -1,0 +1,393 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Settings that define how a benchmark should be executed.
+ */
+public class BenchmarkSettings implements Streamable {
+
+    public static final int DEFAULT_CONCURRENCY = 5;
+    public static final int DEFAULT_ITERATIONS = 5;
+    public static final int DEFAULT_MULTIPLIER = 1000;
+    public static final int DEFAULT_NUM_SLOWEST = 1;
+    public static final boolean DEFAULT_WARMUP = true;
+    public static final SearchType DEFAULT_SEARCH_TYPE = SearchType.DEFAULT;
+
+    private int concurrency = DEFAULT_CONCURRENCY;
+    private int iterations = DEFAULT_ITERATIONS;
+    private int multiplier = DEFAULT_MULTIPLIER;
+    private int numSlowest = DEFAULT_NUM_SLOWEST;
+    private boolean warmup = DEFAULT_WARMUP;
+    private SearchType searchType = DEFAULT_SEARCH_TYPE;
+    private ClearIndicesCacheRequest clearCaches = null;
+    private ClearCachesSettings clearCachesSettings = null;
+    private String[] indices = Strings.EMPTY_ARRAY;
+    private String[] types = Strings.EMPTY_ARRAY;
+    private List<SearchRequest> searchRequests = new ArrayList<>();
+
+    private boolean concurrencyFinalized = false;
+    private boolean iterationsFinalized = false;
+    private boolean multiplierFinalized = false;
+    private boolean numSlowestFinalized = false;
+    private boolean warmupFinalized = false;
+    private boolean searchTypeFinalized = false;
+    private boolean clearCachesSettingsFinalized = false;
+    private boolean allowCacheClearing = true;
+
+    /**
+     * List of indices to execute on
+     * @return  Indices
+     */
+    public String[] indices() {
+        return indices;
+    }
+
+    /**
+     * Sets the indices to execute on
+     * @param indices   Indices
+     */
+    public void indices(String[] indices) {
+        this.indices = (indices == null) ? Strings.EMPTY_ARRAY : indices;
+    }
+
+    /**
+     * List of types to execute on
+     * @return  Types
+     */
+    public String[] types() {
+        return types;
+    }
+
+    /**
+     * Sets the types to execute on
+     * @param types Types
+     */
+    public void types(String[] types) {
+        this.types = (types == null) ? Strings.EMPTY_ARRAY : types;
+    }
+
+    /**
+     * Gets the concurrency level
+     * @return  Concurrency
+     */
+    public int concurrency() {
+        return concurrency;
+    }
+
+    /**
+     * Sets the concurrency level; determines how many threads will be executing the competition concurrently.
+     * @param concurrency   Concurrency
+     * @param finalize      If true, value cannot be overwritten by subsequent calls
+     */
+    public void concurrency(int concurrency, boolean finalize) {
+        if (concurrencyFinalized) {
+            return;
+        }
+        this.concurrency = concurrency;
+        concurrencyFinalized = finalize;
+    }
+
+    /**
+     * How many times to the competition.
+     * @return  Iterations
+     */
+    public int iterations() {
+        return iterations;
+    }
+
+    /**
+     * How many times to run the competition. Requests will be executed a total of (iterations * multiplier).
+     * @param iterations    Iterations
+     * @param finalize      If true, value cannot be overwritten by subsequent calls
+     */
+    public void iterations(int iterations, boolean finalize) {
+        if (iterationsFinalized) {
+            return;
+        }
+        this.iterations = iterations;
+        iterationsFinalized = finalize;
+    }
+
+    /**
+     * Gets the multiplier
+     * @return  Multiplier
+     */
+    public int multiplier() {
+        return multiplier;
+    }
+
+    /**
+     * Sets the multiplier. The multiplier determines how many times each iteration will be run.
+     * @param multiplier    Multiplier
+     * @param finalize      If true, value cannot be overwritten by subsequent calls
+     */
+    public void multiplier(int multiplier, boolean finalize) {
+        if (multiplierFinalized) {
+            return;
+        }
+        this.multiplier = multiplier;
+        multiplierFinalized = finalize;
+    }
+
+    /**
+     * Gets number of slow requests to track
+     * @return  Number of slow requests to track
+     */
+    public int numSlowest() {
+        return numSlowest;
+    }
+
+    /**
+     * How many slow requests to track
+     * @param numSlowest    Number of slow requests to track
+     * @param finalize      If true, value cannot be overwritten by subsequent calls
+     */
+    public void numSlowest(int numSlowest, boolean finalize) {
+        if (numSlowestFinalized) {
+            return;
+        }
+        this.numSlowest = numSlowest;
+        numSlowestFinalized = finalize;
+    }
+
+    /**
+     * Whether to run a warmup search request
+     * @return  True/false
+     */
+    public boolean warmup() {
+        return warmup;
+    }
+
+    /**
+     * Whether to run a warmup search request
+     * @param warmup    True/false
+     * @param finalize  If true, value cannot be overwritten by subsequent calls
+     */
+    public void warmup(boolean warmup, boolean finalize) {
+        if (warmupFinalized) {
+            return;
+        }
+        this.warmup = warmup;
+        warmupFinalized = finalize;
+    }
+
+    /**
+     * Gets the search type
+     * @return  Search type
+     */
+    public SearchType searchType() {
+        return searchType;
+    }
+
+    /**
+     * Sets the search type
+     * @param searchType    Search type
+     * @param finalize      If true, value cannot be overwritten by subsequent calls
+     */
+    public void searchType(SearchType searchType, boolean finalize) {
+        if (searchTypeFinalized) {
+            return;
+        }
+        this.searchType = searchType;
+        searchTypeFinalized = finalize;
+    }
+
+    /**
+     * Gets the list of search requests to benchmark
+     * @return  Search requests
+     */
+    public List<SearchRequest> searchRequests() {
+        return searchRequests;
+    }
+
+    /**
+     * Adds a search request to benchmark
+     * @param searchRequest Search request
+     */
+    public void addSearchRequest(SearchRequest... searchRequest) {
+        searchRequests.addAll(Arrays.asList(searchRequest));
+    }
+
+    /**
+     * Gets the clear caches request
+     * @return  The clear caches request
+     */
+    public ClearIndicesCacheRequest clearCaches() {
+        return clearCaches;
+    }
+
+    public boolean allowCacheClearing() {
+        return allowCacheClearing;
+    }
+
+    public void allowCacheClearing(boolean allowCacheClearing) {
+        this.allowCacheClearing = allowCacheClearing;
+    }
+
+    /**
+     * Gets the clear caches settings
+     * @return  Clear caches settings
+     */
+    public ClearCachesSettings clearCachesSettings() {
+        return clearCachesSettings;
+    }
+
+    /**
+     * Sets the clear caches settings
+     * @param clearCachesSettings   Clear caches settings
+     * @param finalize              If true, value cannot be overwritten by subsequent calls
+     */
+    public void clearCachesSettings(ClearCachesSettings clearCachesSettings, boolean finalize) {
+        if (clearCachesSettingsFinalized) {
+            return;
+        }
+        this.clearCachesSettings = clearCachesSettings;
+        clearCachesSettingsFinalized = finalize;
+    }
+
+    /**
+     * Builds a clear cache request from the settings
+     */
+    public void buildClearCachesRequestFromSettings() {
+        clearCaches = new ClearIndicesCacheRequest(indices);
+        clearCaches.filterCache(clearCachesSettings.filterCache);
+        clearCaches.fieldDataCache(clearCachesSettings.fieldDataCache);
+        clearCaches.idCache(clearCachesSettings.idCache);
+        clearCaches.recycler(clearCachesSettings.recyclerCache);
+        clearCaches.fields(clearCachesSettings.fields);
+        clearCaches.filterKeys(clearCachesSettings.filterKeys);
+    }
+
+    public void buildSearchRequestsFromSettings() {
+        for (SearchRequest searchRequest : searchRequests) {
+            searchRequest.indices(indices);
+            searchRequest.types(types);
+            searchRequest.searchType(searchType);
+        }
+    }
+
+    /**
+     * Merge another settings object with this one, ignoring fields which have been finalized.
+     * This is a convenience so that a global settings object can cascade it's settings
+     * down to specific competitors w/o inadvertently overwriting anything that has already been set.
+     * @param otherSettings The settings to merge into this
+     */
+    public void merge(BenchmarkSettings otherSettings) {
+        if (!concurrencyFinalized) {
+            concurrency = otherSettings.concurrency;
+        }
+        if (!iterationsFinalized) {
+            iterations = otherSettings.iterations;
+        }
+        if (!multiplierFinalized) {
+            multiplier = otherSettings.multiplier;
+        }
+        if (!numSlowestFinalized) {
+            numSlowest = otherSettings.numSlowest;
+        }
+        if (!warmupFinalized) {
+            warmup = otherSettings.warmup;
+        }
+        if (!searchTypeFinalized) {
+            searchType = otherSettings.searchType;
+        }
+        if (!clearCachesSettingsFinalized) {
+            clearCachesSettings = otherSettings.clearCachesSettings;
+        }
+    }
+
+    public static class ClearCachesSettings {
+        private boolean filterCache = false;
+        private boolean fieldDataCache = false;
+        private boolean idCache = false;
+        private boolean recyclerCache = false;
+        private String[] fields = null;
+        private String[] filterKeys = null;
+
+        public void filterCache(boolean filterCache) {
+            this.filterCache = filterCache;
+        }
+        public void fieldDataCache(boolean fieldDataCache) {
+            this.fieldDataCache = fieldDataCache;
+        }
+        public void idCache(boolean idCache) {
+            this.idCache = idCache;
+        }
+        public void recycler(boolean recyclerCache) {
+            this.recyclerCache = recyclerCache;
+        }
+        public void fields(String[] fields) {
+            this.fields = fields;
+        }
+        public void filterKeys(String[] filterKeys) {
+            this.filterKeys = filterKeys;
+        }
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        concurrency = in.readVInt();
+        iterations = in.readVInt();
+        multiplier = in.readVInt();
+        numSlowest = in.readVInt();
+        warmup = in.readBoolean();
+        indices = in.readStringArray();
+        types = in.readStringArray();
+        searchType = SearchType.fromId(in.readByte());
+        clearCaches = in.readOptionalStreamable(new ClearIndicesCacheRequest());
+        final int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.readFrom(in);
+            searchRequests.add(searchRequest);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(concurrency);
+        out.writeVInt(iterations);
+        out.writeVInt(multiplier);
+        out.writeVInt(numSlowest);
+        out.writeBoolean(warmup);
+        out.writeStringArray(indices);
+        out.writeStringArray(types);
+        out.writeByte(searchType.id());
+        out.writeOptionalStreamable(clearCaches);
+        out.writeVInt(searchRequests.size());
+        for (SearchRequest searchRequest : searchRequests) {
+            searchRequest.writeTo(out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusAction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.Client;
+
+/**
+ * Benchmark status action
+ */
+public class BenchmarkStatusAction extends Action<BenchmarkStatusRequest, BenchmarkStatusResponse, BenchmarkStatusRequestBuilder> {
+
+    public static final BenchmarkStatusAction INSTANCE = new BenchmarkStatusAction();
+    public static final String NAME = "benchmark/status";
+
+    public BenchmarkStatusAction() {
+        super(NAME);
+    }
+
+    @Override
+    public BenchmarkStatusResponse newResponse() {
+        return new BenchmarkStatusResponse();
+    }
+
+    @Override
+    public BenchmarkStatusRequestBuilder newRequestBuilder(Client client) {
+        return new BenchmarkStatusRequestBuilder(client);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusNodeResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusNodeResponse.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Node-level response for the status of an on-going benchmark
+ */
+public class BenchmarkStatusNodeResponse extends ActionResponse implements Streamable, ToXContent {
+
+    private String nodeName;
+    private List<BenchmarkResponse> benchmarkResponses;
+
+    public BenchmarkStatusNodeResponse() {
+        benchmarkResponses = new ArrayList<BenchmarkResponse>();
+    }
+
+    public void nodeName(String nodeName) {
+        this.nodeName = nodeName;
+    }
+
+    public String nodeName() {
+        return nodeName;
+    }
+
+    public void addBenchResponse(BenchmarkResponse benchmarkResponse) {
+        benchmarkResponses.add(benchmarkResponse);
+    }
+
+    public List<BenchmarkResponse> benchResponses() {
+        return benchmarkResponses;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("node", nodeName);
+        builder.startArray("responses");
+        for (BenchmarkResponse benchmarkResponse : benchmarkResponses) {
+            benchmarkResponse.toXContent(builder, params);
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        nodeName = in.readString();
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            BenchmarkResponse br = new BenchmarkResponse();
+            br.readFrom(in);
+            benchmarkResponses.add(br);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(nodeName);
+        out.writeVInt(benchmarkResponses.size());
+        for (BenchmarkResponse br : benchmarkResponses) {
+            br.writeTo(out);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+            builder.startObject();
+            toXContent(builder, EMPTY_PARAMS);
+            builder.endObject();
+            return builder.string();
+        } catch (IOException e) {
+            return "{ \"error\" : \"" + e.getMessage() + "\"}";
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Request for status about a running benchmark
+ */
+public class BenchmarkStatusRequest extends MasterNodeOperationRequest<BenchmarkStatusRequest> {
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusRequestBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.internal.InternalClient;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestBuilder;
+
+/**
+ * Request builder for benchmark status
+ */
+public class BenchmarkStatusRequestBuilder extends ActionRequestBuilder<BenchmarkStatusRequest, BenchmarkStatusResponse, BenchmarkStatusRequestBuilder> {
+
+    public BenchmarkStatusRequestBuilder(Client client) {
+        super((InternalClient) client, new BenchmarkStatusRequest());
+    }
+
+    @Override
+    protected void doExecute(ActionListener<BenchmarkStatusResponse> listener) {
+        ((Client) client).benchStatus(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusResponse.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Benchmark status response
+ */
+public class BenchmarkStatusResponse extends ActionResponse implements Streamable, ToXContent {
+
+    private String nodeName;
+    private final List<BenchmarkResponse> benchmarkResponses = new ArrayList<>();
+    private final List<String> errorMessages = new ArrayList<>();
+
+    public BenchmarkStatusResponse() { }
+
+    public BenchmarkStatusResponse(String nodeName) {
+        this.nodeName = nodeName;
+    }
+
+    public void addBenchResponse(BenchmarkResponse response) {
+        benchmarkResponses.add(response);
+    }
+
+    public List<BenchmarkResponse> benchmarkResponses() {
+        return benchmarkResponses;
+    }
+
+    public String nodeName(String nodeName) {
+        this.nodeName = nodeName;
+        return nodeName;
+    }
+
+    public String nodeName() {
+        return nodeName;
+    }
+
+    public void addErrors(List<String> errorMessages) {
+        this.errorMessages.addAll(errorMessages);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        if (errorMessages.size() > 0) {
+            builder.startArray("errors");
+            for (String error : errorMessages) {
+                builder.field(error);
+            }
+            builder.endArray();
+        }
+
+        if (benchmarkResponses.size() > 0) {
+            builder.startObject("active_benchmarks");
+            for (BenchmarkResponse benchmarkResponse : benchmarkResponses) {
+                builder.startObject(benchmarkResponse.benchmarkName());
+                benchmarkResponse.toXContent(builder, params);
+                builder.endObject();
+            }
+            builder.endObject();
+        }
+
+        return builder;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        nodeName = in.readString();
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            BenchmarkResponse br = new BenchmarkResponse();
+            br.readFrom(in);
+            benchmarkResponses.add(br);
+        }
+        errorMessages.addAll(Arrays.asList(in.readStringArray()));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(nodeName);
+        out.writeVInt(benchmarkResponses.size());
+        for (BenchmarkResponse br : benchmarkResponses) {
+            br.writeTo(out);
+        }
+        out.writeStringArray(errorMessages.toArray(new String[errorMessages.size()]));
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/CompetitionDetails.java
+++ b/src/main/java/org/elasticsearch/action/bench/CompetitionDetails.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Detailed statistics for each iteration of a benchmark search competition.
+ */
+public class CompetitionDetails implements ToXContent {
+
+    private List<CompetitionNodeResult> nodeResults;
+
+    public CompetitionDetails(List<CompetitionNodeResult> nodeResults) {
+        this.nodeResults = nodeResults;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        final int highestIteration = highestCompletedIteration();
+        computeAllStatistics();
+        CompetitionIteration prototypical = prototypicalIteration();
+
+        builder.startObject(Fields.ITERATIONS);
+
+        for (int i = 0; i < highestIteration; i++) {
+
+            builder.field(Fields.ITERATION, i);
+            builder.startObject();
+
+            builder.startObject(Fields.MIN);
+            for (CompetitionNodeResult nodeResult : nodeResults) {
+                CompetitionIteration iteration = nodeResult.iterations().get(i);
+                builder.field(nodeResult.nodeName(), iteration == null ? Fields.NULL : iteration.min());
+            }
+            builder.endObject();
+            builder.startObject(Fields.MAX);
+            for (CompetitionNodeResult nodeResult : nodeResults) {
+                CompetitionIteration iteration = nodeResult.iterations().get(i);
+                builder.field(nodeResult.nodeName(), iteration == null ? Fields.NULL : iteration.max());
+            }
+            builder.endObject();
+            builder.startObject(Fields.MEAN);
+            for (CompetitionNodeResult nodeResult : nodeResults) {
+                CompetitionIteration iteration = nodeResult.iterations().get(i);
+                builder.field(nodeResult.nodeName(), iteration == null ? Fields.NULL : iteration.mean());
+            }
+            builder.endObject();
+            builder.startObject(Fields.TOTAL_TIME);
+            for (CompetitionNodeResult nodeResult : nodeResults) {
+                CompetitionIteration iteration = nodeResult.iterations().get(i);
+                builder.field(nodeResult.nodeName(), iteration == null ? Fields.NULL : iteration.totalTime());
+            }
+            builder.endObject();
+            builder.startObject(Fields.QPS);
+            for (CompetitionNodeResult nodeResult : nodeResults) {
+                CompetitionIteration iteration = nodeResult.iterations().get(i);
+                builder.field(nodeResult.nodeName(), iteration == null ? Fields.NULL : iteration.queriesPerSecond());
+            }
+            builder.endObject();
+
+            // All nodes track the same percentiles, so just choose a prototype to iterate
+            if (prototypical != null) {
+                for (Map.Entry<Double, Double> entry : prototypical.percentileValues().entrySet()) {
+                    // Change back to integral value for display purposes
+                    builder.startObject(new XContentBuilderString("percentile_" + entry.getKey().longValue()));
+
+                    for (CompetitionNodeResult nodeResult : nodeResults) {
+                        CompetitionIteration iteration = nodeResult.iterations().get(i);
+                        if (iteration != null) {
+                            Double value = iteration.percentileValues().get(entry.getKey());
+                            builder.field(nodeResult.nodeName(), (value.isNaN()) ? 0.0 : value);
+                        } else {
+                            builder.field(nodeResult.nodeName(), Fields.NULL);
+                        }
+                    }
+                    builder.endObject();
+                }
+            }
+
+            builder.endObject();
+        }
+        return builder;
+    }
+
+    private CompetitionIteration prototypicalIteration() {
+        if (nodeResults != null && nodeResults.size() > 0) {
+            CompetitionNodeResult nodeResult = nodeResults.get(0);
+            if (nodeResult.iterations() != null && nodeResult.iterations().size() > 0) {
+                return nodeResult.iterations().get(0);
+            }
+        }
+        return null;
+    }
+
+    private void computeAllStatistics() {
+        for (CompetitionNodeResult nodeResult : nodeResults) {
+            for (CompetitionIteration iteration : nodeResult.iterations()) {
+                iteration.computeStatistics();
+            }
+        }
+    }
+
+    private int highestCompletedIteration() {
+        int count = 0;
+        for (CompetitionNodeResult nodeResult : nodeResults) {
+            count = Math.max(count, nodeResult.completedIterations());
+        }
+        return count;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString ITERATIONS = new XContentBuilderString("iterations");
+        static final XContentBuilderString ITERATION = new XContentBuilderString("iteration");
+        static final XContentBuilderString TOTAL_TIME = new XContentBuilderString("total_time");
+        static final XContentBuilderString MEAN = new XContentBuilderString("mean");
+        static final XContentBuilderString MIN = new XContentBuilderString("min");
+        static final XContentBuilderString MAX = new XContentBuilderString("max");
+        static final XContentBuilderString QPS = new XContentBuilderString("qps");
+        static final XContentBuilderString NULL = new XContentBuilderString("null");
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/CompetitionIteration.java
+++ b/src/main/java/org/elasticsearch/action/bench/CompetitionIteration.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.common.xcontent.XContentHelper;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Represents a single iteration of a search benchmark competition
+ */
+public class CompetitionIteration implements Streamable {
+
+    private long numQueries;
+    private SlowRequest[] slowRequests;
+    private long totalTime;
+    private long sum;
+    private long sumTotalHits;
+    private double stddev;
+    private long min;
+    private long max;
+    private double mean;
+    private double qps;
+    private double millisPerHit;
+    private double[] percentiles = new double[0];
+    private Map<Double, Double> percentileValues = new TreeMap<>();
+
+    private CompetitionIterationData iterationData;
+
+    public CompetitionIteration() { }
+
+    public CompetitionIteration(SlowRequest[] slowestRequests, long totalTime, long numQueries, long sumTotalHits,
+                                CompetitionIterationData iterationData) {
+        this.totalTime = totalTime;
+        this.sumTotalHits = sumTotalHits;
+        this.slowRequests = slowestRequests;
+        this.numQueries = numQueries;
+        this.iterationData = iterationData;
+        this.millisPerHit = totalTime / (double)sumTotalHits;
+    }
+
+    public void computeStatistics() {
+
+        SinglePassStatistics single = new SinglePassStatistics();
+
+        for (long datum : iterationData.data()) {
+            if (datum > -1) {   // ignore unset values in the underlying array
+                single.push(datum);
+            }
+        }
+
+        sum = single.sum();
+        stddev = single.stddev();
+        min = single.min();
+        max = single.max();
+        mean = single.mean();
+        qps = numQueries * (1000.d / (double) sum);
+
+        for (double percentile : percentiles) {
+            percentileValues.put(percentile, single.percentile(percentile / 100));
+        }
+    }
+
+    public CompetitionIterationData competitionIterationData() {
+        return iterationData;
+    }
+
+    public long numQueries() {
+        return numQueries;
+    }
+
+    public long totalTime() {
+        return totalTime;
+    }
+
+    public long sumTotalHits() {
+        return sumTotalHits;
+    }
+
+    public double millisPerHit() {
+        return millisPerHit;
+    }
+
+    public double queriesPerSecond() {
+        return qps;
+    }
+
+    public SlowRequest[] slowRequests() {
+        return slowRequests;
+    }
+
+    public long min() {
+        return min;
+    }
+
+    public long max() {
+        return max;
+    }
+
+    public double mean() {
+        return mean;
+    }
+
+    public Map<Double, Double> percentileValues() {
+        return percentileValues;
+    }
+
+    public void percentiles(double[] percentiles) {
+        this.percentiles = percentiles;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        totalTime = in.readVLong();
+        sumTotalHits = in.readVLong();
+        numQueries = in.readVLong();
+        millisPerHit = in.readDouble();
+        iterationData = in.readOptionalStreamable(new CompetitionIterationData());
+        int size = in.readVInt();
+        slowRequests = new SlowRequest[size];
+        for (int i = 0; i < size; i++) {
+            slowRequests[i] = new SlowRequest();
+            slowRequests[i].readFrom(in);
+        }
+        percentiles = in.readDoubleArray();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(totalTime);
+        out.writeVLong(sumTotalHits);
+        out.writeVLong(numQueries);
+        out.writeDouble(millisPerHit);
+        out.writeOptionalStreamable(iterationData);
+        out.writeVInt(slowRequests == null ? 0 : slowRequests.length);
+        if (slowRequests != null) {
+            for (SlowRequest slowRequest : slowRequests) {
+                slowRequest.writeTo(out);
+            }
+        }
+        out.writeDoubleArray(percentiles);
+    }
+
+    /**
+     * Represents a 'slow' search request
+     */
+    public static class SlowRequest implements ToXContent, Streamable {
+
+        private long maxTimeTaken;
+        private long avgTimeTaken;
+        private SearchRequest searchRequest;
+
+        public SlowRequest() { }
+
+        public SlowRequest(long avgTimeTaken, long maxTimeTaken, SearchRequest searchRequest) {
+            this.avgTimeTaken = avgTimeTaken;
+            this.maxTimeTaken = maxTimeTaken;
+            this.searchRequest = searchRequest;
+        }
+
+        public long avgTimeTaken() {
+            return avgTimeTaken;
+        }
+
+        public long maxTimeTaken() {
+            return maxTimeTaken;
+        }
+
+        public SearchRequest searchRequest() {
+            return searchRequest;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            avgTimeTaken = in.readVLong();
+            maxTimeTaken = in.readVLong();
+            searchRequest = new SearchRequest();
+            searchRequest.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(avgTimeTaken);
+            out.writeVLong(maxTimeTaken);
+            searchRequest.writeTo(out);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field(Fields.MAX_TIME, maxTimeTaken);
+            builder.field(Fields.AVG_TIME, avgTimeTaken);
+            XContentHelper.writeRawField("request", searchRequest.source(), builder, params);
+            return builder;
+        }
+    }
+
+    static final class Fields {
+        static final XContentBuilderString MAX_TIME = new XContentBuilderString("max_time");
+        static final XContentBuilderString AVG_TIME = new XContentBuilderString("avg_time");
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/CompetitionIterationData.java
+++ b/src/main/java/org/elasticsearch/action/bench/CompetitionIterationData.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+
+/**
+ * Holds data points for a single benchmark iteration
+ *
+ * Note that the underlying data array may be actively populated, so we take care not
+ * to compute statistics on uninitialized elements (which are indicated by a value of -1).
+ * Initialized elements (those with values > -1) will not be changed once set.
+ */
+public class CompetitionIterationData implements Streamable {
+
+    private long[] data;
+
+    public CompetitionIterationData() { }
+
+    public CompetitionIterationData(long[] data) {
+        this.data = data;
+    }
+
+    public long[] data() {
+        return data;
+    }
+
+    /**
+     * The number of data values currently holding valid values
+     *
+     * @return      Number of data values currently holding valid values
+     */
+    public long length() {
+        long length = 0;
+        for (int i = 0; i < data.length; i++) {
+            if (data[i] < 0) {  // Data values can be invalid when computing statistics on actively running benchmarks
+                continue;
+            }
+            length++;
+        }
+        return length;
+    }
+
+    /**
+     * The sum of all currently set values
+     *
+     * @return      The sum of all currently set values
+     */
+    public long sum() {
+        long sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += Math.max(0, data[i]);  // Data values can be invalid when computing statistics on actively running benchmarks
+        }
+        return sum;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        data = in.readLongArray();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLongArray(data);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/CompetitionNodeResult.java
+++ b/src/main/java/org/elasticsearch/action/bench/CompetitionNodeResult.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Per-node result of competition iterations
+ */
+public class CompetitionNodeResult extends ActionResponse implements Streamable {
+
+    private String competitionName;
+    private String nodeName;
+    private int totalIterations = 0;
+    private int completedIterations = 0;
+    private int totalExecutedQueries = 0;
+    private long warmUpTime = 0;
+    private String[] failures = Strings.EMPTY_ARRAY;
+    private List<CompetitionIteration> iterations;
+
+    public CompetitionNodeResult() {
+        iterations = new ArrayList<CompetitionIteration>();
+    }
+
+    public CompetitionNodeResult(String competitionName, String nodeName, int totalIterations, List<CompetitionIteration> iterations) {
+        this.competitionName = competitionName;
+        this.nodeName = nodeName;
+        this.iterations = iterations;
+        this.totalIterations = totalIterations;
+    }
+
+    public String competitionName() {
+        return competitionName;
+    }
+
+    public String nodeName() {
+        return nodeName;
+    }
+
+    public int totalIterations() {
+        return totalIterations;
+    }
+
+    public int completedIterations() {
+        return completedIterations;
+    }
+
+    public void incrementCompletedIterations() {
+        completedIterations++;
+    }
+
+    public long warmUpTime() {
+        return warmUpTime;
+    }
+
+    public void warmUpTime(long warmUpTime) {
+        this.warmUpTime = warmUpTime;
+    }
+
+    public String[] failures() {
+        return this.failures;
+    }
+
+    public void failures(String[] failures) {
+        if (failures == null) {
+            this.failures = Strings.EMPTY_ARRAY;
+        } else {
+            this.failures = failures;
+        }
+    }
+
+    public int totalExecutedQueries() {
+        return totalExecutedQueries;
+    }
+
+    public void totalExecutedQueries(int totalExecutedQueries) {
+        this.totalExecutedQueries = totalExecutedQueries;
+    }
+
+    public List<CompetitionIteration> iterations() {
+        return iterations;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        competitionName = in.readString();
+        nodeName = in.readString();
+        totalIterations = in.readVInt();
+        completedIterations = in.readVInt();
+        totalExecutedQueries = in.readVInt();
+        warmUpTime = in.readVLong();
+        failures = in.readStringArray();
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            CompetitionIteration iteration = new CompetitionIteration();
+            iteration.readFrom(in);
+            iterations.add(iteration);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(competitionName);
+        out.writeString(nodeName);
+        out.writeVInt(totalIterations);
+        out.writeVInt(completedIterations);
+        out.writeVInt(totalExecutedQueries);
+        out.writeVLong(warmUpTime);
+        out.writeStringArray(failures);
+        out.writeVInt(iterations.size());
+        for (CompetitionIteration iteration : iterations) {
+            iteration.writeTo(out);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/CompetitionResult.java
+++ b/src/main/java/org/elasticsearch/action/bench/CompetitionResult.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The result of a benchmark competition. Maintains per-node results.
+ */
+public class CompetitionResult implements Streamable, ToXContent {
+
+    private String competitionName;
+    private int concurrency;
+    private int multiplier;
+    private boolean verbose;
+    private double[] percentiles = DEFAULT_PERCENTILES;
+
+    private List<CompetitionNodeResult> nodeResults = new ArrayList<CompetitionNodeResult>();
+
+    private CompetitionSummary competitionSummary;
+    private CompetitionDetails competitionDetails;
+
+    private static final double[] DEFAULT_PERCENTILES = { 10, 25, 50, 75, 90, 99 };
+
+    public CompetitionResult() { }
+
+    /**
+     * Constructs a competition result
+     * @param competitionName   Competition name
+     * @param concurrency       Concurrency
+     * @param multiplier        Internal multiplier; each iteration will run this many times to smooth out measurements
+     * @param percentiles       Which percentiles to report on
+     */
+    public CompetitionResult(String competitionName, int concurrency, int multiplier, double[] percentiles) {
+        this(competitionName, concurrency, multiplier, false, percentiles);
+    }
+
+    /**
+     * Constructs a competition result
+     * @param competitionName   Competition name
+     * @param concurrency       Concurrency
+     * @param multiplier        Internal multiplier; each iteration will run this many times to smooth out measurements
+     * @param verbose           Whether to report detailed statistics
+     * @param percentiles       Which percentiles to report on
+     */
+    public CompetitionResult(String competitionName, int concurrency, int multiplier, boolean verbose, double[] percentiles) {
+        this.competitionName = competitionName;
+        this.concurrency = concurrency;
+        this.multiplier = multiplier;
+        this.verbose = verbose;
+        this.percentiles = (percentiles != null && percentiles.length > 0) ? percentiles : DEFAULT_PERCENTILES;
+        this.competitionDetails = new CompetitionDetails(nodeResults);
+        this.competitionSummary = new CompetitionSummary(nodeResults, concurrency, multiplier, percentiles);
+    }
+
+    /**
+     * Adds a node-level competition result
+     * @param nodeResult    Node result
+     */
+    public void addCompetitionNodeResult(CompetitionNodeResult nodeResult) {
+        nodeResults.add(nodeResult);
+    }
+
+    /**
+     * Gets detailed statistics for the competition
+     * @return  Detailed statistics
+     */
+    public CompetitionDetails competitionDetails() {
+        return competitionDetails;
+    }
+
+    /**
+     * Gets summary statistics for the competition
+     * @return  Summary statistics
+     */
+    public CompetitionSummary competitionSummary() {
+        return competitionSummary;
+    }
+
+    /**
+     * Gets the name of the competition
+     * @return  Name
+     */
+    public String competitionName() {
+        return competitionName;
+    }
+
+    /**
+     * Gets the concurrency level; determines how many threads will be executing the competition concurrently.
+     * @return  Concurrency
+     */
+    public int concurrency() {
+        return concurrency;
+    }
+
+    /**
+     * Gets the multiplier. The multiplier determines how many times each iteration will be run.
+     * @return  Multipiler
+     */
+    public int multiplier() {
+        return multiplier;
+    }
+
+    /**
+     * Whether to report detailed statistics
+     * @return  True/false
+     */
+    public boolean verbose() {
+        return verbose;
+    }
+
+    /**
+     * Sets whether to report detailed statistics
+     * @param verbose   True/false
+     */
+    public void verbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    /**
+     * Gets list of percentiles to report
+     * @return  List of percentiles
+     */
+    public double[] percentiles() {
+        return percentiles;
+    }
+
+    /**
+     * Sets the list of percentiles to report
+     * @param percentiles   Percentiles
+     */
+    public void percentiles(double[] percentiles) {
+        this.percentiles = percentiles;
+    }
+
+    /**
+     * Whether any failures were encountered
+     * @return  True/false
+     */
+    public boolean hasFailures() {
+        for (CompetitionNodeResult nodeResult : nodeResults) {
+            if (nodeResult.failures() != null && nodeResult.failures().length > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets failure messages from node executions
+     * @return  Node failure messages
+     */
+    public List<String> nodeFailures() {
+        List<String> failures = null;
+        for (CompetitionNodeResult nodeResult : nodeResults) {
+            if (nodeResult.failures() != null && nodeResult.failures().length > 0) {
+                if (failures == null) {
+                    failures = new ArrayList<>();
+                }
+                failures.addAll(Arrays.asList(nodeResult.failures()));
+            }
+        }
+        return failures;
+    }
+
+    /**
+     * Gets the results for each cluster node that the competition executed on.
+     * @return  Node-level results
+     */
+    public List<CompetitionNodeResult> nodeResults() {
+        return nodeResults;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(competitionName);
+        List<String> nodeFailures = nodeFailures();
+        if (nodeFailures != null) {
+            builder.startArray("failures");
+            for (String failure : nodeFailures) {
+                builder.field(failure);
+            }
+            builder.endArray();
+        }
+        competitionSummary.toXContent(builder, params);
+        if (verbose) {
+            competitionDetails.toXContent(builder, params);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        competitionName = in.readString();
+        concurrency = in.readVInt();
+        multiplier = in.readVInt();
+        verbose = in.readBoolean();
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            CompetitionNodeResult result = new CompetitionNodeResult();
+            result.readFrom(in);
+            nodeResults.add(result);
+        }
+        percentiles = in.readDoubleArray();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(competitionName);
+        out.writeVInt(concurrency);
+        out.writeVInt(multiplier);
+        out.writeBoolean(verbose);
+        out.writeVInt(nodeResults.size());
+        for (CompetitionNodeResult result : nodeResults) {
+            result.writeTo(out);
+        }
+        out.writeDoubleArray(percentiles);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/CompetitionSummary.java
+++ b/src/main/java/org/elasticsearch/action/bench/CompetitionSummary.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import org.apache.lucene.util.CollectionUtil;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Summary statistics for a benchmark search competition.
+ *
+ * Statistics are calculated over all iteration results for all nodes
+ * that executed the competition.
+ */
+public class CompetitionSummary implements ToXContent {
+
+    private List<CompetitionNodeResult> nodeResults;
+
+    private long min = 0;
+    private long max = 0;
+    private long totalTime = 0;
+    private long sumTotalHits = 0;
+    private long totalIterations = 0;
+    private long completedIterations = 0;
+    private long totalQueries = 0;
+    private double avgWarmupTime = 0;
+    private int concurrency = 0;
+    private int multiplier = 0;
+    private double mean = 0;
+    private double millisPerHit = 0.0;
+    private double stdDeviation = 0.0;
+    private double queriesPerSecond = 0.0;
+    private double[] percentiles;
+    private Map<Double, Double> percentileValues = new TreeMap<>();
+
+    List<Tuple<String, CompetitionIteration.SlowRequest>> slowest = new ArrayList<>();
+
+    public CompetitionSummary() { }
+
+    public CompetitionSummary(List<CompetitionNodeResult> nodeResults, int concurrency, int multiplier, double[] percentiles) {
+        this.nodeResults = nodeResults;
+        this.concurrency = concurrency;
+        this.multiplier = multiplier;
+        this.percentiles = percentiles;
+    }
+
+    private void computeSummaryStatistics() {
+
+        long totalWarmupTime = 0;
+        SinglePassStatistics single = new SinglePassStatistics();
+
+        for (CompetitionNodeResult nodeResult : nodeResults) {
+
+            totalWarmupTime += nodeResult.warmUpTime();
+            totalIterations += nodeResult.totalIterations();
+            completedIterations += nodeResult.completedIterations();
+
+            // only calculate statistics for iterations completed thus far
+            for (int i = 0; i < nodeResult.completedIterations(); i++) {
+
+                CompetitionIteration competitionIteration = nodeResult.iterations().get(i);
+                CompetitionIterationData iterationData = competitionIteration.competitionIterationData();
+                long[] data = iterationData.data();
+
+                for (long datum : data) {
+                    if (datum > -1) {   // ignore unset values in the underlying array
+                        single.push(datum);
+                    }
+                }
+
+                totalQueries += competitionIteration.numQueries();
+                totalTime += competitionIteration.totalTime();
+                sumTotalHits += competitionIteration.sumTotalHits();
+
+                // keep track of slowest requests
+                if (competitionIteration.slowRequests() != null) {
+                    for (CompetitionIteration.SlowRequest slow : competitionIteration.slowRequests()) {
+                        slowest.add(new Tuple<>(nodeResult.nodeName(), slow));
+                    }
+                }
+            }
+        }
+
+        min = single.min();
+        max = single.max();
+        mean = single.mean();
+        stdDeviation = single.stddev();
+        avgWarmupTime = (nodeResults.size() > 0) ? totalWarmupTime / nodeResults.size() : 0.0;
+        queriesPerSecond = (single.sum() > 0) ? (totalQueries * (1000.0 / (double) single.sum())) : 0.0;
+        millisPerHit = (sumTotalHits > 0) ? (totalTime / (double) sumTotalHits) : 0.0;
+
+        for (double percentile : percentiles) {
+            percentileValues.put(percentile, single.percentile(percentile / 100.0d));
+        }
+
+        CollectionUtil.timSort(slowest, new Comparator<Tuple<String, CompetitionIteration.SlowRequest>>() {
+            @Override
+            public int compare(Tuple<String, CompetitionIteration.SlowRequest> o1, Tuple<String, CompetitionIteration.SlowRequest> o2) {
+                return Long.compare(o2.v2().maxTimeTaken(), o1.v2().maxTimeTaken());
+            }
+        });
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+
+        computeSummaryStatistics();
+
+        builder.startObject(Fields.SUMMARY);
+        builder.startArray(Fields.NODES);
+        for (CompetitionNodeResult nodeResult : nodeResults) {
+            builder.field(nodeResult.nodeName());
+        }
+        builder.endArray();
+
+        builder.field(Fields.TOTAL_ITERATIONS, totalIterations);
+        builder.field(Fields.COMPLETED_ITERATIONS, completedIterations);
+        builder.field(Fields.TOTAL_QUERIES, totalQueries);
+        builder.field(Fields.CONCURRENCY, concurrency);
+        builder.field(Fields.MULTIPLIER, multiplier);
+        builder.field(Fields.AVG_WARMUP_TIME, avgWarmupTime);
+
+        builder.startObject(Fields.STATISTICS);
+        builder.field(Fields.MIN, min == Long.MAX_VALUE ? 0 : min);
+        builder.field(Fields.MAX, max == Long.MIN_VALUE ? 0 : max);
+        builder.field(Fields.MEAN, mean);
+        builder.field(Fields.QPS, queriesPerSecond);
+        builder.field(Fields.STD_DEV, stdDeviation);
+        builder.field(Fields.MILLIS_PER_HIT, millisPerHit);
+
+        for (Map.Entry<Double, Double> entry : percentileValues.entrySet()) {
+            // Change back to integral value for display purposes
+            builder.field(new XContentBuilderString("percentile_" + entry.getKey().longValue()),
+                    (entry.getValue().isNaN()) ? 0.0 : entry.getValue());
+        }
+
+        builder.endObject();
+
+        builder.startArray(Fields.SLOWEST);
+        if (totalIterations > 0 && slowest.size() > 0) {
+            int n = (int) (slowest.size() / totalIterations);
+            for (int i = 0; i < n; i++) {
+                builder.startObject();
+                builder.field(Fields.NODE, slowest.get(i).v1());
+                slowest.get(i).v2().toXContent(builder, params);
+                builder.endObject();
+            }
+        }
+        builder.endArray();
+
+        builder.endObject();
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString SUMMARY = new XContentBuilderString("summary");
+        static final XContentBuilderString NODES = new XContentBuilderString("nodes");
+        static final XContentBuilderString TOTAL_ITERATIONS = new XContentBuilderString("total_iterations");
+        static final XContentBuilderString COMPLETED_ITERATIONS = new XContentBuilderString("completed_iterations");
+        static final XContentBuilderString TOTAL_QUERIES = new XContentBuilderString("total_queries");
+        static final XContentBuilderString CONCURRENCY = new XContentBuilderString("concurrency");
+        static final XContentBuilderString MULTIPLIER = new XContentBuilderString("multiplier");
+        static final XContentBuilderString AVG_WARMUP_TIME = new XContentBuilderString("avg_warmup_time");
+        static final XContentBuilderString STATISTICS = new XContentBuilderString("statistics");
+        static final XContentBuilderString MIN = new XContentBuilderString("min");
+        static final XContentBuilderString MAX = new XContentBuilderString("max");
+        static final XContentBuilderString MEAN = new XContentBuilderString("mean");
+        static final XContentBuilderString QPS = new XContentBuilderString("qps");
+        static final XContentBuilderString STD_DEV = new XContentBuilderString("std_dev");
+        static final XContentBuilderString MILLIS_PER_HIT = new XContentBuilderString("millis_per_hit");
+        static final XContentBuilderString SLOWEST = new XContentBuilderString("slowest");
+        static final XContentBuilderString NODE = new XContentBuilderString("node");
+    }
+}
+

--- a/src/main/java/org/elasticsearch/action/bench/SinglePassStatistics.java
+++ b/src/main/java/org/elasticsearch/action/bench/SinglePassStatistics.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
+
+/**
+ * Utility class for accurately measuring statistical variance in cases where
+ * it is not possible or sensible to retain an entire data set in memory.
+ *
+ * Mean and variance algorithms taken from Donald Knuth's Art of Computer Programming, Vol 2, page 232, 3rd edition.
+ * Based on reference implementation http://www.johndcook.com/standard_deviation.html.
+ *
+ * For each input, the running mean and running sum-of-squares variance is calculated according
+ * to:
+ *      Running mean:     Mk = Mk-1+ (xk - Mk-1)/k
+ *      Running variance: Sk = Sk-1 + (xk - Mk-1)*(xk - Mk)
+ *
+ * Percentile computations use T-Digest: https://github.com/tdunning/t-digest
+ */
+public class SinglePassStatistics {
+
+    private long count = 0;
+    private double runningMean = 0.0;
+    private double runningVariance = 0.0;
+    private long runningSum = 0;
+
+    TDigestState tdigest = new TDigestState(100.0);
+
+    /**
+     * Adds a new value onto the running calculation
+     *
+     * @param value     New value to add to calculation
+     */
+    public void push(long value) {
+        count++;
+        if (count == 1) {
+            runningMean = value;
+            runningVariance = 0.0;
+        } else {
+            double newMean = runningMean + (( value - runningMean) / count );                       // Mk = Mk-1 + ((xk - Mk-1) / k)
+            double newVariance = runningVariance + ( (value - runningMean) * (value - newMean) );   // Sk = Sk-1 + (xk - Mk-1)*(xk - Mk)
+
+            runningMean = newMean;
+            runningVariance = newVariance;
+        }
+
+        runningSum += value;
+        tdigest.add(value);
+    }
+
+    /**
+     * Current value for the running mean
+     *
+     * @return      Current value of running mean
+     */
+    public double mean() {
+        return runningMean;
+    }
+
+    /**
+     * Current value for the running variance from the mean
+     *
+     * @return      Current value for the running variance
+     */
+    public double variance() {
+        if (count > 1) {
+            return runningVariance / (count - 1);
+        } else {
+            return 0.0;
+        }
+    }
+
+    /**
+     * Current running value of standard deviation
+     *
+     * @return      Current running value of standard deviation
+     */
+    public double stddev() {
+        return Math.sqrt(variance());
+    }
+
+    /**
+     * Minimum value in data set
+     *
+     * @return      Minimum value in data set
+     */
+    public long min() {
+        return (long) tdigest.quantile(0.0);
+    }
+
+    /**
+     * Maximum value in data set
+     * @return      Maximum value in data set
+     */
+    public long max() {
+        return (long) tdigest.quantile(1.0);
+    }
+
+    /**
+     * Total number of values seen
+     *
+     * @return      Total number of values seen
+     */
+    public long count() {
+        return count;
+    }
+
+    /**
+     * Running sum of all values
+     *
+     * @return      Running sum of all values
+     */
+    public long sum() {
+        return runningSum;
+    }
+
+    /**
+     * Running percentile
+     * @param q     Percentile to calculate
+     * @return      Running percentile
+     */
+    public double percentile(double q) {
+        return tdigest.quantile(q);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+/**
+ * Transport action for benchmark abort requests
+ */
+public class TransportAbortBenchmarkAction extends TransportMasterNodeOperationAction<AbortBenchmarkRequest, AbortBenchmarkResponse> {
+
+    private final BenchmarkService service;
+
+    @Inject
+    public TransportAbortBenchmarkAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                         ThreadPool threadPool, BenchmarkService service) {
+        super(settings, transportService, clusterService, threadPool);
+        this.service = service;
+    }
+
+    @Override
+    protected String transportAction() {
+        return AbortBenchmarkAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    protected AbortBenchmarkRequest newRequest() {
+        return new AbortBenchmarkRequest();
+    }
+
+    @Override
+    protected AbortBenchmarkResponse newResponse() {
+        return new AbortBenchmarkResponse();
+    }
+
+    @Override
+    protected void masterOperation(AbortBenchmarkRequest request, ClusterState state, final ActionListener<AbortBenchmarkResponse> listener) throws ElasticsearchException {
+        service.abortBenchmark(request.benchmarkName(), listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkAction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+
+
+/**
+ * Transport action for benchmarks
+ */
+public class TransportBenchmarkAction extends TransportMasterNodeOperationAction<BenchmarkRequest, BenchmarkResponse> {
+
+    private final BenchmarkService service;
+
+    @Inject
+    public TransportBenchmarkAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                    ThreadPool threadPool, BenchmarkService service) {
+        super(settings, transportService, clusterService, threadPool);
+        this.service = service;
+    }
+
+    @Override
+    protected String transportAction() {
+        return BenchmarkAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    protected BenchmarkRequest newRequest() {
+        return new BenchmarkRequest();
+    }
+
+    @Override
+    protected BenchmarkResponse newResponse() {
+        return new BenchmarkResponse();
+    }
+
+    @Override
+    protected void masterOperation(BenchmarkRequest request, ClusterState state, ActionListener<BenchmarkResponse> listener) throws ElasticsearchException {
+        service.startBenchmark(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkStatusAction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+
+/**
+ * Transport action for benchmark status requests
+ */
+public class TransportBenchmarkStatusAction extends TransportMasterNodeOperationAction<BenchmarkStatusRequest, BenchmarkStatusResponse> {
+
+    private final BenchmarkService service;
+
+    @Inject
+    public TransportBenchmarkStatusAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                          ThreadPool threadPool, BenchmarkService service) {
+        super(settings, transportService, clusterService, threadPool);
+        this.service = service;
+    }
+
+    @Override
+    protected String transportAction() {
+        return BenchmarkStatusAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    protected BenchmarkStatusRequest newRequest() {
+        return new BenchmarkStatusRequest();
+    }
+
+    @Override
+    protected BenchmarkStatusResponse newResponse() {
+        return new BenchmarkStatusResponse();
+    }
+
+    @Override
+    protected void masterOperation(BenchmarkStatusRequest request, ClusterState state, ActionListener<BenchmarkStatusResponse> listener)
+            throws ElasticsearchException {
+        service.listBenchmarks(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.client;
 
 import org.elasticsearch.action.*;
+import org.elasticsearch.action.bench.*;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -555,4 +556,33 @@ public interface Client {
      */
     void clearScroll(ClearScrollRequest request, ActionListener<ClearScrollResponse> listener);
 
+    /**
+     * Runs a benchmark on the server
+     */
+    void bench(BenchmarkRequest request, ActionListener<BenchmarkResponse> listener);
+
+    /**
+     * Runs a benchmark on the server
+     */
+    BenchmarkRequestBuilder prepareBench(String... indices);
+
+    /**
+     * Aborts a benchmark run on the server
+     */
+    void abortBench(AbortBenchmarkRequest request, ActionListener<AbortBenchmarkResponse> listener);
+
+    /**
+     * Aborts a benchmark run on the server
+     */
+    AbortBenchmarkRequestBuilder prepareAbortBench(String benchmarkId);
+
+    /**
+     * Reports on status of actively running benchmarks
+     */
+    void benchStatus(BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener);
+
+    /**
+     * Reports on status of actively running benchmarks
+     */
+    BenchmarkStatusRequestBuilder prepareBenchStatus();
 }

--- a/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.client.support;
 
 import org.elasticsearch.action.*;
+import org.elasticsearch.action.bench.*;
 import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -380,5 +381,35 @@ public abstract class AbstractClient implements InternalClient {
     @Override
     public ClearScrollRequestBuilder prepareClearScroll() {
         return new ClearScrollRequestBuilder(this);
+    }
+
+    @Override
+    public void bench(BenchmarkRequest request, ActionListener<BenchmarkResponse> listener) {
+        execute(BenchmarkAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public BenchmarkRequestBuilder prepareBench(String... indices) {
+        return new BenchmarkRequestBuilder(this, indices);
+    }
+
+    @Override
+    public void abortBench(AbortBenchmarkRequest request, ActionListener<AbortBenchmarkResponse> listener) {
+        execute(AbortBenchmarkAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public AbortBenchmarkRequestBuilder prepareAbortBench(String benchmarkId) {
+        return new AbortBenchmarkRequestBuilder(this).setBenchmarkName(benchmarkId);
+    }
+
+    @Override
+    public void benchStatus(BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        execute(BenchmarkStatusAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public BenchmarkStatusRequestBuilder prepareBenchStatus() {
+        return new BenchmarkStatusRequestBuilder(this);
     }
 }

--- a/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -23,6 +23,9 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.*;
+import org.elasticsearch.action.bench.BenchmarkRequest;
+import org.elasticsearch.action.bench.BenchmarkRequestBuilder;
+import org.elasticsearch.action.bench.BenchmarkResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.count.CountRequest;
@@ -488,5 +491,15 @@ public class TransportClient extends AbstractClient {
     @Override
     public void explain(ExplainRequest request, ActionListener<ExplainResponse> listener) {
         internalClient.explain(request, listener);
+    }
+
+    @Override
+    public void bench(BenchmarkRequest request, ActionListener<BenchmarkResponse> listener) {
+        internalClient.bench(request, listener);
+    }
+
+    @Override
+    public BenchmarkRequestBuilder prepareBench(String... indices) {
+        return internalClient.prepareBench(indices);
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/metadata/BenchmarkMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/BenchmarkMetaData.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+/**
+ * Meta data about snapshots that are currently executing
+ */
+public class BenchmarkMetaData implements MetaData.Custom {
+    public static final String TYPE = "benchmark";
+
+    public static final Factory FACTORY = new Factory();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BenchmarkMetaData that = (BenchmarkMetaData) o;
+
+        if (!entries.equals(that.entries)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return entries.hashCode();
+    }
+
+    public static class Entry {
+        private final State state;
+        private final String benchmarkId;
+        private final String[] nodeids;
+
+        public Entry(Entry e, State state) {
+            this(e.benchmarkId(), state, e.nodes());
+        }
+
+        public Entry(String benchmarkId, State state, String[] nodeIds) {
+            this.state = state;
+            this.benchmarkId = benchmarkId;
+            this.nodeids =  nodeIds;
+        }
+
+        public String benchmarkId() {
+            return this.benchmarkId;
+        }
+
+        public State state() {
+            return state;
+        }
+
+        public String[] nodes() {
+            return nodeids;
+        }
+
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Entry entry = (Entry) o;
+
+            if (!benchmarkId.equals(entry.benchmarkId)) return false;
+            if (state != entry.state) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = state.hashCode();
+            result = 31 * result + benchmarkId.hashCode();
+            return result;
+        }
+    }
+
+    public static enum State {
+        STARTED((byte) 0),
+        SUCCESS((byte) 1),
+        FAILED((byte) 2),
+        ABORTED((byte) 3);
+
+        private static final State[] STATES = new State[State.values().length];
+
+        static {
+            for (State state : State.values()) {
+                assert state.id() < STATES.length && state.id() >= 0;
+                STATES[state.id()] = state;
+            }
+        }
+
+        private final byte id;
+
+        State(byte id) {
+            this.id = id;
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public boolean completed() {
+            return this == SUCCESS || this == FAILED;
+        }
+
+        public static State fromId(byte id) {
+            if (id < 0 || id >= State.values().length) {
+                throw new ElasticsearchIllegalArgumentException("No benchmark state for value [" + id + "]");
+            }
+            return STATES[id];
+        }
+    }
+
+    private final ImmutableList<Entry> entries;
+
+
+    public BenchmarkMetaData(ImmutableList<Entry> entries) {
+        this.entries = entries;
+    }
+
+    public BenchmarkMetaData(Entry... entries) {
+        this.entries = ImmutableList.copyOf(entries);
+    }
+
+    public ImmutableList<Entry> entries() {
+        return this.entries;
+    }
+
+    public Entry snapshot(SnapshotId snapshotId) {
+        for (Entry entry : entries) {
+            if (snapshotId.equals(entry.benchmarkId())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+
+    public static class Factory implements MetaData.Custom.Factory<BenchmarkMetaData> {
+
+        @Override
+        public String type() {
+            return TYPE;
+        }
+
+        @Override
+        public BenchmarkMetaData readFrom(StreamInput in) throws IOException {
+            Entry[] entries = new Entry[in.readVInt()];
+            for (int i = 0; i < entries.length; i++) {
+                String benchmarkId = in.readString();
+                State state = State.fromId(in.readByte());
+                String[] nodes = in.readStringArray();
+                entries[i] = new Entry(benchmarkId, state, nodes);
+            }
+            return new BenchmarkMetaData(entries);
+        }
+
+        @Override
+        public void writeTo(BenchmarkMetaData repositories, StreamOutput out) throws IOException {
+            out.writeVInt(repositories.entries().size());
+            for (Entry entry : repositories.entries()) {
+                out.writeString(entry.benchmarkId());
+                out.writeByte(entry.state().id());
+                out.writeStringArray(entry.nodes());
+            }
+        }
+
+        @Override
+        public BenchmarkMetaData fromXContent(XContentParser parser) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void toXContent(BenchmarkMetaData customIndexMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startArray("benchmarks");
+            for (Entry entry : customIndexMetaData.entries()) {
+                toXContent(entry, builder, params);
+            }
+            builder.endArray();
+        }
+
+        public void toXContent(Entry entry, XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startObject();
+            builder.field("id", entry.benchmarkId());
+            builder.field("state", entry.state());
+            builder.startArray("on_nodes");
+            for (String nodeid : entry.nodes()) {
+                builder.value(nodeid);
+            }
+            builder.endArray();
+            builder.endObject();
+        }
+
+        public boolean isPersistent() {
+            return false;
+        }
+    }
+
+    public boolean contains(String benchmarkId) {
+        for (Entry e : entries) {
+           if (e.benchmarkId.equals(benchmarkId)) {
+               return true;
+           }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -85,6 +85,7 @@ public class MetaData implements Iterable<IndexMetaData> {
         registerFactory(RepositoriesMetaData.TYPE, RepositoriesMetaData.FACTORY);
         registerFactory(SnapshotMetaData.TYPE, SnapshotMetaData.FACTORY);
         registerFactory(RestoreMetaData.TYPE, RestoreMetaData.FACTORY);
+        registerFactory(BenchmarkMetaData.TYPE, BenchmarkMetaData.FACTORY);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionModule;
+import org.elasticsearch.action.bench.BenchmarkModule;
 import org.elasticsearch.bulk.udp.BulkUdpModule;
 import org.elasticsearch.bulk.udp.BulkUdpService;
 import org.elasticsearch.cache.recycler.CacheRecycler;
@@ -183,6 +184,7 @@ public final class InternalNode implements Node {
         modules.add(new ResourceWatcherModule());
         modules.add(new RepositoriesModule());
         modules.add(new TribeModule());
+        modules.add(new BenchmarkModule());
 
         injector = modules.createInjector();
 

--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -79,6 +79,7 @@ import org.elasticsearch.rest.action.admin.indices.warmer.delete.RestDeleteWarme
 import org.elasticsearch.rest.action.admin.indices.warmer.get.RestGetWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.put.RestPutWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.recovery.RestRecoveryAction;
+import org.elasticsearch.rest.action.bench.RestBenchAction;
 import org.elasticsearch.rest.action.bulk.RestBulkAction;
 import org.elasticsearch.rest.action.cat.*;
 import org.elasticsearch.rest.action.delete.RestDeleteAction;
@@ -211,6 +212,8 @@ public class RestActionModule extends AbstractModule {
         bind(RestExplainAction.class).asEagerSingleton();
 
         bind(RestRecoveryAction.class).asEagerSingleton();
+        // Benchmark API
+        bind(RestBenchAction.class).asEagerSingleton();
 
         // cat API
         Multibinder<AbstractCatAction> catActionMultibinder = Multibinder.newSetBinder(binder(), AbstractCatAction.class);

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.bench;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.bench.*;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.admin.indices.cache.clear.RestClearIndicesCacheAction;
+import org.elasticsearch.rest.action.support.RestBuilderListener;
+
+import com.google.common.primitives.Doubles;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
+import static org.elasticsearch.rest.RestStatus.METHOD_NOT_ALLOWED;
+import static org.elasticsearch.common.xcontent.json.JsonXContent.contentBuilder;
+
+/**
+ * REST handler for benchmark actions.
+ */
+public class RestBenchAction extends BaseRestHandler {
+
+    @Inject
+    public RestBenchAction(Settings settings, Client client, RestController controller) {
+        super(settings, client);
+
+        // List active benchmarks
+        controller.registerHandler(GET, "/_bench", this);
+        controller.registerHandler(GET, "/{index}/_bench", this);
+        controller.registerHandler(GET, "/{index}/{type}/_bench", this);
+
+        // Submit benchmark
+        controller.registerHandler(PUT, "/_bench", this);
+        controller.registerHandler(PUT, "/{index}/_bench", this);
+        controller.registerHandler(PUT, "/{index}/{type}/_bench", this);
+
+        // Abort benchmark
+        controller.registerHandler(POST, "/_bench/abort/{name}", this);
+    }
+
+    @Override
+    public void handleRequest(final RestRequest request, final RestChannel channel) {
+        switch (request.method()) {
+            case POST:
+                handleAbortRequest(request, channel);
+                break;
+            case PUT:
+                handleSubmitRequest(request, channel);
+                break;
+            case GET:
+                handleStatusRequest(request, channel);
+                break;
+            default:
+                // Politely ignore methods we don't support
+                channel.sendResponse(new BytesRestResponse(METHOD_NOT_ALLOWED));
+        }
+    }
+
+    /**
+     * Reports on the status of all actively running benchmarks
+     */
+    private void handleStatusRequest(final RestRequest request, final RestChannel channel) {
+
+        BenchmarkStatusRequest benchmarkStatusRequest = new BenchmarkStatusRequest();
+
+        client.benchStatus(benchmarkStatusRequest, new RestBuilderListener<BenchmarkStatusResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(BenchmarkStatusResponse response, XContentBuilder builder) throws Exception {
+                builder.startObject();
+                response.toXContent(builder, request);
+                builder.endObject();
+                return new BytesRestResponse(RestStatus.OK, builder);
+            }
+        });
+    }
+
+    /**
+     * Aborts an actively running benchmark
+     */
+    private void handleAbortRequest(final RestRequest request, final RestChannel channel) {
+
+        String benchmarkName = request.param("name");
+        AbortBenchmarkRequest abortBenchmarkRequest = new AbortBenchmarkRequest(benchmarkName);
+
+        client.abortBench(abortBenchmarkRequest, new RestBuilderListener<AbortBenchmarkResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(AbortBenchmarkResponse response, XContentBuilder builder) throws Exception {
+                builder.startObject();
+                response.toXContent(builder, request);
+                builder.endObject();
+                return new BytesRestResponse(RestStatus.OK, builder);
+            }
+        });
+    }
+
+    /**
+     * Submits a benchmark for execution
+     */
+    private void handleSubmitRequest(final RestRequest request, final RestChannel channel) {
+
+        String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
+        String[] types = Strings.splitStringByCommaToArray(request.param("type"));
+
+        final BenchmarkRequest benchmarkRequest;
+        try {
+            BenchmarkRequestBuilder builder = new BenchmarkRequestBuilder(client);
+            builder.setVerbose(request.paramAsBoolean("verbose", false));
+            benchmarkRequest = parse(builder, request.content(), request.contentUnsafe());
+            benchmarkRequest.cascadeGlobalSettings();                   // Make sure competitors inherit global settings
+            benchmarkRequest.applyLateBoundSettings(indices, types);    // Some settings cannot be applied until after parsing
+            Exception ex = benchmarkRequest.validate();
+            if (ex != null) {
+                throw ex;
+            }
+            benchmarkRequest.listenerThreaded(false);
+        } catch (Exception e) {
+                logger.debug("failed to parse search request parameters", e);
+            try {
+                channel.sendResponse(new BytesRestResponse(BAD_REQUEST, contentBuilder().startObject().field("error", e.getMessage()).endObject()));
+            } catch (IOException e1) {
+                logger.error("Failed to send failure response", e1);
+            }
+            return;
+        }
+        client.bench(benchmarkRequest, new RestBuilderListener<BenchmarkResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(BenchmarkResponse response, XContentBuilder builder) throws Exception {
+                builder.startObject();
+                response.toXContent(builder, request);
+                builder.endObject();
+                return new BytesRestResponse(RestStatus.OK, builder);
+            }
+        });
+    }
+
+    public static BenchmarkRequest parse(BenchmarkRequestBuilder builder, BytesReference data, boolean contentUnsafe) throws Exception {
+        XContent xContent = XContentFactory.xContent(data);
+        XContentParser p = xContent.createParser(data);
+        XContentParser.Token token = p.nextToken();
+        assert token == XContentParser.Token.START_OBJECT;
+        String fieldName = null;
+        while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+            switch (token) {
+                case START_ARRAY:
+                    if ("requests".equals(fieldName)) {
+                        while ((token = p.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            assert token == XContentParser.Token.START_OBJECT;
+                            XContentBuilder payloadBuilder = XContentFactory.contentBuilder(p.contentType()).copyCurrentStructure(p);
+                            SearchRequest req = new SearchRequest();
+                            req.source(payloadBuilder.bytes(), contentUnsafe);
+                            builder.addSearchRequest(req);
+                        }
+                    } else if ("competitors".equals(fieldName)) {
+                        while (p.nextToken() != XContentParser.Token.END_ARRAY) {
+                            builder.addCompetitor(parse(p, contentUnsafe));
+                        }
+                    } else if ("percentiles".equals(fieldName)) {
+                        List<Double> percentiles = new ArrayList<>();
+                        while (p.nextToken() != XContentParser.Token.END_ARRAY) {
+                            percentiles.add(p.doubleValue());
+                        }
+                        builder.setPercentiles(Doubles.toArray(percentiles));
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing array field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case START_OBJECT:
+                    if ("clear_caches".equals(fieldName)) {
+                        BenchmarkSettings.ClearCachesSettings clearCachesSettings = new BenchmarkSettings.ClearCachesSettings();
+                        builder.setClearCachesSettings(clearCachesSettings);
+                        parseClearCaches(p, clearCachesSettings);
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing object field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case FIELD_NAME:
+                    fieldName = p.text();
+                    break;
+                case VALUE_NUMBER:
+                    if ("num_executor_nodes".equals(fieldName)) {
+                        builder.setNumExecutorNodes(p.intValue());
+                    } else if ("iterations".equals(fieldName)) {
+                        builder.setIterations(p.intValue());
+                    } else if ("concurrency".equals(fieldName)) {
+                        builder.setConcurrency(p.intValue());
+                    } else if ("multiplier".equals(fieldName)) {
+                        builder.setMultiplier(p.intValue());
+                    } else if ("num_slowest".equals(fieldName)) {
+                        builder.setNumSlowest(p.intValue());
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing numeric field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case VALUE_BOOLEAN:
+                    if ("warmup".equals(fieldName)) {
+                        builder.setWarmup(p.booleanValue());
+                    } else if ("clear_caches".equals(fieldName)) {
+                        if (p.booleanValue()) {
+                            throw new ElasticsearchParseException("Failed parsing field [" + fieldName + "] must specify which caches to clear");
+                        } else {
+                            builder.setAllowCacheClearing(false);
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing boolean field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case VALUE_STRING:
+                    if ("name".equals(fieldName)) {
+                        builder.setBenchmarkId(p.text());
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing string field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                default:
+                    throw new ElasticsearchParseException("Failed parsing " + token.name() + " field [" + fieldName + "] field is not recognized");
+            }
+        }
+
+        return builder.request();
+    }
+
+    private static BenchmarkCompetitorBuilder parse(XContentParser p, boolean contentUnsafe) throws Exception {
+        XContentParser.Token token = p.currentToken();
+        BenchmarkCompetitorBuilder builder = new BenchmarkCompetitorBuilder();
+        assert token == XContentParser.Token.START_OBJECT;
+        String fieldName = null;
+        while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+            switch (token) {
+                case START_ARRAY:
+                    if ("requests".equals(fieldName)) {
+                        while ((token = p.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            assert token == XContentParser.Token.START_OBJECT;
+                            XContentBuilder payloadBuilder = XContentFactory.contentBuilder(p.contentType()).copyCurrentStructure(p);
+                            SearchRequest req = new SearchRequest();
+                            req.source(payloadBuilder.bytes(), contentUnsafe);
+                            builder.addSearchRequest(req);
+                        }
+                    } else if ("indices".equals(fieldName)) {
+                        List<String> perCompetitorIndices = new ArrayList<>();
+                        List<String> perCompetitorTypes = new ArrayList<>();
+                        while ((token = p.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (token == XContentParser.Token.VALUE_STRING) {
+                                String[] parts = parseIndexNameAndType(p.text());
+                                perCompetitorIndices.add(parts[0]);
+                                if (parts.length == 2) {
+                                    perCompetitorTypes.add(parts[1]);
+                                }
+                            } else {
+                                throw new ElasticsearchParseException("Failed parsing array field [" + fieldName + "] expected string values but got: "  + token);
+                            }
+                        }
+                        builder.setIndices(perCompetitorIndices.toArray(new String[perCompetitorIndices.size()]));
+                        builder.setTypes(perCompetitorTypes.toArray(new String[perCompetitorTypes.size()]));
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing array field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case START_OBJECT:
+                    if ("clear_caches".equals(fieldName)) {
+                        BenchmarkSettings.ClearCachesSettings clearCachesSettings = new BenchmarkSettings.ClearCachesSettings();
+                        builder.setClearCachesSettings(clearCachesSettings);
+                        parseClearCaches(p, clearCachesSettings);
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing object field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case FIELD_NAME:
+                    fieldName = p.text();
+                    break;
+                case VALUE_NUMBER:
+                    if ("multiplier".equals(fieldName)) {
+                        builder.setMultiplier(p.intValue());
+                    } else if ("num_slowest".equals(fieldName)) {
+                        builder.setNumSlowest(p.intValue());
+                    } else if ("iterations".equals(fieldName)) {
+                        builder.setIterations(p.intValue());
+                    } else if ("concurrency".equals(fieldName)) {
+                        builder.setConcurrency(p.intValue());
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing numeric field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case VALUE_BOOLEAN:
+                    if ("warmup".equals(fieldName)) {
+                        builder.setWarmup(p.booleanValue());
+                    } else if ("clear_caches".equals(fieldName)) {
+                        if (p.booleanValue()) {
+                            throw new ElasticsearchParseException("Failed parsing field [" + fieldName + "] must specify which caches to clear");
+                        } else {
+                            builder.setAllowCacheClearing(false);
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing boolean field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case VALUE_STRING:
+                    if ("name".equals(fieldName)) {
+                        builder.setName(p.text());
+                    } else if ("search_type".equals(fieldName) || "searchType".equals(fieldName)) {
+                        builder.setSearchType(SearchType.fromString(p.text()));
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing string field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                default:
+                    throw new ElasticsearchParseException("Failed parsing " + token.name() + " field [" + fieldName + "] field is not recognized");
+            }
+        }
+        return builder;
+    }
+
+    private static void parseClearCaches(XContentParser p, BenchmarkSettings.ClearCachesSettings clearCachesSettings) throws Exception {
+        XContentParser.Token token;
+        String fieldName = null;
+        while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+            switch (token) {
+                case START_OBJECT:
+                    break;
+                case VALUE_BOOLEAN:
+                    if (RestClearIndicesCacheAction.Fields.FILTER.match(fieldName)) {
+                        clearCachesSettings.filterCache(p.booleanValue());
+                    } else if (RestClearIndicesCacheAction.Fields.FIELD_DATA.match(fieldName)) {
+                        clearCachesSettings.fieldDataCache(p.booleanValue());
+                    } else if (RestClearIndicesCacheAction.Fields.ID.match(fieldName)) {
+                        clearCachesSettings.idCache(p.booleanValue());
+                    } else if (RestClearIndicesCacheAction.Fields.RECYCLER.match(fieldName)) {
+                        clearCachesSettings.recycler(p.booleanValue());
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing " + token.name() + " field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case START_ARRAY:
+                    List<String> fields = new ArrayList<>();
+                    while ((token = p.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        fields.add(p.text());
+                    }
+                    if (RestClearIndicesCacheAction.Fields.FIELDS.match(fieldName)) {
+                        clearCachesSettings.fields(fields.toArray(new String[fields.size()]));
+                    } else if (RestClearIndicesCacheAction.Fields.FILTER_KEYS.match(fieldName)) {
+                        clearCachesSettings.filterKeys(fields.toArray(new String[fields.size()]));
+                    } else {
+                        throw new ElasticsearchParseException("Failed parsing " + token.name() + " field [" + fieldName + "] field is not recognized");
+                    }
+                    break;
+                case FIELD_NAME:
+                    fieldName = p.text();
+                    break;
+                default:
+                    throw new ElasticsearchParseException("Failed parsing " + token.name() + " field [" + fieldName + "] field is not recognized");
+            }
+        }
+    }
+
+    // We allow users to specify competitor index lists as "index_name/index_type"
+    private static String[] parseIndexNameAndType(String indexName) {
+        String[] parts = indexName.split("/", 2);
+        assert parts.length >= 1;
+        return parts;
+    }
+}

--- a/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -76,6 +76,7 @@ public class ThreadPool extends AbstractComponent {
         public static final String WARMER = "warmer";
         public static final String SNAPSHOT = "snapshot";
         public static final String OPTIMIZE = "optimize";
+        public static final String BENCH = "bench";
     }
 
     public static final String THREADPOOL_GROUP = "threadpool.";
@@ -118,6 +119,7 @@ public class ThreadPool extends AbstractComponent {
                 .put(Names.WARMER, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .put(Names.SNAPSHOT, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .put(Names.OPTIMIZE, settingsBuilder().put("type", "fixed").put("size", 1).build())
+                .put(Names.BENCH, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", halfProcMaxAt5).build())
                 .build();
 
         Map<String, ExecutorHolder> executors = Maps.newHashMap();

--- a/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
+++ b/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
@@ -21,6 +21,7 @@ package org.elasticsearch.test.client;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.elasticsearch.action.*;
+import org.elasticsearch.action.bench.*;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -411,6 +412,36 @@ public class RandomizingClient implements InternalClient {
     @Override
     public void clearScroll(ClearScrollRequest request, ActionListener<ClearScrollResponse> listener) {
         delegate.clearScroll(request, listener);
+    }
+
+    @Override
+    public void bench(BenchmarkRequest request, ActionListener<BenchmarkResponse> listener) {
+        delegate.bench(request, listener);
+    }
+
+    @Override
+    public BenchmarkRequestBuilder prepareBench(String... indices) {
+        return delegate.prepareBench(indices);
+    }
+
+    @Override
+    public void abortBench(AbortBenchmarkRequest request, ActionListener<AbortBenchmarkResponse> listener) {
+        delegate.abortBench(request, listener);
+    }
+
+    @Override
+    public AbortBenchmarkRequestBuilder prepareAbortBench(String benchmarkId) {
+        return delegate.prepareAbortBench(benchmarkId);
+    }
+
+    @Override
+    public void benchStatus(BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        delegate.benchStatus(request, listener);
+    }
+
+    @Override
+    public BenchmarkStatusRequestBuilder prepareBenchStatus() {
+        return delegate.prepareBenchStatus();
     }
 
     @Override


### PR DESCRIPTION
Add an API endpoint at /_bench for submitting, listing, and aborting
search benchmarks. This API can be used for timing search requests,
subject to various user-defined settings.

Benchmark results provide summary and detailed statistics on such
values as min, max, and mean time. Values are reported per-node so that
it is easy to spot outliers. Slow requests are also reported.

Long running benchmarks can be viewed with a GET request, or aborted
with a POST request.

Benchmark results are optionally stored in an index for subsequent
analysis.

Closes #5407 
