### PR TITLE
Close Directory / Store once all resources have been released

### DIFF
--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -33,3 +33,10 @@ org.apache.lucene.index.IndexWriter#forceMergeDeletes(boolean) @ use Merges#forc
 
 @defaultMessage QueryWrapperFilter is cachable by default - use Queries#wrap instead
 org.apache.lucene.search.QueryWrapperFilter#<init>(org.apache.lucene.search.Query)
+
+@defaultMessage Only use wait / notify when really needed try to use concurrency primitives, latches or callbacks instead. 
+java.lang.Object#wait()
+java.lang.Object#wait(long)
+java.lang.Object#wait(long,int)
+java.lang.Object#notify()
+java.lang.Object#notifyAll()

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -50,6 +50,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.Adler32;
 
 /**
@@ -61,6 +63,8 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     public static final boolean isChecksum(String name) {
         return name.startsWith(CHECKSUMS_PREFIX);
     }
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final AtomicInteger refCount = new AtomicInteger(1);
 
     private final IndexStore indexStore;
     final CodecService codecService;
@@ -84,14 +88,23 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     }
 
     public IndexStore indexStore() {
+        ensureOpen();
         return this.indexStore;
     }
 
     public Directory directory() {
+        ensureOpen();
         return directory;
     }
 
+    private final void ensureOpen() {
+        if (this.refCount.get() <= 0) {
+            throw new AlreadyClosedException("Store is already closed");
+        }
+    }
+
     public ImmutableMap<String, StoreFileMetaData> list() throws IOException {
+        ensureOpen();
         ImmutableMap.Builder<String, StoreFileMetaData> builder = ImmutableMap.builder();
         for (String name : files) {
             StoreFileMetaData md = metaData(name);
@@ -103,6 +116,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     }
 
     public StoreFileMetaData metaData(String name) throws IOException {
+        ensureOpen();
         StoreFileMetaData md = filesMetadata.get(name);
         if (md == null) {
             return null;
@@ -118,6 +132,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
      * Deletes the content of a shard store. Be careful calling this!.
      */
     public void deleteContent() throws IOException {
+        ensureOpen();
         String[] files = directory.listAll();
         IOException lastException = null;
         for (String file : files) {
@@ -143,14 +158,17 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     }
 
     public StoreStats stats() throws IOException {
+        ensureOpen();
         return new StoreStats(Directories.estimateSize(directory), directoryService.throttleTimeInNanos());
     }
 
     public ByteSizeValue estimateSize() throws IOException {
+        ensureOpen();
         return new ByteSizeValue(Directories.estimateSize(directory));
     }
 
     public void renameFile(String from, String to) throws IOException {
+        ensureOpen();
         synchronized (mutex) {
             StoreFileMetaData fromMetaData = filesMetadata.get(from); // we should always find this one
             if (fromMetaData == null) {
@@ -171,19 +189,11 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
             }
             return readChecksums(dirs, null);
         } finally {
-            for (Directory dir : dirs) {
-                if (dir != null) {
-                    try {
-                        dir.close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
-            }
+            IOUtils.closeWhileHandlingException(dirs);
         }
     }
 
-    static Map<String, String> readChecksums(Directory[] dirs, Map<String, String> defaultValue) throws IOException {
+    private static Map<String, String> readChecksums(Directory[] dirs, Map<String, String> defaultValue) throws IOException {
         long lastFound = -1;
         Directory lastDir = null;
         for (Directory dir : dirs) {
@@ -214,6 +224,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     }
 
     public void writeChecksums() throws IOException {
+        ensureOpen();
         ImmutableMap<String, StoreFileMetaData> files = list();
         String checksumName = CHECKSUMS_PREFIX + System.currentTimeMillis();
         synchronized (mutex) {
@@ -253,18 +264,51 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         return false;
     }
 
+    public final void incRef() {
+        do {
+            int i = refCount.get();
+            if (i > 0) {
+                if (refCount.compareAndSet(i, i+1)) {
+                    return;
+                }
+            } else {
+                throw new AlreadyClosedException("Store is already closed can't increment refCount current count [" + i + "]");
+            }
+        } while(true);
+    }
+
+    public final void decRef() {
+        int i = refCount.decrementAndGet();
+        assert i >= 0;
+        if (i == 0) {
+            closeInternal();
+        }
+
+    }
+
     public void close() {
-        try {
-            directory.close();
-        } catch (IOException e) {
-            logger.debug("failed to close directory", e);
+        if (isClosed.compareAndSet(false, true)) {
+            // only do this once!
+            decRef();
         }
     }
+
+    private void closeInternal() {
+        synchronized (mutex) { // if we close the dir we need to make sure nobody writes checksums
+            try {
+                directory.closeInternal(); // don't call close here we throw an exception there!
+            } catch (IOException e) {
+                logger.debug("failed to close directory", e);
+            }
+        }
+    }
+
 
     /**
      * Creates a raw output, no checksum is computed, and no compression if enabled.
      */
     public IndexOutput createOutputRaw(String name) throws IOException {
+        ensureOpen();
         return directory.createOutput(name, IOContext.DEFAULT, true);
     }
 
@@ -272,6 +316,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
      * Opened an index input in raw form, no decompression for example.
      */
     public IndexInput openInputRaw(String name, IOContext context) throws IOException {
+        ensureOpen();
         StoreFileMetaData metaData = filesMetadata.get(name);
         if (metaData == null) {
             throw new FileNotFoundException(name);
@@ -280,6 +325,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     }
 
     public void writeChecksum(String name, String checksum) throws IOException {
+        ensureOpen();
         // update the metadata to include the checksum and write a new checksums file
         synchronized (mutex) {
             StoreFileMetaData metaData = filesMetadata.get(name);
@@ -290,6 +336,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     }
 
     public void writeChecksums(Map<String, String> checksums) throws IOException {
+        ensureOpen();
         // update the metadata to include the checksum and write a new checksums file
         synchronized (mutex) {
             for (Map.Entry<String, String> entry : checksums.entrySet()) {
@@ -506,14 +553,20 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
         }
 
         @Override
-        public synchronized void close() throws IOException {
-            isOpen = false;
-            for (Directory delegate : distributor.all()) {
-                delegate.close();
-            }
-            synchronized (mutex) {
-                filesMetadata = ImmutableOpenMap.of();
-                files = Strings.EMPTY_ARRAY;
+        public void close() throws IOException {
+            assert false : "Nobody should close this directory except of the Store itself";
+        }
+
+        synchronized void closeInternal() throws IOException {
+            if (isOpen) {
+                isOpen = false;
+                for (Directory delegate : distributor.all()) {
+                    delegate.close();
+                }
+                synchronized (mutex) {
+                    filesMetadata = ImmutableOpenMap.of();
+                    files = Strings.EMPTY_ARRAY;
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
+import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
@@ -119,11 +120,13 @@ public class RecoverySource extends AbstractComponent {
             public void phase1(final SnapshotIndexCommit snapshot) throws ElasticsearchException {
                 long totalSize = 0;
                 long existingTotalSize = 0;
+                final Store store = shard.store();
+                store.incRef();
                 try {
                     StopWatch stopWatch = new StopWatch().start();
 
                     for (String name : snapshot.getFiles()) {
-                        StoreFileMetaData md = shard.store().metaData(name);
+                        StoreFileMetaData md = store.metaData(name);
                         boolean useExisting = false;
                         if (request.existingFiles().containsKey(name)) {
                             // we don't compute checksum for segments, so always recover them
@@ -173,12 +176,13 @@ public class RecoverySource extends AbstractComponent {
                             @Override
                             public void run() {
                                 IndexInput indexInput = null;
+                                store.incRef();
                                 try {
                                     final int BUFFER_SIZE = (int) recoverySettings.fileChunkSize().bytes();
                                     byte[] buf = new byte[BUFFER_SIZE];
-                                    StoreFileMetaData md = shard.store().metaData(name);
+                                    StoreFileMetaData md = store.metaData(name);
                                     // TODO: maybe use IOContext.READONCE?
-                                    indexInput = shard.store().openInputRaw(name, IOContext.READ);
+                                    indexInput = store.openInputRaw(name, IOContext.READ);
                                     boolean shouldCompressRequest = recoverySettings.compress();
                                     if (CompressorFactory.isCompressed(indexInput)) {
                                         shouldCompressRequest = false;
@@ -207,7 +211,11 @@ public class RecoverySource extends AbstractComponent {
                                     lastException.set(e);
                                 } finally {
                                     IOUtils.closeWhileHandlingException(indexInput);
-                                    latch.countDown();
+                                    try {
+                                        store.decRef();
+                                    } finally {
+                                        latch.countDown();
+                                    }
                                 }
                             }
                         });
@@ -229,6 +237,8 @@ public class RecoverySource extends AbstractComponent {
                     response.phase1Time = stopWatch.totalTime().millis();
                 } catch (Throwable e) {
                     throw new RecoverFilesRecoveryException(request.shardId(), response.phase1FileNames.size(), new ByteSizeValue(totalSize), e);
+                } finally {
+                    store.decRef();
                 }
             }
 

--- a/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.elasticsearch.test.TestCluster.RestartCallback;
+import org.elasticsearch.test.store.MockDirectoryHelper;
 import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -304,8 +305,8 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
         ImmutableSettings.Builder settings = settingsBuilder()
                 .put("action.admin.cluster.node.shutdown.delay", "10ms")
                 .put("gateway.recover_after_nodes", 4)
-
-                .put(BalancedShardsAllocator.SETTING_THRESHOLD, 1.1f); // use less aggressive settings
+                .put(MockDirectoryHelper.CRASH_INDEX, false)
+                .put(BalancedShardsAllocator.SETTING_THRESHOLD, 1.1f); // use less agressive settings
 
         cluster().startNode(settings);
         cluster().startNode(settings);
@@ -319,6 +320,8 @@ public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTes
                 client().admin().indices().prepareFlush().execute().actionGet();
             }
         }
+        client().admin().indices().prepareFlush().execute().actionGet();
+
         logger.info("Running Cluster Health");
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/src/test/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -231,19 +231,23 @@ public class MockRepository extends FsRepository {
                 }
             }
 
-            private void maybeIOExceptionOrBlock(String blobName, ImmutableBlobContainer.WriterListener listener) {
+            private boolean maybeIOExceptionOrBlock(String blobName, ImmutableBlobContainer.WriterListener listener) {
                 try {
                     maybeIOExceptionOrBlock(blobName);
+                    return true;
                 } catch (IOException ex) {
                     listener.onFailure(ex);
+                    return false;
                 }
             }
 
-            private void maybeIOExceptionOrBlock(String blobName, ImmutableBlobContainer.ReadBlobListener listener) {
+            private boolean maybeIOExceptionOrBlock(String blobName, ImmutableBlobContainer.ReadBlobListener listener) {
                 try {
                     maybeIOExceptionOrBlock(blobName);
+                    return true;
                 } catch (IOException ex) {
                     listener.onFailure(ex);
+                    return false;
                 }
             }
 
@@ -254,8 +258,9 @@ public class MockRepository extends FsRepository {
 
             @Override
             public void writeBlob(String blobName, InputStream is, long sizeInBytes, WriterListener listener) {
-                maybeIOExceptionOrBlock(blobName, listener);
-                super.writeBlob(blobName, is, sizeInBytes, listener);
+                if (maybeIOExceptionOrBlock(blobName, listener) ) {
+                    super.writeBlob(blobName, is, sizeInBytes, listener);
+                }
             }
 
             @Override
@@ -271,8 +276,9 @@ public class MockRepository extends FsRepository {
 
             @Override
             public void readBlob(String blobName, ReadBlobListener listener) {
-                maybeIOExceptionOrBlock(blobName, listener);
-                super.readBlob(blobName, listener);
+                if (maybeIOExceptionOrBlock(blobName, listener)) {
+                    super.readBlob(blobName, listener);
+                }
             }
 
             @Override

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -311,13 +311,14 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     private static void randomIndexTemplate() {
         // TODO move settings for random directory etc here into the index based randomized settings.
         if (cluster().size() > 0) {
+            ImmutableSettings.Builder builder = setRandomNormsLoading(setRandomMerge(getRandom(), ImmutableSettings.builder())
+                    .put(INDEX_SEED_SETTING, randomLong()))
+                    .put(SETTING_NUMBER_OF_SHARDS, between(DEFAULT_MIN_NUM_SHARDS, DEFAULT_MAX_NUM_SHARDS))
+                    .put(SETTING_NUMBER_OF_REPLICAS, between(0, 1));
             client().admin().indices().preparePutTemplate("random_index_template")
                     .setTemplate("*")
                     .setOrder(0)
-                    .setSettings(setRandomNormsLoading(setRandomMerge(getRandom(), ImmutableSettings.builder())
-                            .put(INDEX_SEED_SETTING, randomLong()))
-                            .put(SETTING_NUMBER_OF_SHARDS, between(DEFAULT_MIN_NUM_SHARDS, DEFAULT_MAX_NUM_SHARDS))
-                            .put(SETTING_NUMBER_OF_REPLICAS, between(0, 1)))
+                    .setSettings(builder)
                     .execute().actionGet();
         }
     }

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -181,14 +181,16 @@ public final class TestCluster implements Iterable<Client> {
         logger.info("Setup TestCluster [{}] with seed [{}] using [{}] nodes", clusterName, SeedUtils.formatSeed(clusterSeed), numSharedNodes);
         this.nodeSettingsSource = nodeSettingsSource;
         Builder builder = ImmutableSettings.settingsBuilder();
-        // randomize (multi/single) data path, special case for 0, don't set it at all...
-        int numOfDataPaths = random.nextInt(5);
-        if (numOfDataPaths > 0) {
-            StringBuilder dataPath = new StringBuilder();
-            for (int i = 0; i < numOfDataPaths; i++) {
-                dataPath.append("data/d").append(i).append(',');
+        if (random.nextInt(5) == 0) { // sometimes set this
+            // randomize (multi/single) data path, special case for 0, don't set it at all...
+            final int numOfDataPaths = random.nextInt(5);
+            if (numOfDataPaths > 0) {
+                StringBuilder dataPath = new StringBuilder();
+                for (int i = 0; i < numOfDataPaths; i++) {
+                    dataPath.append("data/d").append(i).append(',');
+                }
+                builder.put("path.data", dataPath.toString());
             }
-            builder.put("path.data", dataPath.toString());
         }
         defaultSettings = builder.build();
 

--- a/src/test/java/org/elasticsearch/test/engine/MockInternalEngine.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockInternalEngine.java
@@ -83,7 +83,8 @@ public final class MockInternalEngine extends InternalEngine implements Engine {
     }
 
 
-    public void close() throws ElasticsearchException {
+    @Override
+    public void close() {
         try {
             super.close();
         } finally {

--- a/src/test/java/org/elasticsearch/test/store/MockDirectoryHelper.java
+++ b/src/test/java/org/elasticsearch/test/store/MockDirectoryHelper.java
@@ -36,7 +36,6 @@ import org.elasticsearch.index.store.fs.MmapFsDirectoryService;
 import org.elasticsearch.index.store.fs.NioFsDirectoryService;
 import org.elasticsearch.index.store.fs.SimpleFsDirectoryService;
 import org.elasticsearch.index.store.ram.RamDirectoryService;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.io.IOException;
 import java.util.Random;
@@ -46,40 +45,37 @@ public class MockDirectoryHelper {
     public static final String RANDOM_IO_EXCEPTION_RATE = "index.store.mock.random.io_exception_rate";
     public static final String RANDOM_IO_EXCEPTION_RATE_ON_OPEN = "index.store.mock.random.io_exception_rate_on_open";
     public static final String RANDOM_THROTTLE = "index.store.mock.random.throttle";
-    public static final String CHECK_INDEX_ON_CLOSE = "index.store.mock.check_index_on_close";
     public static final String RANDOM_PREVENT_DOUBLE_WRITE = "index.store.mock.random.prevent_double_write";
     public static final String RANDOM_NO_DELETE_OPEN_FILE = "index.store.mock.random.no_delete_open_file";
-    public static final String RANDOM_FAIL_ON_CLOSE= "index.store.mock.random.fail_on_close";
+    public static final String CRASH_INDEX = "index.store.mock.random.crash_index";
 
     public static final Set<ElasticsearchMockDirectoryWrapper> wrappers = ConcurrentCollections.newConcurrentSet();
-    
+
+
     private final Random random;
     private final double randomIOExceptionRate;
     private final double randomIOExceptionRateOnOpen;
     private final Throttling throttle;
-    private final boolean checkIndexOnClose;
     private final Settings indexSettings;
     private final ShardId shardId;
     private final boolean preventDoubleWrite;
     private final boolean noDeleteOpenFile;
     private final ESLogger logger;
-    private final boolean failOnClose;
+    private final boolean crashIndex;
 
-    public MockDirectoryHelper(ShardId shardId, Settings indexSettings, ESLogger logger) {
-        final long seed = indexSettings.getAsLong(ElasticsearchIntegrationTest.INDEX_SEED_SETTING, 0l);
-        random = new Random(seed);
+    public MockDirectoryHelper(ShardId shardId, Settings indexSettings, ESLogger logger, Random random, long seed) {
+        this.random = random;
         randomIOExceptionRate = indexSettings.getAsDouble(RANDOM_IO_EXCEPTION_RATE, 0.0d);
         randomIOExceptionRateOnOpen = indexSettings.getAsDouble(RANDOM_IO_EXCEPTION_RATE_ON_OPEN, 0.0d);
         preventDoubleWrite = indexSettings.getAsBoolean(RANDOM_PREVENT_DOUBLE_WRITE, true); // true is default in MDW
         noDeleteOpenFile = indexSettings.getAsBoolean(RANDOM_NO_DELETE_OPEN_FILE, random.nextBoolean()); // true is default in MDW
         random.nextInt(shardId.getId() + 1); // some randomness per shard
         throttle = Throttling.valueOf(indexSettings.get(RANDOM_THROTTLE, random.nextDouble() < 0.1 ? "SOMETIMES" : "NEVER"));
-        checkIndexOnClose = indexSettings.getAsBoolean(CHECK_INDEX_ON_CLOSE, false);// we can't do this by default since it might close the index input that we still read from in a pending fetch phase.
-        failOnClose = indexSettings.getAsBoolean(RANDOM_FAIL_ON_CLOSE, false);
+        crashIndex = indexSettings.getAsBoolean(CRASH_INDEX, true);
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Using MockDirWrapper with seed [{}] throttle: [{}] checkIndexOnClose: [{}]", SeedUtils.formatSeed(seed),
-                    throttle, checkIndexOnClose);
+            logger.debug("Using MockDirWrapper with seed [{}] throttle: [{}] crashIndex: [{}]", SeedUtils.formatSeed(seed),
+                    throttle, crashIndex);
         }
         this.indexSettings = indexSettings;
         this.shardId = shardId;
@@ -87,11 +83,11 @@ public class MockDirectoryHelper {
     }
 
     public Directory wrap(Directory dir) {
-        final ElasticsearchMockDirectoryWrapper w = new ElasticsearchMockDirectoryWrapper(random, dir, logger, failOnClose);
+        final ElasticsearchMockDirectoryWrapper w = new ElasticsearchMockDirectoryWrapper(random, dir, logger, this.crashIndex);
         w.setRandomIOExceptionRate(randomIOExceptionRate);
         w.setRandomIOExceptionRateOnOpen(randomIOExceptionRateOnOpen);
         w.setThrottling(throttle);
-        w.setCheckIndexOnClose(checkIndexOnClose);
+        w.setCheckIndexOnClose(false); // we do this on the index level
         w.setPreventDoubleWrite(preventDoubleWrite);
         w.setNoDeleteOpenFile(noDeleteOpenFile);
         wrappers.add(w);
@@ -128,31 +124,39 @@ public class MockDirectoryHelper {
     public static final class ElasticsearchMockDirectoryWrapper extends MockDirectoryWrapper {
 
         private final ESLogger logger;
-        private final boolean failOnClose;
+        private final boolean crash;
+        private RuntimeException closeException;
 
-        public ElasticsearchMockDirectoryWrapper(Random random, Directory delegate, ESLogger logger, boolean failOnClose) {
+        public ElasticsearchMockDirectoryWrapper(Random random, Directory delegate, ESLogger logger, boolean crash) {
             super(random, delegate);
+            this.crash = crash;
             this.logger = logger;
-            this.failOnClose = failOnClose;
         }
 
         @Override
-        public  void close() throws IOException {
+        public synchronized void close() throws IOException {
             try {
                 super.close();
             } catch (RuntimeException ex) {
-                if (failOnClose) {
-                    throw ex;
-                }
-                // we catch the exception on close to properly close shards even if there are open files
-                // the test framework will call closeWithRuntimeException after the test exits to fail
-                // on unclosed files.
-                logger.debug("MockDirectoryWrapper#close() threw exception", ex);
+                logger.info("MockDirectoryWrapper#close() threw exception", ex);
+                closeException = ex;
+                throw ex;
             }
         }
 
-        public void closeWithRuntimeException() throws IOException {
-            super.close(); // force fail if open files etc. called in tear down of ElasticsearchIntegrationTest
+        public synchronized boolean successfullyClosed() {
+            return closeException == null && !isOpen();
+        }
+
+        public synchronized RuntimeException closeException() {
+            return closeException;
+        }
+
+        @Override
+        public synchronized void crash() throws IOException {
+            if (crash) {
+                super.crash();
+            }
         }
     }
 }

--- a/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -19,29 +19,61 @@
 
 package org.elasticsearch.test.store;
 
+import com.google.common.base.Charsets;
+import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.LockFactory;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.shard.IndexShardException;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.service.IndexShard;
+import org.elasticsearch.index.shard.service.InternalIndexShard;
 import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.fs.FsDirectoryService;
+import org.elasticsearch.indices.IndicesLifecycle;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Random;
 
 public class MockFSDirectoryService extends FsDirectoryService {
 
     private final MockDirectoryHelper helper;
     private FsDirectoryService delegateService;
+    public static final String CHECK_INDEX_ON_CLOSE = "index.store.mock.check_index_on_close";
+    private final boolean checkIndexOnClose;
 
     @Inject
-    public MockFSDirectoryService(ShardId shardId, @IndexSettings Settings indexSettings, IndexStore indexStore) {
+    public MockFSDirectoryService(final ShardId shardId, @IndexSettings Settings indexSettings, IndexStore indexStore, final IndicesService service) {
         super(shardId, indexSettings, indexStore);
-        helper = new MockDirectoryHelper(shardId, indexSettings, logger);
+        final long seed = indexSettings.getAsLong(ElasticsearchIntegrationTest.INDEX_SEED_SETTING, 0l);
+        Random random = new Random(seed);
+        helper = new MockDirectoryHelper(shardId, indexSettings, logger, random, seed);
+        checkIndexOnClose = indexSettings.getAsBoolean(CHECK_INDEX_ON_CLOSE, random.nextDouble() < 0.1);
+
         delegateService = helper.randomDirectorService(indexStore);
+        if (checkIndexOnClose) {
+            final IndicesLifecycle.Listener listener = new IndicesLifecycle.Listener() {
+                @Override
+                public void beforeIndexShardClosed(ShardId sid, @Nullable IndexShard indexShard) {
+                    if (shardId.equals(sid) && indexShard != null) {
+                        checkIndex(((InternalIndexShard) indexShard).store());
+                    }
+                    service.indicesLifecycle().removeListener(this);
+                }
+            };
+            service.indicesLifecycle().addListener(listener);
+        }
     }
 
     @Override
@@ -53,6 +85,29 @@ public class MockFSDirectoryService extends FsDirectoryService {
     protected synchronized FSDirectory newFSDirectory(File location, LockFactory lockFactory) throws IOException {
         throw new UnsupportedOperationException();
     }
-    
-    
+
+
+    private void checkIndex(Store store) throws IndexShardException {
+        try {
+            if (!Lucene.indexExists(store.directory())) {
+                return;
+            }
+            CheckIndex checkIndex = new CheckIndex(store.directory());
+            BytesStreamOutput os = new BytesStreamOutput();
+            PrintStream out = new PrintStream(os, false, Charsets.UTF_8.name());
+            checkIndex.setInfoStream(out);
+            out.flush();
+            CheckIndex.Status status = checkIndex.checkIndex();
+            if (!status.clean) {
+                logger.warn("check index [failure]\n{}", new String(os.bytes().toBytes(), Charsets.UTF_8));
+                throw new IndexShardException(shardId, "index check failure");
+            } else {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("check index [success]\n{}", new String(os.bytes().toBytes(), Charsets.UTF_8));
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("failed to check index", e);
+        }
+    }
 }

--- a/src/test/java/org/elasticsearch/test/store/MockRamDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/MockRamDirectoryService.java
@@ -25,8 +25,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.io.IOException;
+import java.util.Random;
 
 public class MockRamDirectoryService extends AbstractIndexShardComponent implements DirectoryService {
 
@@ -36,7 +38,9 @@ public class MockRamDirectoryService extends AbstractIndexShardComponent impleme
     @Inject
     public MockRamDirectoryService(ShardId shardId, Settings indexSettings) {
         super(shardId, indexSettings);
-        helper = new MockDirectoryHelper(shardId, indexSettings, logger);
+        final long seed = indexSettings.getAsLong(ElasticsearchIntegrationTest.INDEX_SEED_SETTING, 0l);
+        Random random = new Random(seed);
+        helper = new MockDirectoryHelper(shardId, indexSettings, logger, random, seed);
         delegateService = helper.randomRamDirectoryService();
     }
 


### PR DESCRIPTION
Currently we close the store and therefor the underlying directory
when the engine / shard is closed ie. during relocation etc. We also
just close it while there are still searches going on and/or we are
recovering from it. The recoveries might fail which is ok but searches
etc. will be working like pending fetch phases.

The contract of the Directory doesn't prevent to read from a stream
that was already opened before the Directory was closed but from a
system boundary perspective and from lifecycles that we test it seems
to be the right thing to do to wait until all resources are released.

Additionally it will also help to make sure everything is closed
properly before directories are closed itself.

Note: this commit adds Object#wait & Object@#notify/All to forbidden APIs
