### PR TITLE
Typo in the description for include_in_all

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -707,7 +707,7 @@ it gets processed as a not analyzed string and is accessible under the name `nam
 
 The `include_in_all` setting is ignored on any field that is defined in
 the `fields` options. Setting the `include_in_all` only makes sense on
-the main field, since the raw field value to copied to the `_all` field,
+the main field, since the raw field value is copied to the `_all` field,
 the tokens aren't copied.
 
 [float]


### PR DESCRIPTION
I know this is uber-minor, but I was confused by the phrase "the raw field value to be copied". I assume "is" was supposed to be instead of "to"
