### PR TITLE
Enforce query instance checking before it wrapper as a filter

### DIFF
--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -30,3 +30,6 @@ org.apache.lucene.index.IndexWriter#forceMerge(int) @ use Merges#forceMerge
 org.apache.lucene.index.IndexWriter#forceMerge(int,boolean) @ use Merges#forceMerge
 org.apache.lucene.index.IndexWriter#forceMergeDeletes() @ use Merges#forceMergeDeletes
 org.apache.lucene.index.IndexWriter#forceMergeDeletes(boolean) @ use Merges#forceMergeDeletes
+
+@defaultMessage QueryWrapperFilter is cachable by default - use Queries#wrap instead
+org.apache.lucene.search.QueryWrapperFilter#<init>(org.apache.lucene.search.Query)

--- a/pom.xml
+++ b/pom.xml
@@ -989,6 +989,7 @@
                                 <exclude>org/elasticsearch/Version.class</exclude>
                                 <exclude>org/apache/lucene/queries/XTermsFilter.class</exclude>
                                 <exclude>org/elasticsearch/index/merge/Merges.class</exclude>
+				<exclude>org/elasticsearch/common/lucene/search/Queries$QueryWrapperFilterFactory.class</exclude>
                                 <!-- end excludes for valid system-out -->
                                 <!-- start excludes for Unsafe -->
                                 <exclude>org/elasticsearch/common/util/UnsafeUtils.class</exclude>

