### PR TITLE
Made template endpoint compatible with search endpoint

### DIFF
--- a/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/api/search_template.json
@@ -1,6 +1,6 @@
 {
   "search_template": {
-    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-search.html",
+    "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html",
     "methods": ["GET", "POST"],
     "url": {
       "path": "/_search/template",
@@ -13,6 +13,39 @@
         "type": {
           "type" : "list",
           "description" : "A comma-separated list of document types to search; leave empty to perform the operation on all types"
+        }
+      },
+      "params" : {
+        "ignore_unavailable": {
+            "type" : "boolean",
+            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+        },
+        "allow_no_indices": {
+            "type" : "boolean",
+            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
+        "expand_wildcards": {
+            "type" : "enum",
+            "options" : ["open","closed"],
+            "default" : "open",
+            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "preference": {
+          "type" : "string",
+          "description" : "Specify the node or shard the operation should be performed on (default: random)"
+        },
+        "routing": {
+          "type" : "list",
+          "description" : "A comma-separated list of specific routing values"
+        },
+        "scroll": {
+          "type" : "duration",
+          "description" : "Specify how long a consistent view of the index should be maintained for scrolled search"
+        },
+        "search_type": {
+          "type" : "enum",
+          "options" : ["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"],
+          "description" : "Search operation type"
         }
       }
     },

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -146,11 +146,7 @@ public class RestSearchAction extends BaseRestHandler {
             }
         }
 
-        // add extra source based on the request parameters
-        if (!isTemplateRequest) {
-            searchRequest.extraSource(parseSearchSource(request));
-        }
-
+        searchRequest.extraSource(parseSearchSource(request));
         searchRequest.searchType(request.param("search_type"));
 
         String scroll = request.param("scroll");


### PR DESCRIPTION
Before this the from/size parameters did not work.
Also updated the rest api spec definition file with all the query_string
parameters.

Fixes #5550
