### PR TITLE
Move to Java 1.7 on 1.x branch

### DIFF
--- a/dev-tools/build_randomization.rb
+++ b/dev-tools/build_randomization.rb
@@ -40,8 +40,9 @@ class JDKSelector
 
   # do ranomize selection from a given array
   def select_one(selection_array = nil)
-    selection_array ||= @jdk_list
+    selection_array = filter_java_6(selection_array || @jdk_list)
     selection_array[rand(selection_array.size)]
+
     get_random_one(selection_array)
   end
 end
@@ -50,15 +51,16 @@ def get_random_one(data_array)
   data_array[rand(data_array.size)]
 end
 
+def filter_java_6(files)
+  files.select{ |i| File.basename(i).split(/[^0-9]/)[-1].to_i > 6 }
+end
+
 # given a jdk directory selection, generate relevant environment variables
 def get_env_matrix(data_array)
   
   #refactoring target
   es_test_jvm_option1 = get_random_one(['-server']) #only server for now get_random_one(['-client', '-server'])
-  greater_than_six = File.basename([*data_array].first).split(/[^0-9]/)[-1].to_i > 6
-  es_test_jvm_option2 = greater_than_six ? get_random_one(['-XX:+UseConcMarkSweepGC', '-XX:+UseParallelGC', '-XX:+UseSerialGC',
-                                        '-XX:+UseG1GC']) :
-                        get_random_one(['-XX:+UseConcMarkSweepGC', '-XX:+UseParallelGC', '-XX:+UseSerialGC'])
+  es_test_jvm_option2 = get_random_one(['-XX:+UseConcMarkSweepGC', '-XX:+UseParallelGC', '-XX:+UseSerialGC', '-XX:+UseG1GC'])
 
   es_test_jvm_option3 = get_random_one(['-XX:+UseCompressedOops', '-XX:-UseCompressedOops'])
   es_node_mode =  get_random_one(['local', 'network'])

--- a/dev-tools/build_release.py
+++ b/dev-tools/build_release.py
@@ -40,7 +40,7 @@ from http.client import HTTPConnection
  '--publish' option is set the actual release is done. The script takes over almost all
  steps necessary for a release from a high level point of view it does the following things:
 
-  - run prerequisit checks ie. check for Java 1.6 being presend or S3 credentials available as env variables
+  - run prerequisit checks ie. check for Java 1.7 being presend or S3 credentials available as env variables
   - detect the version to release from the specified branch (--branch) or the current branch
   - creates a release branch & updates pom.xml and Version.java to point to a release version rather than a snapshot
   - builds the artifacts and runs smoke-tests on the build zip & tar.gz files
@@ -87,12 +87,12 @@ try:
 except KeyError:
   raise RuntimeError("""
   Please set JAVA_HOME in the env before running release tool
-  On OSX use: export JAVA_HOME=`/usr/libexec/java_home -v '1.6*'`""")
+  On OSX use: export JAVA_HOME=`/usr/libexec/java_home -v '1.7*'`""")
 
 try:
-  JAVA_HOME = env['JAVA6_HOME']
+  JAVA_HOME = env['JAVA7_HOME']
 except KeyError:
-  pass #no JAVA6_HOME - we rely on JAVA_HOME
+  pass #no JAVA7_HOME - we rely on JAVA_HOME
 
 
 try:
@@ -114,8 +114,8 @@ def verify_java_version(version):
   if s.find(' version "%s.' % version) == -1:
     raise RuntimeError('got wrong version for java %s:\n%s' % (version, s))
 
-# Verifies the java version. We guarantee that we run with Java 1.6
-# If 1.6 is not available fail the build!
+# Verifies the java version. We guarantee that we run with Java 1.7
+# If 1.7 is not available fail the build!
 def verify_mvn_java_version(version, mvn):
   s = os.popen('%s; %s --version 2>&1' % (java_exe(), mvn)).read()
   if s.find('Java version: %s' % version) == -1:
@@ -133,8 +133,8 @@ def get_tag_hash(tag):
 def get_current_branch():
   return os.popen('git rev-parse --abbrev-ref HEAD  2>&1').read().strip()
 
-verify_java_version('1.6') # we require to build with 1.6
-verify_mvn_java_version('1.6', MVN)
+verify_java_version('1.7') # we require to build with 1.7
+verify_mvn_java_version('1.7', MVN)
 
 # Utility that returns the name of the release branch for a given version
 def release_branch(version):

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,26 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.7,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -341,8 +341,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <fork>true</fork>
                     <maxmem>512m</maxmem>
                     <!-- REMOVE WHEN UPGRADE:
@@ -1008,7 +1008,7 @@
                     <execution>
                         <id>check-forbidden-apis</id>
                         <configuration>
-                            <targetVersion>1.6</targetVersion>
+                            <targetVersion>1.7</targetVersion>
                             <!-- disallow undocumented classes like sun.misc.Unsafe: -->
                             <internalRuntimeForbidden>true</internalRuntimeForbidden>
                             <!-- if the used Java version is too new, don't fail, just do nothing: -->
@@ -1047,7 +1047,7 @@
                     <execution>
                         <id>check-forbidden-test-apis</id>
                         <configuration>
-                            <targetVersion>1.6</targetVersion>
+                            <targetVersion>1.7</targetVersion>
                             <!-- disallow undocumented classes like sun.misc.Unsafe: -->
                             <internalRuntimeForbidden>true</internalRuntimeForbidden>
                             <!-- if the used Java version is too new, don't fail, just do nothing: -->
@@ -1240,16 +1240,14 @@
                   <exclude>src/test/java/org/elasticsearch/search/aggregations/metrics/GroupTree.java</exclude>
                 </excludes>
               </configuration>
-              <!--  We can't run by default since the package is broken with java 1.6
-                   see https://github.com/mycila/license-maven-plugin/issues/35
-                   <executions>
-                   <execution>
-                   <goals>
-                   <goal>check</goal>
-                   </goals>
-                   </execution>
-                   </executions>
-              -->
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
           </plugins>
         </build>


### PR DESCRIPTION
This PR moves the 1.x branch to Java 1.7 as min version. This means Elasticsearch 1.2 has Java 7 as min version.