--- a/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.common.lucene.search;
 
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.Query;
+import org.apache.lucene.search.*;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -165,5 +163,22 @@ public class Queries {
         return (optionalClauseCount < result ?
                 optionalClauseCount : (result < 0 ? 0 : result));
 
+    }
+
+    public static Filter wrap(Query query) {
+        return FACTORY.wrap(query);
+    }
+
+    private static final QueryWrapperFilterFactory FACTORY = new QueryWrapperFilterFactory();
+
+    private static final class QueryWrapperFilterFactory {
+
+        public Filter wrap(Query query) {
+            if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
+                return new CustomQueryWrappingFilter(query);
+            } else {
+                return new QueryWrapperFilter(query);
+            }
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -170,7 +170,9 @@ public class Queries {
     }
 
     private static final QueryWrapperFilterFactory FACTORY = new QueryWrapperFilterFactory();
-
+    // NOTE: This is a separate class since we added QueryWrapperFilter as a forbidden API
+    // that way we can exclude only the inner class without excluding the entire Queries class
+    // and potentially miss a forbidden API usage!
     private static final class QueryWrapperFilterFactory {
 
         public Filter wrap(Query query) {

--- a/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -21,8 +21,8 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.cache.filter.support.CacheKeyFilter;
 import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
@@ -86,12 +86,7 @@ public class FQueryFilterParser implements FilterParser {
         if (query == null) {
             return null;
         }
-        Filter filter;
-        if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
-            filter = new CustomQueryWrappingFilter(query);
-        } else {
-            filter = new QueryWrapperFilter(query);
-        }
+        Filter filter = Queries.wrap(query);
         if (cache) {
             filter = parseContext.cacheFilter(filter, cacheKey);
         }

--- a/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/NestedFilterParser.java
@@ -21,11 +21,11 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
 import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -154,9 +154,9 @@ public class NestedFilterParser implements FilterParser {
             Filter nestedFilter;
             if (join) {
                 ToParentBlockJoinQuery joinQuery = new ToParentBlockJoinQuery(query, parentFilter, ScoreMode.None);
-                nestedFilter = new QueryWrapperFilter(joinQuery);
+                nestedFilter = Queries.wrap(joinQuery);
             } else {
-                nestedFilter = new QueryWrapperFilter(query);
+                nestedFilter = Queries.wrap(query);
             }
 
             if (cache) {

--- a/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -21,9 +21,10 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.index.search.child.CustomQueryWrappingFilter;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.lucene.search.Queries;
 
 import java.io.IOException;
 
@@ -33,6 +34,7 @@ import java.io.IOException;
 public class QueryFilterParser implements FilterParser {
 
     public static final String NAME = "query";
+    ESLogger logger = Loggers.getLogger(getClass());
 
     @Inject
     public QueryFilterParser() {
@@ -49,10 +51,6 @@ public class QueryFilterParser implements FilterParser {
         if (query == null) {
             return null;
         }
-        if (CustomQueryWrappingFilter.shouldUseCustomQueryWrappingFilter(query)) {
-            return new CustomQueryWrappingFilter(query);
-        } else {
-            return new QueryWrapperFilter(query);
-        }
+        return Queries.wrap(query);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -25,12 +25,12 @@ import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.similarities.Similarity;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.lucene.search.NoCacheFilter;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.analysis.AnalysisService;
@@ -185,7 +185,7 @@ public class QueryParseContext {
     }
 
     public void addNamedQuery(String name, Query query) {
-        namedFilters.put(name, new QueryWrapperFilter(query));
+        namedFilters.put(name, Queries.wrap(query));
     }
 
     public ImmutableMap<String, Filter> copyNamedFilters() {

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -137,7 +137,6 @@ public class ChildrenQuery extends Query {
     @Override
     public Weight createWeight(IndexSearcher searcher) throws IOException {
         SearchContext searchContext = SearchContext.current();
-
         final Query childQuery;
         if (rewrittenChildQuery == null) {
             childQuery = rewrittenChildQuery = searcher.rewrite(originalChildQuery);
@@ -154,27 +153,36 @@ public class ChildrenQuery extends Query {
         switch (scoreType) {
             case MAX:
                 MaxCollector maxCollector = new MaxCollector(parentChildIndexFieldData, parentType, searchContext);
-                indexSearcher.search(childQuery, maxCollector);
-                parentIds = maxCollector.parentIds;
-                scores = maxCollector.scores;
-                occurrences = null;
-                Releasables.release(maxCollector.parentIdsIndex);
+                try {
+                    indexSearcher.search(childQuery, maxCollector);
+                    parentIds = maxCollector.parentIds;
+                    scores = maxCollector.scores;
+                    occurrences = null;
+                } finally {
+                    Releasables.release(maxCollector.parentIdsIndex);
+                }
                 break;
             case SUM:
                 SumCollector sumCollector = new SumCollector(parentChildIndexFieldData, parentType, searchContext);
-                indexSearcher.search(childQuery, sumCollector);
-                parentIds = sumCollector.parentIds;
-                scores = sumCollector.scores;
-                occurrences = null;
+                try {
+                    indexSearcher.search(childQuery, sumCollector);
+                    parentIds = sumCollector.parentIds;
+                    scores = sumCollector.scores;
+                    occurrences = null;
+                } finally {
                 Releasables.release(sumCollector.parentIdsIndex);
+                }
                 break;
             case AVG:
                 AvgCollector avgCollector = new AvgCollector(parentChildIndexFieldData, parentType, searchContext);
-                indexSearcher.search(childQuery, avgCollector);
-                parentIds = avgCollector.parentIds;
-                scores = avgCollector.scores;
-                occurrences = avgCollector.occurrences;
+                try {
+                    indexSearcher.search(childQuery, avgCollector);
+                    parentIds = avgCollector.parentIds;
+                    scores = avgCollector.scores;
+                    occurrences = avgCollector.occurrences;
+                } finally {
                 Releasables.release(avgCollector.parentIdsIndex);
+                }
                 break;
             default:
                 throw new RuntimeException("Are we missing a score type here? -- " + scoreType);

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -170,7 +170,7 @@ public class ChildrenQuery extends Query {
                     scores = sumCollector.scores;
                     occurrences = null;
                 } finally {
-                Releasables.release(sumCollector.parentIdsIndex);
+                    Releasables.release(sumCollector.parentIdsIndex);
                 }
                 break;
             case AVG:
@@ -181,7 +181,7 @@ public class ChildrenQuery extends Query {
                     scores = avgCollector.scores;
                     occurrences = avgCollector.occurrences;
                 } finally {
-                Releasables.release(avgCollector.parentIdsIndex);
+                    Releasables.release(avgCollector.parentIdsIndex);
                 }
                 break;
             default:

--- a/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -125,7 +125,7 @@ public class ParentQuery extends Query {
         SearchContext searchContext = SearchContext.current();
         ParentIdAndScoreCollector collector = new ParentIdAndScoreCollector(searchContext, parentChildIndexFieldData, parentType);
         ChildWeight childWeight;
-        boolean success = false;
+        boolean releaseCollectorResource = true;
         try {
             final Query parentQuery;
             if (rewrittenParentQuery == null) {
@@ -143,9 +143,10 @@ public class ParentQuery extends Query {
                 return Queries.newMatchNoDocsQuery().createWeight(searcher);
             }
             childWeight = new ChildWeight(searchContext, parentQuery.createWeight(searcher), childrenFilter, parentIds, scores);
-            success = true;
+            releaseCollectorResource = false;
         } finally {
-            if (!success) {
+            if (releaseCollectorResource) {
+                // either if we run into an exception or if we return early
                 Releasables.release(collector.parentIds, collector.scores);
             }
         }

--- a/src/main/java/org/elasticsearch/search/facet/query/QueryFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/query/QueryFacetExecutor.java
@@ -51,7 +51,7 @@ public class QueryFacetExecutor extends FacetExecutor {
         if (possibleFilter != null) {
             this.filter = possibleFilter;
         } else {
-            this.filter = new QueryWrapperFilter(query);
+            this.filter = Queries.wrap(query);
         }
     }
 


### PR DESCRIPTION
We have the default QueryWrapperFilter as well as our custom one while
our wrapper is explicitly marked as no_cache such that it will never
be included in a cache. This was not consistenly used and caused several
problems during tests where p/c related queries were used as filters
and ended up in the cache. This commit adds the QueryWrapperFilter
ctor to the forbidden APIs to enforce the query instance checks.

Unfortunately this doesn't fix cases where such a query is nested in a BQ or so. Yet I want to fix it step by step but this one at least fixes some cases and prevents more misuse.
