### PR TITLE
Freq terms enum

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/index/FilterableTermsEnum.java
+++ b/src/main/java/org/elasticsearch/common/lucene/index/FilterableTermsEnum.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.index;
+
+import com.google.common.collect.Lists;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lucene.docset.DocIdSets;
+import org.elasticsearch.common.lucene.search.ApplyAcceptedDocsFilter;
+import org.elasticsearch.common.lucene.search.Queries;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A frequency TermsEnum that returns frequencies derived from a collection of cached leaf termEnums. 
+ * It also allows to provide a filter to explicitly compute frequencies only for docs that match the filter (heavier!).
+ */
+/**
+ *
+ */
+public class FilterableTermsEnum extends TermsEnum  {
+
+    static class Holder {
+        final TermsEnum termsEnum;
+        @Nullable
+        DocsEnum docsEnum;
+        @Nullable
+        final Bits bits;
+
+        Holder(TermsEnum termsEnum, Bits bits) {
+            this.termsEnum = termsEnum;
+            this.bits = bits;
+        }
+    }
+    protected final static int NOT_FOUND = -2;
+    private final Holder[] enums;
+    protected int currentDocFreq = 0;
+    protected long currentTotalTermFreq = 0;
+    protected BytesRef current;
+    protected boolean needDocFreqs;
+    protected boolean needTotalTermFreqs;
+    protected int numDocs;
+
+    public FilterableTermsEnum(IndexReader reader, String field, boolean needDocFreq, boolean needTotalTermFreq, @Nullable Filter filter) throws IOException {
+        if (!needDocFreq && !needTotalTermFreq) {
+            throw new ElasticsearchIllegalArgumentException("either needDocFreq or needTotalTermFreq must be true");
+        }        
+        this.needDocFreqs = needDocFreq;
+        this.needTotalTermFreqs = needTotalTermFreq;
+        if (filter == null) {
+            numDocs = reader.numDocs();
+        }
+        
+        List<AtomicReaderContext> leaves = reader.leaves();
+        List<Holder> enums = Lists.newArrayListWithExpectedSize(leaves.size());
+        for (AtomicReaderContext context : leaves) {
+            Terms terms = context.reader().terms(field);
+            if (terms == null) {
+                continue;
+            }
+            TermsEnum termsEnum = terms.iterator(null);
+            if (termsEnum == null) {
+                continue;
+            }
+            Bits bits = null;
+            if (filter != null) {
+                if (filter == Queries.MATCH_ALL_FILTER) {
+                    bits = context.reader().getLiveDocs();
+                } else {
+                    // we want to force apply deleted docs
+                    filter = new ApplyAcceptedDocsFilter(filter);
+                    DocIdSet docIdSet = filter.getDocIdSet(context, context.reader().getLiveDocs());
+                    if (DocIdSets.isEmpty(docIdSet)) {
+                        // fully filtered, none matching, no need to iterate on this
+                        continue;
+                    }
+                    bits = DocIdSets.toSafeBits(context.reader(), docIdSet);
+                    // Count how many docs are in our filtered set 
+                    // TODO make this lazy-loaded only for those that need it?
+                    DocIdSetIterator iterator = docIdSet.iterator();
+                    if (iterator != null) {
+                        while (iterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                            numDocs++;
+                        }
+                    }
+                }
+            }
+            enums.add(new Holder(termsEnum, bits));
+        }
+        this.enums = enums.toArray(new Holder[enums.size()]);
+    }
+    
+    public int getNumDocs() {
+        return numDocs;
+    }
+
+    @Override
+    public BytesRef term() throws IOException {
+        return current;
+    }
+
+    @Override
+    public boolean seekExact(BytesRef text) throws IOException {
+        boolean found = false;
+        int docFreq = 0;
+        long totalTermFreq = 0;
+        boolean hasMissingTotalTermFreq = false;
+        for (Holder anEnum : enums) {
+            if (!anEnum.termsEnum.seekExact(text)) {
+                continue;
+            }
+            found = true;
+            if (anEnum.bits == null) {
+                if (needDocFreqs) {
+                    docFreq += anEnum.termsEnum.docFreq();
+                }
+                if (needTotalTermFreqs) {
+                    long leafTotalTermFreq = anEnum.termsEnum.totalTermFreq();
+                    if (leafTotalTermFreq < 0) {
+                        hasMissingTotalTermFreq = true;
+                    } else {
+                        totalTermFreq += leafTotalTermFreq;
+                    }
+                }
+            } else {
+                DocsEnum docsEnum = anEnum.docsEnum = anEnum.termsEnum.docs(anEnum.bits, anEnum.docsEnum, needTotalTermFreqs ? DocsEnum.FLAG_FREQS : DocsEnum.FLAG_NONE);
+                for (int docId = docsEnum.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docsEnum.nextDoc()) {
+                    docFreq++;
+                    if (needTotalTermFreqs) {
+                        totalTermFreq += docsEnum.freq();
+                    }
+                }
+            }
+        }
+
+        current = found ? text : null;
+        if(found){
+            currentDocFreq = docFreq;
+            if (hasMissingTotalTermFreq) {
+                // at least one of the segments has no freqs info so declare result as
+                // missing rather than using partial info
+                currentTotalTermFreq = -1;
+            }else{
+                currentTotalTermFreq = totalTermFreq;
+            }
+        }else{
+            currentDocFreq = NOT_FOUND;
+            currentTotalTermFreq = NOT_FOUND;
+        } 
+
+        return found;
+    }
+
+    @Override
+    public int docFreq() throws IOException {
+        return currentDocFreq;
+    }
+
+    @Override
+    public long totalTermFreq() throws IOException {
+        return currentTotalTermFreq;
+    }
+
+    @Override
+    public void seekExact(long ord) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public SeekStatus seekCeil(BytesRef text) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public long ord() throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public DocsEnum docs(Bits liveDocs, DocsEnum reuse, int flags) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public DocsAndPositionsEnum docsAndPositions(Bits liveDocs, DocsAndPositionsEnum reuse, int flags) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public BytesRef next() throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public Comparator<BytesRef> getComparator() {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+}

--- a/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
+++ b/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
@@ -19,111 +19,41 @@
 
 package org.elasticsearch.common.lucene.index;
 
-import com.google.common.collect.Lists;
-import org.apache.lucene.index.*;
-import org.apache.lucene.search.DocIdSet;
-import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Filter;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.lucene.docset.DocIdSets;
-import org.elasticsearch.common.lucene.search.ApplyAcceptedDocsFilter;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.List;
 
 /**
- * A frequency terms enum that maintains a cache of docFreq, totalTermFreq, or both for repeated term lookup. It also
- * allows to provide a filter to explicitly compute frequencies only for docs that match the filter (heavier!).
+ * A frequency terms enum that maintains a cache of docFreq, totalTermFreq, or both for repeated term lookup. 
  */
-public class FreqTermsEnum extends TermsEnum implements Releasable {
-
-    static class Holder {
-        final TermsEnum termsEnum;
-        @Nullable
-        DocsEnum docsEnum;
-        @Nullable
-        final Bits bits;
-
-        Holder(TermsEnum termsEnum, Bits bits) {
-            this.termsEnum = termsEnum;
-            this.bits = bits;
-        }
-    }
-
-    private final static int NOT_FOUND = -2;
+public class FreqTermsEnum extends FilterableTermsEnum implements Releasable {
 
     private static final int INITIAL_NUM_TERM_FREQS_CACHED = 512;
-
-    private final boolean docFreq;
-    private final boolean totalTermFreq;
-    private final Holder[] enums;
-
     private final BigArrays bigArrays;
     private IntArray termDocFreqs;
     private LongArray termsTotalFreqs;
     private BytesRefHash cachedTermOrds;
 
-    private int currentDocFreq = 0;
-    private long currentTotalTermFreq = 0;
 
-    private BytesRef current;
-
-    public FreqTermsEnum(IndexReader reader, String field, boolean docFreq, boolean totalTermFreq, @Nullable Filter filter, BigArrays bigArrays) throws IOException {
-        this.docFreq = docFreq;
-        this.totalTermFreq = totalTermFreq;
-        if (!docFreq && !totalTermFreq) {
-            throw new ElasticsearchIllegalArgumentException("either docFreq or totalTermFreq must be true");
-        }
-        List<AtomicReaderContext> leaves = reader.leaves();
-        List<Holder> enums = Lists.newArrayListWithExpectedSize(leaves.size());
-        for (AtomicReaderContext context : leaves) {
-            Terms terms = context.reader().terms(field);
-            if (terms == null) {
-                continue;
-            }
-            TermsEnum termsEnum = terms.iterator(null);
-            if (termsEnum == null) {
-                continue;
-            }
-            Bits bits = null;
-            if (filter != null) {
-                if (filter == Queries.MATCH_ALL_FILTER) {
-                    bits = context.reader().getLiveDocs();
-                } else {
-                    // we want to force apply deleted docs
-                    filter = new ApplyAcceptedDocsFilter(filter);
-                    DocIdSet docIdSet = filter.getDocIdSet(context, context.reader().getLiveDocs());
-                    if (DocIdSets.isEmpty(docIdSet)) {
-                        // fully filtered, none matching, no need to iterate on this
-                        continue;
-                    }
-                    bits = DocIdSets.toSafeBits(context.reader(), docIdSet);
-                }
-            }
-            enums.add(new Holder(termsEnum, bits));
-        }
+    public FreqTermsEnum(IndexReader reader, String field, boolean needDocFreq, boolean needTotalTermFreq, @Nullable Filter filter, BigArrays bigArrays) throws IOException {
+        super(reader, field, needDocFreq, needTotalTermFreq, filter);
         this.bigArrays = bigArrays;
-
-        this.enums = enums.toArray(new Holder[enums.size()]);
-
-        if (docFreq) {
+        if (needDocFreq) {
             termDocFreqs = bigArrays.newIntArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
         } else {
             termDocFreqs = null;
         }
-        if (totalTermFreq) {
+        if (needTotalTermFreq) {
             termsTotalFreqs = bigArrays.newLongArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
         } else {
             termsTotalFreqs = null;
@@ -131,24 +61,21 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
         cachedTermOrds = new BytesRefHash(INITIAL_NUM_TERM_FREQS_CACHED, bigArrays);
     }
 
-    @Override
-    public BytesRef term() throws IOException {
-        return current;
-    }
 
     @Override
     public boolean seekExact(BytesRef text) throws IOException {
+        //Check cache
         long currentTermOrd = cachedTermOrds.add(text);
         if (currentTermOrd < 0) { // already seen, initialize instance data with the cached frequencies
             currentTermOrd = -1 - currentTermOrd;
             boolean found = true;
-            if (docFreq) {
+            if (needDocFreqs) {
                 currentDocFreq = termDocFreqs.get(currentTermOrd);
                 if (currentDocFreq == NOT_FOUND) {
                     found = false;
                 }
             }
-            if (totalTermFreq) {
+            if (needTotalTermFreqs) {
                 currentTotalTermFreq = termsTotalFreqs.get(currentTermOrd);
                 if (currentTotalTermFreq == NOT_FOUND) {
                     found = false;
@@ -157,64 +84,22 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
             current = found ? text : null;
             return found;
         }
+        
+        //Cache miss - gather stats
+        boolean found = super.seekExact(text);        
 
-        boolean found = false;
-        int docFreq = 0;
-        long totalTermFreq = 0;
-        for (Holder anEnum : enums) {
-            if (!anEnum.termsEnum.seekExact(text)) {
-                continue;
-            }
-            found = true;
-            if (anEnum.bits == null) {
-                docFreq += anEnum.termsEnum.docFreq();
-                if (this.totalTermFreq) {
-                    totalTermFreq += anEnum.termsEnum.totalTermFreq();
-                }
-            } else {
-                DocsEnum docsEnum = anEnum.docsEnum = anEnum.termsEnum.docs(anEnum.bits, anEnum.docsEnum, this.totalTermFreq ? DocsEnum.FLAG_FREQS : DocsEnum.FLAG_NONE);
-                for (int docId = docsEnum.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docsEnum.nextDoc()) {
-                    docFreq++;
-                    if (this.totalTermFreq) {
-                        totalTermFreq += docsEnum.freq();
-                    }
-                }
-            }
-        }
-
-        current = found ? text : null;
-        if (this.docFreq) {
-            if (!found) {
-                docFreq = NOT_FOUND;
-            }
-            currentDocFreq = docFreq;
+        //Cache the result - found or not. 
+        if (needDocFreqs) {
             termDocFreqs = bigArrays.grow(termDocFreqs, currentTermOrd + 1);
-            termDocFreqs.set(currentTermOrd, docFreq);
+            termDocFreqs.set(currentTermOrd, currentDocFreq);
         }
-        if (this.totalTermFreq) {
-            if (!found) {
-                totalTermFreq = NOT_FOUND;
-            } else if (totalTermFreq < 0) {
-                // no freqs really..., blast
-                totalTermFreq = -1;
-            }
-            currentTotalTermFreq = totalTermFreq;
+        if (needTotalTermFreqs) {
             termsTotalFreqs = bigArrays.grow(termsTotalFreqs, currentTermOrd + 1);
-            termsTotalFreqs.set(currentTermOrd, totalTermFreq);
+            termsTotalFreqs.set(currentTermOrd, currentTotalTermFreq);
         }
-
         return found;
     }
 
-    @Override
-    public int docFreq() throws IOException {
-        return currentDocFreq;
-    }
-
-    @Override
-    public long totalTermFreq() throws IOException {
-        return currentTotalTermFreq;
-    }
 
     @Override
     public boolean release() throws ElasticsearchException {
@@ -228,38 +113,4 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
         return true;
     }
 
-    @Override
-    public void seekExact(long ord) throws IOException {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
-
-    @Override
-    public SeekStatus seekCeil(BytesRef text) throws IOException {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
-
-    @Override
-    public long ord() throws IOException {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
-
-    @Override
-    public DocsEnum docs(Bits liveDocs, DocsEnum reuse, int flags) throws IOException {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
-
-    @Override
-    public DocsAndPositionsEnum docsAndPositions(Bits liveDocs, DocsAndPositionsEnum reuse, int flags) throws IOException {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
-
-    @Override
-    public BytesRef next() throws IOException {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
-
-    @Override
-    public Comparator<BytesRef> getComparator() {
-        throw new UnsupportedOperationException("freq terms enum");
-    }
 }

--- a/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
+++ b/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.index;
+
+import com.google.common.collect.Lists;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lucene.docset.DocIdSets;
+import org.elasticsearch.common.lucene.search.ApplyAcceptedDocsFilter;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.LongArray;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A frequency terms enum that maintains a cache of docFreq, totalTermFreq, or both for repeated term lookup. It also
+ * allows to provide a filter to explicitly compute frequencies only for docs that match the filter (heavier!).
+ */
+public class FreqTermsEnum extends TermsEnum implements Releasable {
+
+    static class Holder {
+        final TermsEnum termsEnum;
+        @Nullable
+        DocsEnum docsEnum;
+        @Nullable
+        final Bits bits;
+
+        Holder(TermsEnum termsEnum, Bits bits) {
+            this.termsEnum = termsEnum;
+            this.bits = bits;
+        }
+    }
+
+    static final int INITIAL_NUM_TERM_FREQS_CACHED = 512;
+
+    private final boolean docFreq;
+    private final boolean totalTermFreq;
+    private final Holder[] enums;
+
+    private final BigArrays bigArrays;
+    private IntArray termDocFreqs;
+    private LongArray termsTotalFreqs;
+    private BytesRefHash cachedTermOrds;
+
+    private int currentDocFreq = 0;
+    private long currentTotalTermFreq = 0;
+
+    private BytesRef current;
+
+    public FreqTermsEnum(IndexReader reader, String field, boolean docFreq, boolean totalTermFreq, @Nullable Filter filter, BigArrays bigArrays) throws IOException {
+        this.docFreq = docFreq;
+        this.totalTermFreq = totalTermFreq;
+        if (!docFreq && !totalTermFreq) {
+            throw new ElasticsearchIllegalArgumentException("either docFreq or totalTermFreq must be true");
+        }
+        List<AtomicReaderContext> leaves = reader.leaves();
+        List<Holder> enums = Lists.newArrayListWithExpectedSize(leaves.size());
+        for (AtomicReaderContext context : leaves) {
+            Terms terms = context.reader().terms(field);
+            if (terms == null) {
+                continue;
+            }
+            TermsEnum termsEnum = terms.iterator(null);
+            if (termsEnum == null) {
+                continue;
+            }
+            Bits bits = null;
+            if (filter != null) {
+                if (filter == Queries.MATCH_ALL_FILTER) {
+                    bits = context.reader().getLiveDocs();
+                } else {
+                    // we want to force apply deleted docs
+                    filter = new ApplyAcceptedDocsFilter(filter);
+                    DocIdSet docIdSet = filter.getDocIdSet(context, context.reader().getLiveDocs());
+                    if (DocIdSets.isEmpty(docIdSet)) {
+                        // fully filtered, none matching, no need to iterate on this
+                        continue;
+                    }
+                    bits = DocIdSets.toSafeBits(context.reader(), docIdSet);
+                }
+            }
+            enums.add(new Holder(termsEnum, bits));
+        }
+        this.bigArrays = bigArrays;
+
+        this.enums = enums.toArray(new Holder[enums.size()]);
+
+        if (docFreq) {
+            termDocFreqs = bigArrays.newIntArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
+        } else {
+            termDocFreqs = null;
+        }
+        if (totalTermFreq) {
+            termsTotalFreqs = bigArrays.newLongArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
+        } else {
+            termsTotalFreqs = null;
+        }
+        cachedTermOrds = new BytesRefHash(INITIAL_NUM_TERM_FREQS_CACHED, bigArrays);
+    }
+
+    @Override
+    public BytesRef term() throws IOException {
+        return current;
+    }
+
+    @Override
+    public boolean seekExact(BytesRef text) throws IOException {
+        long currentTermOrd = cachedTermOrds.add(text);
+        if (currentTermOrd < 0) { // already seen, initialize instance data with the cached frequencies
+            currentTermOrd = -1 - currentTermOrd;
+            boolean found = true;
+            if (docFreq) {
+                currentDocFreq = termDocFreqs.get(currentTermOrd);
+                if (currentDocFreq == -2) {
+                    found = false;
+                }
+            }
+            if (totalTermFreq) {
+                currentTotalTermFreq = termsTotalFreqs.get(currentTermOrd);
+                if (currentTotalTermFreq == -2) {
+                    found = false;
+                }
+            }
+            current = found ? text : null;
+            return found;
+        }
+
+        boolean found = false;
+        int docFreq = 0;
+        long totalTermFreq = 0;
+        for (Holder anEnum : enums) {
+            if (!anEnum.termsEnum.seekExact(text)) {
+                continue;
+            }
+            found = true;
+            if (anEnum.bits == null) {
+                docFreq += anEnum.termsEnum.docFreq();
+                totalTermFreq += anEnum.termsEnum.totalTermFreq();
+            } else {
+                DocsEnum docsEnum = anEnum.docsEnum = anEnum.termsEnum.docs(anEnum.bits, anEnum.docsEnum, this.totalTermFreq ? DocsEnum.FLAG_FREQS : DocsEnum.FLAG_NONE);
+                for (int docId = docsEnum.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docsEnum.nextDoc()) {
+                    docFreq++;
+                    if (this.totalTermFreq) {
+                        totalTermFreq += docsEnum.freq();
+                    }
+                }
+            }
+        }
+
+        current = found ? text : null;
+        if (this.docFreq) {
+            if (!found) {
+                docFreq = -2; // -2 is used to indicate not found
+            }
+            currentDocFreq = docFreq;
+            termDocFreqs = bigArrays.grow(termDocFreqs, currentTermOrd + 1);
+            termDocFreqs.set(currentTermOrd, docFreq);
+        }
+        if (this.totalTermFreq) {
+            if (!found) {
+                totalTermFreq = -2; // -2 is used to indicate not found
+            } else if (totalTermFreq < 0) {
+                // no freqs really..., blast
+                totalTermFreq = -1;
+            }
+            currentTotalTermFreq = totalTermFreq;
+            termsTotalFreqs = bigArrays.grow(termsTotalFreqs, currentTermOrd + 1);
+            termsTotalFreqs.set(currentTermOrd, totalTermFreq);
+        }
+
+        return found;
+    }
+
+    @Override
+    public int docFreq() throws IOException {
+        return currentDocFreq;
+    }
+
+    @Override
+    public long totalTermFreq() throws IOException {
+        return currentTotalTermFreq;
+    }
+
+    @Override
+    public boolean release() throws ElasticsearchException {
+        try {
+            Releasables.release(cachedTermOrds, termDocFreqs, termsTotalFreqs);
+        } finally {
+            cachedTermOrds = null;
+            termDocFreqs = null;
+            termsTotalFreqs = null;
+        }
+        return true;
+    }
+
+    @Override
+    public void seekExact(long ord) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public SeekStatus seekCeil(BytesRef text) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public long ord() throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public DocsEnum docs(Bits liveDocs, DocsEnum reuse, int flags) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public DocsAndPositionsEnum docsAndPositions(Bits liveDocs, DocsAndPositionsEnum reuse, int flags) throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public BytesRef next() throws IOException {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+
+    @Override
+    public Comparator<BytesRef> getComparator() {
+        throw new UnsupportedOperationException("freq terms enum");
+    }
+}

--- a/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
+++ b/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
@@ -62,7 +62,9 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
         }
     }
 
-    static final int INITIAL_NUM_TERM_FREQS_CACHED = 512;
+    private final static int NOT_FOUND = -2;
+
+    private static final int INITIAL_NUM_TERM_FREQS_CACHED = 512;
 
     private final boolean docFreq;
     private final boolean totalTermFreq;
@@ -142,13 +144,13 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
             boolean found = true;
             if (docFreq) {
                 currentDocFreq = termDocFreqs.get(currentTermOrd);
-                if (currentDocFreq == -2) {
+                if (currentDocFreq == NOT_FOUND) {
                     found = false;
                 }
             }
             if (totalTermFreq) {
                 currentTotalTermFreq = termsTotalFreqs.get(currentTermOrd);
-                if (currentTotalTermFreq == -2) {
+                if (currentTotalTermFreq == NOT_FOUND) {
                     found = false;
                 }
             }
@@ -166,7 +168,9 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
             found = true;
             if (anEnum.bits == null) {
                 docFreq += anEnum.termsEnum.docFreq();
-                totalTermFreq += anEnum.termsEnum.totalTermFreq();
+                if (this.totalTermFreq) {
+                    totalTermFreq += anEnum.termsEnum.totalTermFreq();
+                }
             } else {
                 DocsEnum docsEnum = anEnum.docsEnum = anEnum.termsEnum.docs(anEnum.bits, anEnum.docsEnum, this.totalTermFreq ? DocsEnum.FLAG_FREQS : DocsEnum.FLAG_NONE);
                 for (int docId = docsEnum.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docsEnum.nextDoc()) {
@@ -181,7 +185,7 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
         current = found ? text : null;
         if (this.docFreq) {
             if (!found) {
-                docFreq = -2; // -2 is used to indicate not found
+                docFreq = NOT_FOUND;
             }
             currentDocFreq = docFreq;
             termDocFreqs = bigArrays.grow(termDocFreqs, currentTermOrd + 1);
@@ -189,7 +193,7 @@ public class FreqTermsEnum extends TermsEnum implements Releasable {
         }
         if (this.totalTermFreq) {
             if (!found) {
-                totalTermFreq = -2; // -2 is used to indicate not found
+                totalTermFreq = NOT_FOUND;
             } else if (totalTermFreq < 0) {
                 // no freqs really..., blast
                 totalTermFreq = -1;

--- a/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
+++ b/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.lucene.index;
 
+import org.apache.lucene.index.DocsEnum;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.util.BytesRef;
@@ -43,11 +44,15 @@ public class FreqTermsEnum extends FilterableTermsEnum implements Releasable {
     private IntArray termDocFreqs;
     private LongArray termsTotalFreqs;
     private BytesRefHash cachedTermOrds;
+    private final boolean needDocFreqs;
+    private final boolean needTotalTermFreqs;
 
 
     public FreqTermsEnum(IndexReader reader, String field, boolean needDocFreq, boolean needTotalTermFreq, @Nullable Filter filter, BigArrays bigArrays) throws IOException {
-        super(reader, field, needDocFreq, needTotalTermFreq, filter);
+        super(reader, field, needTotalTermFreq ? DocsEnum.FLAG_FREQS : DocsEnum.FLAG_NONE, filter);
         this.bigArrays = bigArrays;
+        this.needDocFreqs = needDocFreq;
+        this.needTotalTermFreqs = needTotalTermFreq;
         if (needDocFreq) {
             termDocFreqs = bigArrays.newIntArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
         } else {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -59,7 +59,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
         final int size = (int) Math.min(bucketOrds.size(), shardSize);
 
-        long supersetSize=termsAggFactory.prepareBackground(context);
+        long supersetSize = termsAggFactory.prepareBackground(context);
         long subsetSize = numCollectedDocs;
 
         BucketSignificancePriorityQueue ordered = new BucketSignificancePriorityQueue(size);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -75,6 +75,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
             if (spare == null) {
                 spare = new SignificantLongTerms.Bucket(0, 0, 0, 0, 0, null);
+                termsAggFactory.buildTermsEnum(context);
             }
             spare.term = bucketOrds.key(i);
             spare.subsetDf = bucketDocCount(ord);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -59,9 +59,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
         final int size = (int) Math.min(bucketOrds.size(), shardSize);
 
-        ContextIndexSearcher searcher = context.searchContext().searcher();
-        IndexReader topReader = searcher.getIndexReader();
-        long supersetSize = topReader.numDocs();
+        long supersetSize=termsAggFactory.prepareBackground(context);
         long subsetSize = numCollectedDocs;
 
         BucketSignificancePriorityQueue ordered = new BucketSignificancePriorityQueue(size);
@@ -75,7 +73,6 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
             if (spare == null) {
                 spare = new SignificantLongTerms.Bucket(0, 0, 0, 0, 0, null);
-                termsAggFactory.buildTermsEnum(context);
             }
             spare.term = bucketOrds.key(i);
             spare.subsetDf = bucketDocCount(ord);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -68,10 +68,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
         assert owningBucketOrdinal == 0;
 
         final int size = (int) Math.min(bucketOrds.size(), shardSize);
-
-        ContextIndexSearcher searcher = context.searchContext().searcher();
-        IndexReader topReader = searcher.getIndexReader();
-        long supersetSize = topReader.numDocs();
+        long supersetSize = termsAggFactory.prepareBackground(context);
         long subsetSize = numCollectedDocs;
 
         BucketSignificancePriorityQueue ordered = new BucketSignificancePriorityQueue(size);
@@ -79,7 +76,6 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
         for (int i = 0; i < bucketOrds.size(); i++) {
             if (spare == null) {
                 spare = new SignificantStringTerms.Bucket(new BytesRef(), 0, 0, 0, 0, null);
-                termsAggFactory.buildTermsEnum(context);
             }
 
             bucketOrds.get(i, spare.termBytes);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -79,6 +79,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
         for (int i = 0; i < bucketOrds.size(); i++) {
             if (spare == null) {
                 spare = new SignificantStringTerms.Bucket(new BytesRef(), 0, 0, 0, 0, null);
+                termsAggFactory.buildTermsEnum(context);
             }
 
             bucketOrds.get(i, spare.termBytes);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
+import org.apache.lucene.index.DocsEnum;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.util.BytesRef;
@@ -167,7 +168,7 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
         try {
             if (numberOfAggregatorsCreated == 1) {
                 // Setup a termsEnum for sole use by one aggregator
-                termsEnum = new FilterableTermsEnum(reader, indexedFieldName, true, false, filter);
+                termsEnum = new FilterableTermsEnum(reader, indexedFieldName, DocsEnum.FLAG_NONE, filter);
             } else {
                 // When we have > 1 agg we have possibility of duplicate term frequency lookups 
                 // and so use a TermsEnum that caches results of all term lookups

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -18,18 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
-import org.apache.lucene.index.*;
-import org.apache.lucene.index.FilterAtomicReader.FilterTermsEnum;
-import org.apache.lucene.util.Bits;
+import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.lucene.index.FreqTermsEnum;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -53,7 +49,6 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
 
     public static final String EXECUTION_HINT_VALUE_MAP = "map";
     public static final String EXECUTION_HINT_VALUE_ORDINALS = "ordinals";
-    static final int INITIAL_NUM_TERM_FREQS_CACHED = 512;
 
     private final int requiredSize;
     private final int shardSize;
@@ -62,14 +57,11 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
     private final String executionHint;
     private String indexedFieldName;
     private FieldMapper mapper;
-    private IntArray termDocFreqs;
-    private BytesRefHash cachedTermOrds;
-    private BigArrays bigArrays;
     private TermsEnum termsEnum;
     private int numberOfAggregatorsCreated = 0;
 
     public SignificantTermsAggregatorFactory(String name, ValuesSourceConfig valueSourceConfig, int requiredSize,
-            int shardSize, long minDocCount, IncludeExclude includeExclude, String executionHint) {
+                                             int shardSize, long minDocCount, IncludeExclude includeExclude, String executionHint) {
 
         super(name, SignificantStringTerms.TYPE.name(), valueSourceConfig);
         this.requiredSize = requiredSize;
@@ -81,7 +73,6 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
             this.indexedFieldName = valuesSourceConfig.fieldContext().field();
             mapper = SearchContext.current().smartNameFieldMapper(indexedFieldName);
         }
-        bigArrays = SearchContext.current().bigArrays();
     }
 
     @Override
@@ -100,31 +91,8 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
 
     @Override
     protected Aggregator create(ValuesSource valuesSource, long expectedBucketsCount, AggregationContext aggregationContext, Aggregator parent) {
-        
         numberOfAggregatorsCreated++;
-        if (numberOfAggregatorsCreated == 1) {
-            // Setup a termsEnum for use by first aggregator
-            try {
-                SearchContext searchContext = aggregationContext.searchContext();
-                ContextIndexSearcher searcher = searchContext.searcher();
-                Terms terms = MultiFields.getTerms(searcher.getIndexReader(), indexedFieldName);
-                // terms can be null if the choice of field is not found in this index
-                if (terms != null) {
-                    termsEnum = terms.iterator(null);
-                }
-            } catch (IOException e) {
-                throw new ElasticsearchException("IOException loading background document frequency info", e);
-            }
-        } else if (numberOfAggregatorsCreated == 2) {
-            // When we have > 1 agg we have possibility of duplicate term frequency lookups and 
-            // so introduce a cache in the form of a wrapper around the plain termsEnum created
-            // for use with the first agg
-            if (termsEnum != null) {
-                SearchContext searchContext = aggregationContext.searchContext();
-                termsEnum = new FrequencyCachingTermsEnumWrapper(termsEnum, searchContext.bigArrays(), true, false);
-            }
-        }
-        
+
         long estimatedBucketCount = valuesSource.metaData().maxAtomicUniqueValuesCount();
         if (estimatedBucketCount < 0) {
             // there isn't an estimation available.. 50 should be a good start
@@ -183,8 +151,34 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
                 "]. It can only be applied to numeric or string fields.");
     }
 
+    public TermsEnum buildTermsEnum(AggregationContext context) {
+        if (termsEnum != null) {
+            return termsEnum;
+        }
+        if (numberOfAggregatorsCreated == 1) {
+            try {
+                // Setup a termsEnum for use by first aggregator
+                SearchContext searchContext = context.searchContext();
+                ContextIndexSearcher searcher = searchContext.searcher();
+                Terms terms = MultiFields.getTerms(searcher.getIndexReader(), indexedFieldName);
+                // terms can be null if the choice of field is not found in this index
+                if (terms != null) {
+                    termsEnum = terms.iterator(null);
+                } else {
+                    // When we have > 1 agg we have possibility of duplicate term frequency lookups and
+                    // so introduce a cache in the form of a wrapper around the plain termsEnum created
+                    // for use with the first agg
+                    termsEnum = new FreqTermsEnum(searchContext.searcher().getIndexReader(), indexedFieldName, true, false, null, context.searchContext().bigArrays());
+                }
+            } catch (IOException e) {
+                throw new ElasticsearchException("failed to build terms enumeration", e);
+            }
+        }
+        return termsEnum;
+    }
+
     public long getBackgroundFrequency(BytesRef termBytes) {
-        assert termsEnum !=null; // having failed to find a field in the index we don't expect any calls for frequencies
+        assert termsEnum != null; // having failed to find a field in the index we don't expect any calls for frequencies
         long result = 0;
         try {
             if (termsEnum.seekExact(termBytes)) {
@@ -213,116 +207,4 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
         }
         return true;
     }
-
-    // A specialist TermsEnum wrapper for use in the repeated look-ups of frequency stats.
-    // TODO factor out as a utility class to replace similar org.elasticsearch.search.suggest.phrase.WordScorer.FrequencyCachingTermsEnumWrapper
-    // This implementation is likely to produce less garbage than WordScorer's impl but will need benchmarking/testing for that use case. 
-    static class FrequencyCachingTermsEnumWrapper extends FilterTermsEnum implements Releasable {
-
-        int currentTermDocFreq = 0;
-        long currentTermTotalFreq = 0;
-        private IntArray termDocFreqs;
-        private LongArray termTotalFreqs;
-        private BytesRefHash cachedTermOrds;
-        protected BigArrays bigArrays;
-        private boolean cacheDocFreqs;
-        private boolean cacheTotalFreqs;
-        private long currentTermOrd;
-
-        public FrequencyCachingTermsEnumWrapper(TermsEnum delegate, BigArrays bigArrays, boolean cacheDocFreqs, boolean cacheTotalFreqs)  {
-            super(delegate);
-            this.bigArrays = bigArrays;
-            this.cacheDocFreqs = cacheDocFreqs;
-            this.cacheTotalFreqs = cacheTotalFreqs;
-            if (cacheDocFreqs) {
-                termDocFreqs = bigArrays.newIntArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
-            }
-            if (cacheTotalFreqs) {
-                termTotalFreqs = bigArrays.newLongArray(INITIAL_NUM_TERM_FREQS_CACHED, false);
-            }
-            cachedTermOrds = new BytesRefHash(INITIAL_NUM_TERM_FREQS_CACHED, bigArrays);
-        }
-
-        @Override
-        public boolean seekExact(BytesRef text) throws IOException {
-            currentTermDocFreq = 0;
-            currentTermTotalFreq = 0;
-            currentTermOrd = cachedTermOrds.add(text);
-            if (currentTermOrd < 0) { // already seen, initialize instance data with the cached frequencies
-                currentTermOrd = -1 - currentTermOrd;
-                if (cacheDocFreqs) {
-                    currentTermDocFreq = termDocFreqs.get(currentTermOrd);
-                }
-                if (cacheTotalFreqs) {
-                    currentTermTotalFreq = termTotalFreqs.get(currentTermOrd);
-                }
-                return true;
-            } else { // cache miss - pre-emptively read and cache the required frequency values
-                if (in.seekExact(text)) {
-                    if (cacheDocFreqs) {
-                        currentTermDocFreq = in.docFreq();
-                        termDocFreqs = bigArrays.grow(termDocFreqs, currentTermOrd + 1);
-                        termDocFreqs.set(currentTermOrd, currentTermDocFreq);
-                    }
-                    if (cacheTotalFreqs) {
-                        currentTermTotalFreq = in.totalTermFreq();
-                        termTotalFreqs = bigArrays.grow(termTotalFreqs, currentTermOrd + 1);
-                        termTotalFreqs.set(currentTermOrd, currentTermTotalFreq);
-                    }
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public long totalTermFreq() throws IOException {
-            assert cacheTotalFreqs;
-            return currentTermTotalFreq;
-        }
-
-        @Override
-        public int docFreq() throws IOException {
-            assert cacheDocFreqs;
-            return currentTermDocFreq;
-        }
-
-        @Override
-        public void seekExact(long ord) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public DocsEnum docs(Bits liveDocs, DocsEnum reuse, int flags) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public DocsAndPositionsEnum docsAndPositions(Bits liveDocs, DocsAndPositionsEnum reuse, int flags) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        public SeekStatus seekCeil(BytesRef text) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public BytesRef next() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean release() throws ElasticsearchException {
-            try {
-                Releasables.release(cachedTermOrds, termDocFreqs, termTotalFreqs);
-            } finally {
-                cachedTermOrds = null;
-                termDocFreqs = null;
-                termTotalFreqs = null;
-            }
-            return true;
-        }
-
-    }
-    
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -164,12 +164,17 @@ public class SignificantTermsAggregatorFactory extends ValueSourceAggregatorFact
                 // terms can be null if the choice of field is not found in this index
                 if (terms != null) {
                     termsEnum = terms.iterator(null);
-                } else {
-                    // When we have > 1 agg we have possibility of duplicate term frequency lookups and
-                    // so introduce a cache in the form of a wrapper around the plain termsEnum created
-                    // for use with the first agg
-                    termsEnum = new FreqTermsEnum(searchContext.searcher().getIndexReader(), indexedFieldName, true, false, null, context.searchContext().bigArrays());
                 }
+            } catch (IOException e) {
+                throw new ElasticsearchException("failed to build terms enumeration", e);
+            }
+        } else {
+            try {
+                // When we have > 1 agg we have possibility of duplicate term frequency lookups and
+                // so introduce a cache in the form of a wrapper around the plain termsEnum created
+                // for use with the first agg
+                SearchContext searchContext = context.searchContext();
+                termsEnum = new FreqTermsEnum(searchContext.searcher().getIndexReader(), indexedFieldName, true, false, null, context.searchContext().bigArrays());
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to build terms enumeration", e);
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
+import org.apache.lucene.search.Filter;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -61,6 +62,7 @@ public class SignificantTermsParser implements Aggregator.Parser {
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
 
         String field = null;
+        Filter filter = null;
         int requiredSize = DEFAULT_REQUIRED_SIZE;
         int shardSize = DEFAULT_SHARD_SIZE;
         String format = null;
@@ -101,6 +103,18 @@ public class SignificantTermsParser implements Aggregator.Parser {
                     throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
+                // TODO not sure if code below is the best means to declare a filter for 
+                // defining an alternative background stats context.
+                // In trial runs it becomes obvious that the choice of background does have to  
+                // be a strict superset of the foreground subset otherwise the significant terms algo
+                // immediately singles out the odd terms that are in the foreground but not represented
+                // in the background. So a better approach may be to use a designated parent agg as the  
+                // background because parent aggs are always guaranteed to be a superset whereas arbitrary
+                // filters defined by end users and parsed below are not.
+//                if ("background_context".equals(currentFieldName)) {
+//                    filter = context.queryParserService().parseInnerFilter(parser).filter();
+//                } else
+
                 if ("include".equals(currentFieldName)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {
@@ -169,7 +183,7 @@ public class SignificantTermsParser implements Aggregator.Parser {
         if (mapper == null) {
             ValuesSourceConfig<?> config = new ValuesSourceConfig<>(BytesValuesSource.class);
             config.unmapped(true);
-            return new SignificantTermsAggregatorFactory(aggregationName, config, requiredSize, shardSize, minDocCount, includeExclude, executionHint);
+            return new SignificantTermsAggregatorFactory(aggregationName, config, requiredSize, shardSize, minDocCount, includeExclude, executionHint, filter);
         }
         IndexFieldData<?> indexFieldData = context.fieldData().getForField(mapper);
 
@@ -206,7 +220,7 @@ public class SignificantTermsParser implements Aggregator.Parser {
         // We need values to be unique to be able to run terms aggs efficiently
         config.ensureUnique(true);
 
-        return new SignificantTermsAggregatorFactory(aggregationName, config, requiredSize, shardSize, minDocCount, includeExclude, executionHint);
+        return new SignificantTermsAggregatorFactory(aggregationName, config, requiredSize, shardSize, minDocCount, includeExclude, executionHint, filter);
     }
 
 }

--- a/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
+++ b/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.index;
+
+import com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.collect.Lists;
+import com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.*;
+import org.apache.lucene.queries.TermsFilter;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.test.ElasticsearchLuceneTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ */
+public class FreqTermsEnumTests extends ElasticsearchLuceneTestCase {
+
+    private String[] terms;
+    private IndexWriter iw;
+    private IndexReader reader;
+    private Map<String, FreqHolder> referenceAll;
+    private Map<String, FreqHolder> referenceNotDeleted;
+    private Map<String, FreqHolder> referenceFilter;
+    private Filter filter;
+
+    static class FreqHolder {
+        int docFreq;
+        long totalTermFreq;
+    }
+
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        referenceAll = Maps.newHashMap();
+        referenceNotDeleted = Maps.newHashMap();
+        referenceFilter = Maps.newHashMap();
+
+        Directory dir = newDirectory();
+        IndexWriterConfig conf = newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random()));
+        conf.setMergeScheduler(NoMergeScheduler.INSTANCE); // we don't want to do any merges, so we won't expunge deletes
+        iw = new IndexWriter(dir, conf);
+        terms = new String[scaledRandomIntBetween(10, 300)];
+        for (int i = 0; i < terms.length; i++) {
+            terms[i] = randomAsciiOfLength(5);
+        }
+
+        int numberOfDocs = scaledRandomIntBetween(30, 300);
+        Document[] docs = new Document[numberOfDocs];
+        for (int i = 0; i < numberOfDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("id", Integer.toString(i), Field.Store.YES));
+            docs[i] = doc;
+            for (String term : terms) {
+                if (randomBoolean()) {
+                    continue;
+                }
+                int freq = randomIntBetween(1, 3);
+                for (int j = 0; j < freq; j++) {
+                    doc.add(new TextField("field", term, Field.Store.YES));
+                }
+            }
+        }
+
+        // add all docs
+
+        for (int i = 0; i < docs.length; i++) {
+            Document doc = docs[i];
+            iw.addDocument(doc);
+            if (randomInt(10) == 5) {
+                iw.commit();
+            }
+        }
+
+        Set<String> deletedIds = Sets.newHashSet();
+        for (int i = 0; i < docs.length; i++) {
+            Document doc = docs[i];
+            if (randomInt(5) == 2) {
+                Term idTerm = new Term("id", Integer.toString(i));
+                deletedIds.add(idTerm.text());
+                iw.deleteDocuments(idTerm);
+            }
+        }
+
+
+        // now go over each doc, build the relevant references and filter
+        reader = DirectoryReader.open(iw, true);
+        List<Term> filterTerms = Lists.newArrayList();
+        for (int docId = 0; docId < reader.maxDoc(); docId++) {
+            Document doc = reader.document(docId);
+            addFreqs(doc, referenceAll);
+            if (!deletedIds.contains(doc.getField("id").stringValue())) {
+                addFreqs(doc, referenceNotDeleted);
+                if (randomBoolean()) {
+                    filterTerms.add(new Term("id", doc.getField("id").stringValue()));
+                    addFreqs(doc, referenceFilter);
+                }
+            }
+        }
+        filter = new TermsFilter(filterTerms);
+    }
+
+    private void addFreqs(Document doc, Map<String, FreqHolder> reference) {
+        Set<String> addedDocFreq = Sets.newHashSet();
+        for (IndexableField field : doc.getFields("field")) {
+            String term = field.stringValue();
+            FreqHolder freqHolder = reference.get(term);
+            if (freqHolder == null) {
+                freqHolder = new FreqHolder();
+                reference.put(term, freqHolder);
+            }
+            if (!addedDocFreq.contains(term)) {
+                freqHolder.docFreq++;
+                addedDocFreq.add(term);
+            }
+            freqHolder.totalTermFreq++;
+        }
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        if (reader != null) {
+            reader.close();
+        }
+        iw.rollback();
+        iw.getDirectory().close();
+        super.tearDown();
+    }
+
+    @Test
+    public void testAllFreqs() throws Exception {
+        assertAgainstReference(true, true, null, referenceAll);
+        assertAgainstReference(true, false, null, referenceAll);
+        assertAgainstReference(false, true, null, referenceAll);
+    }
+
+    @Test
+    public void testNonDeletedFreqs() throws Exception {
+        assertAgainstReference(true, true, Queries.MATCH_ALL_FILTER, referenceNotDeleted);
+        assertAgainstReference(true, false, Queries.MATCH_ALL_FILTER, referenceNotDeleted);
+        assertAgainstReference(false, true, Queries.MATCH_ALL_FILTER, referenceNotDeleted);
+    }
+
+    @Test
+    public void testFilterFreqs() throws Exception {
+        assertAgainstReference(true, true, filter, referenceFilter);
+        assertAgainstReference(true, false, filter, referenceFilter);
+        assertAgainstReference(false, true, filter, referenceFilter);
+    }
+
+    private void assertAgainstReference(boolean docFreq, boolean totalTermFreq, Filter filter, Map<String, FreqHolder> reference) throws Exception {
+        FreqTermsEnum freqTermsEnum = new FreqTermsEnum(reader, "field", docFreq, totalTermFreq, filter, BigArrays.NON_RECYCLING_INSTANCE);
+        assertAgainstReference(freqTermsEnum, reference, docFreq, totalTermFreq);
+    }
+
+    private void assertAgainstReference(FreqTermsEnum termsEnum, Map<String, FreqHolder> reference, boolean docFreq, boolean totalTermFreq) throws Exception {
+        int cycles = randomIntBetween(1, 5);
+        for (int i = 0; i < cycles; i++) {
+            List<String> terms = Lists.newArrayList(Arrays.asList(this.terms));
+            //Collections.shuffle(terms, getRandom());
+            for (String term : terms) {
+                if (!termsEnum.seekExact(new BytesRef(term))) {
+                    continue;
+                }
+                if (docFreq) {
+                    assertThat("cycle " + i + ", term " + term + ", docFreq", termsEnum.docFreq(), equalTo(reference.get(term).docFreq));
+                }
+                if (totalTermFreq) {
+                    assertThat("cycle " + i + ", term " + term + ", totalTermFreq", termsEnum.totalTermFreq(), equalTo(reference.get(term).totalTermFreq));
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
+++ b/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
@@ -32,6 +32,7 @@ import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.test.ElasticsearchLuceneTestCase;
@@ -104,7 +105,7 @@ public class FreqTermsEnumTests extends ElasticsearchLuceneTestCase {
         for (int i = 0; i < docs.length; i++) {
             Document doc = docs[i];
             iw.addDocument(doc);
-            if (randomInt(10) == 5) {
+            if (rarely()) {
                 iw.commit();
             }
         }
@@ -157,11 +158,7 @@ public class FreqTermsEnumTests extends ElasticsearchLuceneTestCase {
     @After
     @Override
     public void tearDown() throws Exception {
-        if (reader != null) {
-            reader.close();
-        }
-        iw.rollback();
-        iw.getDirectory().close();
+        IOUtils.close(reader, iw, iw.getDirectory());
         super.tearDown();
     }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
@@ -27,11 +27,14 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTerms.Bucket;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
@@ -135,6 +138,35 @@ public class SignificantTermsTests extends ElasticsearchIntegrationTest {
         SignificantTerms topTerms = response.getAggregations().get("mySignificantTerms");
         checkExpectedStringTermsFound(topTerms);
     }    
+    
+    @Test
+    public void nestedAggs() throws Exception {
+        String[][] expectedKeywordsByCategory={
+                { "paul", "weller", "jam", "style", "council" },                
+                { "paul", "smith" },
+                { "craig", "kelly", "terje", "haakonsen", "burton" }};
+        SearchResponse response = client().prepareSearch("test")
+                .setSearchType(SearchType.QUERY_AND_FETCH)
+                .addAggregation(new TermsBuilder("myCategories").field("fact_category").minDocCount(2)
+                        .subAggregation(
+                                   new SignificantTermsBuilder("mySignificantTerms").field("description")
+                                   .minDocCount(2)))
+                .execute()
+                .actionGet();
+        Terms topCategoryTerms = response.getAggregations().get("myCategories");
+        for (org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket topCategory : topCategoryTerms.getBuckets()) {
+            SignificantTerms topTerms = topCategory.getAggregations().get("mySignificantTerms");
+            HashSet<String> foundTopWords = new HashSet<String>();
+            for (Bucket topTerm : topTerms) {
+                foundTopWords.add(topTerm.getKey());
+            }
+            String[] expectedKeywords = expectedKeywordsByCategory[Integer.parseInt(topCategory.getKey()) - 1];
+            for (String expectedKeyword : expectedKeywords) {
+                assertTrue(expectedKeyword + " missing from category keywords", foundTopWords.contains(expectedKeyword));
+            }
+        }
+    }    
+
 
     @Test
     public void partiallyUnmapped() throws Exception {


### PR DESCRIPTION
Based on the work started in https://github.com/elasticsearch/elasticsearch/pull/5489
Two new utility classes to support analysis of term frequencies used by significant_terms agg and phrase suggester. The FilterableTermsEnum base class provides access to stats with an optional filter (this will be of use in examining significant_terms against a background other than the entire index).
The FreqTermsEnum subclass adds caching support for scenarios where there are likely to be repeated calls for the same term's counts.
