### PR TITLE
Fix include_in_all for multi field

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -156,6 +156,7 @@ public class ParseContext {
     private boolean mappingsModified = false;
     private boolean withinNewMapper = false;
     private boolean withinCopyTo = false;
+    private boolean withinMultiFields = false;
 
     private boolean externalValueSet;
 
@@ -235,6 +236,14 @@ public class ParseContext {
 
     public boolean isWithinCopyTo() {
         return withinCopyTo;
+    }
+
+    public void setWithinMultiFields() {
+        this.withinMultiFields = true;
+    }
+
+    public void clearWithinMultiFields() {
+        this.withinMultiFields = false;
     }
 
     public String index() {
@@ -358,6 +367,9 @@ public class ParseContext {
      */
     private boolean includeInAll(Boolean specificIncludeInAll, boolean indexed) {
         if (withinCopyTo) {
+            return false;
+        }
+        if (withinMultiFields) {
             return false;
         }
         if (!docMapper.allFieldMapper().enabled()) {

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -911,6 +911,8 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
                 return;
             }
 
+            context.setWithinMultiFields();
+
             ContentPath.Type origPathType = context.path().pathType();
             context.path().pathType(pathType);
 
@@ -920,6 +922,8 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             }
             context.path().remove();
             context.path().pathType(origPathType);
+
+            context.clearWithinMultiFields();
         }
 
         // No need for locking, because locking is taken care of in ObjectMapper#merge and DocumentMapper#merge

--- a/src/test/java/org/elasticsearch/index/mapper/all/multifield-mapping.json
+++ b/src/test/java/org/elasticsearch/index/mapper/all/multifield-mapping.json
@@ -1,0 +1,23 @@
+{
+    "test": {
+        "properties": {
+            "foo": {
+                "type": "nested",
+                "include_in_all": false,
+                "properties": {
+                    "bar": {
+                        "type": "string",
+                        "index": "not_analyzed",
+                        "include_in_all": false,
+                        "fields": {
+                            "lower": {
+                                "analyzer": "standard",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As in document http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-core-types.html#_include_in_all

The `include_in_all` should be ignored for multi-field. Currently it will set the `includeInAll` to `null`, then it will be default to `true` if `index` is not set to `no`. I think it should be set to `false` instead of `null`.

btw, seems `AllFieldMapper.IncludeInAll.unsetIncludeInAll()` will not be used anywhere after this change, should that be removed?

closes #5364
