### PR TITLE
Search template: Put source param into template variable

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -422,9 +422,9 @@ public class SearchRequest extends ActionRequest<SearchRequest> {
     /**
      * The template of the search request.
      */
-    public SearchRequest templateSource(String source) {
-        this.source = new BytesArray(source);
-        this.sourceUnsafe = false;
+    public SearchRequest templateSource(String template) {
+        this.templateSource = new BytesArray(template);
+        this.templateSourceUnsafe = false;
         return this;
     }
 


### PR DESCRIPTION
If a search template was created using the source parameter, the
content of the parameter was put as source instead of sourceTemplate

Fixes #5556
