### PR TITLE
Add global ordinals

### DIFF
--- a/docs/reference/index-modules/fielddata.asciidoc
+++ b/docs/reference/index-modules/fielddata.asciidoc
@@ -125,6 +125,41 @@ field data format.
     Computes and stores field data data-structures on disk at indexing time.
 
 [float]
+==== Global ordinals
+
+coming[1.2.0]
+
+Global ordinals is a data-structure on top of field data, that maintains an
+incremental numbering for all the terms in field data in a lexicographic order.
+Each term has a unique number and the number of term 'A' is lower than the number
+of term 'B'. Global ordinals are only supported on string fields.
+
+Field data on string also has ordinals, which is a unique numbering for all terms
+in a particular segment and field. Global ordinals just build on top of this,
+by providing a mapping between the segment ordinals and the global ordinals.
+The latter being unique across the entire shard.
+
+Global ordinals can be beneficial in search features that use segment ordinals already
+such as the terms aggregator to improve the execution time. Often these search features
+need to merge the segment ordinal results to a cross segment terms result. With
+global ordinals this mapping happens during field data load time instead of during each
+query execution. With global ordinals search features only need to resolve the actual
+term when building the (shard) response, but during the execution there is no need
+at all to use the actual terms and the unique numbering global ordinals provided is
+sufficient and improves the execution time.
+
+Global ordinals for a specified field are tied to all the segments of a shard (Lucene index),
+which is different than for field data for a specific field which is tied to a single segment.
+For this reason global ordinals need to be rebuilt in its entirety once new segments
+become visible. This one time cost would happen anyway without global ordinals, but
+then it would happen for each search execution instead!
+
+The loading time of global ordinals depends on the number of terms in a field, but in general
+it is low, since it source field data has already been loaded. The memory overhead of global
+ordinals is a small because it is very efficiently compressed. Eager loading of global ordinals
+can move the loading time from the first search request, to the refresh itself.
+
+[float]
 === Fielddata loading
 
 By default, field data is loaded lazily, ie. the first time that a query that
@@ -146,6 +181,23 @@ It is possible to force field data to be loaded and cached eagerly through the
     }
 }
 --------------------------------------------------
+
+Global ordinals can also be eagerly loaded:
+
+[source,js]
+--------------------------------------------------
+{
+    category: {
+        type:      "string",
+        fielddata: {
+            loading: "eager_global_ordinals"
+        }
+    }
+}
+--------------------------------------------------
+
+With the above setting both field data and global ordinals for a specific field
+are eagerly loaded.
 
 [float]
 ==== Disabling field data loading

--- a/docs/reference/search/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/terms-aggregation.asciidoc
@@ -310,12 +310,15 @@ http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#UNIX_LINES
 
 ==== Execution hint
 
-There are two mechanisms by which terms aggregations can be executed: either by using field values directly in order to aggregate
-data per-bucket (`map`), or by using ordinals of the field values instead of the values themselves (`ordinals`). Although the
-latter execution mode can be expected to be slightly faster, it is only available for use when the underlying data source exposes
-those terms ordinals. Moreover, it may actually be slower if most field values are unique. Elasticsearch tries to have sensible
-defaults when it comes to the execution mode that should be used, but in case you know that one execution mode may perform better
-than the other one, you have the ability to "hint" it to Elasticsearch:
+coming[1.2.0] The `global_ordinals` execution mode
+
+There are three mechanisms by which terms aggregations can be executed: either by using field values directly in order to aggregate
+data per-bucket (`map`), by using ordinals of the field values instead of the values themselves (`ordinals`) or by using global
+ordinals of the field (`global_ordinals`). The latter is faster, especially for fields with many unique
+values. However it can be slower if only a few documents match, when for example a terms aggregator is nested in another
+aggregator, this applies for both `ordinals` and `global_ordinals` execution modes. Elasticsearch tries to have sensible
+defaults when it comes to the execution mode that should be used, but  in case you know that one execution mode may
+perform better than the other one, you have the ability to "hint" it to Elasticsearch:
 
 [source,js]
 --------------------------------------------------
@@ -331,6 +334,6 @@ than the other one, you have the ability to "hint" it to Elasticsearch:
 }
 --------------------------------------------------
 
-<1> the possible values are `map` and `ordinals`
+<1> the possible values are `map`, `ordinals` and `global_ordinals`
 
 Please note that Elasticsearch will ignore this execution hint if it is not applicable.

--- a/src/main/java/org/elasticsearch/common/lucene/TopReaderContextAware.java
+++ b/src/main/java/org/elasticsearch/common/lucene/TopReaderContextAware.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.lucene;
+
+import org.apache.lucene.index.IndexReaderContext;
+
+/**
+ *
+ */
+public interface TopReaderContextAware {
+
+    public void setNextReader(IndexReaderContext reader);
+}

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1560,6 +1560,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                                 new SimpleSearcher("warmer", newSearcher));
                         warmer.warm(context);
                     }
