### PR TITLE
Fix cardinality memory-usage considerations.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregatorFactory.java
@@ -64,8 +64,8 @@ final class CardinalityAggregatorFactory extends ValueSourceAggregatorFactory<Va
     private int defaultPrecision(Aggregator parent) {
         int precision = HyperLogLogPlusPlus.DEFAULT_PRECISION;
         while (parent != null) {
-            if (parent.bucketAggregationMode() == BucketAggregationMode.MULTI_BUCKETS) {
-                // if the parent is a multi-bucket aggregator, we substract 5 to the precision,
+            if (parent.bucketAggregationMode() == BucketAggregationMode.PER_BUCKET) {
+                // if the parent is a per-bucket aggregator, we substract 5 to the precision,
                 // which will effectively divide the memory usage of each counter by 32
                 precision -= 5;
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
@@ -75,6 +75,13 @@ public final class HyperLogLogPlusPlus implements Releasable {
         return precision;
     }
 
+    /**
+     * Return the expected per-bucket memory usage for the given precision.
+     */
+    public static long memoryUsage(int precision) {
+        return 1L << precision;
+    }
+
     // these static tables come from the appendix of the paper
     private static final double[][] RAW_ESTIMATE_DATA = {
         // precision 4


### PR DESCRIPTION
Default precision was computed based on the number of MULTI_BUCKET parents
instead of PER_BUCKET.

The ordinals-based execution mode was almost always used although ordinals
might have non-negligible memory usage compared to the counters.
