### PR TITLE
Check "store" parameter for binary mapper and check "index_name" for all mappers

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -123,6 +123,31 @@ public interface FieldMapper<T> extends Mapper {
         public Term createIndexNameTerm(BytesRef value) {
             return new Term(indexName, value);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Names names = (Names) o;
+
+            if (!fullName.equals(names.fullName)) return false;
+            if (!indexName.equals(names.indexName)) return false;
+            if (!indexNameClean.equals(names.indexNameClean)) return false;
+            if (!name.equals(names.name)) return false;
+            if (!sourcePath.equals(names.sourcePath)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + indexName.hashCode();
+            result = 31 * result + indexNameClean.hashCode();
+            result = 31 * result + fullName.hashCode();
+            result = 31 * result + sourcePath.hashCode();
+            return result;
+        }
     }
 
     public static enum Loading {

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -606,6 +606,9 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         } else if (!this.indexAnalyzer.name().equals(fieldMergeWith.indexAnalyzer.name())) {
             mergeContext.addConflict("mapper [" + names.fullName() + "] has different index_analyzer");
         }
+        if (!this.names().equals(fieldMergeWith.names())) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different index_name");
+        }
 
         if (this.similarity == null) {
             if (fieldMergeWith.similarity() != null) {

--- a/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -225,7 +225,25 @@ public class BinaryFieldMapper extends AbstractFieldMapper<BytesReference> {
 
     @Override
     public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
+        if (!(mergeWith instanceof BinaryFieldMapper)) {
+            String mergedType = mergeWith.getClass().getSimpleName();
+            if (mergeWith instanceof AbstractFieldMapper) {
+                mergedType = ((AbstractFieldMapper) mergeWith).contentType();
+            }
+            mergeContext.addConflict("mapper [" + names.fullName() + "] of different type, current_type [" + contentType() + "], merged_type [" + mergedType + "]");
+            // different types, return
+            return;
+        }
+
         BinaryFieldMapper sourceMergeWith = (BinaryFieldMapper) mergeWith;
+
+        if (this.fieldType().stored() != sourceMergeWith.fieldType().stored()) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different store values");
+        }
+        if (!this.names().equals(sourceMergeWith.names())) {
+            mergeContext.addConflict("mapper [" + names.fullName() + "] has different index_name");
+        }
+
         if (!mergeContext.mergeFlags().simulate()) {
             if (sourceMergeWith.compress != null) {
                 this.compress = sourceMergeWith.compress;


### PR DESCRIPTION
closes #5474

the "index_name" is also ignored without throw exception, added check for that as well
