### PR TITLE
Update CORS to respond with specific origin

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -75,7 +75,11 @@ public class NettyHttpChannel implements HttpChannel {
         if (RestUtils.isBrowser(request.headers().get(HttpHeaders.Names.USER_AGENT))) {
             if (transport.settings().getAsBoolean("http.cors.enabled", true)) {
                 // Add support for cross-origin Ajax requests (CORS)
-                resp.headers().add("Access-Control-Allow-Origin", transport.settings().get("http.cors.allow-origin", "*"));
+                String origin = request.headers().get(HttpHeaders.Names.ORIGIN);
+                if (origin == null) {
+                  origin = "*";
+                }
+                resp.headers().add("Access-Control-Allow-Origin", transport.settings().get("http.cors.allow-origin", origin));
                 if (request.getMethod() == HttpMethod.OPTIONS) {
                     // Allow Ajax requests based on the CORS "preflight" request
                     resp.headers().add("Access-Control-Max-Age", transport.settings().getAsInt("http.cors.max-age", 1728000));


### PR DESCRIPTION
When put behind basic auth, CORS requests don't allow the use of
a wildcard ("*") for Access-Control-Allow-Origin:

http://www.w3.org/TR/cors/#resource-requests

We ran into this while having nginx with basic auth proxy to our es
node. It should effectively be the same as what is there for CORS
requests, but respond with the origin. Happy to update for any
changes neccessary.
