### PR TITLE
Replaces usage of `StringBuffer` with `StringBuilder`

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
@@ -207,13 +207,13 @@ public class PluginInfo implements Streamable, Serializable, ToXContent {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("PluginInfo{");
+        final StringBuilder sb = new StringBuilder("PluginInfo{");
         sb.append("name='").append(name).append('\'');
         sb.append(", description='").append(description).append('\'');
         sb.append(", site=").append(site);
         sb.append(", jvm=").append(jvm);
         sb.append(", version='").append(version).append('\'');
-        sb.append(", isolation='").append(isolation);
+        sb.append(", isolation=").append(isolation);
         sb.append('}');
         return sb.toString();
     }

--- a/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
+++ b/src/test/java/org/elasticsearch/stresstest/fullrestart/FullRestartStressTest.java
@@ -172,7 +172,7 @@ public class FullRestartStressTest {
             for (int b = 0; b < numberOfBulks; b++) {
                 BulkRequestBuilder bulk = client.client().prepareBulk();
                 for (int k = 0; k < bulkSize; k++) {
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     XContentBuilder json = XContentFactory.jsonBuilder().startObject()
                             .field("field", "value" + ThreadLocalRandom.current().nextInt());
 


### PR DESCRIPTION
Closes #5605

Also fixes stray single quote in the same `PluginInfo#toString()` method.