+                    warmer.warmTop(new IndicesWarmer.WarmerContext(shardId, searcher.getIndexReader()));
                 } catch (Throwable e) {
                     if (!closed) {
                         logger.warn("failed to prepare/warm", e);

--- a/src/main/java/org/elasticsearch/index/fielddata/AbstractIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AbstractIndexFieldData.java
@@ -53,6 +53,10 @@ public abstract class AbstractIndexFieldData<FD extends AtomicFieldData> extends
         return this.fieldNames;
     }
 
+    public FieldDataType getFieldDataType() {
+        return fieldDataType;
+    }
+
     @Override
     public void clear() {
         cache.clear(fieldNames.indexName());

--- a/src/main/java/org/elasticsearch/index/fielddata/AtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AtomicFieldData.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.index.fielddata;
 
+import org.apache.lucene.index.TermsEnum;
+
 /**
  * The thread safe {@link org.apache.lucene.index.AtomicReader} level cache of the data.
  */
-public interface AtomicFieldData<Script extends ScriptDocValues> {
+public interface AtomicFieldData<Script extends ScriptDocValues> extends RamUsage {
 
     /**
      * If this method returns false, this means that no document has multiple values. However this method may return true even if all
@@ -45,11 +47,6 @@ public interface AtomicFieldData<Script extends ScriptDocValues> {
      * An upper limit of the number of unique values in this atomic field data.
      */
     long getNumberUniqueValues();
-
-    /**
-     * Size (in bytes) of memory used by this field data.
-     */
-    long getMemorySizeInBytes();
 
     /**
      * Use a non thread safe (lightweight) view of the values as bytes.
@@ -78,6 +75,12 @@ public interface AtomicFieldData<Script extends ScriptDocValues> {
          * @param needsHashes
          */
         BytesValues.WithOrdinals getBytesValues(boolean needsHashes);
+
+        /**
+         * Returns a terms enum to iterate over all the underlying values.
+         */
+        TermsEnum getTermsEnum();
+
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/fielddata/FieldDataType.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FieldDataType.java
@@ -27,8 +27,6 @@ import org.elasticsearch.index.mapper.FieldMapper.Loading;
  */
 public class FieldDataType {
 
-
-
     public static final String FORMAT_KEY = "format";
     public static final String DOC_VALUES_FORMAT_VALUE = "doc_values";
 

--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexComponent;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -55,6 +56,11 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
      * The field name.
      */
     FieldMapper.Names getFieldNames();
+
+    /**
+     * The field data type.
+     */
+    FieldDataType getFieldDataType();
 
     /**
      * Are the values ordered? (in ascending manner).
@@ -173,7 +179,7 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
     interface Builder {
 
         IndexFieldData build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
-                             CircuitBreakerService breakerService, MapperService mapperService);
+                             CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder);
     }
 
     public interface WithOrdinals<FD extends AtomicFieldData.WithOrdinals> extends IndexFieldData<FD> {
@@ -187,6 +193,11 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
          * Loads directly the atomic field data for the reader, ignoring any caching involved.
          */
         FD loadDirect(AtomicReaderContext context) throws Exception;
+
+        WithOrdinals loadGlobal(IndexReader indexReader);
+
+        WithOrdinals localGlobalDirect(IndexReader indexReader) throws Exception;
+
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/RamUsage.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/RamUsage.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata;
+
+/**
+ */
+public interface RamUsage {
+
+    /**
+     * Size (in bytes) of memory used by this particular instance.
+     */
+    long getMemorySizeInBytes();
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata.ordinals;
+
+import org.apache.lucene.index.IndexReader;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
+
+import java.io.IOException;
+
+/**
+*/
+public interface GlobalOrdinalsBuilder {
+
+    IndexFieldData.WithOrdinals build(IndexReader indexReader, IndexFieldData.WithOrdinals indexFieldData, Settings settings, CircuitBreakerService breakerService) throws IOException;
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata.ordinals;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.AbstractIndexComponent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.plain.AtomicFieldDataWithOrdinalsTermsEnum;
+import org.elasticsearch.index.mapper.FieldMapper;
+
+import static org.elasticsearch.index.fielddata.ordinals.InternalGlobalOrdinalsBuilder.OrdinalMappingSource;
+
+/**
+ * {@link IndexFieldData} impl based on global ordinals.
+ */
+public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent implements IndexFieldData.WithOrdinals, RamUsage {
+
+    private final FieldMapper.Names fieldNames;
+    private final FieldDataType fieldDataType;
+    private final Atomic[] atomicReaders;
+    private final long memorySizeInBytes;
+
+    public GlobalOrdinalsIndexFieldData(Index index, Settings settings, FieldMapper.Names fieldNames, FieldDataType fieldDataType, AtomicFieldData.WithOrdinals[] segmentAfd, LongValues globalOrdToFirstSegment, LongValues globalOrdToFirstSegmentDelta, OrdinalMappingSource[] segmentOrdToGlobalOrds, long memorySizeInBytes) {
+        super(index, settings);
+        this.fieldNames = fieldNames;
+        this.fieldDataType = fieldDataType;
+        this.atomicReaders = new Atomic[segmentAfd.length];
+        for (int i = 0; i < segmentAfd.length; i++) {
+            atomicReaders[i] = new Atomic(segmentAfd[i], globalOrdToFirstSegment, globalOrdToFirstSegmentDelta, segmentOrdToGlobalOrds[i]);
+        }
+        this.memorySizeInBytes = memorySizeInBytes;
+    }
+
+    @Override
+    public AtomicFieldData.WithOrdinals load(AtomicReaderContext context) {
+        return atomicReaders[context.ord];
+    }
+
+    @Override
+    public AtomicFieldData.WithOrdinals loadDirect(AtomicReaderContext context) throws Exception {
+        return load(context);
+    }
+
+    @Override
+    public WithOrdinals loadGlobal(IndexReader indexReader) {
+        return this;
+    }
+
+    @Override
+    public WithOrdinals localGlobalDirect(IndexReader indexReader) throws Exception {
+        return this;
+    }
+
+    @Override
+    public FieldMapper.Names getFieldNames() {
+        return fieldNames;
+    }
+
+    @Override
+    public FieldDataType getFieldDataType() {
+        return fieldDataType;
+    }
+
+    @Override
+    public boolean valuesOrdered() {
+        return false;
+    }
+
+    @Override
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+        throw new UnsupportedOperationException("no global ordinals sorting yet");
+    }
+
+    @Override
+    public void clear() {
+        // no need to clear, because this is cached and cleared in AbstractBytesIndexFieldData
+    }
+
+    @Override
+    public void clear(IndexReader reader) {
+        // no need to clear, because this is cached and cleared in AbstractBytesIndexFieldData
+    }
+
+    @Override
+    public long getMemorySizeInBytes() {
+        return memorySizeInBytes;
+    }
+
+    private final class Atomic implements AtomicFieldData.WithOrdinals {
+
+        private final AtomicFieldData.WithOrdinals afd;
+        private final OrdinalMappingSource segmentOrdToGlobalOrdLookup;
+        private final LongValues globalOrdToFirstSegment;
+        private final LongValues globalOrdToFirstSegmentDelta;
+
+        private Atomic(WithOrdinals afd, LongValues globalOrdToFirstSegment, LongValues globalOrdToFirstSegmentDelta, OrdinalMappingSource segmentOrdToGlobalOrdLookup) {
+            this.afd = afd;
+            this.segmentOrdToGlobalOrdLookup = segmentOrdToGlobalOrdLookup;
+            this.globalOrdToFirstSegment = globalOrdToFirstSegment;
+            this.globalOrdToFirstSegmentDelta = globalOrdToFirstSegmentDelta;
+        }
+
+        @Override
+        public BytesValues.WithOrdinals getBytesValues(boolean needsHashes) {
+            BytesValues.WithOrdinals values = afd.getBytesValues(false);
+            Ordinals.Docs segmentOrdinals = values.ordinals();
+            Ordinals.Docs globalOrdinals = segmentOrdToGlobalOrdLookup.globalOrdinals(segmentOrdinals);
+
+            final BytesValues.WithOrdinals[] bytesValues = new BytesValues.WithOrdinals[atomicReaders.length];
+            for (int i = 0; i < bytesValues.length; i++) {
+                bytesValues[i] = atomicReaders[i].afd.getBytesValues(false);
+            }
+            return new BytesValues.WithOrdinals(globalOrdinals) {
+
+                int readerIndex;
+
+                @Override
+                public BytesRef getValueByOrd(long globalOrd) {
+                    final long segmentOrd = globalOrd - globalOrdToFirstSegmentDelta.get(globalOrd);
+                    readerIndex = (int) globalOrdToFirstSegment.get(globalOrd);
+                    return bytesValues[readerIndex].getValueByOrd(segmentOrd);
+                }
+
+                @Override
+                public BytesRef copyShared() {
+                    return bytesValues[readerIndex].copyShared();
+                }
+
+                @Override
+                public int currentValueHash() {
+                    return bytesValues[readerIndex].currentValueHash();
+                }
+            };
+        }
+
+        @Override
+        public boolean isMultiValued() {
+            return afd.isMultiValued();
+        }
+
+        @Override
+        public boolean isValuesOrdered() {
+            return afd.isValuesOrdered();
+        }
+
+        @Override
+        public int getNumDocs() {
+            return afd.getNumDocs();
+        }
+
+        @Override
+        public long getNumberUniqueValues() {
+            return afd.getNumberUniqueValues();
+        }
+
+        @Override
+        public long getMemorySizeInBytes() {
+            return afd.getMemorySizeInBytes();
+        }
+
+        @Override
+        public ScriptDocValues getScriptValues() {
+            throw new UnsupportedOperationException("Script values not supported on global ordinals");
+        }
+
+        @Override
+        public TermsEnum getTermsEnum() {
+            return new AtomicFieldDataWithOrdinalsTermsEnum(this);
+        }
+
+        @Override
+        public void close() {
+        }
+
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
@@ -1,0 +1,466 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata.ordinals;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.LongsRef;
+import org.apache.lucene.util.PriorityQueue;
+import org.apache.lucene.util.packed.AppendingPackedLongBuffer;
+import org.apache.lucene.util.packed.MonotonicAppendingLongBuffer;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.AbstractIndexComponent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ */
+public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implements GlobalOrdinalsBuilder {
+
+    public final static int ORDINAL_MAPPING_THRESHOLD_DEFAULT = 2048;
+    public final static String ORDINAL_MAPPING_THRESHOLD_KEY = "global_ordinals_compress_threshold";
+    public final static String ORDINAL_MAPPING_THRESHOLD_INDEX_SETTING_KEY = "index." + ORDINAL_MAPPING_THRESHOLD_KEY;
+
+    public InternalGlobalOrdinalsBuilder(Index index, @IndexSettings Settings indexSettings) {
+        super(index, indexSettings);
+    }
+
+    @Override
+    public IndexFieldData.WithOrdinals build(final IndexReader indexReader, IndexFieldData.WithOrdinals indexFieldData, Settings settings, CircuitBreakerService breakerService) throws IOException {
+        assert indexReader.leaves().size() > 1;
+        long startTime = System.currentTimeMillis();
+
+        // It makes sense to make the overhead ratio configurable for the mapping from segment ords to global ords
+        // However, other mappings are never the bottleneck and only used to get the original value from an ord, so
+        // it makes sense to force COMPACT for them
+        final float acceptableOverheadRatio = settings.getAsFloat("acceptable_overhead_ratio", PackedInts.FAST);
+        final AppendingPackedLongBuffer globalOrdToFirstSegment = new AppendingPackedLongBuffer(PackedInts.COMPACT);
+        globalOrdToFirstSegment.add(0);
+        final MonotonicAppendingLongBuffer globalOrdToFirstSegmentDelta = new MonotonicAppendingLongBuffer(PackedInts.COMPACT);
+        globalOrdToFirstSegmentDelta.add(0);
+
+        FieldDataType fieldDataType = indexFieldData.getFieldDataType();
+        int defaultThreshold = settings.getAsInt(ORDINAL_MAPPING_THRESHOLD_INDEX_SETTING_KEY, ORDINAL_MAPPING_THRESHOLD_DEFAULT);
+        int threshold = fieldDataType.getSettings().getAsInt(ORDINAL_MAPPING_THRESHOLD_KEY, defaultThreshold);
+        OrdinalMappingSourceBuilder ordinalMappingBuilder = new OrdinalMappingSourceBuilder(
+                indexReader.leaves().size(), acceptableOverheadRatio, threshold
+        );
+
+        long currentGlobalOrdinal = 0;
+        final AtomicFieldData.WithOrdinals[] withOrdinals = new AtomicFieldData.WithOrdinals[indexReader.leaves().size()];
+        TermIterator termIterator = new TermIterator(indexFieldData, indexReader.leaves(), withOrdinals);
+        for (BytesRef term = termIterator.next(); term != null; term = termIterator.next()) {
+            currentGlobalOrdinal++;
+            globalOrdToFirstSegment.add(termIterator.firstReaderIndex());
+            long globalOrdinalDelta = currentGlobalOrdinal - termIterator.firstLocalOrdinal();
+            globalOrdToFirstSegmentDelta.add(globalOrdinalDelta);
+            for (TermIterator.LeafSource leafSource : termIterator.competitiveLeafs()) {
+                ordinalMappingBuilder.onOrdinal(leafSource.context.ord, leafSource.tenum.ord(), currentGlobalOrdinal);
+            }
+        }
+
+        // ram used for the globalOrd to segmentOrd and segmentOrd to firstReaderIndex lookups
+        long memorySizeInBytesCounter = 0;
+        globalOrdToFirstSegment.freeze();
+        memorySizeInBytesCounter += globalOrdToFirstSegment.ramBytesUsed();
+        globalOrdToFirstSegmentDelta.freeze();
+        memorySizeInBytesCounter += globalOrdToFirstSegmentDelta.ramBytesUsed();
+
+        final long maxOrd = currentGlobalOrdinal + 1;
+        OrdinalMappingSource[] segmentOrdToGlobalOrdLookups = ordinalMappingBuilder.build(maxOrd);
+        // add ram used for the main segmentOrd to globalOrd lookups
+        memorySizeInBytesCounter += ordinalMappingBuilder.getMemorySizeInBytes();
+
+        final long memorySizeInBytes = memorySizeInBytesCounter;
+        breakerService.getBreaker().addWithoutBreaking(memorySizeInBytes);
+
+        if (logger.isDebugEnabled()) {
+            String implName = segmentOrdToGlobalOrdLookups[0].getClass().getSimpleName();
+            logger.debug(
+                    "Global-ordinals[{}][{}][{}] took {} ms",
+                    implName,
+                    indexFieldData.getFieldNames().fullName(),
+                    maxOrd,
+                    (System.currentTimeMillis() - startTime)
+            );
+        }
+        return new GlobalOrdinalsIndexFieldData(indexFieldData.index(), settings, indexFieldData.getFieldNames(),
+                fieldDataType, withOrdinals, globalOrdToFirstSegment, globalOrdToFirstSegmentDelta,
+                segmentOrdToGlobalOrdLookups, memorySizeInBytes
+        );
+    }
+
+    public interface OrdinalMappingSource {
+
+        Ordinals.Docs globalOrdinals(Ordinals.Docs segmentOrdinals);
+
+    }
+
+    private static abstract class GlobalOrdinalMapping implements Ordinals.Docs {
+
+        protected final Ordinals.Docs segmentOrdinals;
+        private final long memorySizeInBytes;
+        protected final long maxOrd;
+
+        protected long currentGlobalOrd;
+
+        private GlobalOrdinalMapping(Ordinals.Docs segmentOrdinals, long memorySizeInBytes, long maxOrd) {
+            this.segmentOrdinals = segmentOrdinals;
+            this.memorySizeInBytes = memorySizeInBytes;
+            this.maxOrd = maxOrd;
+        }
+
+        @Override
+        public final Ordinals ordinals() {
+            return new Ordinals() {
+                @Override
+                public long getMemorySizeInBytes() {
+                    return memorySizeInBytes;
+                }
+
+                @Override
+                public boolean isMultiValued() {
+                    return GlobalOrdinalMapping.this.isMultiValued();
+                }
+
+                @Override
+                public int getNumDocs() {
+                    return GlobalOrdinalMapping.this.getNumDocs();
+                }
+
+                @Override
+                public long getNumOrds() {
+                    return GlobalOrdinalMapping.this.getNumOrds();
+                }
+
+                @Override
+                public long getMaxOrd() {
+                    return GlobalOrdinalMapping.this.getMaxOrd();
+                }
+
+                @Override
+                public Docs ordinals() {
+                    return GlobalOrdinalMapping.this;
+                }
+            };
+        }
+
+        @Override
+        public final int getNumDocs() {
+            return segmentOrdinals.getNumDocs();
+        }
+
+        @Override
+        public final long getNumOrds() {
+            return maxOrd - Ordinals.MIN_ORDINAL;
+        }
+
+        @Override
+        public final long getMaxOrd() {
+            return maxOrd;
+        }
+
+        @Override
+        public final boolean isMultiValued() {
+            return segmentOrdinals.isMultiValued();
+        }
+
+        @Override
+        public final int setDocument(int docId) {
+            return segmentOrdinals.setDocument(docId);
+        }
+
+        @Override
+        public final long currentOrd() {
+            return currentGlobalOrd;
+        }
+
+        @Override
+        public final long getOrd(int docId) {
+            long segmentOrd = segmentOrdinals.getOrd(docId);
+            return currentGlobalOrd = getGlobalOrd(segmentOrd);
+        }
+
+        @Override
+        public final LongsRef getOrds(int docId) {
+            LongsRef refs = segmentOrdinals.getOrds(docId);
+            for (int i = refs.offset; i < refs.length; i++) {
+                refs.longs[i] = getGlobalOrd(refs.longs[i]);
+            }
+            return refs;
+        }
+
+        @Override
+        public final long nextOrd() {
+            long segmentOrd = segmentOrdinals.nextOrd();
+            return currentGlobalOrd = getGlobalOrd(segmentOrd);
+        }
+
+        protected abstract long getGlobalOrd(long segmentOrd);
+
+    }
+
+    private final static class OrdinalMappingSourceBuilder {
+
+        final MonotonicAppendingLongBuffer[] segmentOrdToGlobalOrdDeltas;
+        final float acceptableOverheadRatio;
+        final int numSegments;
+        final int threshold;
+
+        long memorySizeInBytesCounter;
+
+        private OrdinalMappingSourceBuilder(int numSegments, float acceptableOverheadRatio, int threshold) {
+            segmentOrdToGlobalOrdDeltas = new MonotonicAppendingLongBuffer[numSegments];
+            for (int i = 0; i < segmentOrdToGlobalOrdDeltas.length; i++) {
+                segmentOrdToGlobalOrdDeltas[i] = new MonotonicAppendingLongBuffer(acceptableOverheadRatio);
+                segmentOrdToGlobalOrdDeltas[i].add(0);
+            }
+            this.numSegments = numSegments;
+            this.acceptableOverheadRatio = acceptableOverheadRatio;
+            this.threshold = threshold;
+        }
+
+        public void onOrdinal(int readerIndex, long segmentOrdinal, long globalOrdinal) {
+            long delta = globalOrdinal - segmentOrdinal;
+            segmentOrdToGlobalOrdDeltas[readerIndex].add(delta);
+        }
+
+        public OrdinalMappingSource[] build(long maxOrd) {
+            // If we find out that there are less then predefined number of ordinals, it is better to put the the
+            // segment ordinal to global ordinal mapping in a packed ints, since the amount values are small and
+            // will most likely fit in the CPU caches and MonotonicAppendingLongBuffer's compression will just be
+            // unnecessary.
+
+            if (maxOrd <= threshold) {
+                // Rebuilding from MonotonicAppendingLongBuffer to PackedInts.Mutable is fast
+                PackedInts.Mutable[] newSegmentOrdToGlobalOrdDeltas = new PackedInts.Mutable[numSegments];
+                for (int i = 0; i < segmentOrdToGlobalOrdDeltas.length; i++) {
+                    newSegmentOrdToGlobalOrdDeltas[i] = PackedInts.getMutable((int) segmentOrdToGlobalOrdDeltas[i].size(), PackedInts.bitsRequired(maxOrd), acceptableOverheadRatio);
+                }
+
+                for (int readerIndex = 0; readerIndex < segmentOrdToGlobalOrdDeltas.length; readerIndex++) {
+                    MonotonicAppendingLongBuffer segmentOrdToGlobalOrdDelta = segmentOrdToGlobalOrdDeltas[readerIndex];
+
+                    for (long ordIndex = 0; ordIndex < segmentOrdToGlobalOrdDelta.size(); ordIndex++) {
+                        long ordDelta = segmentOrdToGlobalOrdDelta.get(ordIndex);
+                        newSegmentOrdToGlobalOrdDeltas[readerIndex].set((int) ordIndex, ordDelta);
+                    }
+                }
+
+                PackedIntOrdinalMappingSource[] sources = new PackedIntOrdinalMappingSource[numSegments];
+                for (int i = 0; i < newSegmentOrdToGlobalOrdDeltas.length; i++) {
+                    PackedInts.Reader segmentOrdToGlobalOrdDelta = newSegmentOrdToGlobalOrdDeltas[i];
+                    long ramUsed = segmentOrdToGlobalOrdDelta.ramBytesUsed();
+                    sources[i] = new PackedIntOrdinalMappingSource(segmentOrdToGlobalOrdDelta, ramUsed, maxOrd);
+                    memorySizeInBytesCounter += ramUsed;
+                }
+                return sources;
+            } else {
+                OrdinalMappingSource[] sources = new OrdinalMappingSource[segmentOrdToGlobalOrdDeltas.length];
+                for (int i = 0; i < segmentOrdToGlobalOrdDeltas.length; i++) {
+                    MonotonicAppendingLongBuffer segmentOrdToGlobalOrdLookup = segmentOrdToGlobalOrdDeltas[i];
+                    segmentOrdToGlobalOrdLookup.freeze();
+                    long ramUsed = segmentOrdToGlobalOrdLookup.ramBytesUsed();
+                    sources[i] = new CompressedOrdinalMappingSource(segmentOrdToGlobalOrdLookup, ramUsed, maxOrd);
+                    memorySizeInBytesCounter += ramUsed;
+                }
+                return sources;
+            }
+        }
+
+        public long getMemorySizeInBytes() {
+            return memorySizeInBytesCounter;
+        }
+    }
+
+    private final static class CompressedOrdinalMappingSource implements OrdinalMappingSource {
+
+        private final MonotonicAppendingLongBuffer globalOrdinalMapping;
+        private final long memorySizeInBytes;
+        private final long maxOrd;
+
+        private CompressedOrdinalMappingSource(MonotonicAppendingLongBuffer globalOrdinalMapping, long memorySizeInBytes, long maxOrd) {
+            this.globalOrdinalMapping = globalOrdinalMapping;
+            this.memorySizeInBytes = memorySizeInBytes;
+            this.maxOrd = maxOrd;
+        }
+
+        @Override
+        public Ordinals.Docs globalOrdinals(Ordinals.Docs segmentOrdinals) {
+            return new GlobalOrdinalsDocs(segmentOrdinals, globalOrdinalMapping, memorySizeInBytes, maxOrd);
+        }
+
+        private final static class GlobalOrdinalsDocs extends GlobalOrdinalMapping {
+
+            private final MonotonicAppendingLongBuffer segmentOrdToGlobalOrdLookup;
+
+            private GlobalOrdinalsDocs(Ordinals.Docs segmentOrdinals, MonotonicAppendingLongBuffer segmentOrdToGlobalOrdLookup, long memorySizeInBytes, long maxOrd) {
+                super(segmentOrdinals, memorySizeInBytes, maxOrd);
+                this.segmentOrdToGlobalOrdLookup = segmentOrdToGlobalOrdLookup;
+            }
+
+            @Override
+            protected long getGlobalOrd(long segmentOrd) {
+                return segmentOrd + segmentOrdToGlobalOrdLookup.get(segmentOrd);
+            }
+        }
+
+    }
+
+    private static final class PackedIntOrdinalMappingSource implements OrdinalMappingSource {
+
+        private final PackedInts.Reader segmentOrdToGlobalOrdLookup;
+        private final long memorySizeInBytes;
+        private final long maxOrd;
+
+        private PackedIntOrdinalMappingSource(PackedInts.Reader segmentOrdToGlobalOrdLookup, long memorySizeInBytes, long maxOrd) {
+            this.segmentOrdToGlobalOrdLookup = segmentOrdToGlobalOrdLookup;
+            this.memorySizeInBytes = memorySizeInBytes;
+            this.maxOrd = maxOrd;
+        }
+
+        @Override
+        public Ordinals.Docs globalOrdinals(Ordinals.Docs segmentOrdinals) {
+            return new GlobalOrdinalsDocs(segmentOrdinals, memorySizeInBytes, maxOrd, segmentOrdToGlobalOrdLookup);
+        }
+
+        private final static class GlobalOrdinalsDocs extends GlobalOrdinalMapping {
+
+            private final PackedInts.Reader segmentOrdToGlobalOrdLookup;
+
+            private GlobalOrdinalsDocs(Ordinals.Docs segmentOrdinals, long memorySizeInBytes, long maxOrd, PackedInts.Reader segmentOrdToGlobalOrdLookup) {
+                super(segmentOrdinals, memorySizeInBytes, maxOrd);
+                this.segmentOrdToGlobalOrdLookup = segmentOrdToGlobalOrdLookup;
+            }
+
+            @Override
+            protected long getGlobalOrd(long segmentOrd) {
+                return segmentOrd + segmentOrdToGlobalOrdLookup.get((int) segmentOrd);
+            }
+        }
+
+    }
+
+    private final static class TermIterator implements BytesRefIterator {
+
+        private final LeafSourceQueue sources;
+        private final List<LeafSource> competitiveLeafs = new ArrayList<>();
+
+        private TermIterator(IndexFieldData.WithOrdinals indexFieldData, List<AtomicReaderContext> leaves, AtomicFieldData.WithOrdinals[] withOrdinals) throws IOException {
+            this.sources = new LeafSourceQueue(leaves.size());
+            for (int i = 0; i < leaves.size(); i++) {
+                AtomicReaderContext atomicReaderContext = leaves.get(i);
+                AtomicFieldData.WithOrdinals afd = indexFieldData.load(atomicReaderContext);
+                withOrdinals[i] = afd;
+                LeafSource leafSource = new LeafSource(afd, atomicReaderContext);
+                if (leafSource.current != null) {
+                    sources.add(leafSource);
+                }
+            }
+        }
+
+        public BytesRef next() throws IOException {
+            for (LeafSource top : competitiveLeafs) {
+                if (top.next() != null) {
+                    sources.add(top);
+                }
+            }
+            competitiveLeafs.clear();
+            if (sources.size() == 0) {
+                return null;
+            }
+
+            do {
+                LeafSource competitiveLeaf = sources.pop();
+                competitiveLeafs.add(competitiveLeaf);
+            } while (sources.size() > 0 && competitiveLeafs.get(0).current.equals(sources.top().current));
+            return competitiveLeafs.get(0).current;
+        }
+
+        @Override
+        public Comparator<BytesRef> getComparator() {
+            return BytesRef.getUTF8SortedAsUnicodeComparator();
+        }
+
+        List<LeafSource> competitiveLeafs() throws IOException {
+            return competitiveLeafs;
+        }
+
+        int firstReaderIndex() {
+            return competitiveLeafs.get(0).context.ord;
+        }
+
+        long firstLocalOrdinal() throws IOException {
+            return competitiveLeafs.get(0).tenum.ord();
+        }
+
+        private static class LeafSource {
+
+            final TermsEnum tenum;
+            final AtomicReaderContext context;
+
+            BytesRef current;
+
+            private LeafSource(AtomicFieldData.WithOrdinals afd, AtomicReaderContext context) throws IOException {
+                this.tenum = afd.getTermsEnum();
+                this.context = context;
+                this.current = tenum.next();
+            }
+
+            BytesRef next() throws IOException {
+                return current = tenum.next();
+            }
+
+        }
+
+        private final static class LeafSourceQueue extends PriorityQueue<LeafSource> {
+
+            private final Comparator<BytesRef> termComp = BytesRef.getUTF8SortedAsUnicodeComparator();
+
+            LeafSourceQueue(int size) {
+                super(size);
+            }
+
+            @Override
+            protected boolean lessThan(LeafSource termsA, LeafSource termsB) {
+                final int cmp = termComp.compare(termsA.current, termsB.current);
+                if (cmp != 0) {
+                    return cmp < 0;
+                } else {
+                    return termsA.context.ord < termsB.context.ord;
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicFieldDataWithOrdinalsTermsEnum.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AtomicFieldDataWithOrdinalsTermsEnum.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata.plain;
+
+import org.apache.lucene.index.DocsAndPositionsEnum;
+import org.apache.lucene.index.DocsEnum;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.BytesValues;
+import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * A general {@link org.apache.lucene.index.TermsEnum} to iterate over terms from a {@link AtomicFieldData.WithOrdinals}
+ * instance.
+ */
+public class AtomicFieldDataWithOrdinalsTermsEnum extends TermsEnum {
+
+    private final BytesValues.WithOrdinals bytesValues;
+    private final Ordinals.Docs ordinals;
+    private final long maxOrd;
+
+    private long currentOrd = Ordinals.MISSING_ORDINAL;
+    private BytesRef currentTerm;
+
+    public AtomicFieldDataWithOrdinalsTermsEnum(AtomicFieldData.WithOrdinals afd) {
+        this.bytesValues = afd.getBytesValues(false);
+        this.ordinals = bytesValues.ordinals();
+        this.maxOrd = ordinals.getMaxOrd();
+    }
+
+    @Override
+    public SeekStatus seekCeil(BytesRef text) throws IOException {
+        long ord = binarySearch(bytesValues, text);
+        if (ord >= 0) {
+            currentOrd = ord;
+            currentTerm = bytesValues.getValueByOrd(currentOrd);
+            return SeekStatus.FOUND;
+        } else {
+            currentOrd = -ord - 1;
+            if (ord >= maxOrd) {
+                return SeekStatus.END;
+            } else {
+                currentTerm = bytesValues.getValueByOrd(currentOrd);
+                return SeekStatus.NOT_FOUND;
+            }
+        }
+    }
+
+    @Override
+    public void seekExact(long ord) throws IOException {
+        assert ord >= 0 && ord < ordinals.getMaxOrd();
+        currentOrd = ord;
+        if (currentOrd == Ordinals.MISSING_ORDINAL) {
+            currentTerm = null;
+        } else {
+            currentTerm = bytesValues.getValueByOrd(currentOrd);
+        }
+    }
+
+    @Override
+    public BytesRef term() throws IOException {
+        return currentTerm;
+    }
+
+    @Override
+    public long ord() throws IOException {
+        return currentOrd;
+    }
+
+    @Override
+    public int docFreq() throws IOException {
+        throw new UnsupportedOperationException("docFreq not supported");
+    }
+
+    @Override
+    public long totalTermFreq() throws IOException {
+        return -1;
+    }
+
+    @Override
+    public DocsEnum docs(Bits liveDocs, DocsEnum reuse, int flags) throws IOException {
+        throw new UnsupportedOperationException("docs not supported");
+    }
+
+    @Override
+    public DocsAndPositionsEnum docsAndPositions(Bits liveDocs, DocsAndPositionsEnum reuse, int flags) throws IOException {
+        throw new UnsupportedOperationException("docsAndPositions not supported");
+    }
+
+    @Override
+    public BytesRef next() throws IOException {
+        if (++currentOrd < maxOrd) {
+            return currentTerm = bytesValues.getValueByOrd(currentOrd);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Comparator<BytesRef> getComparator() {
+        return BytesRef.getUTF8SortedAsUnicodeComparator();
+    }
+
+    final private static long binarySearch(BytesValues.WithOrdinals a, BytesRef key) {
+        long low = 1;
+        long high = a.ordinals().getMaxOrd();
+        while (low <= high) {
+            long mid = (low + high) >>> 1;
+            BytesRef midVal = a.getValueByOrd(mid);
+            int cmp;
+            if (midVal != null) {
+                cmp = midVal.compareTo(key);
+            } else {
+                cmp = -1;
+            }
+
+            if (cmp < 0)
+                low = mid + 1;
+            else if (cmp > 0)
+                high = mid - 1;
+            else
+                return mid;
+        }
+        return -(low + 1);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVIndexFieldData.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
@@ -28,8 +29,8 @@ import org.elasticsearch.index.mapper.FieldMapper.Names;
 
 public class BinaryDVIndexFieldData extends DocValuesIndexFieldData implements IndexFieldData<BinaryDVAtomicFieldData> {
 
-    public BinaryDVIndexFieldData(Index index, Names fieldNames) {
-        super(index, fieldNames);
+    public BinaryDVIndexFieldData(Index index, Names fieldNames, FieldDataType fieldDataType) {
+        super(index, fieldNames, fieldDataType);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
@@ -36,8 +37,8 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
 
     private final NumericType numericType;
 
-    public BinaryDVNumericIndexFieldData(Index index, Names fieldNames, NumericType numericType) {
-        super(index, fieldNames);
+    public BinaryDVNumericIndexFieldData(Index index, Names fieldNames, NumericType numericType, FieldDataType fieldDataType) {
+        super(index, fieldNames, fieldDataType);
         Preconditions.checkArgument(numericType != null, "numericType must be non-null");
         this.numericType = numericType;
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.index.mapper.MapperService;
@@ -40,7 +41,7 @@ public final class DisabledIndexFieldData extends AbstractIndexFieldData<AtomicF
     public static class Builder implements IndexFieldData.Builder {
         @Override
         public IndexFieldData<AtomicFieldData<?>> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
-                                                        IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+                                                        IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             // Ignore Circuit Breaker
             return new DisabledIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -48,7 +49,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<DoubleArra
 
         @Override
         public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
-                                       CircuitBreakerService breakerService, MapperService mapperService) {
+                                       CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             return new DoubleArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.fst.*;
@@ -125,7 +126,10 @@ public class FSTBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<Scr
         return new ScriptDocValues.Strings(getBytesValues(false));
     }
 
-
+    @Override
+    public TermsEnum getTermsEnum() {
+        return new AtomicFieldDataWithOrdinalsTermsEnum(this);
+    }
 
     static class BytesValues extends org.elasticsearch.index.fielddata.BytesValues.WithOrdinals {
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -47,14 +48,15 @@ public class FSTBytesIndexFieldData extends AbstractBytesIndexFieldData<FSTBytes
 
         @Override
         public IndexFieldData<FSTBytesAtomicFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
-                                                             IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
-            return new FSTBytesIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
+                                                             IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService,
+                                                             GlobalOrdinalsBuilder globalOrdinalBuilder) {
+            return new FSTBytesIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService, globalOrdinalBuilder);
         }
     }
 
     FSTBytesIndexFieldData(Index index, @IndexSettings Settings indexSettings, FieldMapper.Names fieldNames, FieldDataType fieldDataType,
-                           IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-        super(index, indexSettings, fieldNames, fieldDataType, cache);
+                           IndexFieldDataCache cache, CircuitBreakerService breakerService, GlobalOrdinalsBuilder globalOrdinalsBuilder) {
+        super(index, indexSettings, fieldNames, fieldDataType, cache, globalOrdinalsBuilder, breakerService);
         this.breakerService = breakerService;
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -47,7 +48,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<FloatArrayA
 
         @Override
         public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
-                                       CircuitBreakerService breakerService, MapperService mapperService) {
+                                       CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             return new FloatArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.index.mapper.MapperService;
@@ -36,8 +37,8 @@ import java.io.IOException;
 
 public class GeoPointBinaryDVIndexFieldData extends DocValuesIndexFieldData implements IndexGeoPointFieldData<AtomicGeoPointFieldData<ScriptDocValues>> {
 
-    public GeoPointBinaryDVIndexFieldData(Index index, Names fieldNames) {
-        super(index, fieldNames);
+    public GeoPointBinaryDVIndexFieldData(Index index, Names fieldNames, FieldDataType fieldDataType) {
+        super(index, fieldNames, fieldDataType);
     }
 
     @Override
@@ -68,10 +69,10 @@ public class GeoPointBinaryDVIndexFieldData extends DocValuesIndexFieldData impl
 
         @Override
         public IndexFieldData<?> build(Index index, Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
-                                       CircuitBreakerService breakerService, MapperService mapperService) {
+                                       CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             // Ignore breaker
             final FieldMapper.Names fieldNames = mapper.names();
-            return new GeoPointBinaryDVIndexFieldData(index, fieldNames);
+            return new GeoPointBinaryDVIndexFieldData(index, fieldNames, mapper.fieldDataType());
         }
 
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.unit.DistanceUnit.Distance;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -52,7 +53,7 @@ public class GeoPointCompressedIndexFieldData extends AbstractGeoPointIndexField
 
         @Override
         public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
-                                       CircuitBreakerService breakerService, MapperService mapperService) {
+                                       CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             FieldDataType type = mapper.fieldDataType();
             final String precisionAsString = type.getSettings().get(PRECISION_KEY);
             final Distance precision;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigDoubleArrayList;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -45,7 +46,7 @@ public class GeoPointDoubleArrayIndexFieldData extends AbstractGeoPointIndexFiel
 
         @Override
         public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper, IndexFieldDataCache cache,
-                                       CircuitBreakerService breakerService, MapperService mapperService) {
+                                       CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             return new GeoPointDoubleArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
@@ -28,8 +29,8 @@ import org.elasticsearch.index.mapper.FieldMapper.Names;
 
 public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements IndexNumericFieldData<NumericDVAtomicFieldData> {
 
-    public NumericDVIndexFieldData(Index index, Names fieldNames) {
-        super(index, fieldNames);
+    public NumericDVIndexFieldData(Index index, Names fieldNames, FieldDataType fieldDataType) {
+        super(index, fieldNames, fieldDataType);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.fielddata.RamAccountingTermsEnum;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -65,7 +66,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
 
         @Override
         public IndexFieldData<AtomicNumericFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
-                                                            IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
+                                                            IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             return new PackedArrayIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, numericType, breakerService);
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PagedBytes;
 import org.apache.lucene.util.PagedBytes.Reader;
@@ -118,6 +119,11 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
     @Override
     public ScriptDocValues.Strings getScriptValues() {
         return new ScriptDocValues.Strings(getBytesValues(false));
+    }
+
+    @Override
+    public TermsEnum getTermsEnum() {
+        return new AtomicFieldDataWithOrdinalsTermsEnum(this);
     }
 
     static class BytesValues extends org.elasticsearch.index.fielddata.BytesValues.WithOrdinals {

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.RamAccountingTermsEnum;
 import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -41,21 +42,21 @@ import java.io.IOException;
  */
 public class PagedBytesIndexFieldData extends AbstractBytesIndexFieldData<PagedBytesAtomicFieldData> {
 
-    private final CircuitBreakerService breakerService;
 
     public static class Builder implements IndexFieldData.Builder {
 
         @Override
         public IndexFieldData<PagedBytesAtomicFieldData> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
-                                                               IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService) {
-            return new PagedBytesIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService);
+                                                               IndexFieldDataCache cache, CircuitBreakerService breakerService, MapperService mapperService,
+                                                               GlobalOrdinalsBuilder globalOrdinalBuilder) {
+            return new PagedBytesIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, breakerService, globalOrdinalBuilder);
         }
     }
 
     public PagedBytesIndexFieldData(Index index, @IndexSettings Settings indexSettings, FieldMapper.Names fieldNames,
-                                    FieldDataType fieldDataType, IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-        super(index, indexSettings, fieldNames, fieldDataType, cache);
-        this.breakerService = breakerService;
+                                    FieldDataType fieldDataType, IndexFieldDataCache cache, CircuitBreakerService breakerService,
+                                    GlobalOrdinalsBuilder globalOrdinalsBuilder) {
+        super(index, indexSettings, fieldNames, fieldDataType, cache, globalOrdinalsBuilder, breakerService);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -199,7 +200,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<ParentChil
         @Override
         public IndexFieldData<?> build(Index index, @IndexSettings Settings indexSettings, FieldMapper<?> mapper,
                                        IndexFieldDataCache cache, CircuitBreakerService breakerService,
-                                       MapperService mapperService) {
+                                       MapperService mapperService, GlobalOrdinalsBuilder globalOrdinalBuilder) {
             return new ParentChildIndexFieldData(index, indexSettings, mapper.names(), mapper.fieldDataType(), cache, mapperService, breakerService);
         }
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -46,4 +46,5 @@ public final class SortedSetDVBytesAtomicFieldData extends SortedSetDVAtomicFiel
     public Strings getScriptValues() {
         return new ScriptDocValues.Strings(getBytesValues(false));
     }
+
 }

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -162,15 +162,24 @@ public interface FieldMapper<T> extends Mapper {
             public String toString() {
                 return EAGER_VALUE;
             }
+        },
+        EAGER_GLOBAL_ORDINALS {
+            @Override
+            public String toString() {
+                return EAGER_GLOBAL_ORDINALS_VALUE;
+            }
         };
 
         public static final String KEY = "loading";
+        public static final String EAGER_GLOBAL_ORDINALS_VALUE = "eager_global_ordinals";
         public static final String EAGER_VALUE = "eager";
         public static final String LAZY_VALUE = "lazy";
 
         public static Loading parse(String loading, Loading defaultValue) {
             if (Strings.isNullOrEmpty(loading)) {
                 return defaultValue;
+            } else if (EAGER_GLOBAL_ORDINALS_VALUE.equalsIgnoreCase(loading)) {
+                return EAGER_GLOBAL_ORDINALS;
             } else if (EAGER_VALUE.equalsIgnoreCase(loading)) {
                 return EAGER;
             } else if (LAZY_VALUE.equalsIgnoreCase(loading)) {

--- a/src/main/java/org/elasticsearch/index/shard/ShardUtils.java
+++ b/src/main/java/org/elasticsearch/index/shard/ShardUtils.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.shard;
 
 import org.apache.lucene.index.AtomicReader;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.SegmentReader;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.SegmentReaderUtils;
@@ -50,6 +51,13 @@ public class ShardUtils {
             if (storeDir != null) {
                 return storeDir.shardId();
             }
+        }
+        return null;
+    }
+
+    public static ShardId extractShardId(IndexReader reader) {
+        if (!reader.leaves().isEmpty()) {
+            return extractShardId(reader.leaves().get(0).reader());
         }
         return null;
     }

--- a/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCacheListener.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCacheListener.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.indices.fielddata.cache;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.RamUsage;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
 
@@ -43,11 +42,11 @@ public class IndicesFieldDataCacheListener implements IndexFieldDataCache.Listen
     }
 
     @Override
-    public void onLoad(FieldMapper.Names fieldNames, FieldDataType fieldDataType, AtomicFieldData fieldData) {
+    public void onLoad(FieldMapper.Names fieldNames, FieldDataType fieldDataType, RamUsage fieldData) {
     }
 
     @Override
-    public void onUnload(FieldMapper.Names fieldNames, FieldDataType fieldDataType, boolean wasEvicted, long sizeInBytes, @Nullable AtomicFieldData fieldData) {
+    public void onUnload(FieldMapper.Names fieldNames, FieldDataType fieldDataType, boolean wasEvicted, long sizeInBytes) {
         assert sizeInBytes >= 0 : "When reducing circuit breaker, it should be adjusted with a number higher or equal to 0 and not [" + sizeInBytes + "]";
         circuitBreakerService.getBreaker().addWithoutBreaking(-sizeInBytes);
     }

--- a/src/main/java/org/elasticsearch/indices/warmer/IndicesWarmer.java
+++ b/src/main/java/org/elasticsearch/indices/warmer/IndicesWarmer.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.indices.warmer;
 
+import org.apache.lucene.index.IndexReader;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
@@ -49,6 +50,10 @@ public interface IndicesWarmer {
 
         /** Queue tasks to warm-up the given segments and return handles that allow to wait for termination of the execution of those tasks. */
         public abstract TerminationHandle warm(IndexShard indexShard, IndexMetaData indexMetaData, WarmerContext context, ThreadPool threadPool);
+
+        public TerminationHandle warmTop(IndexShard indexShard, IndexMetaData indexMetaData, WarmerContext context, ThreadPool threadPool) {
+            return TerminationHandle.NO_WAIT;
+        }
     }
 
     public static class WarmerContext {
@@ -57,9 +62,18 @@ public interface IndicesWarmer {
 
         private final Engine.Searcher newSearcher;
 
+        private final IndexReader indexReader;
+
         public WarmerContext(ShardId shardId, Engine.Searcher newSearcher) {
             this.shardId = shardId;
             this.newSearcher = newSearcher;
+            this.indexReader = null;
+        }
+
+        public WarmerContext(ShardId shardId, IndexReader indexReader) {
+            this.shardId = shardId;
+            this.newSearcher = null;
+            this.indexReader = indexReader;
         }
 
         public ShardId shardId() {
@@ -69,6 +83,10 @@ public interface IndicesWarmer {
         /** Return a searcher instance that only wraps the segments to warm. */
         public Engine.Searcher newSearcher() {
             return newSearcher;
+        }
+
+        public IndexReader indexReader() {
+            return indexReader;
         }
     }
 

--- a/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -107,6 +107,7 @@ abstract class QueryCollector extends Collector {
             if (!aggregatorCollectors.isEmpty()) {
                 facetAggCollectorBuilder.add(new AggregationPhase.AggregationsCollector(aggregatorCollectors, aggregationContext));
             }
+            aggregationContext.setNextReader(context.searcher().getIndexReader().getContext());
         }
         facetAndAggregatorCollector = facetAggCollectorBuilder.build();
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -90,6 +90,7 @@ public class AggregationPhase implements SearchPhase {
             if (!collectors.isEmpty()) {
                 context.searcher().addMainQueryCollector(new AggregationsCollector(collectors, aggregationContext));
             }
+            aggregationContext.setNextReader(context.searcher().getIndexReader().getContext());
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -54,6 +54,13 @@ public abstract class BucketsAggregator extends Aggregator {
     }
 
     /**
+     * Return an upper bound of the maximum bucket ordinal seen so far.
+     */
+    protected final long maxBucketOrd() {
+        return docCounts.size();
+    }
+
+    /**
      * Utility method to collect the given doc in the given bucket (identified by the bucket ordinal)
      */
     protected final void collectBucket(int doc, long bucketOrd) throws IOException {
@@ -106,6 +113,17 @@ public abstract class BucketsAggregator extends Aggregator {
             aggregations[i] = bucketDocCount == 0L
                     ? subAggregators[i].buildEmptyAggregation()
                     : subAggregators[i].buildAggregation(bucketOrd);
+        }
+        return new InternalAggregations(Arrays.asList(aggregations));
+    }
+
+    /**
+     * Utility method to build empty aggregations of the sub aggregators.
+     */
+    protected final InternalAggregations bucketEmptyAggregations() {
+        final InternalAggregation[] aggregations = new InternalAggregation[subAggregators.length];
+        for (int i = 0; i < subAggregators.length; i++) {
+            aggregations[i] = subAggregators[i].buildEmptyAggregation();
         }
         return new InternalAggregations(Arrays.asList(aggregations));
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.util.Collections;
+
+abstract class AbstractStringTermsAggregator extends BucketsAggregator {
+
+    protected final InternalOrder order;
+    protected final int requiredSize;
+    protected final int shardSize;
+    protected final long minDocCount;
+
+    public AbstractStringTermsAggregator(String name, AggregatorFactories factories,
+            long estimatedBucketsCount, AggregationContext context, Aggregator parent,
+            InternalOrder order, int requiredSize, int shardSize, long minDocCount) {
+        super(name, BucketAggregationMode.PER_BUCKET, factories, estimatedBucketsCount, context, parent);
+        this.order = InternalOrder.validate(order, this);
+        this.requiredSize = requiredSize;
+        this.shardSize = shardSize;
+        this.minDocCount = minDocCount;
+    }
+
+    @Override
+    public boolean shouldCollect() {
+        return true;
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new StringTerms(name, order, requiredSize, minDocCount, Collections.<InternalTerms.Bucket>emptyList());
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.index.fielddata.BytesValues;
+import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.support.BucketPriorityQueue;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * An aggregator of string values that relies on global ordinals in order to build buckets.
+ */
+public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggregator {
+
+    private final ValuesSource.Bytes.WithOrdinals.FieldData valuesSource;
+    private BytesValues.WithOrdinals globalValues;
+    private Ordinals.Docs globalOrdinals;
+
+    public GlobalOrdinalsStringTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Bytes.WithOrdinals.FieldData valuesSource, long estimatedBucketCount,
+            InternalOrder order, int requiredSize, int shardSize, long minDocCount, AggregationContext aggregationContext, Aggregator parent) {
+        super(name, factories, estimatedBucketCount, aggregationContext, parent, order, requiredSize, shardSize, minDocCount);
+        this.valuesSource = valuesSource;
+    }
+
+    protected long createBucketOrd(long termOrd) {
+        return termOrd;
+    }
+
+    protected long getBucketOrd(long termOrd) {
+        return termOrd;
+    }
+
+    @Override
+    public boolean shouldCollect() {
+        return true;
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        globalValues = valuesSource.globalBytesValues();
+        globalOrdinals = globalValues.ordinals();
+    }
+
+    @Override
+    public void collect(int doc, long owningBucketOrdinal) throws IOException {
+        final int numOrds = globalOrdinals.setDocument(doc);
+        for (int i = 0; i < numOrds; i++) {
+            final long globalOrd = globalOrdinals.nextOrd();
+            collectBucket(doc, createBucketOrd(globalOrd));
+        }
+    }
+
+    private static void copy(BytesRef from, BytesRef to) {
+        if (to.bytes.length < from.length) {
+            to.bytes = new byte[ArrayUtil.oversize(from.length, RamUsageEstimator.NUM_BYTES_BYTE)];
+        }
+        to.offset = 0;
+        to.length = from.length;
+        System.arraycopy(from.bytes, from.offset, to.bytes, 0, from.length);
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        if (globalOrdinals == null) { // no context in this reader
+            return buildEmptyAggregation();
+        }
+
+        final int size;
+        if (minDocCount == 0) {
+            // if minDocCount == 0 then we can end up with more buckets then maxBucketOrd() returns
+            size = shardSize;
+        } else {
+            size = (int) Math.min(maxBucketOrd(), shardSize);
+        }
+        BucketPriorityQueue ordered = new BucketPriorityQueue(size, order.comparator(this));
+        StringTerms.Bucket spare = null;
+        for (long termOrd = Ordinals.MIN_ORDINAL; termOrd < globalOrdinals.getMaxOrd(); ++termOrd) {
+            final long bucketOrd = getBucketOrd(termOrd);
+            final long bucketDocCount = bucketOrd < 0 ? 0 : bucketDocCount(bucketOrd);
+            if (minDocCount > 0 && bucketDocCount == 0) {
+                continue;
+            }
+            if (spare == null) {
+                spare = new StringTerms.Bucket(new BytesRef(), 0, null);
+            }
+            spare.bucketOrd = bucketOrd;
+            spare.docCount = bucketDocCount;
+            copy(globalValues.getValueByOrd(termOrd), spare.termBytes);
+            spare = (StringTerms.Bucket) ordered.insertWithOverflow(spare);
+        }
+
+        final InternalTerms.Bucket[] list = new InternalTerms.Bucket[ordered.size()];
+        for (int i = ordered.size() - 1; i >= 0; --i) {
+            final StringTerms.Bucket bucket = (StringTerms.Bucket) ordered.pop();
+            bucket.aggregations = bucket.docCount == 0 ? bucketEmptyAggregations() : bucketAggregations(bucket.bucketOrd);
+            list[i] = bucket;
+        }
+
+        return new StringTerms(name, order, requiredSize, minDocCount, Arrays.asList(list));
+    }
+
+    /**
+     * Variant of {@link GlobalOrdinalsStringTermsAggregator} that rebases hashes in order to make them dense. Might be
+     * useful in case few hashes are visited.
+     */
+    public static class WithHash extends GlobalOrdinalsStringTermsAggregator {
+
+        private final LongHash bucketOrds;
+
+        public WithHash(String name, AggregatorFactories factories, ValuesSource.Bytes.WithOrdinals.FieldData valuesSource, long estimatedBucketCount,
+                InternalOrder order, int requiredSize, int shardSize, long minDocCount, AggregationContext aggregationContext,
+                Aggregator parent) {
+            super(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+            bucketOrds = new LongHash(estimatedBucketCount, aggregationContext.bigArrays());
+        }
+
+        @Override
+        protected long createBucketOrd(long termOrd) {
+            long bucketOrd = bucketOrds.add(termOrd);
+            if (bucketOrd < 0) {
+                bucketOrd = -1 - bucketOrd;
+            }
+            return bucketOrd;
+        }
+
+        @Override
+        protected long getBucketOrd(long termOrd) {
+            return bucketOrds.find(termOrd);
+        }
+
+        @Override
+        protected void doRelease() {
+            Releasables.release(bucketOrds);
+        }
+
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -98,7 +98,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         final int size;
         if (minDocCount == 0) {
             // if minDocCount == 0 then we can end up with more buckets then maxBucketOrd() returns
-            size = shardSize;
+            size = (int) Math.min(globalOrdinals.getMaxOrd(), shardSize);
         } else {
             size = (int) Math.min(maxBucketOrd(), shardSize);
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -34,7 +34,6 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.support.BucketPriorityQueue;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
@@ -46,13 +45,9 @@ import java.util.*;
 /**
  * An aggregator of string values.
  */
-public class StringTermsAggregator extends BucketsAggregator {
+public class StringTermsAggregator extends AbstractStringTermsAggregator {
 
     private final ValuesSource valuesSource;
-    private final InternalOrder order;
-    protected final int requiredSize;
-    protected final int shardSize;
-    protected final long minDocCount;
     protected final BytesRefHash bucketOrds;
     private final IncludeExclude includeExclude;
     private BytesValues values;
@@ -61,12 +56,8 @@ public class StringTermsAggregator extends BucketsAggregator {
                                  InternalOrder order, int requiredSize, int shardSize, long minDocCount,
                                  IncludeExclude includeExclude, AggregationContext aggregationContext, Aggregator parent) {
 
-        super(name, BucketAggregationMode.PER_BUCKET, factories, estimatedBucketCount, aggregationContext, parent);
+        super(name, factories, estimatedBucketCount, aggregationContext, parent, order, requiredSize, shardSize, minDocCount);
         this.valuesSource = valuesSource;
-        this.order = InternalOrder.validate(order, this);
-        this.requiredSize = requiredSize;
-        this.shardSize = shardSize;
-        this.minDocCount = minDocCount;
         this.includeExclude = includeExclude;
         bucketOrds = new BytesRefHash(estimatedBucketCount, aggregationContext.bigArrays());
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -18,12 +18,10 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.search.aggregations.*;
 import org.elasticsearch.search.aggregations.Aggregator.BucketAggregationMode;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -38,6 +36,7 @@ import org.elasticsearch.search.aggregations.support.format.ValueParser;
 public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     public enum ExecutionMode {
+
         MAP(new ParseField("map")) {
 
             @Override
@@ -45,6 +44,11 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
                     AggregationContext aggregationContext, Aggregator parent) {
                 return new StringTermsAggregator(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, includeExclude, aggregationContext, parent);
+            }
+
+            @Override
+            boolean needsGlobalOrdinals() {
+                return false;
             }
 
         },
@@ -60,6 +64,46 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 return new StringTermsAggregator.WithOrdinals(name, factories, (ValuesSource.Bytes.WithOrdinals) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
             }
 
+            @Override
+            boolean needsGlobalOrdinals() {
+                return false;
+            }
+
+        },
+        GLOBAL_ORDINALS(new ParseField("global_ordinals")) {
+
+            @Override
+            Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
+                              InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              AggregationContext aggregationContext, Aggregator parent) {
+                if (includeExclude != null) {
+                    throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
+                }
+                return new GlobalOrdinalsStringTermsAggregator(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+            }
+
+            @Override
+            boolean needsGlobalOrdinals() {
+                return true;
+            }
+
+        },
+        GLOBAL_ORDINALS_HASH(new ParseField("global_ordinals_hash")) {
+
+            @Override
+            Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
+                              InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              AggregationContext aggregationContext, Aggregator parent) {
+                if (includeExclude != null) {
+                    throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
+                }
+                return new GlobalOrdinalsStringTermsAggregator.WithHash(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+            }
+
+            @Override
+            boolean needsGlobalOrdinals() {
+                return true;
+            }
         };
 
         public static ExecutionMode fromString(String value) {
@@ -80,6 +124,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         abstract Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
                 InternalOrder order, int requiredSize, int shardSize, long minDocCount,
                 IncludeExclude includeExclude, AggregationContext aggregationContext, Aggregator parent);
+
+        abstract boolean needsGlobalOrdinals();
 
         @Override
         public String toString() {
@@ -127,31 +173,6 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         }
     }
 
-    private boolean shouldUseOrdinals(Aggregator parent, ValuesSource valuesSource, AggregationContext context) {
-        // if there is a parent bucket aggregator the number of instances of this aggregator is going to be unbounded and most instances
-        // may only aggregate few documents, so don't use ordinals
-        if (hasParentBucketAggregator(parent)) {
-            return false;
-        }
-
-        // be defensive: if the number of unique values is unknown, don't use ordinals
-        final long maxNumUniqueValues = valuesSource.metaData().maxAtomicUniqueValuesCount();
-        if (maxNumUniqueValues == -1) {
-            return false;
-        }
-
-        // if the number of unique values is high compared to the document count, then ordinals are only going to make things slower
-        int maxDoc = 0;
-        for (AtomicReaderContext ctx : context.searchContext().searcher().getTopReaderContext().reader().leaves()) {
-            maxDoc = Math.max(maxDoc, ctx.reader().maxDoc());
-        }
-        if (maxNumUniqueValues > (maxDoc >>> 4)) {
-            return false;
-        }
-
-        return true;
-    }
-
     @Override
     protected Aggregator create(ValuesSource valuesSource, long expectedBucketsCount, AggregationContext aggregationContext, Aggregator parent) {
         long estimatedBucketCount = valuesSource.metaData().maxAtomicUniqueValuesCount();
@@ -181,17 +202,19 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 execution = ExecutionMode.MAP;
             }
 
+            // Let's try to use a good default
             if (execution == null) {
-                // Let's try to use a good default
-                if ((valuesSource instanceof ValuesSource.Bytes.WithOrdinals)
-                        && shouldUseOrdinals(parent, valuesSource, aggregationContext)) {
-                    execution = ExecutionMode.ORDINALS;
+                // if there is a parent bucket aggregator the number of instances of this aggregator is going
+                // to be unbounded and most instances may only aggregate few documents, so use hashed based
+                // global ordinals to keep the bucket ords dense.
+                if (hasParentBucketAggregator(parent)) {
+                    execution = ExecutionMode.GLOBAL_ORDINALS_HASH;
                 } else {
-                    execution = ExecutionMode.MAP;
+                    execution = ExecutionMode.GLOBAL_ORDINALS;
                 }
             }
             assert execution != null;
-
+            valuesSource.setNeedsGlobalOrdinals(execution.needsGlobalOrdinals());
             return execution.create(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, includeExclude, aggregationContext, parent);
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -19,11 +19,13 @@
 package org.elasticsearch.search.aggregations.support;
 
 import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
 import org.apache.lucene.util.InPlaceMergeSorter;
 import org.elasticsearch.common.lucene.ReaderContextAware;
+import org.elasticsearch.common.lucene.TopReaderContextAware;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.AtomicFieldData.Order;
@@ -143,21 +145,33 @@ public abstract class ValuesSource {
      */
     public void setNeedsHashes(boolean needsHashes) {}
 
+    public void setNeedsGlobalOrdinals(boolean needsGlobalOrdinals) {}
+
     public abstract MetaData metaData();
 
     public static abstract class Bytes extends ValuesSource {
 
-        public static abstract class WithOrdinals extends Bytes {
+        public static abstract class WithOrdinals extends Bytes implements TopReaderContextAware {
 
             public abstract BytesValues.WithOrdinals bytesValues();
+
+            public abstract void setNextReader(IndexReaderContext reader);
+
+            public abstract BytesValues.WithOrdinals globalBytesValues();
 
             public static class FieldData extends WithOrdinals implements ReaderContextAware {
 
                 protected boolean needsHashes;
                 protected final IndexFieldData.WithOrdinals<?> indexFieldData;
                 protected final MetaData metaData;
+                private boolean needsGlobalOrdinals;
+
                 protected AtomicFieldData.WithOrdinals<?> atomicFieldData;
                 private BytesValues.WithOrdinals bytesValues;
+
+                protected IndexFieldData.WithOrdinals<?> globalFieldData;
+                protected AtomicFieldData.WithOrdinals<?> globalAtomicFieldData;
+                private BytesValues.WithOrdinals globalBytesValues;
 
                 public FieldData(IndexFieldData.WithOrdinals<?> indexFieldData, MetaData metaData) {
                     this.indexFieldData = indexFieldData;
@@ -175,10 +189,21 @@ public abstract class ValuesSource {
                 }
 
                 @Override
+                public void setNeedsGlobalOrdinals(boolean needsGlobalOrdinals) {
+                    this.needsGlobalOrdinals = needsGlobalOrdinals;
+                }
+
+                @Override
                 public void setNextReader(AtomicReaderContext reader) {
                     atomicFieldData = indexFieldData.load(reader);
                     if (bytesValues != null) {
                         bytesValues = atomicFieldData.getBytesValues(needsHashes);
+                    }
+                    if (globalFieldData != null) {
+                        globalAtomicFieldData = globalFieldData.load(reader);
+                        if (globalBytesValues != null) {
+                            globalBytesValues = globalAtomicFieldData.getBytesValues(needsHashes);
+                        }
                     }
                 }
 
@@ -190,6 +215,20 @@ public abstract class ValuesSource {
                     return bytesValues;
                 }
 
+                @Override
+                public void setNextReader(IndexReaderContext reader) {
+                    if (needsGlobalOrdinals) {
+                        globalFieldData = indexFieldData.loadGlobal(reader.reader());
+                    }
+                }
+
+                @Override
+                public BytesValues.WithOrdinals globalBytesValues() {
+                    if (globalBytesValues == null) {
+                        globalBytesValues = globalAtomicFieldData.getBytesValues(needsHashes);
+                    }
+                    return globalBytesValues;
+                }
             }
 
         }

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/GlobalOrdinalsBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/GlobalOrdinalsBenchmark.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.benchmark.search.aggregations;
+
+import com.carrotsearch.hppc.IntIntOpenHashMap;
+import com.carrotsearch.hppc.ObjectOpenHashSet;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.benchmark.search.aggregations.TermsAggregationSearchBenchmark.StatsResult;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.jna.Natives;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.SizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.index.fielddata.ordinals.InternalGlobalOrdinalsBuilder;
+import org.elasticsearch.indices.IndexAlreadyExistsException;
+import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.transport.TransportModule;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+/**
+ *
+ */
+public class GlobalOrdinalsBenchmark {
+
+    private static final String INDEX_NAME = "index";
+    private static final String TYPE_NAME = "type";
+    private static final int QUERY_WARMUP = 25;
+    private static final int QUERY_COUNT = 100;
+    private static final int FIELD_START = 1 << 22;
+    private static final int FIELD_LIMIT = 1 << 22;
+    private static final boolean USE_DOC_VALUES = false;
+
+    static long COUNT = SizeValue.parseSizeValue("5m").singles();
+    static InternalNode node;
+    static Client client;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("es.logger.prefix", "");
+        Natives.tryMlockall();
+        Random random = new Random();
+
+        Settings settings = settingsBuilder()
+                .put("index.refresh_interval", "-1")
+                .put("gateway.type", "local")
+                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(TransportModule.TRANSPORT_TYPE_KEY, "local")
+                .build();
+
+        String clusterName = GlobalOrdinalsBenchmark.class.getSimpleName();
+        node = (InternalNode) nodeBuilder().clusterName(clusterName)
+                    .settings(settingsBuilder().put(settings))
+                    .node();
+
+        client = node.client();
+
+        try {
+            client.admin().indices().prepareCreate(INDEX_NAME)
+                    .addMapping(TYPE_NAME, jsonBuilder().startObject().startObject(TYPE_NAME)
+                            .startArray("dynamic_templates")
+                                .startObject()
+                                    .startObject("default")
+                                        .field("match", "*")
+                                        .field("match_mapping_type", "string")
+                                        .startObject("mapping")
+                                            .field("type", "string")
+                                            .field("index", "not_analyzed")
+                                            .startObject("fields")
+                                                .startObject("doc_values")
+                                                    .field("type", "string")
+                                                    .field("index", "no")
+                                                    .startObject("fielddata")
+                                                        .field("format", "doc_values")
+                                                    .endObject()
+                                                .endObject()
+                                            .endObject()
+                                        .endObject()
+                                    .endObject()
+                                .endObject()
+                            .endArray()
+                    .endObject().endObject())
+                    .get();
+            ObjectOpenHashSet<String> uniqueTerms = ObjectOpenHashSet.newInstance();
+            for (int i = 0; i < FIELD_LIMIT; i++) {
+                boolean added;
+                do {
+                    added = uniqueTerms.add(RandomStrings.randomAsciiOfLength(random, 8));
+                } while (!added);
+            }
+            String[] sValues = uniqueTerms.toArray(String.class);
+            uniqueTerms = null;
+
+            BulkRequestBuilder builder = client.prepareBulk();
+            IntIntOpenHashMap tracker = new IntIntOpenHashMap();
+            for (int i = 0; i < COUNT; i++) {
+                Map<String, Object> fieldValues = new HashMap<>();
+                for (int fieldSuffix = 1; fieldSuffix <= FIELD_LIMIT; fieldSuffix <<= 1) {
+                    int index;
+                    if (tracker.containsKey(fieldSuffix)) {
+                        index = tracker.lget();
+                    } else {
+                        tracker.put(fieldSuffix, index = 0);
+                    }
+                    if (index >= fieldSuffix) {
+                        index = random.nextInt(fieldSuffix);
+                        fieldValues.put("field_" + fieldSuffix, sValues[index]);
+                    } else {
+                        fieldValues.put("field_" + fieldSuffix, sValues[index]);
+                        tracker.put(fieldSuffix, ++index);
+                    }
+                }
+                builder.add(
+                        client.prepareIndex(INDEX_NAME, TYPE_NAME, String.valueOf(i))
+                        .setSource(fieldValues)
+                );
+
+                if (builder.numberOfActions() >= 1000) {
+                    builder.get();
+                    builder = client.prepareBulk();
+                }
+            }
+            if (builder.numberOfActions() > 0) {
+                builder.get();
+            }
+        } catch (IndexAlreadyExistsException e) {
+            System.out.println("--> Index already exists, ignoring indexing phase, waiting for green");
+            ClusterHealthResponse clusterHealthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("10m").execute().actionGet();
+            if (clusterHealthResponse.isTimedOut()) {
+                System.err.println("--> Timed out waiting for cluster health");
+            }
+        }
+
+        client.admin().cluster().prepareUpdateSettings()
+                .setTransientSettings(ImmutableSettings.builder().put("logger.index.fielddata.ordinals", "DEBUG"))
+                .get();
+
+        client.admin().indices().prepareRefresh(INDEX_NAME).execute().actionGet();
+        COUNT = client.prepareCount(INDEX_NAME).setQuery(matchAllQuery()).execute().actionGet().getCount();
+        System.out.println("--> Number of docs in index: " + COUNT);
+
+        List<StatsResult> stats = new ArrayList<>();
+        int[] thresholds = new int[]{2048};
+        for (int threshold : thresholds) {
+            updateThresholdInMapping(threshold);
+
+            for (int fieldSuffix = FIELD_START; fieldSuffix <= FIELD_LIMIT; fieldSuffix <<= 1) {
+                String fieldName = "field_" + fieldSuffix;
+                String name = threshold + "-" + fieldName;
+                if (USE_DOC_VALUES) {
+                    fieldName = fieldName + ".doc_values";
+                    name = name + "_doc_values"; // can't have . in agg name
+                }
+                stats.add(terms(name, fieldName, "global_ordinals"));
+            }
+        }
+
+        for (int fieldSuffix = FIELD_START; fieldSuffix <= FIELD_LIMIT; fieldSuffix <<= 1) {
+            String fieldName = "field_" + fieldSuffix;
+            String name = "segment-ordinals-" + fieldName;
+            if (USE_DOC_VALUES) {
+                fieldName = fieldName + ".doc_values";
+                name = name + "_doc_values"; // can't have . in agg name
+            }
+            stats.add(terms(name, fieldName, "ordinals"));
+        }
+
+        System.out.println("------------------ SUMMARY ----------------------------------------------");
+        System.out.format(Locale.ENGLISH, "%40s%10s%10s%15s\n", "name", "took", "millis", "fieldata size");
+        for (StatsResult stat : stats) {
+            System.out.format(Locale.ENGLISH, "%40s%10s%10d%15s\n", stat.name, TimeValue.timeValueMillis(stat.took), (stat.took / QUERY_COUNT), stat.fieldDataMemoryUsed);
+        }
+        System.out.println("------------------ SUMMARY ----------------------------------------------");
+
+        client.close();
+        node.close();
+    }
+
+    private static void updateThresholdInMapping(int threshold) throws IOException {
+        XContentBuilder builder = jsonBuilder().startObject().startObject(TYPE_NAME).startObject("properties");
+        for (int fieldSuffix = FIELD_START; fieldSuffix <= FIELD_LIMIT; fieldSuffix <<= 1) {
+            builder.startObject("field_" + fieldSuffix)
+                    .field("type", "string")
+                    .field("index", "not_analyzed")
+                    .startObject("fielddata")
+                        .field(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_KEY, threshold)
+                    .endObject()
+            .endObject();
+        }
+        builder = builder.endObject().endObject().endObject();
+
+        client.admin().indices().preparePutMapping(INDEX_NAME).setType(TYPE_NAME).setSource(builder).get();
+    }
+
+    private static StatsResult terms(String name, String field, String executionHint) {
+        long totalQueryTime;// LM VALUE
+
+        client.admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
+        System.gc();
+
+        System.out.println("--> Warmup (" + name + ")...");
+        // run just the child query, warm up first
+        for (int j = 0; j < QUERY_WARMUP; j++) {
+            SearchResponse searchResponse = client.prepareSearch(INDEX_NAME)
+                    .setSearchType(SearchType.COUNT)
+                    .setQuery(matchAllQuery())
+                    .addAggregation(AggregationBuilders.terms(name).field(field).executionHint(executionHint))
+                    .get();
+            if (j == 0) {
+                System.out.println("--> Loading (" + field + "): took: " + searchResponse.getTook());
+            }
+            if (searchResponse.getHits().totalHits() != COUNT) {
+                System.err.println("--> mismatch on hits");
+            }
+        }
+        System.out.println("--> Warmup (" + name + ") DONE");
+
+
+        System.out.println("--> Running (" + name + ")...");
+        totalQueryTime = 0;
+        for (int j = 0; j < QUERY_COUNT; j++) {
+            SearchResponse searchResponse = client.prepareSearch(INDEX_NAME)
+                    .setSearchType(SearchType.COUNT)
+                    .setQuery(matchAllQuery())
+                    .addAggregation(AggregationBuilders.terms(name).field(field).executionHint(executionHint))
+                    .get();
+            if (searchResponse.getHits().totalHits() != COUNT) {
+                System.err.println("--> mismatch on hits");
+            }
+            totalQueryTime += searchResponse.getTookInMillis();
+        }
+        System.out.println("--> Terms Agg (" + name + "): " + (totalQueryTime / QUERY_COUNT) + "ms");
+
+        String nodeId = node.injector().getInstance(Discovery.class).localNode().getId();
+        ClusterStatsResponse clusterStateResponse = client.admin().cluster().prepareClusterStats().setNodesIds(nodeId).get();
+        System.out.println("--> Heap used: " + clusterStateResponse.getNodesStats().getJvm().getHeapUsed());
+        ByteSizeValue fieldDataMemoryUsed = clusterStateResponse.getIndicesStats().getFieldData().getMemorySize();
+        System.out.println("--> Fielddata memory size: " + fieldDataMemoryUsed);
+
+        return new StatsResult(name, totalQueryTime, fieldDataMemoryUsed);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/TermsAggregationSearchAndIndexingBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/TermsAggregationSearchAndIndexingBenchmark.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.benchmark.search.aggregations;
+
+import com.carrotsearch.hppc.ObjectOpenHashSet;
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import jsr166y.ThreadLocalRandom;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.jna.Natives;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.SizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.indices.IndexAlreadyExistsException;
+import org.elasticsearch.node.internal.InternalNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+import static org.elasticsearch.benchmark.search.aggregations.TermsAggregationSearchBenchmark.Method;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+/**
+ *
+ */
+public class TermsAggregationSearchAndIndexingBenchmark {
+
+    static String indexName = "test";
+    static String typeName = "type1";
+    static Random random = new Random();
+
+    static long COUNT = SizeValue.parseSizeValue("2m").singles();
+    static int BATCH = 1000;
+    static int NUMBER_OF_TERMS = (int) SizeValue.parseSizeValue("100k").singles();
+    static int NUMBER_OF_MULTI_VALUE_TERMS = 10;
+    static int STRING_TERM_SIZE = 5;
+
+    static InternalNode[] nodes;
+
+    public static void main(String[] args) throws Exception {
+        Natives.tryMlockall();
+        Settings settings = settingsBuilder()
+                .put("refresh_interval", "-1")
+                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .build();
+
+        String clusterName = TermsAggregationSearchAndIndexingBenchmark.class.getSimpleName();
+        nodes = new InternalNode[1];
+        for (int i = 0; i < nodes.length; i++) {
+            nodes[i] = (InternalNode) nodeBuilder().settings(settingsBuilder().put(settings).put("name", "node1"))
+                    .clusterName(clusterName)
+                    .node();
+        }
+        Client client = nodes[0].client();
+
+        client.admin().cluster().prepareHealth(indexName).setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
+        try {
+            client.admin().indices().prepareCreate(indexName)
+                    .addMapping(typeName, generateMapping("eager", "lazy"))
+                    .get();
+            Thread.sleep(5000);
+
+            long startTime = System.currentTimeMillis();
+            ObjectOpenHashSet<String> uniqueTerms = ObjectOpenHashSet.newInstance();
+            for (int i = 0; i < NUMBER_OF_TERMS; i++) {
+                boolean added;
+                do {
+                    added = uniqueTerms.add(RandomStrings.randomAsciiOfLength(random, STRING_TERM_SIZE));
+                } while (!added);
+            }
+            String[] sValues = uniqueTerms.toArray(String.class);
+            long ITERS = COUNT / BATCH;
+            long i = 1;
+            int counter = 0;
+            for (; i <= ITERS; i++) {
+                BulkRequestBuilder request = client.prepareBulk();
+                for (int j = 0; j < BATCH; j++) {
+                    counter++;
+
+                    XContentBuilder builder = jsonBuilder().startObject();
+                    builder.field("id", Integer.toString(counter));
+                    final String sValue = sValues[counter % sValues.length];
+                    builder.field("s_value", sValue);
+                    builder.field("s_value_dv", sValue);
+
+                    for (String field : new String[] {"sm_value", "sm_value_dv"}) {
+                        builder.startArray(field);
+                        for (int k = 0; k < NUMBER_OF_MULTI_VALUE_TERMS; k++) {
+                            builder.value(sValues[ThreadLocalRandom.current().nextInt(sValues.length)]);
+                        }
+                        builder.endArray();
+                    }
+
+                    request.add(Requests.indexRequest(indexName).type("type1").id(Integer.toString(counter))
+                            .source(builder));
+                }
+                BulkResponse response = request.execute().actionGet();
+                if (response.hasFailures()) {
+                    System.err.println("--> failures...");
+                }
+                if (((i * BATCH) % 10000) == 0) {
+                    System.out.println("--> Indexed " + (i * BATCH));
+                }
+            }
+
+            System.out.println("--> Indexing took " + ((System.currentTimeMillis() - startTime) / 1000) + " seconds.");
+        } catch (IndexAlreadyExistsException e) {
+            System.out.println("--> Index already exists, ignoring indexing phase, waiting for green");
+            ClusterHealthResponse clusterHealthResponse = client.admin().cluster().prepareHealth(indexName).setWaitForGreenStatus().setTimeout("10m").execute().actionGet();
+            if (clusterHealthResponse.isTimedOut()) {
+                System.err.println("--> Timed out waiting for cluster health");
+            }
+        }
+        client.admin().indices().preparePutMapping(indexName)
+                .setType(typeName)
+                .setSource(generateMapping("lazy", "lazy"))
+                .get();
+        client.admin().indices().prepareRefresh().execute().actionGet();
+        System.out.println("--> Number of docs in index: " + client.prepareCount().setQuery(matchAllQuery()).execute().actionGet().getCount());
+
+
+        String[] nodeIds = new String[nodes.length];
+        for (int i = 0; i < nodeIds.length; i++) {
+            nodeIds[i] = nodes[i].injector().getInstance(Discovery.class).localNode().getId();
+        }
+
+        List<TestRun> testRuns = new ArrayList<>();
+        testRuns.add(new TestRun("Regular field ordinals", "eager", "lazy", "s_value", "ordinals"));
+        testRuns.add(new TestRun("Docvalues field ordinals", "lazy", "eager", "s_value_dv", "ordinals"));
+        testRuns.add(new TestRun("Regular field global ordinals", "eager_global_ordinals", "lazy", "s_value", null));
+        testRuns.add(new TestRun("Docvalues field global", "lazy", "eager_global_ordinals", "s_value_dv", null));
+
+        List<TestResult> testResults = new ArrayList<>();
+        for (TestRun testRun : testRuns) {
+            client.admin().indices().preparePutMapping(indexName).setType(typeName)
+                    .setSource(generateMapping(testRun.indexedFieldEagerLoading, testRun.docValuesEagerLoading)).get();
+            client.admin().indices().prepareClearCache(indexName).setFieldDataCache(true).get();
+            SearchThread searchThread = new SearchThread(client, testRun.termsAggsField, testRun.termsAggsExecutionHint);
+            RefreshThread refreshThread = new RefreshThread(client);
+            System.out.println("--> Running '" + testRun.name + "' round...");
+            new Thread(refreshThread).start();
+            new Thread(searchThread).start();
+            Thread.sleep(2 * 60 * 1000);
+            refreshThread.stop();
+            searchThread.stop();
+
+            System.out.println("--> Avg refresh time: " + refreshThread.avgRefreshTime + " ms");
+            System.out.println("--> Avg query time: " + searchThread.avgQueryTime + " ms");
+
+            ClusterStatsResponse clusterStateResponse = client.admin().cluster().prepareClusterStats().setNodesIds(nodeIds).get();
+            System.out.println("--> Heap used: " + clusterStateResponse.getNodesStats().getJvm().getHeapUsed());
+            ByteSizeValue fieldDataMemoryUsed = clusterStateResponse.getIndicesStats().getFieldData().getMemorySize();
+            System.out.println("--> Fielddata memory size: " + fieldDataMemoryUsed);
+            testResults.add(new TestResult(testRun.name, refreshThread.avgRefreshTime, searchThread.avgQueryTime, fieldDataMemoryUsed));
+        }
+
+        System.out.println("----------------------------------------- SUMMARY ----------------------------------------------");
+        System.out.format(Locale.ENGLISH, "%30s%18s%15s%15s\n", "name", "avg refresh time", "avg query time", "fieldata size");
+        for (TestResult testResult : testResults) {
+            System.out.format(Locale.ENGLISH, "%30s%18s%15s%15s\n", testResult.name, testResult.avgRefreshTime, testResult.avgQueryTime, testResult.fieldDataSizeInMemory);
+        }
+        System.out.println("----------------------------------------- SUMMARY ----------------------------------------------");
+
+        client.close();
+        for (InternalNode node : nodes) {
+            node.close();
+        }
+    }
+
+    static class RefreshThread implements Runnable {
+
+        private final Client client;
+        private volatile boolean run = true;
+        private volatile boolean stopped = false;
+        private volatile long avgRefreshTime = 0;
+
+        RefreshThread(Client client) throws IOException {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            long totalRefreshTime = 0;
+            int numExecutedRefreshed = 0;
+            while (run) {
+                long docIdLimit = COUNT;
+                for (long docId = 1; run && docId < docIdLimit;) {
+                    try {
+                        for (int j = 0; j < 8; j++) {
+                            GetResponse getResponse = client
+                                    .prepareGet(indexName, "type1", String.valueOf(++docId))
+                                    .get();
+                            client.prepareIndex(indexName, "type1", getResponse.getId())
+                                    .setSource(getResponse.getSource())
+                                    .get();
+                        }
+                        long startTime = System.currentTimeMillis();
+                        client.admin().indices().prepareRefresh(indexName).execute().actionGet();
+                        totalRefreshTime += System.currentTimeMillis() - startTime;
+                        numExecutedRefreshed++;
+                        Thread.sleep(500);
+                    } catch (Throwable e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            avgRefreshTime = totalRefreshTime / numExecutedRefreshed;
+            stopped = true;
+        }
+
+        public void stop() throws InterruptedException {
+            run = false;
+            while (!stopped) {
+                Thread.sleep(100);
+            }
+        }
+
+    }
+
+    private static class TestRun {
+
+        final String name;
+        final String indexedFieldEagerLoading;
+        final String docValuesEagerLoading;
+        final String termsAggsField;
+        final String termsAggsExecutionHint;
+
+        private TestRun(String name, String indexedFieldEagerLoading, String docValuesEagerLoading, String termsAggsField, String termsAggsExecutionHint) {
+            this.name = name;
+            this.indexedFieldEagerLoading = indexedFieldEagerLoading;
+            this.docValuesEagerLoading = docValuesEagerLoading;
+            this.termsAggsField = termsAggsField;
+            this.termsAggsExecutionHint = termsAggsExecutionHint;
+        }
+    }
+
+    private static class TestResult {
+
+        final String name;
+        final TimeValue avgRefreshTime;
+        final TimeValue avgQueryTime;
+        final ByteSizeValue fieldDataSizeInMemory;
+
+        private TestResult(String name, long avgRefreshTime, long avgQueryTime, ByteSizeValue fieldDataSizeInMemory) {
+            this.name = name;
+            this.avgRefreshTime = TimeValue.timeValueMillis(avgRefreshTime);
+            this.avgQueryTime = TimeValue.timeValueMillis(avgQueryTime);
+            this.fieldDataSizeInMemory = fieldDataSizeInMemory;
+        }
+    }
+
+    static class SearchThread implements Runnable {
+
+        private final Client client;
+        private final String field;
+        private final String executionHint;
+        private volatile boolean run = true;
+        private volatile boolean stopped = false;
+        private volatile long avgQueryTime = 0;
+
+        SearchThread(Client client, String field, String executionHint) {
+            this.client = client;
+            this.field = field;
+            this.executionHint = executionHint;
+        }
+
+        @Override
+        public void run() {
+            long totalQueryTime = 0;
+            int numExecutedQueries = 0;
+            while (run) {
+                try {
+                    SearchResponse searchResponse = Method.AGGREGATION.addTermsAgg(client.prepareSearch()
+                            .setSearchType(SearchType.COUNT)
+                            .setQuery(matchAllQuery()), "test", field, executionHint)
+                            .execute().actionGet();
+                    if (searchResponse.getHits().totalHits() != COUNT) {
+                        System.err.println("--> mismatch on hits");
+                    }
+                    totalQueryTime += searchResponse.getTookInMillis();
+                    numExecutedQueries++;
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                }
+            }
+            avgQueryTime = totalQueryTime / numExecutedQueries;
+            stopped = true;
+        }
+
+        public void stop() throws InterruptedException {
+            run = false;
+            while (!stopped) {
+                Thread.sleep(100);
+            }
+        }
+
+    }
+
+    private static XContentBuilder generateMapping(String loading1, String loading2) throws IOException {
+        return jsonBuilder().startObject().startObject("type1").startObject("properties")
+                .startObject("s_value")
+                .field("type", "string")
+                .field("index", "not_analyzed")
+                .startObject("fielddata")
+                .field("loading", loading1)
+                .endObject()
+                .endObject()
+                .startObject("s_value_dv")
+                .field("type", "string")
+                .field("index", "no")
+                .startObject("fielddata")
+                .field("loading", loading2)
+                .field("format", "doc_values")
+                .endObject()
+                .endObject()
+                .endObject().endObject().endObject();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/TermsAggregationSearchBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/TermsAggregationSearchBenchmark.java
@@ -18,10 +18,12 @@
  */
 package org.elasticsearch.benchmark.search.aggregations;
 
+import com.carrotsearch.hppc.ObjectOpenHashSet;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import com.google.common.collect.Lists;
 import jsr166y.ThreadLocalRandom;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -30,11 +32,15 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.jna.Natives;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.SizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 
 import java.util.List;
@@ -65,8 +71,9 @@ public class TermsAggregationSearchBenchmark {
     static int STRING_TERM_SIZE = 5;
 
     static Client client;
+    static InternalNode[] nodes;
 
-    private enum Method {
+    public enum Method {
         FACET {
             @Override
             SearchRequestBuilder addTermsAgg(SearchRequestBuilder builder, String name, String field, String executionHint) {
@@ -94,6 +101,7 @@ public class TermsAggregationSearchBenchmark {
     }
 
     public static void main(String[] args) throws Exception {
+        Natives.tryMlockall();
         Random random = new Random();
 
         Settings settings = settingsBuilder()
@@ -104,9 +112,9 @@ public class TermsAggregationSearchBenchmark {
                 .build();
 
         String clusterName = TermsAggregationSearchBenchmark.class.getSimpleName();
-        Node[] nodes = new Node[1];
+        nodes = new InternalNode[1];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = nodeBuilder().clusterName(clusterName)
+            nodes[i] = (InternalNode) nodeBuilder().clusterName(clusterName)
                     .settings(settingsBuilder().put(settings).put("name", "node" + i))
                     .node();
         }
@@ -116,15 +124,6 @@ public class TermsAggregationSearchBenchmark {
                 .settings(settingsBuilder().put(settings).put("name", "client")).client(true).node();
 
         client = clientNode.client();
-
-        long[] lValues = new long[NUMBER_OF_TERMS];
-        for (int i = 0; i < NUMBER_OF_TERMS; i++) {
-            lValues[i] = ThreadLocalRandom.current().nextLong();
-        }
-        String[] sValues = new String[NUMBER_OF_TERMS];
-        for (int i = 0; i < NUMBER_OF_TERMS; i++) {
-            sValues[i] = RandomStrings.randomAsciiOfLength(random, STRING_TERM_SIZE);
-        }
 
         Thread.sleep(10000);
         try {
@@ -164,6 +163,20 @@ public class TermsAggregationSearchBenchmark {
                 .endObject()
               .endObject())).actionGet();
 
+            long[] lValues = new long[NUMBER_OF_TERMS];
+            for (int i = 0; i < NUMBER_OF_TERMS; i++) {
+                lValues[i] = ThreadLocalRandom.current().nextLong();
+            }
+            ObjectOpenHashSet<String> uniqueTerms = ObjectOpenHashSet.newInstance();
+            for (int i = 0; i < NUMBER_OF_TERMS; i++) {
+                boolean added;
+                do {
+                    added = uniqueTerms.add(RandomStrings.randomAsciiOfLength(random, STRING_TERM_SIZE));
+                } while (!added);
+            }
+            String[] sValues = uniqueTerms.toArray(String.class);
+            uniqueTerms = null;
+
             StopWatch stopWatch = new StopWatch().start();
 
             System.out.println("--> Indexing [" + COUNT + "] ...");
@@ -177,8 +190,8 @@ public class TermsAggregationSearchBenchmark {
 
                     XContentBuilder builder = jsonBuilder().startObject();
                     builder.field("id", Integer.toString(counter));
-                    final String sValue = sValues[counter % sValues.length];
-                    final long lValue = lValues[counter % lValues.length];
+                    final String sValue = sValues[ThreadLocalRandom.current().nextInt(sValues.length)];
+                    final long lValue = lValues[ThreadLocalRandom.current().nextInt(lValues.length)];
                     builder.field("s_value", sValue);
                     builder.field("l_value", lValue);
                     builder.field("s_value_dv", sValue);
@@ -233,7 +246,9 @@ public class TermsAggregationSearchBenchmark {
         stats.add(terms("terms_facet_map_s", Method.FACET, "s_value", "map"));
         stats.add(terms("terms_facet_map_s_dv", Method.FACET, "s_value_dv", "map"));
         stats.add(terms("terms_agg_s", Method.AGGREGATION, "s_value", null));
+        stats.add(terms("terms_agg_s_local_ordinals", Method.AGGREGATION, "s_value", "ordinals"));
         stats.add(terms("terms_agg_s_dv", Method.AGGREGATION, "s_value_dv", null));
+        stats.add(terms("terms_agg_s_dv_local_ordinals", Method.AGGREGATION, "s_value_dv", "ordinals"));
         stats.add(terms("terms_agg_map_s", Method.AGGREGATION, "s_value", "map"));
         stats.add(terms("terms_agg_map_s_dv", Method.AGGREGATION, "s_value_dv", "map"));
         stats.add(terms("terms_facet_l", Method.FACET, "l_value", null));
@@ -245,7 +260,9 @@ public class TermsAggregationSearchBenchmark {
         stats.add(terms("terms_facet_map_sm", Method.FACET, "sm_value", "map"));
         stats.add(terms("terms_facet_map_sm_dv", Method.FACET, "sm_value_dv", "map"));
         stats.add(terms("terms_agg_sm", Method.AGGREGATION, "sm_value", null));
+        stats.add(terms("terms_agg_sm_local_ordinals", Method.AGGREGATION, "sm_value", "ordinals"));
         stats.add(terms("terms_agg_sm_dv", Method.AGGREGATION, "sm_value_dv", null));
+        stats.add(terms("terms_agg_sm_dv_local_ordinals", Method.AGGREGATION, "sm_value_dv", "ordinals"));
         stats.add(terms("terms_agg_map_sm", Method.AGGREGATION, "sm_value", "map"));
         stats.add(terms("terms_agg_map_sm_dv", Method.AGGREGATION, "sm_value_dv", "map"));
         stats.add(terms("terms_facet_lm", Method.FACET, "lm_value", null));
@@ -266,12 +283,25 @@ public class TermsAggregationSearchBenchmark {
         stats.add(termsStats("terms_stats_agg_sm_l", Method.AGGREGATION, "sm_value", "l_value", null));
         stats.add(termsStats("terms_stats_agg_sm_l_dv", Method.AGGREGATION, "sm_value_dv", "l_value_dv", null));
 
-        System.out.println("------------------ SUMMARY -------------------------------");
-        System.out.format(Locale.ENGLISH, "%25s%10s%10s\n", "name", "took", "millis");
+        stats.add(termsStats("terms_stats_facet_s_l", Method.FACET, "s_value", "l_value", null));
+        stats.add(termsStats("terms_stats_facet_s_l_dv", Method.FACET, "s_value_dv", "l_value_dv", null));
+        stats.add(termsStats("terms_stats_agg_s_l", Method.AGGREGATION, "s_value", "l_value", null));
+        stats.add(termsStats("terms_stats_agg_s_l_dv", Method.AGGREGATION, "s_value_dv", "l_value_dv", null));
+        stats.add(termsStats("terms_stats_facet_s_lm", Method.FACET, "s_value", "lm_value", null));
+        stats.add(termsStats("terms_stats_facet_s_lm_dv", Method.FACET, "s_value_dv", "lm_value_dv", null));
+        stats.add(termsStats("terms_stats_agg_s_lm", Method.AGGREGATION, "s_value", "lm_value", null));
+        stats.add(termsStats("terms_stats_agg_s_lm_dv", Method.AGGREGATION, "s_value_dv", "lm_value_dv", null));
+        stats.add(termsStats("terms_stats_facet_sm_l", Method.FACET, "sm_value", "l_value", null));
+        stats.add(termsStats("terms_stats_facet_sm_l_dv", Method.FACET, "sm_value_dv", "l_value_dv", null));
+        stats.add(termsStats("terms_stats_agg_sm_l", Method.AGGREGATION, "sm_value", "l_value", null));
+        stats.add(termsStats("terms_stats_agg_sm_l_dv", Method.AGGREGATION, "sm_value_dv", "l_value_dv", null));
+        
+        System.out.println("------------------ SUMMARY ----------------------------------------------");
+        System.out.format(Locale.ENGLISH, "%35s%10s%10s%15s\n", "name", "took", "millis", "fieldata size");
         for (StatsResult stat : stats) {
-            System.out.format(Locale.ENGLISH, "%25s%10s%10d\n", stat.name, TimeValue.timeValueMillis(stat.took), (stat.took / QUERY_COUNT));
+            System.out.format(Locale.ENGLISH, "%35s%10s%10d%15s\n", stat.name, TimeValue.timeValueMillis(stat.took), (stat.took / QUERY_COUNT), stat.fieldDataMemoryUsed);
         }
-        System.out.println("------------------ SUMMARY -------------------------------");
+        System.out.println("------------------ SUMMARY ----------------------------------------------");
 
         clientNode.close();
 
@@ -280,13 +310,15 @@ public class TermsAggregationSearchBenchmark {
         }
     }
 
-    static class StatsResult {
+    public static class StatsResult {
         final String name;
         final long took;
+        final ByteSizeValue fieldDataMemoryUsed;
 
-        StatsResult(String name, long took) {
+        public StatsResult(String name, long took, ByteSizeValue fieldDataMemoryUsed) {
             this.name = name;
             this.took = took;
+            this.fieldDataMemoryUsed = fieldDataMemoryUsed;
         }
     }
 
@@ -294,11 +326,12 @@ public class TermsAggregationSearchBenchmark {
         long totalQueryTime;// LM VALUE
 
         client.admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
+        System.gc();
 
         System.out.println("--> Warmup (" + name + ")...");
         // run just the child query, warm up first
         for (int j = 0; j < QUERY_WARMUP; j++) {
-            SearchResponse searchResponse = method.addTermsAgg(client.prepareSearch()
+            SearchResponse searchResponse = method.addTermsAgg(client.prepareSearch("test")
                     .setSearchType(SearchType.COUNT)
                     .setQuery(matchAllQuery()), name, field, executionHint)
                     .execute().actionGet();
@@ -325,13 +358,25 @@ public class TermsAggregationSearchBenchmark {
             totalQueryTime += searchResponse.getTookInMillis();
         }
         System.out.println("--> Terms Agg (" + name + "): " + (totalQueryTime / QUERY_COUNT) + "ms");
-        return new StatsResult(name, totalQueryTime);
+
+        String[] nodeIds = new String[nodes.length];
+        for (int i = 0; i < nodeIds.length; i++) {
+            nodeIds[i] = nodes[i].injector().getInstance(Discovery.class).localNode().getId();
+        }
+
+        ClusterStatsResponse clusterStateResponse = client.admin().cluster().prepareClusterStats().setNodesIds(nodeIds).get();
+        System.out.println("--> Heap used: " + clusterStateResponse.getNodesStats().getJvm().getHeapUsed());
+        ByteSizeValue fieldDataMemoryUsed = clusterStateResponse.getIndicesStats().getFieldData().getMemorySize();
+        System.out.println("--> Fielddata memory size: " + fieldDataMemoryUsed);
+
+        return new StatsResult(name, totalQueryTime, fieldDataMemoryUsed);
     }
 
     private static StatsResult termsStats(String name, Method method, String keyField, String valueField, String executionHint) {
         long totalQueryTime;
 
         client.admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
+        System.gc();
 
         System.out.println("--> Warmup (" + name + ")...");
         // run just the child query, warm up first
@@ -363,6 +408,6 @@ public class TermsAggregationSearchBenchmark {
             totalQueryTime += searchResponse.getTookInMillis();
         }
         System.out.println("--> Terms stats agg (" + name + "): " + (totalQueryTime / QUERY_COUNT) + "ms");
-        return new StatsResult(name, totalQueryTime);
+        return new StatsResult(name, totalQueryTime, ByteSizeValue.parseBytesSizeValue("0b"));
     }
 }

--- a/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
+import org.junit.Test;
 
 /** Returns an implementation based on paged bytes which doesn't implement WithOrdinals in order to visit different paths in the code,
  *  eg. BytesRefFieldComparatorSource makes decisions based on whether the field data implements WithOrdinals. */
@@ -44,6 +45,11 @@ public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTes
             @Override
             public Names getFieldNames() {
                 return in.getFieldNames();
+            }
+
+            @Override
+            public FieldDataType getFieldDataType() {
+                return in.getFieldDataType();
             }
 
             @Override
@@ -79,4 +85,9 @@ public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTes
         };
     }
 
+    @Test
+    @Override
+    public void testTermsEnum() throws Exception {
+        // We can't test this, since the returned IFD instance doesn't implement IndexFieldData.WithOrdinals
+    }
 }

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -59,6 +59,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.engine.IndexEngineModule;
+import org.elasticsearch.index.fielddata.ordinals.InternalGlobalOrdinalsBuilder;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.search.SearchService;
@@ -78,12 +79,13 @@ import java.io.Closeable;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsBoolean;
-import static com.google.common.collect.Maps.newTreeMap;
 import static org.apache.lucene.util.LuceneTestCase.rarely;
 import static org.apache.lucene.util.LuceneTestCase.usually;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -278,6 +280,7 @@ public final class TestCluster extends ImmutableTestCluster {
             }
         }
         builder.put("plugins.isolation", random.nextBoolean());
+        builder.put(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_INDEX_SETTING_KEY, randomIntBetween(1, InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_DEFAULT));
         return builder.build();
     }
 

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -84,7 +84,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsBoolean;
 import static org.apache.lucene.util.LuceneTestCase.rarely;
 import static org.apache.lucene.util.LuceneTestCase.usually;
@@ -280,7 +279,7 @@ public final class TestCluster extends ImmutableTestCluster {
             }
         }
         builder.put("plugins.isolation", random.nextBoolean());
-        builder.put(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_INDEX_SETTING_KEY, randomIntBetween(1, InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_DEFAULT));
+        builder.put(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_INDEX_SETTING_KEY, 1 + random.nextInt(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_DEFAULT));
         return builder.build();
     }
 


### PR DESCRIPTION
Global ordinals is a data-structure on top of field data, that maintains an incremental numbering for all the terms in field data in a lexicographic order. The performance of search features like terms aggregator can be improved using global ordinals. 

This PR also adds a new execution mode `global_ordinals` to terms aggregation, that is used by default for non nested terms aggregations. 
