### PR TITLE
Added StreamOutput.writeOptionalStreamableOnOrAfter()

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -609,9 +609,7 @@ public class CommonStats implements Streamable, ToXContent {
             segments.writeTo(out);
         }
         out.writeOptionalStreamable(translog);
-        if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
-            out.writeOptionalStreamable(suggest);
-        }
+        out.writeOptionalStreamableOnOrAfter(suggest, Version.V_1_2_0);
     }
 
     // note, requires a wrapping object

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -464,4 +464,18 @@ public abstract class StreamOutput extends OutputStream {
             writeBoolean(false);
         }
     }
+
+    /**
+     * Serializes a potential null value only if a certain version is matched
+     */
+    public void writeOptionalStreamableOnOrAfter(@Nullable Streamable streamable, Version expectedVersion) throws IOException {
+        if (this.version.onOrAfter(expectedVersion)) {
+            if (streamable != null) {
+                writeBoolean(true);
+                streamable.writeTo(this);
+            } else {
+                writeBoolean(false);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This method supports to specify a version, which is going to be checked
in order to prevent the longer if-statements usually used in the
writeTo() methods.
