### PR TITLE
Let ByteArray/BigByteArray.get() indicate whether a byte[] was materialized.

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -127,11 +127,12 @@ public class BigArrays extends AbstractComponent {
         }
 
         @Override
-        public void get(long index, int len, BytesRef ref) {
+        public boolean get(long index, int len, BytesRef ref) {
             assert indexIsInt(index);
             ref.bytes = array;
             ref.offset = (int) index;
             ref.length = len;
+            return false;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -65,7 +65,7 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
     }
 
     @Override
-    public void get(long index, int len, BytesRef ref) {
+    public boolean get(long index, int len, BytesRef ref) {
         assert index + len <= size();
         int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
@@ -73,6 +73,7 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
             ref.bytes = pages[pageIndex];
             ref.offset = indexInPage;
             ref.length = len;
+            return false;
         } else {
             ref.bytes = new byte[len];
             ref.offset = 0;
@@ -84,6 +85,7 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
                 System.arraycopy(pages[pageIndex], 0, ref.bytes, ref.length, copyLength);
                 ref.length += copyLength;
             } while (ref.length < len);
+            return true;
         }
     }
 

--- a/src/main/java/org/elasticsearch/common/util/ByteArray.java
+++ b/src/main/java/org/elasticsearch/common/util/ByteArray.java
@@ -38,8 +38,10 @@ public interface ByteArray extends BigArray {
 
     /**
      * Get a reference to a slice.
+     * 
+     * @return <code>true</code> when a byte[] was materialized, <code>false</code> otherwise.
      */
-    public abstract void get(long index, int len, BytesRef ref);
+    public abstract boolean get(long index, int len, BytesRef ref);
 
     /**
      * Bulk set.

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -289,8 +289,8 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
-        public void get(long index, int len, BytesRef ref) {
-            in.get(index, len, ref);
+        public boolean get(long index, int len, BytesRef ref) {
+            return in.get(index, len, ref);
         }
 
         @Override


### PR DESCRIPTION
Necessary and cleaner instead of letting client code "guess" whether pages are shared or copied.
