### PR TITLE
Fail the engine/shard when refresh failed

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -730,6 +730,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 } else if (currentWriter != indexWriter) {
                     // an index writer got replaced on us, ignore
                 } else {
+                    failEngine(e);
                     throw new RefreshFailedEngineException(shardId, e);
                 }
             }


### PR DESCRIPTION
When refresh failed, it would fail due to a serious issue in the shard (mainly corrupted index). Fail the engine in that cause, which will cause the shard to fail. The reason why its not only on CorruptedIndex failed is that any type of failure seems to be relevant here to fail the shard
