### PR TITLE
REST API: Removed support for aliases as part of index settings

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -541,19 +541,6 @@ public class IndexMetaData {
             ImmutableOpenMap.Builder<String, AliasMetaData> tmpAliases = aliases;
             Settings tmpSettings = settings;
 
-            // For backward compatibility
-            String[] legacyAliases = settings.getAsArray("index.aliases");
-            if (legacyAliases.length > 0) {
-                tmpAliases = ImmutableOpenMap.builder();
-                for (String alias : legacyAliases) {
-                    AliasMetaData aliasMd = AliasMetaData.newAliasMetaDataBuilder(alias).build();
-                    tmpAliases.put(alias, aliasMd);
-                }
-                tmpAliases.putAll(aliases);
-                // Remove index.aliases from settings once they are migrated to the new data structure
-                tmpSettings = ImmutableSettings.settingsBuilder().put(settings).putArray("index.aliases").build();
-            }
-
             // update default mapping on the MappingMetaData
             if (mappings.containsKey(MapperService.DEFAULT_MAPPING)) {
                 MappingMetaData defaultMapping = mappings.get(MapperService.DEFAULT_MAPPING);

--- a/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -68,9 +68,7 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
                 .put(IndexMetaData.builder("test6")
                         .settings(settingsBuilder()
                                 .put("setting1", "value1")
-                                .put("setting2", "value2")
-                                .put("index.aliases.0", "alias3")
-                                .put("index.aliases.1", "alias1"))
+                                .put("setting2", "value2"))
                         .numberOfShards(1)
                         .numberOfReplicas(2)
                         .putMapping("mapping1", MAPPING_SOURCE1)
@@ -80,9 +78,7 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
                 .put(IndexMetaData.builder("test7")
                         .settings(settingsBuilder()
                                 .put("setting1", "value1")
-                                .put("setting2", "value2")
-                                .put("index.aliases.0", "alias3")
-                                .put("index.aliases.1", "alias1"))
+                                .put("setting2", "value2"))
                         .numberOfShards(1)
                         .numberOfReplicas(2)
                         .putMapping("mapping1", MAPPING_SOURCE1)
@@ -159,10 +155,9 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
         assertThat(indexMetaData.mappings().size(), equalTo(2));
         assertThat(indexMetaData.mappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
         assertThat(indexMetaData.mappings().get("mapping2").source().string(), equalTo(MAPPING_SOURCE2));
-        assertThat(indexMetaData.aliases().size(), equalTo(3));
+        assertThat(indexMetaData.aliases().size(), equalTo(2));
         assertThat(indexMetaData.aliases().get("alias1").alias(), equalTo("alias1"));
         assertThat(indexMetaData.aliases().get("alias2").alias(), equalTo("alias2"));
-        assertThat(indexMetaData.aliases().get("alias3").alias(), equalTo("alias3"));
 
         indexMetaData = parsedMetaData.index("test7");
         assertThat(indexMetaData.numberOfShards(), equalTo(1));
@@ -173,13 +168,11 @@ public class ToAndFromJsonMetaDataTests extends ElasticsearchTestCase {
         assertThat(indexMetaData.mappings().size(), equalTo(2));
         assertThat(indexMetaData.mappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
         assertThat(indexMetaData.mappings().get("mapping2").source().string(), equalTo(MAPPING_SOURCE2));
-        assertThat(indexMetaData.aliases().size(), equalTo(4));
+        assertThat(indexMetaData.aliases().size(), equalTo(3));
         assertThat(indexMetaData.aliases().get("alias1").alias(), equalTo("alias1"));
         assertThat(indexMetaData.aliases().get("alias1").filter().string(), equalTo(ALIAS_FILTER1));
         assertThat(indexMetaData.aliases().get("alias2").alias(), equalTo("alias2"));
         assertThat(indexMetaData.aliases().get("alias2").filter(), nullValue());
-        assertThat(indexMetaData.aliases().get("alias3").alias(), equalTo("alias3"));
-        assertThat(indexMetaData.aliases().get("alias3").filter(), nullValue());
         assertThat(indexMetaData.aliases().get("alias4").alias(), equalTo("alias4"));
         assertThat(indexMetaData.aliases().get("alias4").filter().string(), equalTo(ALIAS_FILTER2));
 

--- a/src/test/java/org/elasticsearch/document/AliasedIndexDocumentActionsTests.java
+++ b/src/test/java/org/elasticsearch/document/AliasedIndexDocumentActionsTests.java
@@ -19,8 +19,9 @@
 
 package org.elasticsearch.document;
 
+import org.elasticsearch.action.admin.indices.alias.Alias;
+
 import static org.elasticsearch.client.Requests.createIndexRequest;
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
 /**
  *
@@ -35,7 +36,7 @@ public class AliasedIndexDocumentActionsTests extends DocumentActionsTests {
             // ignore
         }
         logger.info("--> creating index test");
-        client().admin().indices().create(createIndexRequest("test1").settings(settingsBuilder().putArray("index.aliases", "test"))).actionGet();
+        client().admin().indices().create(createIndexRequest("test1").alias(new Alias("test"))).actionGet();
     }
 
     @Override


### PR DESCRIPTION
Now that we have explicit support for aliases when creating indices and as part of index templates, we may remove support for aliases (only names) as part of index settings. The change is marked as breaking as the following calls:

```
curl -XPUT localhost:9200/index -d '{
  "settings" : {
    "aliases" : [ "alias1"]
  }
}
```

and

```
curl -XPUT localhost:9200/index -d '{
  "settings" : {
    "index.aliases" : [ "alias1"]
  }
}
```

won't be supported anymore and will need to be replaced with

```
curl -XPUT localhost:9200/index -d '{
  "aliases" : {
    "alias1": {}
  }
}
```
