### PR TITLE
Geo Point Fieldmapper: Allow distance for geohash precision

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -226,7 +226,11 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
                 } else if (fieldName.equals("precision_step")) {
                     builder.precisionStep(XContentMapValues.nodeIntegerValue(fieldNode));
                 } else if (fieldName.equals("geohash_precision")) {
-                    builder.geoHashPrecision(XContentMapValues.nodeIntegerValue(fieldNode));
+                    if (fieldNode instanceof Integer) {
+                        builder.geoHashPrecision(XContentMapValues.nodeIntegerValue(fieldNode));
+                    } else {
+                        builder.geoHashPrecision(GeoUtils.geoHashLevelsForPrecision(fieldNode.toString()));
+                    }
                 } else if (fieldName.equals("validate")) {
                     builder.validateLat = XContentMapValues.nodeBooleanValue(fieldNode);
                     builder.validateLon = XContentMapValues.nodeBooleanValue(fieldNode);
@@ -450,6 +454,10 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
 
     public StringFieldMapper geoHashStringMapper() {
         return this.geohashMapper;
+    }
+
+    int geoHashPrecision() {
+        return geoHashPrecision;
     }
 
     public boolean isEnableLatLon() {

--- a/src/test/java/org/elasticsearch/index/mapper/geo/GeohashMappingGeoPointTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/geo/GeohashMappingGeoPointTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper.geo;
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperTestUtils;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.test.ElasticsearchTestCase;
@@ -91,5 +92,29 @@ public class GeohashMappingGeoPointTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(doc.rootDoc().getField("point.lon"), nullValue());
         MatcherAssert.assertThat(doc.rootDoc().get("point.geohash"), equalTo(GeoHashUtils.encode(1.2, 1.3)));
         MatcherAssert.assertThat(doc.rootDoc().get("point"), notNullValue());
+    }
+
+    @Test
+    public void testGeoHashPrecisionAsInteger() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("point").field("type", "geo_point").field("geohash_precision", 10).endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper defaultMapper = MapperTestUtils.newParser().parse(mapping);
+        FieldMapper mapper = defaultMapper.mappers().smartName("point").mapper();
+        assertThat(mapper, instanceOf(GeoPointFieldMapper.class));
+        GeoPointFieldMapper geoPointFieldMapper = (GeoPointFieldMapper) mapper;
+        assertThat(geoPointFieldMapper.geoHashPrecision(), is(10));
+    }
+
+    @Test
+    public void testGeoHashPrecisionAsLength() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("point").field("type", "geo_point").field("geohash_precision", "5m").endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper defaultMapper = MapperTestUtils.newParser().parse(mapping);
+        FieldMapper mapper = defaultMapper.mappers().smartName("point").mapper();
+        assertThat(mapper, instanceOf(GeoPointFieldMapper.class));
+        GeoPointFieldMapper geoPointFieldMapper = (GeoPointFieldMapper) mapper;
+        assertThat(geoPointFieldMapper.geoHashPrecision(), is(10));
     }
 }


### PR DESCRIPTION
Even though mentioned differently in the docs, the geohash precision needed to
be an integer instead of a DistanceUnit.

Closes #5448
