### PR TITLE
Suggest REST endpoint fix for POST/PUT

### DIFF
--- a/rest-api-spec/api/suggest.json
+++ b/rest-api-spec/api/suggest.json
@@ -1,15 +1,19 @@
 {
   "suggest": {
     "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-search.html",
-    "methods": ["POST", "GET"],
+    "methods": ["PUT", "POST", "GET"],
     "url": {
       "path": "/_suggest",
-      "paths": ["/_suggest", "/{index}/_suggest"],
+      "paths": ["/_suggest", "/{index}/_suggest", "/{index}/{type}/_suggest"],
       "parts": {
         "index": {
           "type" : "list",
           "description" : "A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"
-        }
+        },
+          "type": {
+              "type" : "list",
+              "description" : "A comma-separated list of document types to search; leave empty to perform the operation on all types"
+          }
       },
       "params": {
         "ignore_unavailable": {

--- a/src/test/java/org/elasticsearch/action/suggest/SuggestActionRestTests.java
+++ b/src/test/java/org/elasticsearch/action/suggest/SuggestActionRestTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.suggest;
+
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.rest.ElasticsearchRestIntegrationTest;
+
+import org.elasticsearch.test.rest.client.RestException;
+import org.elasticsearch.test.rest.client.RestResponse;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
+
+
+/**
+ * Tests for the suggest REST API endpoint.
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+public class SuggestActionRestTests extends ElasticsearchRestIntegrationTest {
+
+    private static final String TEST_INDEX = "test_idx_1";
+    private static final String TEST_TYPE = "test_type_1";
+
+    @Test
+    public void postIndexTypeSuggest() throws Exception {
+
+        createIndex(TEST_INDEX);
+        Map<String, String> params = new HashMap<>();
+        params.put("index", TEST_INDEX);
+        params.put("type", TEST_TYPE);
+        RestResponse response = null;
+
+        try {
+            response = restClient.callApi("suggest", "POST", params, "{user:andrew}");
+        } catch (RestException e) {
+            assertThat(e.statusCode(), equalTo(BAD_REQUEST.getStatus()));
+            return;
+        }
+
+        Assert.fail("Expected response code " + BAD_REQUEST.getStatus() + " but got " + response.getStatusCode());
+    }
+
+    @Test
+    public void putIndexTypeSuggest() throws Exception {
+
+        createIndex(TEST_INDEX);
+        Map<String, String> params = new HashMap<>();
+        params.put("index", TEST_INDEX);
+        params.put("type", TEST_TYPE);
+        RestResponse response = null;
+
+        try {
+            response = restClient.callApi("suggest", "PUT", params, "{user:andrew}");
+        } catch (RestException e) {
+            assertThat(e.statusCode(), equalTo(BAD_REQUEST.getStatus()));
+            return;
+        }
+
+        Assert.fail("Expected response code " + BAD_REQUEST.getStatus() + " but got " + response.getStatusCode());
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.rest.client.RestClient;
+import org.elasticsearch.test.rest.client.RestException;
+import org.elasticsearch.test.rest.spec.RestSpec;
+import org.elasticsearch.test.rest.support.PathUtils;
+
+import org.junit.Before;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * {@link ElasticsearchRestIntegrationTest} is an abstract base class for integration tests
+ * that require the ability to talk to a JVM private Elasticsearch cluster via the REST API.
+ *
+ * This class add a {@link org.elasticsearch.test.rest.client.RestClient} for use in testing
+ * the REST API.
+ *
+ * {@see ElasticsearchIntegrationTest}
+ */
+public abstract class ElasticsearchRestIntegrationTest extends ElasticsearchIntegrationTest {
+
+    private static final String DEFAULT_SPEC_PATH = "/rest-api-spec/api";
+    private static final String REST_TESTS_SPEC = "tests.rest.spec";
+
+    protected RestClient restClient;
+
+    @Before
+    public void beforeTest() throws IOException, RestException {
+
+        if (restClient == null) {
+            List<InetSocketAddress> addresses = Lists.newArrayList();
+            for (HttpServerTransport httpServerTransport : cluster().getInstances(HttpServerTransport.class)) {
+                addresses.add(((InetSocketTransportAddress) httpServerTransport.boundAddress().publishAddress()).address());
+            }
+
+            String[] specPaths = PathUtils.resolvePathsProperty(REST_TESTS_SPEC, DEFAULT_SPEC_PATH);
+            RestSpec restSpec = RestSpec.parseFrom(DEFAULT_SPEC_PATH, specPaths);
+            restClient = new RestClient(addresses.toArray(new InetSocketAddress[addresses.size()]), restSpec);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/rest/junit/RestTestSuiteRunner.java
+++ b/src/test/java/org/elasticsearch/test/rest/junit/RestTestSuiteRunner.java
@@ -42,6 +42,7 @@ import org.elasticsearch.test.rest.section.TestSection;
 import org.elasticsearch.test.rest.spec.RestSpec;
 import org.elasticsearch.test.rest.support.Features;
 import org.elasticsearch.test.rest.support.FileUtils;
+import org.elasticsearch.test.rest.support.PathUtils;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
@@ -207,7 +208,7 @@ public class RestTestSuiteRunner extends ParentRunner<RestTestCandidate> {
         }
 
         try {
-            String[] specPaths = resolvePathsProperty(REST_TESTS_SPEC, DEFAULT_SPEC_PATH);
+            String[] specPaths = PathUtils.resolvePathsProperty(REST_TESTS_SPEC, DEFAULT_SPEC_PATH);
             RestSpec restSpec = RestSpec.parseFrom(DEFAULT_SPEC_PATH, specPaths);
             this.restTestExecutionContext = new RestTestExecutionContext(addresses.toArray(new InetSocketAddress[addresses.size()]), restSpec);
             this.rootDescription = createRootDescription(getRootSuiteTitle());
@@ -228,7 +229,7 @@ public class RestTestSuiteRunner extends ParentRunner<RestTestCandidate> {
      */
     protected List<RestTestCandidate> collectTestCandidates(Description rootDescription) throws InitializationError, IOException {
 
-        String[] paths = resolvePathsProperty(REST_TESTS_SUITE, DEFAULT_TESTS_PATH);
+        String[] paths = PathUtils.resolvePathsProperty(REST_TESTS_SUITE, DEFAULT_TESTS_PATH);
         Map<String, Set<File>> yamlSuites = FileUtils.findYamlSuites(DEFAULT_TESTS_PATH, paths);
 
         String sectionFilter = System.getProperty(REST_TESTS_SECTION);
@@ -366,15 +367,6 @@ public class RestTestSuiteRunner extends ParentRunner<RestTestCandidate> {
             throw new IllegalArgumentException("System property " + SYSPROP_ITERATIONS() + " must be >= 1 but was [" + iterations + "]");
         }
         return iterations;
-    }
-
-    protected static String[] resolvePathsProperty(String propertyName, String defaultValue) {
-        String property = System.getProperty(propertyName);
-        if (!Strings.hasLength(property)) {
-            return new String[]{defaultValue};
-        } else {
-            return property.split(PATHS_SEPARATOR);
-        }
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/rest/support/PathUtils.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/PathUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.support;
+
+import org.elasticsearch.common.Strings;
+
+/**
+ *
+ */
+public class PathUtils {
+
+    private static final String PATHS_SEPARATOR = ",";
+
+    public static String[] resolvePathsProperty(String propertyName, String defaultValue) {
+        String property = System.getProperty(propertyName);
+        if (!Strings.hasLength(property)) {
+            return new String[]{defaultValue};
+        } else {
+            return property.split(PATHS_SEPARATOR);
+        }
+    }
+}


### PR DESCRIPTION
Fix an odd behavior whereby a user can create documents with id=_suggest
by issuing POST/PUT requests to
http://localhost:9200/{index}/{type}/_suggest.

This fix intercepts such requests and returns a 400 BAD_REQUEST
response.

Additionally, this commit includes an extension to the standard
integration test facilities which allows a subclass to use a RestClient
instance to issue REST requests.

Closes #5442
