### PR TITLE
Add caching support to Geohash Cell Filter

### DIFF
--- a/docs/reference/query-dsl/filters/geohash-cell-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geohash-cell-filter.asciidoc
@@ -60,3 +60,11 @@ next to the given cell.
     }
 }
 --------------------------------------------------
+
+
+[float]
+==== Caching
+
+By default, the result of the filter will be cached if the `precision`
+is larger than `1000km`. The `_cache` can be set to `true` to always
+cache the *result* of the filter or `false` to disable the cache.


### PR DESCRIPTION
closes #5462

a few things not sure:
- currently it's hard code to cache if the `precision` is larger than `1000km`, should we add a config for this?
- Should we separate the builder and parser to 2 files to be consistent with other filter builder/parser?
- the `GeohashCellFilter.create()` is only used in this class and only in the parser, should we move that to the parser
