### PR TITLE
Add the `field_value_factor` function to the function_score query

### DIFF
--- a/docs/reference/mapping/fields/boost-field.asciidoc
+++ b/docs/reference/mapping/fields/boost-field.asciidoc
@@ -56,8 +56,8 @@ any field the document:
                 }
             },
             "functions": [{
-                "script_score": { <2>
-                    "script": "doc['my_boost_field'].value"
+                "field_value_factor": { <2>
+                    "field": "my_boost_field"
                 }
             }],
             "score_mode": "multiply"
@@ -66,7 +66,5 @@ any field the document:
 }
 --------------------------------------------------
 <1> The original query, now wrapped in a `function_score` query.
-<2> This script returns the value in `my_boost_field`, which is then
+<2> This function returns the value in `my_boost_field`, which is then
     multiplied by the query `_score` for each document.
-
-

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -248,7 +248,7 @@ scale value.
 
 ===== Field Value factor
 The `field_value_factor` function allows you to use a field from a document to
-influnce the score. It's similar to using the `script_score` function, however,
+influence the score. It's similar to using the `script_score` function, however,
 it avoids the overhead of scripting. If used on a multi-valued field, only the
 first value of the field is used in calculations.
 
@@ -277,12 +277,13 @@ There are a number of options for the `field_value_factor` function:
 |`field` |Field to be extracted from the document.
 |`factor` |Optional factor to multiply the field value with, defaults to 1.
 |`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
- `ln`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
+ `log1p` `ln`, `ln1p`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
 |=======================================================================
 
 Keep in mind that taking the log() of 0, or the square root of a negative number
 is an illegal operation, and an exception will be thrown. Be sure to limit the
-values of the field with a range filter to avoid this.
+values of the field with a range filter to avoid this, or use `log1p` and
+`ln1p`.
 
 ==== Detailed example
 

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -246,6 +246,43 @@ In contrast to the normal and exponential decay, this function actually
 sets the score to 0 if the field value exceeds twice the user given
 scale value.
 
+===== Field Value factor
+The `field_value_factor` function allows you to use a field from a document to
+influnce the score. It's similar to using the `script_score` function, however,
+it avoids the overhead of scripting. If used on a multi-valued field, only the
+first value of the field is used in calculations.
+
+As an example, imagine you have a document indexed with a numeric `popularity`
+field and wish in influence the score of a document with this field, an example
+doing so would look like:
+
+[source,js]
+--------------------------------------------------
+"field_value_factor": {
+  "field": "popularity",
+  "factor": 1.2,
+  "modifier": "sqrt"
+}
+--------------------------------------------------
+
+Which will translate into the following forumla for scoring:
+
+`_score * sqrt(1.2 * doc['popularity'].value)`
+
+There are a number of options for the `field_value_factor` function:
+
+[cols="<,<",options="header",]
+|=======================================================================
+| Parameter |Description
+|`field` |Field to be extracted from the document.
+|`factor` |Optional factor to multiply the field value with, defaults to 1.
+|`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
+ `ln`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
+|`lenient` |Flag specifying whether to ignore non-numeric results (NaN and
+ Infinity), defaults to false, meaning an exception will be thrown on dividing
+ by zero or taking the square root of a negative number.
+|=======================================================================
+
 ==== Detailed example
 
 Suppose you are searching for a hotel in a certain town. Your budget is
@@ -487,5 +524,3 @@ becomes:
     "score_mode": "first"
 }
 --------------------------------------------------
