### PR TITLE
merge GeoPoint specific mapping properties

### DIFF
--- a/docs/reference/mapping/types/geo-point-type.asciidoc
+++ b/docs/reference/mapping/types/geo-point-type.asciidoc
@@ -154,6 +154,10 @@ is `true`).
 |`normalize_lat` |Set to `true` to normalize latitude.
 
 |`normalize_lon` |Set to `true` to normalize longitude.
+
+|`precision_step` |The precision step (number of terms generated for
+each number value) for `.lat` and `.lon` fields if `lat_lon` is set to `true`.
+Defaults to `4`.
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -394,8 +394,8 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
 
     private final StringFieldMapper geohashMapper;
 
-    private final boolean validateLon;
-    private final boolean validateLat;
+    private boolean validateLon;
+    private boolean validateLat;
 
     private final boolean normalizeLon;
     private final boolean normalizeLat;
@@ -613,7 +613,38 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
     @Override
     public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
         super.merge(mergeWith, mergeContext);
-        // TODO: geo-specific properties
+        if (!this.getClass().equals(mergeWith.getClass())) {
+            return;
+        }
+        GeoPointFieldMapper fieldMergeWith = (GeoPointFieldMapper) mergeWith;
+
+        if (this.enableLatLon != fieldMergeWith.enableLatLon) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different lat_lon");
+        }
+        if (this.enableGeoHash != fieldMergeWith.enableGeoHash) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different geohash");
+        }
+        if (this.geoHashPrecision != fieldMergeWith.geoHashPrecision) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different geohash_precision");
+        }
+        if (this.enableGeohashPrefix != fieldMergeWith.enableGeohashPrefix) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different geohash_prefix");
+        }
+        if (this.normalizeLat != fieldMergeWith.normalizeLat) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different normalize_lat");
+        }
+        if (this.normalizeLon != fieldMergeWith.normalizeLon) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different normalize_lon");
+        }
+        if (this.precisionStep != fieldMergeWith.precisionStep) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different precision_step");
+        }
+
+
+        if (!mergeContext.mergeFlags().simulate()) {
+            this.validateLat = fieldMergeWith.validateLat;
+            this.validateLon = fieldMergeWith.validateLon;
+        }
     }
 
     @Override


### PR DESCRIPTION
closes #5505
I assume only `validate_lat` and `validate_lon` can be updated, other fields will throw exceptions. Please let me know if I was wrong.

Also added `precision_step` to the document page
