### PR TITLE
Add support for lossless storage of BigDecimal numeric values in _source

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -476,13 +476,18 @@ public final class XContentBuilder implements BytesStream {
     }
 
     public XContentBuilder field(String name, BigDecimal value) throws IOException {
-        return field(name, value, value.scale(), RoundingMode.HALF_UP, true);
+        field(name);
+        generator.writeNumber(value);
+        return this;
     }
 
     public XContentBuilder field(XContentBuilderString name, BigDecimal value) throws IOException {
-        return field(name, value, value.scale(), RoundingMode.HALF_UP, true);
+        field(name);
+        generator.writeNumber(value);
+        return this;
     }
 
+    // TODO: Consider deprecating / removing ?
     public XContentBuilder field(String name, BigDecimal value, int scale, RoundingMode rounding, boolean toDouble) throws IOException {
         field(name);
         if (toDouble) {
@@ -497,6 +502,7 @@ public final class XContentBuilder implements BytesStream {
         return this;
     }
 
+    // TODO: Consider deprecating / removing ?
     public XContentBuilder field(XContentBuilderString name, BigDecimal value, int scale, RoundingMode rounding, boolean toDouble) throws IOException {
         field(name);
         if (toDouble) {
@@ -1127,6 +1133,8 @@ public final class XContentBuilder implements BytesStream {
             generator.writeNumber(((Float) value).floatValue());
         } else if (type == Double.class) {
             generator.writeNumber(((Double) value).doubleValue());
+        } else if (type == BigDecimal.class) {
+            generator.writeNumber((BigDecimal) value);
         } else if (type == Short.class) {
             generator.writeNumber(((Short) value).shortValue());
         } else if (type == Boolean.class) {

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentGenerator.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentGenerator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 
 /**
  *
@@ -65,6 +66,8 @@ public interface XContentGenerator {
     void writeNumber(double d) throws IOException;
 
     void writeNumber(float f) throws IOException;
+
+    void writeNumber(BigDecimal bd) throws IOException;
 
     void writeBoolean(boolean state) throws IOException;
 

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Map;
 
 /**
@@ -166,7 +167,9 @@ public interface XContentParser extends Closeable {
     float floatValue(boolean coerce) throws IOException;
 
     double doubleValue(boolean coerce) throws IOException;
-    
+
+    BigDecimal decimalValue(boolean coerce) throws IOException;
+
     short shortValue() throws IOException;
 
     int intValue() throws IOException;
@@ -176,6 +179,8 @@ public interface XContentParser extends Closeable {
     float floatValue() throws IOException;
 
     double doubleValue() throws IOException;
+
+    BigDecimal decimalValue() throws IOException;
 
     /**
      * returns true if the current value is boolean in nature.

--- a/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -45,6 +45,7 @@ public class JsonXContent implements XContent {
         jsonFactory = new JsonFactory();
         jsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
         jsonFactory.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, true);
+        jsonFactory.configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
         jsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         jsonXContent = new JsonXContent();
     }

--- a/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 
 /**
  *
@@ -129,6 +130,11 @@ public class JsonXContentGenerator implements XContentGenerator {
     @Override
     public void writeNumber(float f) throws IOException {
         generator.writeNumber(f);
+    }
+
+    @Override
+    public void writeNumber(BigDecimal bd) throws IOException {
+        generator.writeNumber(bd);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 /**
  *
@@ -176,6 +177,10 @@ public class JsonXContentParser extends AbstractXContentParser {
     @Override
     public double doDoubleValue() throws IOException {
         return parser.getDoubleValue();
+    }
+    @Override
+    public BigDecimal doDecimalValue() throws IOException {
+        return parser.getDecimalValue();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/source/BigDecimalSupportTests.java
+++ b/src/test/java/org/elasticsearch/search/source/BigDecimalSupportTests.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.source;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BigDecimalSupportTests extends ElasticsearchIntegrationTest {
+
+    public static final String TEST_INDEX = "test";
+    public static final String TEST_TYPE = "type1";
+    private final String verySmallValueAsString = "0.0000000000000000000000000000000000000100";
+    private final String veryBigValueAsString = "10000000000000000000000000000000000000.01000";
+    BigDecimal verySmallValue = new BigDecimal(verySmallValueAsString);
+    BigDecimal veryBigValue = new BigDecimal(veryBigValueAsString);
+    String verySmallValueKey = "verySmallValue";
+    String veryBigValueKey = "veryBigValue";
+
+    Map<String, Object> data = new HashMap<String, Object>(){{
+        put(verySmallValueKey, verySmallValue);
+        put(veryBigValueKey, veryBigValue);
+    }};
+
+    @Test
+    public void testWillPreserveBigDecimalValuesInAMapFaithfully() {
+        createIndex(TEST_INDEX);
+        ensureGreen();
+
+
+        index(TEST_INDEX, TEST_TYPE, "1", data);
+        refresh();
+
+        SearchResponse response = client().prepareSearch(TEST_INDEX).get();
+        Map<String, Object> source = response.getHits().getAt(0).getSource();
+
+        assertValueEquals(source, verySmallValueKey, verySmallValueAsString, verySmallValue);
+        assertValueEquals(source, veryBigValueKey, veryBigValueAsString, veryBigValue);
+    }
+
+    @Test
+    public void testWillPreserveBigDecimalValuesFaithfully() {
+        createIndex(TEST_INDEX);
+        ensureGreen();
+
+
+        index(TEST_INDEX, TEST_TYPE, "2",
+                verySmallValueKey, verySmallValue,
+                veryBigValueKey, veryBigValue
+        );
+        refresh();
+
+        SearchResponse response = client().prepareSearch(TEST_INDEX).get();
+        Map<String, Object> source = response.getHits().getAt(0).getSource();
+
+        assertValueEquals(source, verySmallValueKey, verySmallValueAsString, verySmallValue);
+        assertValueEquals(source, veryBigValueKey, veryBigValueAsString, veryBigValue);
+    }
+
+    private void assertValueEquals(Map<String, Object> source, String valueKey, String valueAsString, BigDecimal value) {
+        Object retrievedSmallValue = source.get(valueKey);
+        assertThat(retrievedSmallValue, Matchers.instanceOf(BigDecimal.class));
+        assertEquals(valueAsString, ((BigDecimal) retrievedSmallValue).toPlainString());
+        assertEquals(value, retrievedSmallValue);
+    }
+
+    @Test
+    public void testWillPreserveBigDecimalValuesInJson() {
+        createIndex(TEST_INDEX);
+        ensureGreen();
+
+        Map<String, Object> data = new HashMap<String, Object>(){{
+            put(verySmallValueKey, verySmallValue);
+            put(veryBigValueKey, veryBigValue);
+        }};
+
+
+        index(TEST_INDEX, TEST_TYPE, "3", data);
+        refresh();
+
+        SearchResponse response = client().prepareSearch(TEST_INDEX).get();
+        assertThat(response.getHits().getAt(0).getSourceAsString(), Matchers.equalTo("{\"veryBigValue\":" + veryBigValueAsString + ",\"verySmallValue\":" + verySmallValueAsString + "}"));
+    }
+}


### PR DESCRIPTION
Issue #5380

Want to be able to save BigDecimal in and get BigDecimal back out - and not have any loss of info due to conversion to double on the way.

Not sure how it should be configured yet - just put a static field for now.
