### PR TITLE
add test for ElasticSearchPostingsFormat

### DIFF
--- a/src/test/java/org/elasticsearch/index/codec/postingformat/ElasticsearchPostingsFormatTest.java
+++ b/src/test/java/org/elasticsearch/index/codec/postingformat/ElasticsearchPostingsFormatTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.codec.postingformat;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BasePostingsFormatTestCase;
+import org.apache.lucene.util._TestUtil;
+import org.elasticsearch.index.codec.postingsformat.Elasticsearch090PostingsFormat;
+
+/** Runs elasticsearch postings format against lucene's standard postings format tests */
+public class ElasticsearchPostingsFormatTest extends BasePostingsFormatTestCase {
+
+    @Override
+    protected Codec getCodec() {
+        return _TestUtil.alwaysPostingsFormat(new Elasticsearch090PostingsFormat());
+    }
+    
+}


### PR DESCRIPTION
We have a custom postingsformat at the moment, and Lucene has a useful base test class to test these.
