### PR TITLE
Allow to disable norms on an existing field.

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -112,6 +112,7 @@ all.
 
 |`norms.enabled` |Boolean value if norms should be enabled or not. Defaults
 to `true` for `analyzed` fields, and to `false` for `not_analyzed` fields.
+See the <<norms,section about norms>>.
 
 |`norms.loading` |Describes how norms should be loaded, possible values are
 `eager` and `lazy` (default). It is possible to change the default value to
@@ -165,6 +166,27 @@ Otherwise, the structure would interpret "message" as a value of type
 "object". The key `_value` (or `value`) in the inner document specifies
 the real string content that should eventually be indexed. The `_boost`
 (or `boost`) key specifies the per field document boost (here 2.0).
+
+[float]
+[[norms]]
+===== Norms
+
+Norms store various normalization factors that are later used (at query time)
+in order to compute the score of a document relatively to a query.
+
+Although useful for scoring, norms also require quite a lot of memory
+(typically in the order of one byte per document per field in your index,
+even for documents that don't have this specific field). As a consequence, if
+you don't need scoring on a specific field, it is highly recommended to disable
+norms on it. In  particular, this is the case for fields that are used solely
+for filtering or aggregations.
+
+In case you would like to disable norms after the fact, it is possible to do so
+by using the <<indices-put-mapping,PUT mapping API>>. Please however note that
+norms won't be removed instantly, but as your index will receive new insertions
+or updates, and segments get merged. Any score computation on a field that got
+norms removed might return inconsistent results since some documents won't have
+norms anymore while other documents might still have norms.
 
 [float]
 [[number]]

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -620,7 +620,9 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
 
         if (!mergeContext.mergeFlags().simulate()) {
             // apply changeable values
-            this.fieldType = fieldMergeWith.fieldType;
+            this.fieldType = new FieldType(this.fieldType);
+            this.fieldType.setOmitNorms(fieldMergeWith.fieldType.omitNorms());
+            this.fieldType.freeze();
             this.boost = fieldMergeWith.boost;
             this.normsLoading = fieldMergeWith.normsLoading;
             this.copyTo = fieldMergeWith.copyTo;

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -264,7 +264,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
 
     protected final Names names;
     protected float boost;
-    protected final FieldType fieldType;
+    protected FieldType fieldType;
     private final boolean docValues;
     protected final NamedAnalyzer indexAnalyzer;
     protected NamedAnalyzer searchAnalyzer;
@@ -579,8 +579,8 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             // when the doc_values field data format is configured
             mergeContext.addConflict("mapper [" + names.fullName() + "] has different " + TypeParsers.DOC_VALUES + " values");
         }
-        if (this.fieldType().omitNorms() != fieldMergeWith.fieldType.omitNorms()) {
-            mergeContext.addConflict("mapper [" + names.fullName() + "] has different `norms.enabled` values");
+        if (this.fieldType().omitNorms() && !fieldMergeWith.fieldType.omitNorms()) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] cannot enable norms (`norms.enabled`)");
         }
         if (this.fieldType().tokenized() != fieldMergeWith.fieldType().tokenized()) {
             mergeContext.addConflict("mapper [" + names.fullName() + "] has different tokenize values");
@@ -620,6 +620,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
 
         if (!mergeContext.mergeFlags().simulate()) {
             // apply changeable values
+            this.fieldType = fieldMergeWith.fieldType;
             this.boost = fieldMergeWith.boost;
             this.normsLoading = fieldMergeWith.normsLoading;
             this.copyTo = fieldMergeWith.copyTo;


### PR DESCRIPTION
I followed @nik9000 's idea to carefully document the caveat of disabling
norms as opposed to trying to wrap readers at search time to hide norms.

Close #4813
