### PR TITLE
Add slop to prefix phrase query after parsing query string

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -261,6 +261,7 @@ public class MatchQuery {
                 for (int i = 0; i < terms.length; i++) {
                     prefixQuery.add(new Term[] {terms[i]}, positions[i]);
                 }
+                prefixQuery.setSlop(phraseSlop);
                 return prefixQuery;
             } else if (query instanceof MultiPhraseQuery) {
                 MultiPhraseQuery pq = (MultiPhraseQuery)query;
@@ -271,6 +272,7 @@ public class MatchQuery {
                 for (int i = 0; i < terms.size(); i++) {
                     prefixQuery.add(terms.get(i), positions[i]);
                 }
+                prefixQuery.setSlop(phraseSlop);
                 return prefixQuery;
             }
             return query;

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -2292,4 +2292,14 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
         assertHitCount(searchResponse, 1l);
     }
 
+    public void testMatchPhrasePrefixQuery() {
+        createIndex("test1");
+        client().prepareIndex("test1", "type1", "1").setSource("field", "Johnnie Walker Black Label").get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("field", "Johnnie la").slop(between(2,5)).type(Type.PHRASE_PREFIX)).get();
+        assertHitCount(searchResponse, 1l);
+        assertSearchHits(searchResponse, "1");
+    }
+
 }


### PR DESCRIPTION
This fixes a regression introduced by #5005 where the query slop
was simply ignored when a `match_phrase_prefix` type was set.

Closes #5437
