### PR TITLE
[DOCS] add compass and compress_threshold to binary field mapping doc

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -427,6 +427,9 @@ Defaults to the property/field name.
 |`store` |Set to `true` to store actual field in the index, `false` to not
 store it. Defaults to `false` (note, the JSON document itself is stored,
 and it can be retrieved from it).
+|`compress` |Set to `true` to compress the binary value.
+|`compress_threshold` |Minimal binary value size that compress operation
+should be performed. Defaults to `-1`
 |=======================================================================
 
 [float]


### PR DESCRIPTION
`compress` and `compress_threshold` are exist in BinaryFieldMapper however are not documented
