### PR TITLE
Snapshot checksum verification

### DIFF
--- a/src/main/java/org/apache/lucene/store/BufferedChecksumIndexOutput.java
+++ b/src/main/java/org/apache/lucene/store/BufferedChecksumIndexOutput.java
@@ -91,11 +91,8 @@ public class BufferedChecksumIndexOutput extends BufferedIndexOutput {
 
     @Override
     public void seek(long pos) throws IOException {
-        // seek might be called on files, which means that the checksum is not file checksum
-        // but a checksum of the bytes written to this stream, which is the same for each
-        // type of file in lucene
-        super.seek(pos);
-        delegate.seek(pos);
+        // in order to calculate true checksum of the file this method is no longer supported
+        throw new UnsupportedOperationException("only append-only codecs are supported");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/lucene/store/ChecksumIndexOutput.java
+++ b/src/main/java/org/elasticsearch/common/lucene/store/ChecksumIndexOutput.java
@@ -87,7 +87,7 @@ public class ChecksumIndexOutput extends IndexOutput {
 
     @Override
     public void seek(long pos) throws IOException {
-        out.seek(pos);
+        throw new UnsupportedOperationException("only append-only codecs are supported");
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/store/CorruptibleFSDirectoryService.java
+++ b/src/test/java/org/elasticsearch/test/store/CorruptibleFSDirectoryService.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.store;
+
+import org.apache.lucene.store.BaseDirectoryWrapper;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.test.TestCluster;
+
+import java.io.IOException;
+import java.util.Random;
+
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.cluster;
+
+public class CorruptibleFSDirectoryService extends MockFSDirectoryService {
+
+    private final Random random;
+
+    private volatile String[] fileNameMask;
+
+    @Inject
+    public CorruptibleFSDirectoryService(final ShardId shardId, @IndexSettings Settings indexSettings, IndexStore indexStore, final IndicesService service) {
+        super(shardId, indexSettings, indexStore, service);
+        final long seed = indexSettings.getAsLong(TestCluster.SETTING_INDEX_SEED, 0l);
+        random = new Random(seed);
+        fileNameMask = null;
+    }
+
+    @Override
+    public Directory[] build() throws IOException {
+        return wrapAllInPlace(super.build());
+    }
+
+    private Directory[] wrapAllInPlace(Directory[] directories) {
+        for (int i=0; i<directories.length; i++) {
+            directories[i] = wrap(directories[i]);
+        }
+        return directories;
+    }
+
+    private Directory wrap(Directory directory) {
+        return new CorruptibleDirectoryWrapper(directory);
+    }
+
+    private void enableCorruption(String fileNameMask) {
+        if (fileNameMask != null) {
+            logger.info("enabling corruption [{}]", fileNameMask);
+            this.fileNameMask = Strings.splitStringByCommaToArray(fileNameMask);
+        } else {
+            logger.info("disabling corruption");
+            this.fileNameMask = null;
+        }
+    }
+
+    public static void enableCorruption(String node, String index, String fileNameMask) {
+        IndicesService indicesService = cluster().getInstance(IndicesService.class, node);
+        IndexService indexService = indicesService.indexServiceSafe(index);
+        for(int shardId : indexService.shardIds()) {
+            DirectoryService directoryService = indexService.shardInjectorSafe(shardId).getInstance(DirectoryService.class);
+            if (directoryService instanceof CorruptibleFSDirectoryService) {
+                CorruptibleFSDirectoryService corruptibleFSDirectoryService = (CorruptibleFSDirectoryService)directoryService;
+                corruptibleFSDirectoryService.enableCorruption(fileNameMask);
+            }
+        }
+    }
+
+    public final class CorruptibleDirectoryWrapper extends BaseDirectoryWrapper {
+
+        public CorruptibleDirectoryWrapper(Directory delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public synchronized IndexInput openInput(String name, IOContext context) throws IOException {
+            if (Regex.simpleMatch(fileNameMask, name) ) {
+                logger.debug("corrupting file [{}]", name);
+                return new CorruptibleIndexInput(super.openInput(name, context), logger, random);
+            } else {
+                logger.trace("not corrupting file [{}]", name);
+                return super.openInput(name, context);
+            }
+        }
+
+    }
+
+    public static final class CorruptibleIndexInput extends IndexInput {
+        private final IndexInput delegate;
+        private final Random random;
+        private final ESLogger logger;
+
+        public CorruptibleIndexInput(IndexInput delegate, ESLogger logger, Random random) {
+            super("CorruptibleIndexInput(" + delegate + ")");
+            this.delegate = delegate;
+            this.random = random;
+            this.logger = logger;
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            final byte b = delegate.readByte();
+            return b;
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            long prevPos = delegate.getFilePointer();
+            delegate.readBytes(b, offset, len);
+            if (len > 0 ) {
+                int pos = random.nextInt(len);
+                b[pos] ^= 42;
+                logger.info("Corrupted byte [{}] in file [{}]", prevPos + pos, delegate);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public long getFilePointer() {
+            return delegate.getFilePointer();
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            delegate.seek(pos);
+        }
+
+        @Override
+        public long length() {
+            return delegate.length();
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/store/CorruptibleFSIndexStore.java
+++ b/src/test/java/org/elasticsearch/test/store/CorruptibleFSIndexStore.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.store;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.fs.FsIndexStore;
+import org.elasticsearch.indices.store.IndicesStore;
+
+public class CorruptibleFSIndexStore extends FsIndexStore {
+
+    @Inject
+    public CorruptibleFSIndexStore(Index index, Settings indexSettings, IndexService indexService, IndicesStore indicesStore, NodeEnvironment nodeEnv) {
+        super(index, indexSettings, indexService, indicesStore, nodeEnv);
+
+    }
+
+    @Override
+    public Class<? extends DirectoryService> shardDirectory() {
+        return CorruptibleFSDirectoryService.class;
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/store/CorruptibleFSIndexStoreModule.java
+++ b/src/test/java/org/elasticsearch/test/store/CorruptibleFSIndexStoreModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.store;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.index.store.IndexStore;
+
+public class CorruptibleFSIndexStoreModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(IndexStore.class).to(CorruptibleFSIndexStore.class).asEagerSingleton();
+    }
+
+}


### PR DESCRIPTION
Disables support for non append-only codecs and adds automatic verification of all files that are being snapshotted. Closes #5593