-
-

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -278,9 +278,9 @@ There are a number of options for the `field_value_factor` function:
 |`factor` |Optional factor to multiply the field value with, defaults to 1.
 |`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
  `ln`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
-|`lenient` |Flag specifying whether to ignore non-numeric results (NaN and
- Infinity), defaults to false, meaning an exception will be thrown on dividing
- by zero or taking the square root of a negative number.
+|`ignore_missing` |Flag specifying whether to return the score unmodified if the
+ field does not exist. Defaults to false, meaning an exception will be thrown if
+ the field is not in the document.
 |=======================================================================
 
 ==== Detailed example

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -267,7 +267,7 @@ doing so would look like:
 
 Which will translate into the following forumla for scoring:
 
-`_score * sqrt(1.2 * doc['popularity'].value)`
+`sqrt(1.2 * doc['popularity'].value)`
 
 There are a number of options for the `field_value_factor` function:
 
@@ -280,8 +280,13 @@ There are a number of options for the `field_value_factor` function:
  `ln`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
 |`ignore_missing` |Flag specifying whether to return the score unmodified if the
  field does not exist. Defaults to false, meaning an exception will be thrown if
- the field is not in the document.
+ the field is not in the document. If set to true, 0 is used in place of missing
+ values.
 |=======================================================================
+
+Keep in mind that taking the log() of 0, or the square root of a negative number
+is an illegal operation, and an exception will be thrown. Be sure to limit the
+values of the field with a range query to avoid this.
 
 ==== Detailed example
 

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -277,7 +277,8 @@ There are a number of options for the `field_value_factor` function:
 |`field` |Field to be extracted from the document.
 |`factor` |Optional factor to multiply the field value with, defaults to 1.
 |`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
