### PR TITLE
BytesReference usage to properly work when hasArray is not available

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -105,7 +105,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
         /** Returns the mappings as a map. Note that the returned map has a single key which is always the field's {@link Mapper#name}. */
         public Map<String, Object> sourceAsMap() {
-            return XContentHelper.convertToMap(source.array(), source.arrayOffset(), source.length(), true).v2();
+            return XContentHelper.convertToMap(source, true).v2();
         }
 
         public boolean isNull() {

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
@@ -356,7 +356,7 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
             try {
                 fos = new FileOutputStream(stateFile);
                 BytesReference bytes = builder.bytes();
-                fos.write(bytes.array(), bytes.arrayOffset(), bytes.length());
+                bytes.writeTo(fos);
                 fos.getChannel().force(true);
                 fos.close();
                 wroteAtLeastOnce = true;
@@ -412,7 +412,7 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
             try {
                 fos = new FileOutputStream(stateFile);
                 BytesReference bytes = builder.bytes();
-                fos.write(bytes.array(), bytes.arrayOffset(), bytes.length());
+                bytes.writeTo(fos);
                 fos.getChannel().force(true);
                 fos.close();
                 wroteAtLeastOnce = true;

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/LocalGatewayShardsState.java
@@ -289,7 +289,7 @@ public class LocalGatewayShardsState extends AbstractComponent implements Cluste
             try {
                 fos = new FileOutputStream(stateFile);
                 BytesReference bytes = builder.bytes();
-                fos.write(bytes.array(), bytes.arrayOffset(), bytes.length());
+                bytes.writeTo(fos);
                 fos.getChannel().force(true);
                 fos.close();
                 wroteAtLeastOnce = true;
@@ -301,7 +301,7 @@ public class LocalGatewayShardsState extends AbstractComponent implements Cluste
         }
 
         if (!wroteAtLeastOnce) {
-            logger.warn("[{}][{}]: failed to write shard state", shardId.index().name(), shardId.id(), lastFailure);
+            logger.warn("[{}][{}]: failed to write shard state", lastFailure, shardId.index().name(), shardId.id());
             throw new IOException("failed to write shard state for " + shardId, lastFailure);
         }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -341,6 +341,9 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
                 }
             }
         }
+        if (!source.hasArray()) {
+            source = source.toBytesArray();
+        }
         assert source.hasArray();
         fields.add(new StoredField(names().indexName(), source.array(), source.arrayOffset(), source.length()));
     }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -350,6 +350,10 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
             out.seek(size);
 
             BytesReference ref = out.bytes();
+            // TODO: pass teh BytesReference to the FsTranslogFile and have them optimize writing
+            if (!ref.hasArray()) {
+                ref = ref.toBytesArray();
+            }
             byte[] refBytes = ref.array();
             int refBytesOffset = ref.arrayOffset();
             Location location = current.add(refBytes, refBytesOffset, size);

--- a/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -235,7 +235,7 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
                 .field("foo", "bar")
                 .field("_id", 1)
                 .field("foobar", "foobar")
-                .endObject().bytes().array();
+                .endObject().bytes().toBytes();
         Document doc = builtDocMapper.parse(new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         if (enabled) {


### PR DESCRIPTION
when a BytesReference doesn't have a backing array, properly handle the case in places where its applicable
