### PR TITLE
Remove ScriptDocValues.EMPTY.

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.util.SlicedObjectList;
 import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,7 +37,9 @@ import java.util.List;
  */
 public abstract class ScriptDocValues {
 
-    public static final ScriptDocValues EMPTY = new Empty();
+    public static final Longs EMPTY_LONGS = new Longs(LongValues.EMPTY);
+    public static final Doubles EMPTY_DOUBLES = new Doubles(DoubleValues.EMPTY);
+    public static final GeoPoints EMPTY_GEOPOINTS = new GeoPoints(GeoPointValues.EMPTY);
     public static final Strings EMPTY_STRINGS = new Strings(BytesValues.EMPTY);
     protected int docId;
     protected boolean listLoaded = false;
@@ -51,23 +52,6 @@ public abstract class ScriptDocValues {
     public abstract boolean isEmpty();
 
     public abstract List<?> getValues();
-
-    public static class Empty extends ScriptDocValues {
-        @Override
-        public void setNextDocId(int docId) {
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return true;
-        }
-
-        @Override
-        public List<?> getValues() {
-            return Collections.emptyList();
-        }
-
-    }
 
     public final static class Strings extends ScriptDocValues {
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractGeoPointIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractGeoPointIndexFieldData.java
@@ -76,7 +76,7 @@ abstract class AbstractGeoPointIndexFieldData extends AbstractIndexFieldData<Ato
 
         @Override
         public ScriptDocValues getScriptValues() {
-            return ScriptDocValues.EMPTY;
+            return ScriptDocValues.EMPTY_GEOPOINTS;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
@@ -94,7 +94,7 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
 
         @Override
         public ScriptDocValues getScriptValues() {
-            return ScriptDocValues.EMPTY;
+            return ScriptDocValues.EMPTY_DOUBLES;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
@@ -93,7 +93,7 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
 
         @Override
         public ScriptDocValues getScriptValues() {
-            return ScriptDocValues.EMPTY;
+            return ScriptDocValues.EMPTY_DOUBLES;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
@@ -95,7 +95,7 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
 
         @Override
         public ScriptDocValues getScriptValues() {
-            return ScriptDocValues.EMPTY;
+            return ScriptDocValues.EMPTY_LONGS;
         }
     }
 


### PR DESCRIPTION
Instead the default implementation is used, but on top of empty
(Bytes|Long|Double|GeoPoint)Values. This makes sure there is no
inconsistency between documents depending on whether other documents in the
segment have values or not.

Close #5646
