### PR TITLE
Add MediaWiki integration to list

### DIFF
--- a/docs/community/integrations.asciidoc
+++ b/docs/community/integrations.asciidoc
@@ -82,3 +82,6 @@
 
 * https://github.com/kzwang/elasticsearch-osem[elasticsearch-osem]:
   A Java Object Search Engine Mapping (OSEM) for Elasticsearch
+
+* https://www.mediawiki.org/wiki/Extension:CirrusSearch[CirrusSearch]:
+  Elasticsearch for MediaWiki.


### PR DESCRIPTION
MediaWiki can use Elasticsearch to power its search backend via the CirrusSearch extension.
