### PR TITLE
Blob store-based gateways shouldn't serialize transient metadata

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -114,7 +114,9 @@ public class MetaData implements Iterable<IndexMetaData> {
 
     public static final MetaData EMPTY_META_DATA = builder().build();
 
-    public static final String GLOBAL_PERSISTENT_ONLY_PARAM = "global_persistent_only";
+    public static final String GLOBAL_ONLY_PARAM = "global_only";
+
+    public static final String PERSISTENT_ONLY_PARAM = "persistent_only";
 
     private final String uuid;
     private final long version;
@@ -1230,7 +1232,8 @@ public class MetaData implements Iterable<IndexMetaData> {
         }
 
         public static void toXContent(MetaData metaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
-            boolean globalPersistentOnly = params.paramAsBoolean(GLOBAL_PERSISTENT_ONLY_PARAM, false);
+            boolean globalOnly = params.paramAsBoolean(GLOBAL_ONLY_PARAM, false);
+            boolean persistentOnly = params.paramAsBoolean(PERSISTENT_ONLY_PARAM, false);
             builder.startObject("meta-data");
 
             builder.field("version", metaData.version());
@@ -1244,7 +1247,7 @@ public class MetaData implements Iterable<IndexMetaData> {
                 builder.endObject();
             }
 
-            if (!globalPersistentOnly && !metaData.transientSettings().getAsMap().isEmpty()) {
+            if (!persistentOnly && !metaData.transientSettings().getAsMap().isEmpty()) {
                 builder.startObject("transient_settings");
                 for (Map.Entry<String, String> entry : metaData.transientSettings().getAsMap().entrySet()) {
                     builder.field(entry.getKey(), entry.getValue());
@@ -1258,7 +1261,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             }
             builder.endObject();
 
-            if (!globalPersistentOnly && !metaData.indices().isEmpty()) {
+            if (!globalOnly && !metaData.indices().isEmpty()) {
                 builder.startObject("indices");
                 for (IndexMetaData indexMetaData : metaData) {
                     IndexMetaData.Builder.toXContent(indexMetaData, builder, params);
@@ -1268,7 +1271,7 @@ public class MetaData implements Iterable<IndexMetaData> {
 
             for (ObjectObjectCursor<String, Custom> cursor : metaData.customs()) {
                 Custom.Factory factory = lookupFactorySafe(cursor.key);
-                if (!globalPersistentOnly || factory.isPersistent()) {
+                if (!persistentOnly || factory.isPersistent()) {
                     builder.startObject(cursor.key);
                     factory.toXContent(cursor.value, builder, params);
                     builder.endObject();

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalGatewayMetaState.java
@@ -132,12 +132,14 @@ public class LocalGatewayMetaState extends AbstractComponent implements ClusterS
             formatParams = new ToXContent.MapParams(params);
             Map<String, String> globalOnlyParams = Maps.newHashMap();
             globalOnlyParams.put("binary", "true");
-            globalOnlyParams.put(MetaData.GLOBAL_PERSISTENT_ONLY_PARAM, "true");
+            globalOnlyParams.put(MetaData.PERSISTENT_ONLY_PARAM, "true");
+            globalOnlyParams.put(MetaData.GLOBAL_ONLY_PARAM, "true");
             globalOnlyFormatParams = new ToXContent.MapParams(globalOnlyParams);
         } else {
             formatParams = ToXContent.EMPTY_PARAMS;
             Map<String, String> globalOnlyParams = Maps.newHashMap();
-            globalOnlyParams.put(MetaData.GLOBAL_PERSISTENT_ONLY_PARAM, "true");
+            globalOnlyParams.put(MetaData.PERSISTENT_ONLY_PARAM, "true");
+            globalOnlyParams.put(MetaData.GLOBAL_ONLY_PARAM, "true");
             globalOnlyFormatParams = new ToXContent.MapParams(globalOnlyParams);
         }
 

--- a/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -137,7 +137,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         this.repositoryName = repositoryName;
         this.indexShardRepository = (BlobStoreIndexShardRepository) indexShardRepository;
         Map<String, String> globalOnlyParams = Maps.newHashMap();
-        globalOnlyParams.put(MetaData.GLOBAL_PERSISTENT_ONLY_PARAM, "true");
+        globalOnlyParams.put(MetaData.PERSISTENT_ONLY_PARAM, "true");
+        globalOnlyParams.put(MetaData.GLOBAL_ONLY_PARAM, "true");
         globalOnlyFormatParams = new ToXContent.MapParams(globalOnlyParams);
         snapshotRateLimiter = getRateLimiter(repositorySettings, "max_snapshot_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB));
         restoreRateLimiter = getRateLimiter(repositorySettings, "max_restore_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB));


### PR DESCRIPTION
Fixes #5615

I would like to merge the first commit b0172c0 to 1.1, 1.x and master since it looks like a good change anyway. The second commit will go only to 1.1 because 1.x and master no longer have blob store based gateways (S3, shared filesystem, etc). 
