### PR TITLE
Forbid Math.abs(int/long).

### DIFF
--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -40,3 +40,7 @@ java.lang.Object#wait(long)
 java.lang.Object#wait(long,int)
 java.lang.Object#notify()
 java.lang.Object#notifyAll()
+
+@defaultMessage Beware of the behavior of this method on MIN_VALUE
+java.lang.Math#abs(int)
+java.lang.Math#abs(long)

--- a/pom.xml
+++ b/pom.xml
@@ -1048,6 +1048,10 @@
                                 <!-- start excludes for Unsafe -->
                                 <exclude>org/elasticsearch/common/util/UnsafeUtils.class</exclude>
                                 <!-- end excludes for Unsafe -->
+                                <!-- start excludes for Math.abs -->
+                                <exclude>org/elasticsearch/common/util/MathUtils.class</exclude>
+                                <exclude>org/elasticsearch/common/math/UnboxedMathUtils.class</exclude>
+                                <!-- end excludes for Math.abs -->
                             </excludes>
                             <bundledSignatures>
                                 <!-- This will automatically choose the right signatures based on 'maven.compiler.target': -->

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataService.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.metadata;
 import org.elasticsearch.cluster.routing.operation.hash.djb.DjbHashFunction;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.math.MathUtils;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.concurrent.Semaphore;
@@ -42,6 +43,6 @@ public class MetaDataService extends AbstractComponent {
     }
 
     public Semaphore indexMetaDataLock(String index) {
-        return indexMdLocks[Math.abs(DjbHashFunction.DJB_HASH(index) % indexMdLocks.length)];
+        return indexMdLocks[MathUtils.mod(DjbHashFunction.DJB_HASH(index), indexMdLocks.length)];
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/operation/plain/PlainOperationRouting.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/operation/plain/PlainOperationRouting.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.math.MathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexShardMissingException;
@@ -265,12 +266,12 @@ public class PlainOperationRouting extends AbstractComponent implements Operatio
     private int shardId(ClusterState clusterState, String index, String type, @Nullable String id, @Nullable String routing) {
         if (routing == null) {
             if (!useType) {
-                return Math.abs(hash(id) % indexMetaData(clusterState, index).numberOfShards());
+                return MathUtils.mod(hash(id), indexMetaData(clusterState, index).numberOfShards());
             } else {
-                return Math.abs(hash(type, id) % indexMetaData(clusterState, index).numberOfShards());
+                return MathUtils.mod(hash(type, id), indexMetaData(clusterState, index).numberOfShards());
             }
         }
-        return Math.abs(hash(routing) % indexMetaData(clusterState, index).numberOfShards());
+        return MathUtils.mod(hash(routing), indexMetaData(clusterState, index).numberOfShards());
     }
 
     protected int hash(String routing) {

--- a/src/main/java/org/elasticsearch/common/math/MathUtils.java
+++ b/src/main/java/org/elasticsearch/common/math/MathUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.math;
+
+public enum MathUtils {
+    ;
+
+    /**
+     * Return the (positive) remainder of the division of <code>v</code> by <code>mod</code>.
+     */
+    public static int mod(int v, int m) {
+        int r = v % m;
+        if (r < 0) {
+            r += m;
+        }
+        return r;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.SegmentReaderUtils;
 import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.math.MathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -1265,11 +1266,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
     private Object dirtyLock(BytesRef uid) {
         int hash = DjbHashFunction.DJB_HASH(uid.bytes, uid.offset, uid.length);
-        // abs returns Integer.MIN_VALUE, so we need to protect against it...
-        if (hash == Integer.MIN_VALUE) {
-            hash = 0;
-        }
-        return dirtyLocks[Math.abs(hash) % dirtyLocks.length];
+        return dirtyLocks[MathUtils.mod(hash, dirtyLocks.length)];
     }
 
     private Object dirtyLock(Term uid) {

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.HandlesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.math.MathUtils;
 import org.elasticsearch.common.netty.NettyStaticSetup;
 import org.elasticsearch.common.netty.OpenChannelsHandler;
 import org.elasticsearch.common.network.NetworkService;
@@ -911,15 +912,15 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
 
         public Channel channel(TransportRequestOptions.Type type) {
             if (type == TransportRequestOptions.Type.REG) {
-                return reg[Math.abs(regCounter.incrementAndGet()) % reg.length];
+                return reg[MathUtils.mod(regCounter.incrementAndGet(), reg.length)];
             } else if (type == TransportRequestOptions.Type.STATE) {
-                return state[Math.abs(stateCounter.incrementAndGet()) % state.length];
+                return state[MathUtils.mod(stateCounter.incrementAndGet(), state.length)];
             } else if (type == TransportRequestOptions.Type.PING) {
-                return ping[Math.abs(pingCounter.incrementAndGet()) % ping.length];
+                return ping[MathUtils.mod(pingCounter.incrementAndGet(), ping.length)];
             } else if (type == TransportRequestOptions.Type.BULK) {
-                return bulk[Math.abs(bulkCounter.incrementAndGet()) % bulk.length];
+                return bulk[MathUtils.mod(bulkCounter.incrementAndGet(), bulk.length)];
             } else if (type == TransportRequestOptions.Type.RECOVERY) {
-                return recovery[Math.abs(recoveryCounter.incrementAndGet()) % recovery.length];
+                return recovery[MathUtils.mod(recoveryCounter.incrementAndGet(), recovery.length)];
             } else {
                 throw new ElasticsearchIllegalArgumentException("no type channel for [" + type + "]");
             }

--- a/src/test/java/org/elasticsearch/common/math/MathUtilsTests.java
+++ b/src/test/java/org/elasticsearch/common/math/MathUtilsTests.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.math;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+public class MathUtilsTests extends ElasticsearchTestCase {
+
+    @Test
+    public void mod() {
+        final int iters = scaledRandomIntBetween(1000, 10000);
+        for (int i = 0; i < iters; ++i) {
+            final int v = rarely() ? Integer.MIN_VALUE : rarely() ? Integer.MAX_VALUE : randomInt();
+            final int m = rarely() ? Integer.MAX_VALUE : randomIntBetween(1, Integer.MAX_VALUE);
+            final int mod = MathUtils.mod(v, m);
+            assertTrue(mod >= 0);
+            assertTrue(mod < m);
+        }
+    }
+
+}


### PR DESCRIPTION
We have had a couple of bugs because of the use of these methods without paying
attention that it might return a negative value when provided with MIN_VALUE.
There is one common and legitimate usage of this method in order to perform
a modulo operation which would always return a positive number. This use-case
has been extracted to MathUtils.mod.
