### PR TITLE
Geo context suggester: Require precision in mapping

### DIFF
--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -174,13 +174,12 @@ geohash of a certain precision, which provides the context.
 
 [float]
 ==== Geo location Mapping
-The mapping for a geo context accepts four settings:
+The mapping for a geo context accepts four settings, only of which `precision` is required:
 
 [horizontal]
 `precision`::  This defines the precision of the geohash and can be specified as `5m`, `10km`,
                or as a raw geohash precision: `1`..`12`. It's also possible to setup multiple
                precisions by defining a list of precisions: `["5m", "10km"]`
-               (default is a geohash level of 12)
 `neighbors`::  Geohashes are rectangles, so a geolocation, which in reality is only 1 metre
                away from the specified point, may fall into the neighbouring rectangle. Set
                `neighbours` to `true` to include the neighbouring geohashes in the context.

--- a/rest-api-spec/test/suggest/20_context.yaml
+++ b/rest-api-spec/test/suggest/20_context.yaml
@@ -33,6 +33,7 @@ setup:
                      "context":
                         "location":
                             "type" : "geo"
+                            "precision" : "5km"
 
 ---
 "Simple context suggestion should work":
@@ -202,7 +203,11 @@ setup:
       indices.refresh: {}
 
   - do:
+      indices.get_mapping: {}
+
+  - do:
       suggest:
+        index: test
         body:
           result:
             text: "hote"

--- a/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.suggest.completion;
 
-import org.apache.lucene.search.suggest.analyzing.XFuzzySuggester;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.suggest.SuggestBuilder;
 

--- a/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
+++ b/src/main/java/org/elasticsearch/search/suggest/context/GeolocationContextMapping.java
@@ -114,6 +114,10 @@ public class GeolocationContextMapping extends ContextMapping {
      *         <code>config</code>
      */
     protected static GeolocationContextMapping load(String name, Map<String, Object> config) {
+        if (!config.containsKey(FIELD_PRECISION)) {
+            throw new ElasticsearchParseException("field [precision] is missing");
+        }
+
         final GeolocationContextMapping.Builder builder = new GeolocationContextMapping.Builder(name);
 
         if (config != null) {
@@ -379,6 +383,10 @@ public class GeolocationContextMapping extends ContextMapping {
                 } else {
                     point = new GeoPoint(lat, lon);
                 }
+            }
+
+            if (precision == null || precision.length == 0) {
+                precision = this.precision;
             }
 
             return new GeoQuery(name, point.geohash(), precision);

--- a/src/test/java/org/elasticsearch/search/suggest/context/GeoLocationContextMappingTest.java
+++ b/src/test/java/org/elasticsearch/search/suggest/context/GeoLocationContextMappingTest.java
@@ -18,12 +18,13 @@
  */
 package org.elasticsearch.search.suggest.context;
 
-import com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.collect.Maps;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
+
+import java.util.HashMap;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
@@ -38,7 +39,9 @@ public class GeoLocationContextMappingTest extends ElasticsearchTestCase {
         XContentParser parser = XContentHelper.createParser(builder.bytes());
         parser.nextToken();
 
-        GeolocationContextMapping mapping = GeolocationContextMapping.load("foo", Maps.newHashMap());
+        HashMap<String, Object> config = new HashMap<>();
+        config.put("precision", 12);
+        GeolocationContextMapping mapping = GeolocationContextMapping.load("foo", config);
         mapping.parseQuery("foo", parser);
     }
 


### PR DESCRIPTION
The default precision was way too exact and could lead people to
think that geo context suggestions are not working. This patch now
requires you to set the precision in the mapping, as elasticsearch itself
can never tell exactly, what the required precision for the users
suggestions are.

Closes #5621
