### PR TITLE
TransportMasterNodeOperationAction: tighter check for postAdded cluster state change

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
@@ -220,8 +220,9 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
                             @Override
                             public void postAdded() {
                                 ClusterState clusterStateV2 = clusterService.state();
-                                if (clusterState.version() != clusterStateV2.version()) {
-                                    // something changed while adding, try again
+                                // checking for changes that happened while adding the listener. We can't check using cluster
+                                // state versions as mater election doesn't increase version numbers
+                                if (clusterState != clusterStateV2) {
                                     clusterService.remove(this);
                                     innerExecute(request, listener, false);
                                 }


### PR DESCRIPTION
If a node fails to forward a master node operation to the current master, it will schedule a retry using a listener for cluster state changes. Once the listener is in place (and future changes are guaranteed to be observed) it will double check nothing has change during the addition of the listener. This check has previously been change to use cluster state versions (see: #5499). This is however not reliable solution as master elections (which change the master) do not increment the cluster state version and thus could be missed. This commit changes the check to use reference equality making it stricter.
