### PR TITLE
Findbug warning supression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1294,6 +1294,13 @@
             <value>true</value>
           </property>
         </activation>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+              <artifactId>findbugs-maven-plugin</artifactId>
+              <version>2.5.3</version>
+          </dependency>
+        </dependencies>
         <build>
           <plugins>
             <plugin>

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -94,6 +94,7 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
     }
 
     @Override
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings("NP_NULL_ON_SOME_PATH")
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (snapshot == null) {


### PR DESCRIPTION
Added logic to enable findbug warnings suppression via annotations
Tagging on annotation requires findbug dependency during compilation stage.
