### PR TITLE
Make cache-recycling operations thread-safe.

### DIFF
--- a/src/main/java/org/elasticsearch/common/recycler/SoftThreadLocalRecycler.java
+++ b/src/main/java/org/elasticsearch/common/recycler/SoftThreadLocalRecycler.java
@@ -46,7 +46,7 @@ public class SoftThreadLocalRecycler<T> extends Recycler<T> {
         SoftReference<ThreadLocalRecycler.Stack<T>> ref = threadLocal.get();
         ThreadLocalRecycler.Stack<T> stack = (ref == null) ? null : ref.get();
         if (stack == null) {
-            stack = new ThreadLocalRecycler.Stack<T>(stackLimit, Thread.currentThread());
+            stack = new ThreadLocalRecycler.Stack<T>(stackLimit);
             threadLocal.set(new SoftReference<ThreadLocalRecycler.Stack<T>>(stack));
         }
 

--- a/src/test/java/org/elasticsearch/search/facet/DFSFacetTests.java
+++ b/src/test/java/org/elasticsearch/search/facet/DFSFacetTests.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.facet;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.search.facet.terms.TermsFacetBuilder;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+// see https://github.com/elasticsearch/elasticsearch/issues/4754
+public class DFSFacetTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void foo() throws Exception {
+        createIndex("test-index");
+        client().prepareIndex("test-index", "test-type")
+                .setSource("{ \"id\": 123, \"test-value\": 321 }")
+                .setRefresh(true)
+                .execute()
+                .actionGet();
+        ensureGreen();
+
+        SearchResponse searchResponse = client()
+                .prepareSearch("test-index")
+                .setQuery(new MatchAllQueryBuilder())
+                .addFacet(new TermsFacetBuilder("test-facet").field("test-value"))
+                .setSearchType(SearchType.DFS_QUERY_AND_FETCH)
+                .execute()
+                .actionGet();
+
+        assertEquals(0, searchResponse.getFailedShards()); // Failing!
+    }
+
+}


### PR DESCRIPTION
When using DFS-query-then-fetch, some facet data-structures are acquired and
released on a different thread, which is something that is not supported by
the (soft) thread-local cache recycler.

On 1.x, this limitation has been removed, and all recyclers actually support
acquisitions and relases on different threads. This commit makes sure it also
works on 0.90 by making the stack that is used to store pending objects
synchronized. The performance impact of these synchronized blocks is expected
to be very low as there would be very little contention. By the way calls to
acquire/release are synchronized on the default cache recycler on 1.x.

Close #4754
