### PR TITLE
Fix IndexShardRoutingTable's shard randomization to not throw out-of-bounds exceptions.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.collect.UnmodifiableIterator;
+import jsr166y.ThreadLocalRandom;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -68,7 +69,7 @@ public class IndexRoutingTable implements Iterable<IndexShardRoutingTable> {
 
     IndexRoutingTable(String index, ImmutableOpenIntMap<IndexShardRoutingTable> shards) {
         this.index = index;
-        this.shuffler = new RotationShardShuffler();
+        this.shuffler = new RotationShardShuffler(ThreadLocalRandom.current().nextInt());
         this.shards = shards;
         ImmutableList.Builder<ShardRouting> allShards = ImmutableList.builder();
         ImmutableList.Builder<ShardRouting> allActiveShards = ImmutableList.builder();
@@ -272,14 +273,14 @@ public class IndexRoutingTable implements Iterable<IndexShardRoutingTable> {
      * Returns an unordered iterator over all shards (including replicas).
      */
     public ShardsIterator randomAllShardsIt() {
-        return new PlainShardsIterator(shuffler.shuffle(allShards, shuffler.nextSeed()));
+        return new PlainShardsIterator(shuffler.shuffle(allShards));
     }
 
     /**
      * Returns an unordered iterator over all active shards (including replicas).
      */
     public ShardsIterator randomAllActiveShardsIt() {
-        return new PlainShardsIterator(shuffler.shuffle(allActiveShards, shuffler.nextSeed()));
+        return new PlainShardsIterator(shuffler.shuffle(allActiveShards));
     }
 
     /**

--- a/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.routing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.UnmodifiableIterator;
-import jsr166y.ThreadLocalRandom;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -32,7 +31,6 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -45,6 +43,7 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class IndexShardRoutingTable implements Iterable<ShardRouting> {
 
+    final ShardShuffler shuffler;
     final ShardId shardId;
 
     final ShardRouting primary;
@@ -60,15 +59,13 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
      */
     final ImmutableList<ShardRouting> allInitializingShards;
 
-    final AtomicInteger counter;
-
     final boolean primaryAllocatedPostApi;
 
     IndexShardRoutingTable(ShardId shardId, ImmutableList<ShardRouting> shards, boolean primaryAllocatedPostApi) {
         this.shardId = shardId;
+        this.shuffler = new RotationShardShuffler();
         this.shards = shards;
         this.primaryAllocatedPostApi = primaryAllocatedPostApi;
-        this.counter = new AtomicInteger(ThreadLocalRandom.current().nextInt(shards.size()));
 
         ShardRouting primary = null;
         ImmutableList.Builder<ShardRouting> replicas = ImmutableList.builder();
@@ -259,27 +256,27 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     public ShardIterator shardsRandomIt() {
-        return new PlainShardIterator(shardId, shards, pickIndex());
+        return new PlainShardIterator(shardId, shuffler.shuffle(shards, shuffler.nextSeed()));
     }
 
     public ShardIterator shardsIt() {
         return new PlainShardIterator(shardId, shards);
     }
 
-    public ShardIterator shardsIt(int index) {
-        return new PlainShardIterator(shardId, shards, index);
+    public ShardIterator shardsIt(int seed) {
+        return new PlainShardIterator(shardId, shuffler.shuffle(shards, seed));
     }
 
     public ShardIterator activeShardsRandomIt() {
-        return new PlainShardIterator(shardId, activeShards, pickIndex());
+        return new PlainShardIterator(shardId, shuffler.shuffle(activeShards, shuffler.nextSeed()));
     }
 
     public ShardIterator activeShardsIt() {
         return new PlainShardIterator(shardId, activeShards);
     }
 
-    public ShardIterator activeShardsIt(int index) {
-        return new PlainShardIterator(shardId, activeShards, index);
+    public ShardIterator activeShardsIt(int seed) {
+        return new PlainShardIterator(shardId, shuffler.shuffle(activeShards, seed));
     }
 
     /**
@@ -287,33 +284,33 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
      * its random within the active shards, and initializing shards are the last to iterate through.
      */
     public ShardIterator activeInitializingShardsRandomIt() {
-        return activeInitializingShardsIt(pickIndex());
+        return activeInitializingShardsIt(shuffler.nextSeed());
     }
 
     /**
      * Returns an iterator over active and initializing shards. Making sure though that
      * its random within the active shards, and initializing shards are the last to iterate through.
      */
-    public ShardIterator activeInitializingShardsIt(int index) {
+    public ShardIterator activeInitializingShardsIt(int seed) {
         if (allInitializingShards.isEmpty()) {
-            return new PlainShardIterator(shardId, activeShards, index);
+            return new PlainShardIterator(shardId, shuffler.shuffle(activeShards, seed));
         }
         ArrayList<ShardRouting> ordered = new ArrayList<ShardRouting>(activeShards.size() + allInitializingShards.size());
-        addToListFromIndex(activeShards, ordered, index);
+        ordered.addAll(shuffler.shuffle(activeShards, seed));
         ordered.addAll(allInitializingShards);
         return new PlainShardIterator(shardId, ordered);
     }
 
     public ShardIterator assignedShardsRandomIt() {
-        return new PlainShardIterator(shardId, assignedShards, pickIndex());
+        return new PlainShardIterator(shardId, shuffler.shuffle(assignedShards, shuffler.nextSeed()));
     }
 
     public ShardIterator assignedShardsIt() {
         return new PlainShardIterator(shardId, assignedShards);
     }
 
-    public ShardIterator assignedShardsIt(int index) {
-        return new PlainShardIterator(shardId, assignedShards, index);
+    public ShardIterator assignedShardsIt(int seed) {
+        return new PlainShardIterator(shardId, shuffler.shuffle(assignedShards, seed));
     }
 
     /**
@@ -334,14 +331,11 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     public ShardIterator primaryFirstActiveInitializingShardsIt() {
         ArrayList<ShardRouting> ordered = new ArrayList<ShardRouting>(activeShards.size() + allInitializingShards.size());
         // fill it in a randomized fashion
-        int index = Math.abs(pickIndex());
-        for (int i = 0; i < activeShards.size(); i++) {
-            int loc = (index + i) % activeShards.size();
-            ShardRouting shardRouting = activeShards.get(loc);
+        for (ShardRouting shardRouting : shuffler.shuffle(activeShards, shuffler.nextSeed())) {
             ordered.add(shardRouting);
             if (shardRouting.primary()) {
                 // switch, its the matching node id
-                ordered.set(i, ordered.get(0));
+                ordered.set(ordered.size() - 1, ordered.get(0));
                 ordered.set(0, shardRouting);
             }
         }
@@ -373,14 +367,11 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     public ShardIterator preferNodeActiveInitializingShardsIt(String nodeId) {
         ArrayList<ShardRouting> ordered = new ArrayList<ShardRouting>(activeShards.size() + allInitializingShards.size());
         // fill it in a randomized fashion
-        int index = pickIndex();
-        for (int i = 0; i < activeShards.size(); i++) {
-            int loc = (index + i) % activeShards.size();
-            ShardRouting shardRouting = activeShards.get(loc);
+        for (ShardRouting shardRouting : shuffler.shuffle(activeShards, shuffler.nextSeed())) {
             ordered.add(shardRouting);
             if (nodeId.equals(shardRouting.currentNodeId())) {
                 // switch, its the matching node id
-                ordered.set(i, ordered.get(0));
+                ordered.set(ordered.size() - 1, ordered.get(0));
                 ordered.set(0, shardRouting);
             }
         }
@@ -474,10 +465,10 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     public ShardIterator preferAttributesActiveInitializingShardsIt(String[] attributes, DiscoveryNodes nodes) {
-        return preferAttributesActiveInitializingShardsIt(attributes, nodes, pickIndex());
+        return preferAttributesActiveInitializingShardsIt(attributes, nodes, shuffler.nextSeed());
     }
 
-    public ShardIterator preferAttributesActiveInitializingShardsIt(String[] attributes, DiscoveryNodes nodes, int index) {
+    public ShardIterator preferAttributesActiveInitializingShardsIt(String[] attributes, DiscoveryNodes nodes, int seed) {
         AttributesKey key = new AttributesKey(attributes);
         AttributesRoutings activeRoutings = getActiveAttribute(key, nodes);
         AttributesRoutings initializingRoutings = getInitializingAttribute(key, nodes);
@@ -485,11 +476,10 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         // we now randomize, once between the ones that have the same attributes, and once for the ones that don't
         // we don't want to mix between the two!
         ArrayList<ShardRouting> ordered = new ArrayList<ShardRouting>(activeRoutings.totalSize + initializingRoutings.totalSize);
-        index = Math.abs(index);
-        addToListFromIndex(activeRoutings.withSameAttribute, ordered, index);
-        addToListFromIndex(activeRoutings.withoutSameAttribute, ordered, index);
-        addToListFromIndex(initializingRoutings.withSameAttribute, ordered, index);
-        addToListFromIndex(initializingRoutings.withoutSameAttribute, ordered, index);
+        ordered.addAll(shuffler.shuffle(activeRoutings.withSameAttribute, seed));
+        ordered.addAll(shuffler.shuffle(activeRoutings.withoutSameAttribute, seed));
+        ordered.addAll(shuffler.shuffle(initializingRoutings.withSameAttribute, seed));
+        ordered.addAll(shuffler.shuffle(initializingRoutings.withoutSameAttribute, seed));
         return new PlainShardIterator(shardId, ordered);
     }
 
@@ -523,23 +513,6 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
             }
         }
         return shards;
-    }
-
-    /**
-     * Adds from list to list, starting from the given index (wrapping around if needed).
-     */
-    @SuppressWarnings("unchecked")
-    private void addToListFromIndex(List from, List to, int index) {
-        index = Math.abs(index);
-        for (int i = 0; i < from.size(); i++) {
-            int loc = (index + i) % from.size();
-            to.add(from.get(loc));
-        }
-    }
-
-    // TODO: we can move to random based on ThreadLocalRandom, or make it pluggable
-    private int pickIndex() {
-        return Math.abs(counter.incrementAndGet());
     }
 
     public static class Builder {

--- a/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.routing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.UnmodifiableIterator;
+import jsr166y.ThreadLocalRandom;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -63,7 +64,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
 
     IndexShardRoutingTable(ShardId shardId, ImmutableList<ShardRouting> shards, boolean primaryAllocatedPostApi) {
         this.shardId = shardId;
-        this.shuffler = new RotationShardShuffler();
+        this.shuffler = new RotationShardShuffler(ThreadLocalRandom.current().nextInt());
         this.shards = shards;
         this.primaryAllocatedPostApi = primaryAllocatedPostApi;
 
@@ -256,7 +257,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     public ShardIterator shardsRandomIt() {
-        return new PlainShardIterator(shardId, shuffler.shuffle(shards, shuffler.nextSeed()));
+        return new PlainShardIterator(shardId, shuffler.shuffle(shards));
     }
 
     public ShardIterator shardsIt() {
@@ -268,7 +269,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     public ShardIterator activeShardsRandomIt() {
-        return new PlainShardIterator(shardId, shuffler.shuffle(activeShards, shuffler.nextSeed()));
+        return new PlainShardIterator(shardId, shuffler.shuffle(activeShards));
     }
 
     public ShardIterator activeShardsIt() {
@@ -302,7 +303,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     public ShardIterator assignedShardsRandomIt() {
-        return new PlainShardIterator(shardId, shuffler.shuffle(assignedShards, shuffler.nextSeed()));
+        return new PlainShardIterator(shardId, shuffler.shuffle(assignedShards));
     }
 
     public ShardIterator assignedShardsIt() {
@@ -331,7 +332,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     public ShardIterator primaryFirstActiveInitializingShardsIt() {
         ArrayList<ShardRouting> ordered = new ArrayList<ShardRouting>(activeShards.size() + allInitializingShards.size());
         // fill it in a randomized fashion
-        for (ShardRouting shardRouting : shuffler.shuffle(activeShards, shuffler.nextSeed())) {
+        for (ShardRouting shardRouting : shuffler.shuffle(activeShards)) {
             ordered.add(shardRouting);
             if (shardRouting.primary()) {
                 // switch, its the matching node id
@@ -367,7 +368,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     public ShardIterator preferNodeActiveInitializingShardsIt(String nodeId) {
         ArrayList<ShardRouting> ordered = new ArrayList<ShardRouting>(activeShards.size() + allInitializingShards.size());
         // fill it in a randomized fashion
-        for (ShardRouting shardRouting : shuffler.shuffle(activeShards, shuffler.nextSeed())) {
+        for (ShardRouting shardRouting : shuffler.shuffle(activeShards)) {
             ordered.add(shardRouting);
             if (nodeId.equals(shardRouting.currentNodeId())) {
                 // switch, its the matching node id

--- a/src/main/java/org/elasticsearch/cluster/routing/PlainShardIterator.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/PlainShardIterator.java
@@ -43,18 +43,6 @@ public class PlainShardIterator extends PlainShardsIterator implements ShardIter
         this.shardId = shardId;
     }
 
-    /**
-     * Creates a {@link PlainShardIterator} instance that iterates over a subset of the given shards
-     * this the a given <code>shardId</code>.
-     *
-     * @param shardId shard id of the group
-     * @param shards  shards to iterate
-     * @param index   the offset in the shards list to start the iteration from
-     */
-    public PlainShardIterator(ShardId shardId, List<ShardRouting> shards, int index) {
-        super(shards, index);
-        this.shardId = shardId;
-    }
 
     @Override
     public ShardId shardId() {

--- a/src/main/java/org/elasticsearch/cluster/routing/RotationShardShuffler.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RotationShardShuffler.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import jsr166y.ThreadLocalRandom;
+import org.elasticsearch.common.util.CollectionUtils;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Basic {@link ShardShuffler} implementation that uses an {@link AtomicInteger} to generate seeds and uses a rotation to permute shards.
+ */
+public class RotationShardShuffler implements ShardShuffler {
+
+    private final AtomicInteger seed;
+
+    public RotationShardShuffler() {
+        seed = new AtomicInteger(ThreadLocalRandom.current().nextInt());
+    }
+
+    @Override
+    public int nextSeed() {
+        return seed.getAndIncrement();
+    }
+
+    @Override
+    public List<ShardRouting> shuffle(List<ShardRouting> shards, int seed) {
+        return CollectionUtils.rotate(shards, seed);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/cluster/routing/RotationShardShuffler.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RotationShardShuffler.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing;
 
-import jsr166y.ThreadLocalRandom;
 import org.elasticsearch.common.util.CollectionUtils;
 
 import java.util.List;
@@ -28,12 +27,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Basic {@link ShardShuffler} implementation that uses an {@link AtomicInteger} to generate seeds and uses a rotation to permute shards.
  */
-public class RotationShardShuffler implements ShardShuffler {
+public class RotationShardShuffler extends ShardShuffler {
 
     private final AtomicInteger seed;
 
-    public RotationShardShuffler() {
-        seed = new AtomicInteger(ThreadLocalRandom.current().nextInt());
+    public RotationShardShuffler(int seed) {
+        this.seed = new AtomicInteger(seed);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/routing/ShardShuffler.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/ShardShuffler.java
@@ -24,17 +24,24 @@ import java.util.List;
 /**
  * A shuffler for shards whose primary goal is to balance load.
  */
-public interface ShardShuffler {
+public abstract class ShardShuffler {
 
     /**
      * Return a new seed.
      */
-    int nextSeed();
+    public abstract int nextSeed();
 
     /**
      * Return a shuffled view over the list of shards. The behavior of this method must be deterministic: if the same list and the same seed
      * are provided twice, then the result needs to be the same.
      */
-    List<ShardRouting> shuffle(List<ShardRouting> shards, int seed);
+    public abstract List<ShardRouting> shuffle(List<ShardRouting> shards, int seed);
+
+    /**
+     * Equivalent to calling <code>shuffle(shards, nextSeed())</code>.
+     */
+    public List<ShardRouting> shuffle(List<ShardRouting> shards) {
+        return shuffle(shards, nextSeed());
+    }
 
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/ShardShuffler.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/ShardShuffler.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import java.util.List;
+
+/**
+ * A shuffler for shards whose primary goal is to balance load.
+ */
+public interface ShardShuffler {
+
+    /**
+     * Return a new seed.
+     */
+    int nextSeed();
+
+    /**
+     * Return a shuffled view over the list of shards. The behavior of this method must be deterministic: if the same list and the same seed
+     * are provided twice, then the result needs to be the same.
+     */
+    List<ShardRouting> shuffle(List<ShardRouting> shards, int seed);
+
+}

--- a/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -24,9 +24,11 @@ import com.carrotsearch.hppc.FloatArrayList;
 import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.primitives.Longs;
 import org.apache.lucene.util.IntroSorter;
+import org.elasticsearch.common.Preconditions;
 
 import java.util.AbstractList;
 import java.util.List;
+import java.util.RandomAccess;
 
 /** Collections-related utility methods. */
 public enum CollectionUtils {
@@ -190,12 +192,12 @@ public enum CollectionUtils {
         }
         return uniqueCount;
     }
-    
+
     /**
      * Checks if the given array contains any elements.
-     * 
+     *
      * @param array The array to check
-     * 
+     *
      * @return false if the array contains an element, true if not or the array is null.
      */
     public static boolean isEmpty(Object[] array) {
@@ -219,27 +221,35 @@ public enum CollectionUtils {
             return list;
         }
 
-        return rotate1(list, d);
+        return new RotatedList<>(list, d);
     }
 
-    private static <T> List<T> rotate1(final List<T> list, final int distance) {
-        return new AbstractList<T>() {
+    private static class RotatedList<T> extends AbstractList<T> implements RandomAccess {
 
-            @Override
-            public T get(int index) {
-                int idx = distance + index;
-                if (idx < 0 || idx >= list.size()) {
-                    idx -= list.size();
-                }
-                return list.get(idx);
+        private final List<T> in;
+        private final int distance;
+
+        public RotatedList(List<T> list, int distance) {
+            Preconditions.checkArgument(distance >= 0 && distance < list.size());
+            Preconditions.checkArgument(list instanceof RandomAccess);
+            this.in = list;
+            this.distance = distance;
+        }
+
+        @Override
+        public T get(int index) {
+            int idx = distance + index;
+            if (idx < 0 || idx >= in.size()) {
+                idx -= in.size();
             }
+            return in.get(idx);
+        }
 
-            @Override
-            public int size() {
-                return list.size();
-            }
+        @Override
+        public int size() {
+            return in.size();
+        }
 
-        };
-    }
+    };
 
 }

--- a/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -25,6 +25,9 @@ import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.primitives.Longs;
 import org.apache.lucene.util.IntroSorter;
 
+import java.util.AbstractList;
+import java.util.List;
+
 /** Collections-related utility methods. */
 public enum CollectionUtils {
     ;
@@ -197,6 +200,46 @@ public enum CollectionUtils {
      */
     public static boolean isEmpty(Object[] array) {
         return array == null || array.length == 0;
+    }
+
+    /**
+     * Return a rotated view of the given list with the given distance.
+     */
+    public static <T> List<T> rotate(final List<T> list, int distance) {
+        if (list.isEmpty()) {
+            return list;
+        }
+
+        int d = distance % list.size();
+        if (d < 0) {
+            d += list.size();
+        }
+
+        if (d == 0) {
+            return list;
+        }
+
+        return rotate1(list, d);
+    }
+
+    private static <T> List<T> rotate1(final List<T> list, final int distance) {
+        return new AbstractList<T>() {
+
+            @Override
+            public T get(int index) {
+                int idx = distance + index;
+                if (idx < 0 || idx >= list.size()) {
+                    idx -= list.size();
+                }
+                return list.get(idx);
+            }
+
+            @Override
+            public int size() {
+                return list.size();
+            }
+
+        };
     }
 
 }

--- a/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
+++ b/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
@@ -43,8 +43,8 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
 
     @Test
     public void testEmptyIterator() {
-        ShardShuffler shuffler = new RotationShardShuffler();
-        ShardIterator shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 0));
+        ShardShuffler shuffler = new RotationShardShuffler(0);
+        ShardIterator shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
@@ -53,7 +53,7 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 1));
+        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
@@ -62,7 +62,7 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 2));
+        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
@@ -71,7 +71,7 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 3));
+        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));

--- a/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
+++ b/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
@@ -43,7 +43,8 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
 
     @Test
     public void testEmptyIterator() {
-        ShardIterator shardIterator = new PlainShardIterator(new ShardId("test1", 0), ImmutableList.<ShardRouting>of(), 0);
+        ShardShuffler shuffler = new RotationShardShuffler();
+        ShardIterator shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 0));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
@@ -52,7 +53,7 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), ImmutableList.<ShardRouting>of(), 1);
+        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 1));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
@@ -61,7 +62,7 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), ImmutableList.<ShardRouting>of(), 2);
+        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 2));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
@@ -70,7 +71,7 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), ImmutableList.<ShardRouting>of(), 3);
+        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(ImmutableList.<ShardRouting>of(), 3));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.firstOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));

--- a/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
+++ b/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class CollectionUtilsTests extends ElasticsearchTestCase {
+
+    @Test
+    public void rotateEmpty() {
+        assertTrue(CollectionUtils.rotate(ImmutableList.of(), randomInt()).isEmpty());
+    }
+
+    @Test
+    public void rotate() {
+        final int iters = scaledRandomIntBetween(10, 100);
+        for (int k = 0; k < iters; ++k) {
+            final int size = randomIntBetween(1, 100);
+            List<Object> list = new ArrayList<>();
+            for (int i = 0; i < size; ++i) {
+                list.add(new Object());
+            }
+            final List<Object> rotated = CollectionUtils.rotate(list, size);
+            assertEquals(rotated.size(), list.size());
+            assertEquals(Iterables.size(rotated), list.size());
+            assertEquals(new HashSet<>(rotated), new HashSet<>(list));
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
+++ b/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
@@ -40,14 +40,24 @@ public class CollectionUtilsTests extends ElasticsearchTestCase {
         final int iters = scaledRandomIntBetween(10, 100);
         for (int k = 0; k < iters; ++k) {
             final int size = randomIntBetween(1, 100);
+            final int distance = randomInt();
             List<Object> list = new ArrayList<>();
             for (int i = 0; i < size; ++i) {
                 list.add(new Object());
             }
-            final List<Object> rotated = CollectionUtils.rotate(list, size);
+            final List<Object> rotated = CollectionUtils.rotate(list, distance);
+            // check content is the same
             assertEquals(rotated.size(), list.size());
             assertEquals(Iterables.size(rotated), list.size());
             assertEquals(new HashSet<>(rotated), new HashSet<>(list));
+            // check stability
+            for (int j = randomInt(4); j >= 0; --j) {
+                assertEquals(rotated, CollectionUtils.rotate(list, distance));
+            }
+            // reverse
+            if (distance != Integer.MIN_VALUE) {
+                assertEquals(list, CollectionUtils.rotate(CollectionUtils.rotate(list, distance), -distance));
+            }
         }
     }
 


### PR DESCRIPTION
I initially wanted to make the diff minimal but this ended up being quite complicated
so I finally refactored a bit the way shards are randomized. Yet, it uses the same logic:
- rotations to shuffle shards,
- an AtomicInteger to generate the distances to use for the rotations.

Close #5559
