### PR TITLE
Eager fielddata loading not working

### DIFF
--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -773,7 +773,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                         if (parentFieldMapper.active()) {
                             warmUp.put(indexName, parentFieldMapper);
                         }
-                    } else if (fieldDataType.getLoading() != Loading.EAGER && warmUp.containsKey(indexName)) {
+                    } else if (fieldDataType.getLoading() != Loading.EAGER && !warmUp.containsKey(indexName)) {
                         warmUp.put(indexName, fieldMapper);
                     }
                 }

--- a/src/test/java/org/elasticsearch/index/fielddata/FieldDataLoadingTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/FieldDataLoadingTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ */
+public class FieldDataLoadingTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testEagerFieldDataLoading() throws Exception {
+        assertAcked(prepareCreate("test")
+                .addMapping("type", jsonBuilder().startObject().startObject("type").startObject("properties")
+                        .startObject("name")
+                        .field("type", "string")
+                        .startObject("fielddata").field("loading", "eager").endObject()
+                        .endObject()
+                        .endObject().endObject().endObject()));
+        ensureGreen();
+
+        client().prepareIndex("test", "type", "1").setSource("name", "name").get();
+        client().admin().indices().prepareRefresh("test").get();
+
+        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+    }
+
+}


### PR DESCRIPTION
Fixes a bug when the field has been configured with eager fielddata loadng, the fielddata is not being loaded.

Note this bug only exists in ES version: `1.1.0`
