### PR TITLE
`flush` method for BulkProcessor class.

### DIFF
--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -586,9 +586,8 @@ public class BulkTests extends ElasticsearchIntegrationTest {
             public void afterBulk(long executionId, BulkRequest request, Throwable failure) {}
         };
 
-        BulkProcessor processor = null;
-        try {
-            processor = BulkProcessor.builder(client(), listener).setBulkActions(5).setConcurrentRequests(1).setName("foo").build();
+        try (BulkProcessor processor = BulkProcessor.builder(client(), listener).setBulkActions(5)
+                                        .setConcurrentRequests(1).setName("foo").build()) {
             Map<String, Object> data = Maps.newHashMap();
             data.put("foo", "bar");
 
@@ -601,11 +600,42 @@ public class BulkTests extends ElasticsearchIntegrationTest {
             BulkResponse response = responseQueue.poll(5, TimeUnit.SECONDS);
             assertThat("Could not get a bulk response in 5 seconds", response, is(notNullValue()));
             assertThat(response.getItems().length, is(5));
-        } finally {
-            if (processor != null) {
-                processor.close();
-            }
         }
     }
 
+    @Test
+    public void testBulkProcessorFlush() throws InterruptedException {
+        final BlockingQueue<BulkResponse> responseQueue = new SynchronousQueue();
+
+        BulkProcessor.Listener listener = new BulkProcessor.Listener() {
+            @Override
+            public void beforeBulk(long executionId, BulkRequest request) {}
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+                responseQueue.add(response);
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, Throwable failure) {}
+        };
+
+        try (BulkProcessor processor = BulkProcessor.builder(client(), listener).setBulkActions(6)
+                                        .setConcurrentRequests(1).setName("foo").build()) {
+            Map<String, Object> data = Maps.newHashMap();
+            data.put("foo", "bar");
+
+            processor.add(new IndexRequest("test", "test", "1").source(data));
+            processor.add(new IndexRequest("test", "test", "2").source(data));
+            processor.add(new IndexRequest("test", "test", "3").source(data));
+            processor.add(new IndexRequest("test", "test", "4").source(data));
+            processor.add(new IndexRequest("test", "test", "5").source(data));
+
+            processor.flush();
+
+            BulkResponse response = responseQueue.poll(1, TimeUnit.SECONDS);
+            assertThat("Could not get a bulk response even after an explicit flush.", response, is(notNullValue()));
+            assertThat(response.getItems().length, is(5));
+        }
+    }
 }


### PR DESCRIPTION
This is for #5570.

There is no explicit method `flush/execute` in [BulkProcessor](http://javadoc.kyubu.de/elasticsearch/v0.90.0/org/elasticsearch/action/bulk/BulkProcessor.html) class. This can be useful in certain scenarios. Currently it requires to close and create a new BulkProcessor if one wants an immediate flush.
