### PR TITLE
Convert TermQuery to PrefixQuery if PHRASE_PREFIX is set

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -251,28 +251,28 @@ public class MatchQuery {
 
 
         public Query createPhrasePrefixQuery(String field, String queryText, int phraseSlop, int maxExpansions) {
-            Query query = createFieldQuery(getAnalyzer(), Occur.MUST, field, queryText, true, phraseSlop);
+            final Query query = createFieldQuery(getAnalyzer(), Occur.MUST, field, queryText, true, phraseSlop);
+            final MultiPhrasePrefixQuery prefixQuery = new MultiPhrasePrefixQuery();
+            prefixQuery.setMaxExpansions(maxExpansions);
+            prefixQuery.setSlop(phraseSlop);
             if (query instanceof PhraseQuery) {
                 PhraseQuery pq = (PhraseQuery)query;
-                MultiPhrasePrefixQuery prefixQuery = new MultiPhrasePrefixQuery();
-                prefixQuery.setMaxExpansions(maxExpansions);
                 Term[] terms = pq.getTerms();
                 int[] positions = pq.getPositions();
                 for (int i = 0; i < terms.length; i++) {
                     prefixQuery.add(new Term[] {terms[i]}, positions[i]);
                 }
-                prefixQuery.setSlop(phraseSlop);
                 return prefixQuery;
             } else if (query instanceof MultiPhraseQuery) {
                 MultiPhraseQuery pq = (MultiPhraseQuery)query;
-                MultiPhrasePrefixQuery prefixQuery = new MultiPhrasePrefixQuery();
-                prefixQuery.setMaxExpansions(maxExpansions);
                 List<Term[]> terms = pq.getTermArrays();
                 int[] positions = pq.getPositions();
                 for (int i = 0; i < terms.size(); i++) {
                     prefixQuery.add(terms.get(i), positions[i]);
                 }
-                prefixQuery.setSlop(phraseSlop);
+                return prefixQuery;
+            } else if (query instanceof TermQuery) {
+                prefixQuery.add(((TermQuery) query).getTerm());
                 return prefixQuery;
             }
             return query;

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -2295,11 +2295,18 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
     public void testMatchPhrasePrefixQuery() {
         createIndex("test1");
         client().prepareIndex("test1", "type1", "1").setSource("field", "Johnnie Walker Black Label").get();
+        client().prepareIndex("test1", "type1", "2").setSource("field", "trying out Elasticsearch").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("field", "Johnnie la").slop(between(2,5)).type(Type.PHRASE_PREFIX)).get();
         assertHitCount(searchResponse, 1l);
         assertSearchHits(searchResponse, "1");
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field", "trying").type(Type.PHRASE_PREFIX)).get();
+        assertHitCount(searchResponse, 1l);
+        assertSearchHits(searchResponse, "2");
+        searchResponse = client().prepareSearch().setQuery(matchQuery("field", "try").type(Type.PHRASE_PREFIX)).get();
+        assertHitCount(searchResponse, 1l);
+        assertSearchHits(searchResponse, "2");
     }
 
 }


### PR DESCRIPTION
We miss to add a single term to a prefix query if the query in only a
single term.

Closes #5551