- `log1p` `ln`, `ln1p`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
+ `log1p`, `log2p`, `ln`, `ln1p`, `ln2p`, `square`, `sqrt`, or `reciprocal`.
+ Defaults to `none`.
 |=======================================================================
 
 Keep in mind that taking the log() of 0, or the square root of a negative number

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -278,15 +278,11 @@ There are a number of options for the `field_value_factor` function:
 |`factor` |Optional factor to multiply the field value with, defaults to 1.
 |`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
  `ln`, `square`, `sqrt`, or `reciprocal`. Defaults to `none`.
-|`ignore_missing` |Flag specifying whether to return the score unmodified if the
- field does not exist. Defaults to false, meaning an exception will be thrown if
- the field is not in the document. If set to true, 0 is used in place of missing
- values.
 |=======================================================================
 
 Keep in mind that taking the log() of 0, or the square root of a negative number
 is an illegal operation, and an exception will be thrown. Be sure to limit the
-values of the field with a range query to avoid this.
+values of the field with a range filter to avoid this.
 
 ==== Detailed example
 

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.search.function;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * A function_score function that multiplies the score with the value of a
+ * field from the document, optionally multiplying the field by a factor first,
+ * and applying a modification (log, ln, sqrt, square, etc) afterwards.
+ */
+public class FieldValueFactorFunction extends ScoreFunction {
+    private final String field;
+    private final float boostFactor;
+    private final Modifier modifier;
+    private final boolean lenient;
+    private AtomicReaderContext currentContext;
+
+    public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType, boolean lenient) {
+        super(CombineFunction.MULT);
+        this.field = field;
+        this.boostFactor = boostFactor;
+        this.modifier = modifierType;
+        this.lenient = lenient;
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext context) {
+        this.currentContext = context;
+    }
+
+    @Override
+    public double score(int docId, float subQueryScore) {
+        SearchContext searchContext = SearchContext.current();
+        FieldMapper mapper = searchContext.mapperService().smartNameFieldMapper(field);
+        if (mapper != null) {
+            AtomicFieldData data = searchContext.fieldData().getForField(mapper).load(currentContext);
+            ScriptDocValues values = data.getScriptValues();
+            values.setNextDocId(docId);
+            List<?> actualValues = values.getValues();
+            if (actualValues.size() > 0) {
+                Object o = actualValues.get(0);
+                double val;
+                if (o instanceof Long) {
+                    val = (long)o;
+                } else if (o instanceof Double) {
+                    val = (double)o;
+                } else {
+                    throw new ElasticsearchException("Invalid data type for field [" + field + "]");
+                }
+                return subQueryScore * Modifier.apply(modifier, val * boostFactor, lenient);
+            } else {
+                return subQueryScore;
+            }
+        }
+        throw new ElasticsearchException("Unable to find a fieldmapper for field [" + field + "]");
+    }
+
+    @Override
+    public Explanation explainScore(int docId, Explanation subQueryExpl) {
+        Explanation exp = new Explanation();
+        String modifierStr = modifier != null ? modifier.toString() : "";
+        double score = score(docId, subQueryExpl.getValue());
+        exp.setValue(CombineFunction.toFloat(score));
+        exp.setDescription("field value function, score=" + score +
+                " product of " + "_score=" + subQueryExpl.getValue() + " * " +
+                modifierStr + "(" + "val * factor=" + boostFactor + ")");
+        exp.addDetail(subQueryExpl);
+        return exp;
+    }
+
+    /**
+     * The Type class encapsulates the modification types that can be applied
+     * to the score/value product.
+     */
+    public enum Modifier {
+        NONE,
+        LOG,
+        LN,
+        SQUARE,
+        SQRT,
+        RECIPROCAL;
+
+        public static double apply(Modifier t, double n, boolean lenient) {
+            if (t == null) {
+                return n;
+            }
+            double result = n;
+            switch (t) {
+                case NONE:
+                    break;
+                case LOG:
+                    result = Math.log10(n);
+                    break;
+                case LN:
+                    result = Math.log(n);
+                    break;
+                case SQUARE:
+                    result = Math.pow(n, 2);
+                    break;
+                case SQRT:
+                    result = Math.sqrt(n);
+                    break;
+                case RECIPROCAL:
+                    result = 1.0 / n;
+                    break;
+                default: throw new ElasticsearchIllegalArgumentException("Unknown modifier type: [" + t + "]");
+            }
+            if (Double.isNaN(result) || Double.isInfinite(result)) {
+                if (lenient) {
+                    return 0;
+                } else {
+                    throw new ElasticsearchException("Result of field modification [" + t.toString() +
+                            "(" + n + ")] must be a number");
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            if (this == NONE) {
+                return "";
+            }
+            return super.toString().toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -100,7 +100,9 @@ public class FieldValueFactorFunction extends ScoreFunction {
     public enum Modifier {
         NONE,
         LOG,
+        LOG1P,
         LN,
+        LN1P,
         SQUARE,
         SQRT,
         RECIPROCAL;
@@ -116,8 +118,14 @@ public class FieldValueFactorFunction extends ScoreFunction {
                 case LOG:
                     result = Math.log10(n);
                     break;
+                case LOG1P:
+                    result = Math.log10(n + 1);
+                    break;
                 case LN:
                     result = Math.log(n);
+                    break;
+                case LN1P:
+                    result = Math.log1p(n);
                     break;
                 case SQUARE:
                     result = Math.pow(n, 2);

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -26,8 +26,6 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.util.List;
 import java.util.Locale;
@@ -41,21 +39,15 @@ public class FieldValueFactorFunction extends ScoreFunction {
     private final String field;
     private final float boostFactor;
     private final Modifier modifier;
-    private final FieldMapper mapper;
     private final IndexFieldData indexFieldData;
     private AtomicFieldData fieldData;
 
-    public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType) {
+    public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType, IndexFieldData indexFieldData) {
         super(CombineFunction.MULT);
         this.field = field;
         this.boostFactor = boostFactor;
         this.modifier = modifierType;
-        SearchContext searchContext = SearchContext.current();
-        this.mapper = searchContext.mapperService().smartNameFieldMapper(field);
-        if (this.mapper == null) {
-            throw new ElasticsearchException("Unable to find a field mapper for field [" + field + "]");
-        }
-        this.indexFieldData = searchContext.fieldData().getForField(mapper);
+        this.indexFieldData = indexFieldData;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -103,6 +103,12 @@ public class FieldValueFactorFunction extends ScoreFunction {
                 return Math.log10(n + 1);
             }
         },
+        LOG2P {
+            @Override
+            public double apply(double n) {
+                return Math.log10(n + 2);
+            }
+        },
         LN {
             @Override
             public double apply(double n) {
@@ -113,6 +119,12 @@ public class FieldValueFactorFunction extends ScoreFunction {
             @Override
             public double apply(double n) {
                 return Math.log1p(n);
+            }
+        },
+        LN2P {
+            @Override
+            public double apply(double n) {
+                return Math.log1p(n + 1);
             }
         },
         SQUARE {

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -44,7 +44,6 @@ public class FieldValueFactorFunction extends ScoreFunction {
     private final FieldMapper mapper;
     private final IndexFieldData indexFieldData;
     private AtomicFieldData fieldData;
-    private AtomicReaderContext currentContext;
 
     public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType) {
         super(CombineFunction.MULT);

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -75,12 +75,12 @@ public class FieldValueFactorFunction extends ScoreFunction {
                 } else {
                     throw new ElasticsearchException("Invalid data type for field [" + field + "]");
                 }
-                return subQueryScore * Modifier.apply(modifier, val * boostFactor);
+                return Modifier.apply(modifier, val * boostFactor);
             } else {
                 if (ignoreMissing) {
-                    return subQueryScore;
+                    return 0;
                 } else {
-                    throw new ElasticsearchException("Invalid data type for field [" + field + "]");
+                    throw new ElasticsearchException("Missing value for field [" + field + "]");
                 }
             }
         }
@@ -93,9 +93,8 @@ public class FieldValueFactorFunction extends ScoreFunction {
         String modifierStr = modifier != null ? modifier.toString() : "";
         double score = score(docId, subQueryExpl.getValue());
         exp.setValue(CombineFunction.toFloat(score));
-        exp.setDescription("field value function, score=" + score +
-                " product of " + "_score=" + subQueryExpl.getValue() + " * " +
-                modifierStr + "(" + "val * factor=" + boostFactor + ")");
+        exp.setDescription("field value function: " +
+                modifierStr + "(" + "doc['" + field + "'].value * factor=" + boostFactor + ")");
         exp.addDetail(subQueryExpl);
         return exp;
     }

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -40,15 +40,13 @@ public class FieldValueFactorFunction extends ScoreFunction {
     private final String field;
     private final float boostFactor;
     private final Modifier modifier;
-    private final boolean ignoreMissing;
     private AtomicReaderContext currentContext;
 
-    public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType, boolean ignoreMissing) {
+    public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType) {
         super(CombineFunction.MULT);
         this.field = field;
         this.boostFactor = boostFactor;
         this.modifier = modifierType;
-        this.ignoreMissing = ignoreMissing;
     }
 
     @Override
@@ -77,11 +75,7 @@ public class FieldValueFactorFunction extends ScoreFunction {
                 }
                 return Modifier.apply(modifier, val * boostFactor);
             } else {
-                if (ignoreMissing) {
-                    return 0;
-                } else {
-                    throw new ElasticsearchException("Missing value for field [" + field + "]");
-                }
+                throw new ElasticsearchException("Missing value for field [" + field + "]");
             }
         }
         throw new ElasticsearchException("Unable to find a fieldmapper for field [" + field + "]");

--- a/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.internal.SearchContext;
@@ -40,6 +41,9 @@ public class FieldValueFactorFunction extends ScoreFunction {
     private final String field;
     private final float boostFactor;
     private final Modifier modifier;
+    private final FieldMapper mapper;
+    private final IndexFieldData indexFieldData;
+    private AtomicFieldData fieldData;
     private AtomicReaderContext currentContext;
 
     public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType) {
@@ -47,38 +51,38 @@ public class FieldValueFactorFunction extends ScoreFunction {
         this.field = field;
         this.boostFactor = boostFactor;
         this.modifier = modifierType;
+        SearchContext searchContext = SearchContext.current();
+        this.mapper = searchContext.mapperService().smartNameFieldMapper(field);
+        if (this.mapper == null) {
+            throw new ElasticsearchException("Unable to find a field mapper for field [" + field + "]");
+        }
+        this.indexFieldData = searchContext.fieldData().getForField(mapper);
     }
 
     @Override
     public void setNextReader(AtomicReaderContext context) {
-        this.currentContext = context;
+        this.fieldData = this.indexFieldData.load(context);
     }
 
     @Override
     public double score(int docId, float subQueryScore) {
-        SearchContext searchContext = SearchContext.current();
-        FieldMapper mapper = searchContext.mapperService().smartNameFieldMapper(field);
-        if (mapper != null) {
-            AtomicFieldData data = searchContext.fieldData().getForField(mapper).load(currentContext);
-            ScriptDocValues values = data.getScriptValues();
-            values.setNextDocId(docId);
-            List<?> actualValues = values.getValues();
-            if (actualValues.size() > 0) {
-                Object o = actualValues.get(0);
-                double val;
-                if (o instanceof Long) {
-                    val = (long)o;
-                } else if (o instanceof Double) {
-                    val = (double)o;
-                } else {
-                    throw new ElasticsearchException("Invalid data type for field [" + field + "]");
-                }
-                return Modifier.apply(modifier, val * boostFactor);
+        ScriptDocValues values = this.fieldData.getScriptValues();
+        values.setNextDocId(docId);
+        List<?> actualValues = values.getValues();
+        if (actualValues.size() > 0) {
+            Object o = actualValues.get(0);
+            double val;
+            if (o instanceof Long) {
+                val = (long)o;
+            } else if (o instanceof Double) {
+                val = (double)o;
             } else {
-                throw new ElasticsearchException("Missing value for field [" + field + "]");
+                throw new ElasticsearchException("Invalid data type for field [" + field + "]");
             }
+            return Modifier.apply(modifier, val * boostFactor);
+        } else {
+            throw new ElasticsearchException("Missing value for field [" + field + "]");
         }
-        throw new ElasticsearchException("Unable to find a fieldmapper for field [" + field + "]");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreModule.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreModule.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.Multibinder;
 import org.elasticsearch.index.query.functionscore.exp.ExponentialDecayFunctionParser;
 import org.elasticsearch.index.query.functionscore.factor.FactorParser;
+import org.elasticsearch.index.query.functionscore.fieldvaluefactor.FieldValueFactorFunctionParser;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionParser;
 import org.elasticsearch.index.query.functionscore.lin.LinearDecayFunctionParser;
 import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionParser;
@@ -44,6 +45,7 @@ public class FunctionScoreModule extends AbstractModule {
         registerParser(LinearDecayFunctionParser.class);
         registerParser(ExponentialDecayFunctionParser.class);
         registerParser(RandomScoreFunctionParser.class);
+        registerParser(FieldValueFactorFunctionParser.class);
     }
 
     public void registerParser(Class<? extends ScoreFunctionParser> parser) {

--- a/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilders.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query.functionscore;
 
 import org.elasticsearch.index.query.functionscore.exp.ExponentialDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.factor.FactorBuilder;
+import org.elasticsearch.index.query.functionscore.fieldvaluefactor.FieldValueFactorFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.lin.LinearDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionBuilder;
@@ -76,5 +77,9 @@ public class ScoreFunctionBuilders {
 
     public static RandomScoreFunctionBuilder randomFunction(long seed) {
         return (new RandomScoreFunctionBuilder()).seed(seed);
+    }
+
+    public static FieldValueFactorFunctionBuilder fieldValueFactorFunction(String fieldName) {
+        return new FieldValueFactorFunctionBuilder(fieldName);
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
@@ -33,7 +33,7 @@ import java.util.Locale;
 public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
     private String field = null;
     private Float factor = null;
-    private Boolean lenient = null;
+    private Boolean ignoreMissing = null;
     private FieldValueFactorFunction.Modifier modifier = null;
 
     public FieldValueFactorFunctionBuilder(String fieldName) {
@@ -55,8 +55,8 @@ public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
         return this;
     }
 
-    public FieldValueFactorFunctionBuilder lenient(boolean lenient) {
-        this.lenient = lenient;
+    public FieldValueFactorFunctionBuilder ignoreMissing(boolean ignoreMissing) {
+        this.ignoreMissing = ignoreMissing;
         return this;
     }
 
@@ -75,8 +75,8 @@ public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
             builder.field("modifier", modifier.toString().toLowerCase(Locale.ROOT));
         }
 
-        if (lenient != null) {
-            builder.field("lenient", lenient);
+        if (ignoreMissing != null) {
+            builder.field("ignore_missing", ignoreMissing);
         }
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
@@ -33,7 +33,6 @@ import java.util.Locale;
 public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
     private String field = null;
     private Float factor = null;
-    private Boolean ignoreMissing = null;
     private FieldValueFactorFunction.Modifier modifier = null;
 
     public FieldValueFactorFunctionBuilder(String fieldName) {
@@ -55,11 +54,6 @@ public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
         return this;
     }
 
-    public FieldValueFactorFunctionBuilder ignoreMissing(boolean ignoreMissing) {
-        this.ignoreMissing = ignoreMissing;
-        return this;
-    }
-
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getName());
@@ -73,10 +67,6 @@ public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
 
         if (modifier != null) {
             builder.field("modifier", modifier.toString().toLowerCase(Locale.ROOT));
-        }
-
-        if (ignoreMissing != null) {
-            builder.field("ignore_missing", ignoreMissing);
         }
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.functionscore.fieldvaluefactor;
+
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Builder to construct {@code field_value_factor} functions for a function
+ * score query.
+ */
+public class FieldValueFactorFunctionBuilder implements ScoreFunctionBuilder {
+    private String field = null;
+    private Float factor = null;
+    private Boolean lenient = null;
+    private FieldValueFactorFunction.Modifier modifier = null;
+
+    public FieldValueFactorFunctionBuilder(String fieldName) {
+        this.field = fieldName;
+    }
+
+    @Override
+    public String getName() {
+        return FieldValueFactorFunctionParser.NAMES[0];
+    }
+
+    public FieldValueFactorFunctionBuilder factor(float boostFactor) {
+        this.factor = boostFactor;
+        return this;
+    }
+
+    public FieldValueFactorFunctionBuilder modifier(FieldValueFactorFunction.Modifier modifier) {
+        this.modifier = modifier;
+        return this;
+    }
+
+    public FieldValueFactorFunctionBuilder lenient(boolean lenient) {
+        this.lenient = lenient;
+        return this;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(getName());
+        if (field != null) {
+            builder.field("field", field);
+        }
+
+        if (factor != null) {
+            builder.field("factor", factor);
+        }
+
+        if (modifier != null) {
+            builder.field("modifier", modifier.toString().toLowerCase(Locale.ROOT));
+        }
+
+        if (lenient != null) {
+            builder.field("lenient", lenient);
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
@@ -54,7 +55,7 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
         String currentFieldName = null;
         String field = null;
         float boostFactor = 1;
-        FieldValueFactorFunction.Modifier modifier = null;
+        FieldValueFactorFunction.Modifier modifier = FieldValueFactorFunction.Modifier.NONE;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -81,7 +82,8 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
         if (mapper == null) {
             throw new ElasticsearchException("Unable to find a field mapper for field [" + field + "]");
         }
-        return new FieldValueFactorFunction(field, boostFactor, modifier, searchContext.fieldData().getForField(mapper));
+        return new FieldValueFactorFunction(field, boostFactor, modifier,
+                (IndexNumericFieldData)searchContext.fieldData().getForField(mapper));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.functionscore.fieldvaluefactor;
+
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Parses out a function_score function that looks like:
+ *
+ * <pre>
+ *     {
+ *         "field_value_factor": {
+ *             "field": "myfield",
+ *             "factor": 1.5,
+ *             "modifier": "square"
+ *         }
+ *     }
+ * </pre>
+ */
+public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
+    public static String[] NAMES = { "field_value_factor", "fieldValueFactor" };
+
+    @Override
+    public ScoreFunction parse(QueryParseContext parseContext, XContentParser parser) throws IOException, QueryParsingException {
+
+        String currentFieldName = null;
+        String field = null;
+        boolean lenient = false;
+        float boostFactor = 1;
+        FieldValueFactorFunction.Modifier modifier = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if ("field".equals(currentFieldName)) {
+                    field = parser.text();
+                } else if ("factor".equals(currentFieldName)) {
+                    boostFactor = parser.floatValue();
+                } else if ("modifier".equals(currentFieldName)) {
+                    modifier = FieldValueFactorFunction.Modifier.valueOf(parser.text().toUpperCase(Locale.ROOT));
+                } else if ("lenient".equals(currentFieldName)) {
+                    lenient = parser.booleanValue();
+                } else {
+                    throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
+                }
+            }
+        }
+
+        return new FieldValueFactorFunction(field, boostFactor, modifier, lenient);
+    }
+
+    @Override
+    public String[] getNames() {
+        return NAMES;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -50,7 +50,6 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
 
         String currentFieldName = null;
         String field = null;
-        boolean ignoreMissing = false;
         float boostFactor = 1;
         FieldValueFactorFunction.Modifier modifier = null;
         XContentParser.Token token;
@@ -64,8 +63,6 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
                     boostFactor = parser.floatValue();
                 } else if ("modifier".equals(currentFieldName)) {
                     modifier = FieldValueFactorFunction.Modifier.valueOf(parser.text().toUpperCase(Locale.ROOT));
-                } else if ("ignore_missing".equals(currentFieldName)) {
-                    ignoreMissing = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
@@ -76,7 +73,7 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
             throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing");
         }
 
-        return new FieldValueFactorFunction(field, boostFactor, modifier, ignoreMissing);
+        return new FieldValueFactorFunction(field, boostFactor, modifier);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -72,6 +72,10 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
             }
         }
 
+        if (field == null) {
+            throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing");
+        }
+
         return new FieldValueFactorFunction(field, boostFactor, modifier, lenient);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionParser.java
@@ -50,7 +50,7 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
 
         String currentFieldName = null;
         String field = null;
-        boolean lenient = false;
+        boolean ignoreMissing = false;
         float boostFactor = 1;
         FieldValueFactorFunction.Modifier modifier = null;
         XContentParser.Token token;
@@ -64,8 +64,8 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
                     boostFactor = parser.floatValue();
                 } else if ("modifier".equals(currentFieldName)) {
                     modifier = FieldValueFactorFunction.Modifier.valueOf(parser.text().toUpperCase(Locale.ROOT));
-                } else if ("lenient".equals(currentFieldName)) {
-                    lenient = parser.booleanValue();
+                } else if ("ignore_missing".equals(currentFieldName)) {
+                    ignoreMissing = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), NAMES[0] + " query does not support [" + currentFieldName + "]");
                 }
@@ -76,7 +76,7 @@ public class FieldValueFactorFunctionParser implements ScoreFunctionParser {
             throw new QueryParsingException(parseContext.index(), "[" + NAMES[0] + "] required field 'field' missing");
         }
 
-        return new FieldValueFactorFunction(field, boostFactor, modifier, lenient);
+        return new FieldValueFactorFunction(field, boostFactor, modifier, ignoreMissing);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
@@ -59,19 +59,19 @@ public class FunctionScoreFieldValueTests extends ElasticsearchIntegrationTest {
         ensureYellow();
 
         client().prepareIndex("test", "type1", "1").setSource("test", 5, "body", "foo").get();
-        client().prepareIndex("test", "type1", "2").setSource("test", 7, "body", "foo").get();
+        client().prepareIndex("test", "type1", "2").setSource("test", 17, "body", "foo").get();
         client().prepareIndex("test", "type1", "3").setSource("body", "bar").get();
 
         refresh();
 
-        // document 2 scores higher because 7 > 5
+        // document 2 scores higher because 17 > 5
         SearchResponse response = client().prepareSearch("test")
                 .setExplain(randomBoolean())
                 .setQuery(functionScoreQuery(simpleQueryString("foo"), fieldValueFactorFunction("test")))
                 .get();
         assertOrderedSearchHits(response, "2", "1");
 
-        // document 1 scores higher because 1/5 > 1/7
+        // document 1 scores higher because 1/5 > 1/17
         response = client().prepareSearch("test")
                 .setExplain(randomBoolean())
                 .setQuery(functionScoreQuery(simpleQueryString("foo"),

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.functionscore;
+
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.fieldValueFactorFunction;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+
+/**
+ * Tests for the {@code field_value_factor} function in a function_score query.
+ */
+public class FunctionScoreFieldValueTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testFieldValueFactor() throws IOException {
+        assertAcked(prepareCreate("test").addMapping(
+                "type1",
+                jsonBuilder()
+                        .startObject()
+                        .startObject("type1")
+                        .startObject("properties")
+                        .startObject("test")
+                        .field("type", randomFrom(new String[] {"short", "float", "long", "integer", "double"}))
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()).get());
+        ensureYellow();
+
+        client().prepareIndex("test", "type1", "1").setSource("test", 5).get();
+        client().prepareIndex("test", "type1", "2").setSource("test", 7).get();
+
+        refresh();
+
+        // document 2 scores higher because 7 > 5
+        SearchResponse response = client().prepareSearch("test")
+                .setExplain(randomBoolean())
+                .setQuery(functionScoreQuery(matchAllQuery(), fieldValueFactorFunction("test")))
+                .get();
+        assertOrderedSearchHits(response, "2", "1");
+
+        // document 1 scores higher because 1/5 > 1/7
+        response = client().prepareSearch("test")
+                .setExplain(randomBoolean())
+                .setQuery(functionScoreQuery(matchAllQuery(),
+                        fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL)))
+                .get();
+        assertOrderedSearchHits(response, "1", "2");
+
+        // n divided by 0 is infinity, which should provoke an exception.
+        try {
+            response = client().prepareSearch("test")
+                    .setExplain(randomBoolean())
+                    .setQuery(functionScoreQuery(matchAllQuery(),
+                            fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).factor(0)))
+                    .get();
+            assertFailures(response);
+        } catch (SearchPhaseExecutionException e) {
+            // This is fine, the query will throw an exception if executed
+            // locally, instead of just having failures
+        }
+
+        // Same case, but with the lenient flag
+        response = client().prepareSearch("test")
+                .setExplain(randomBoolean())
+                .setQuery(functionScoreQuery(matchAllQuery(),
+                        fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).factor(0).lenient(true)))
+                .get();
+        // Order doesn't matter here, only that no exceptions were thrown with the lenient flag.
+        assertNoFailures(response);
+        assertHitCount(response, 2);
+    }
+}

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueTests.java
@@ -60,7 +60,7 @@ public class FunctionScoreFieldValueTests extends ElasticsearchIntegrationTest {
 
         client().prepareIndex("test", "type1", "1").setSource("test", 5, "body", "foo").get();
         client().prepareIndex("test", "type1", "2").setSource("test", 7, "body", "foo").get();
-        client().prepareIndex("test", "type1", "3").setSource("body", "foo").get();
+        client().prepareIndex("test", "type1", "3").setSource("body", "bar").get();
 
         refresh();
 


### PR DESCRIPTION
The `field_value_factor` function uses the value of a field in the document to influence the score. This is a common case that script scoring was previously used for.

For example, a query that looks like:

``` json
{
  "query": {
    "function_score": {
      "query": {"match": { "body": "foo" }},
      "functions": [
        {
          "field_value_factor": {
            "field": "popularity",
            "factor": 1.1,
            "modifier": "square"
          }
        }
      ],
      "score_mode": "max",
      "boost_mode": "sum"
    }
  }
}
```

Would have the score modified for each document by:

```
square(1.1 * doc['popularity'].value)
```

This is faster and less error-prone than using scripting to influence the score. Speed-wise, I used the IMDB movie database and tested with two different queries:

``` json
{
  "query": {
    "function_score": {
      "query": {"match_all": {}},
      "functions": [
        {
          "field_value_factor": {
            "field": "runtime",
            "modifier": "none"
          }
        }
      ],
      "score_mode": "max",
      "boost_mode": "sum"
    }
  }
}
```

vs:

``` json
{
  "query": {
    "function_score": {
      "query": {"match_all": {}},
      "functions": [
        {
          "script_score": {
            "script": "_score * doc['runtime'].value"
          }
        }
      ],
      "score_mode": "max",
      "boost_mode": "sum"
    }
  }
}
```

The `field_value_factor` version took about 75ms on average, the `script_score` version took about 145ms on average (after field data was loaded for both versions).
