### PR TITLE
Use BytesReference to write to translog files

### DIFF
--- a/src/main/java/org/elasticsearch/common/bytes/ByteBufferBytesReference.java
+++ b/src/main/java/org/elasticsearch/common/bytes/ByteBufferBytesReference.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.channels.GatheringByteChannel;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
@@ -81,6 +82,11 @@ public class ByteBufferBytesReference implements BytesReference {
                 os.write(tmp);
             }
         }
+    }
+
+    @Override
+    public void writeTo(GatheringByteChannel channel) throws IOException {
+        channel.write(buffer);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -19,10 +19,7 @@
 
 package org.elasticsearch.common.bytes;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Arrays;
-
+import com.google.common.base.Charsets;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
@@ -31,7 +28,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
 
-import com.google.common.base.Charsets;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
+import java.util.Arrays;
 
 public class BytesArray implements BytesReference {
 
@@ -104,6 +105,11 @@ public class BytesArray implements BytesReference {
     @Override
     public void writeTo(OutputStream os) throws IOException {
         os.write(bytes, offset, length);
+    }
+
+    @Override
+    public void writeTo(GatheringByteChannel channel) throws IOException {
+        channel.write(ByteBuffer.wrap(bytes, offset, length()));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -24,6 +24,7 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.GatheringByteChannel;
 
 /**
  * A reference to bytes.
@@ -94,6 +95,11 @@ public interface BytesReference {
      * Writes the bytes directly to the output stream.
      */
     void writeTo(OutputStream os) throws IOException;
+
+    /**
+     * Writes the bytes directly to the channel.
+     */
+    void writeTo(GatheringByteChannel channel) throws IOException;
 
     /**
      * Returns the bytes as a single byte array.

--- a/src/main/java/org/elasticsearch/common/bytes/ChannelBufferBytesReference.java
+++ b/src/main/java/org/elasticsearch/common/bytes/ChannelBufferBytesReference.java
@@ -26,6 +26,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.WritableByteChannel;
 
 /**
  */
@@ -60,6 +62,11 @@ public class ChannelBufferBytesReference implements BytesReference {
     @Override
     public void writeTo(OutputStream os) throws IOException {
         buffer.getBytes(buffer.readerIndex(), os, length());
+    }
+
+    @Override
+    public void writeTo(GatheringByteChannel channel) throws IOException {
+        buffer.getBytes(buffer.readerIndex(), channel, length());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/bytes/HashedBytesArray.java
+++ b/src/main/java/org/elasticsearch/common/bytes/HashedBytesArray.java
@@ -28,6 +28,8 @@ import org.jboss.netty.buffer.ChannelBuffers;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
 
 /**
  * A bytes array reference that caches the hash code.
@@ -71,6 +73,11 @@ public class HashedBytesArray implements BytesReference {
     @Override
     public void writeTo(OutputStream os) throws IOException {
         os.write(bytes);
+    }
+
+    @Override
+    public void writeTo(GatheringByteChannel channel) throws IOException {
+        channel.write(ByteBuffer.wrap(bytes));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/translog/fs/BufferingFsTranslogFile.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/BufferingFsTranslogFile.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.index.translog.fs;
 
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogException;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -47,6 +49,7 @@ public class BufferingFsTranslogFile implements FsTranslogFile {
 
     private byte[] buffer;
     private int bufferCount;
+    private WrapperOutputStream bufferOs = new WrapperOutputStream();
 
     public BufferingFsTranslogFile(ShardId shardId, long id, RafReference raf, int bufferSize) throws IOException {
         this.shardId = shardId;
@@ -69,27 +72,26 @@ public class BufferingFsTranslogFile implements FsTranslogFile {
     }
 
     @Override
-    public Translog.Location add(byte[] data, int from, int size) throws IOException {
+    public Translog.Location add(BytesReference data) throws IOException {
         rwl.writeLock().lock();
         try {
             operationCounter++;
             long position = lastPosition;
-            if (size >= buffer.length) {
+            if (data.length() >= buffer.length) {
                 flushBuffer();
                 // we use the channel to write, since on windows, writing to the RAF might not be reflected
                 // when reading through the channel
-                raf.channel().write(ByteBuffer.wrap(data, from, size));
-                lastWrittenPosition += size;
-                lastPosition += size;
-                return new Translog.Location(id, position, size);
+                data.writeTo(raf.channel());
+                lastWrittenPosition += data.length();
+                lastPosition += data.length();
+                return new Translog.Location(id, position, data.length());
             }
-            if (size > buffer.length - bufferCount) {
+            if (data.length() > buffer.length - bufferCount) {
                 flushBuffer();
             }
-            System.arraycopy(data, from, buffer, bufferCount, size);
-            bufferCount += size;
-            lastPosition += size;
-            return new Translog.Location(id, position, size);
+            data.writeTo(bufferOs);
+            lastPosition += data.length();
+            return new Translog.Location(id, position, data.length());
         } finally {
             rwl.writeLock().unlock();
         }
@@ -209,6 +211,21 @@ public class BufferingFsTranslogFile implements FsTranslogFile {
             throw new TranslogException(shardId, "failed to flush", e);
         } finally {
             rwl.writeLock().unlock();
+        }
+    }
+
+    class WrapperOutputStream extends OutputStream {
+
+        @Override
+        public void write(int b) throws IOException {
+            buffer[bufferCount++] = (byte) b;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            // we do safety checked when we decide to use this stream...
+            System.arraycopy(b, off, buffer, bufferCount, len);
+            bufferCount += len;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -349,21 +349,15 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
             // seek back to end
             out.seek(size);
 
-            BytesReference ref = out.bytes();
-            // TODO: pass the BytesReference to the FsTranslogFile and have them optimize writing
-            if (!ref.hasArray()) {
-                ref = ref.toBytesArray();
-            }
-            byte[] refBytes = ref.array();
-            int refBytesOffset = ref.arrayOffset();
-            Location location = current.add(refBytes, refBytesOffset, size);
+            BytesReference bytes = out.bytes();
+            Location location = current.add(bytes);
             if (syncOnEachOperation) {
                 current.sync();
             }
             FsTranslogFile trans = this.trans;
             if (trans != null) {
                 try {
-                    location = trans.add(refBytes, refBytesOffset, size);
+                    location = trans.add(bytes);
                 } catch (ClosedChannelException e) {
                     // ignore
                 }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslogFile.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslogFile.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.translog.fs;
 
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogException;
@@ -61,7 +62,7 @@ public interface FsTranslogFile {
 
     long translogSizeInBytes();
 
-    Translog.Location add(byte[] data, int from, int size) throws IOException;
+    Translog.Location add(BytesReference data) throws IOException;
 
     byte[] read(Translog.Location location) throws IOException;
 


### PR DESCRIPTION
Instead of using byte arrays, pass the BytesReference to the actual translog file, and use the new copyTo(channel) method to write. This will improve by not potentially having to convert the data to a byte array
