### PR TITLE
Make Releasable extend AutoCloseable.

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
@@ -164,7 +164,7 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
                 shardStatus.docs.maxDoc = searcher.reader().maxDoc();
                 shardStatus.docs.deletedDocs = searcher.reader().numDeletedDocs();
             } finally {
-                searcher.release();
+                searcher.close();
             }
 
             shardStatus.mergeStats = indexShard.mergeScheduler().stats();

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -202,7 +202,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
                 valid = false;
                 error = e.getMessage();
             } finally {
-                SearchContext.current().release();
+                SearchContext.current().close();
                 SearchContext.removeCurrent();
             }
         }

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -199,7 +199,7 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
             }
         } finally {
             // this will also release the index searcher
-            context.release();
+            context.close();
             SearchContext.removeCurrent();
         }
     }

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -149,7 +149,7 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
         } catch (IOException e) {
             throw new ElasticsearchException("Could not explain", e);
         } finally {
-            context.release();
+            context.close();
             SearchContext.removeCurrent();
         }
     }

--- a/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -170,7 +170,7 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
         } catch (Throwable ex) {
             throw new ElasticsearchException("failed to execute suggest", ex);
         } finally {
-            searcher.release();
+            searcher.close();
             if (parser != null) {
                 parser.close();
             }

--- a/src/main/java/org/elasticsearch/common/lease/Releasable.java
+++ b/src/main/java/org/elasticsearch/common/lease/Releasable.java
@@ -22,9 +22,9 @@ package org.elasticsearch.common.lease;
 import org.elasticsearch.ElasticsearchException;
 
 /**
- *
+ * Specialization of {@link AutoCloseable} that may only throw an {@link ElasticsearchException}.
  */
-public interface Releasable {
+public interface Releasable extends AutoCloseable {
 
-    boolean release() throws ElasticsearchException;
+    void close() throws ElasticsearchException;
 }

--- a/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
+++ b/src/main/java/org/elasticsearch/common/lucene/index/FreqTermsEnum.java
@@ -107,15 +107,14 @@ public class FreqTermsEnum extends FilterableTermsEnum implements Releasable {
 
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    public void close() throws ElasticsearchException {
         try {
-            Releasables.release(cachedTermOrds, termDocFreqs, termsTotalFreqs);
+            Releasables.close(cachedTermOrds, termDocFreqs, termsTotalFreqs);
         } finally {
             cachedTermOrds = null;
             termDocFreqs = null;
             termsTotalFreqs = null;
         }
-        return true;
     }
 
 }

--- a/src/main/java/org/elasticsearch/common/netty/ReleaseChannelFutureListener.java
+++ b/src/main/java/org/elasticsearch/common/netty/ReleaseChannelFutureListener.java
@@ -37,6 +37,6 @@ public class ReleaseChannelFutureListener implements ChannelFutureListener {
 
     @Override
     public void operationComplete(ChannelFuture future) throws Exception {
-        releasable.release();
+        releasable.close();
     }
 }

--- a/src/main/java/org/elasticsearch/common/recycler/DequeRecycler.java
+++ b/src/main/java/org/elasticsearch/common/recycler/DequeRecycler.java
@@ -87,7 +87,7 @@ public class DequeRecycler<T> extends AbstractRecycler<T> {
         }
 
         @Override
-        public boolean release() {
+        public void close() {
             if (value == null) {
                 throw new ElasticsearchIllegalStateException("recycler entry already released...");
             }
@@ -101,7 +101,6 @@ public class DequeRecycler<T> extends AbstractRecycler<T> {
             }
             value = null;
             afterRelease(recycle);
-            return true;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/common/recycler/NoneRecycler.java
+++ b/src/main/java/org/elasticsearch/common/recycler/NoneRecycler.java
@@ -58,12 +58,11 @@ public class NoneRecycler<T> extends AbstractRecycler<T> {
         }
 
         @Override
-        public boolean release() {
+        public void close() {
             if (value == null) {
                 throw new ElasticsearchIllegalStateException("recycler entry already released...");
             }
             value = null;
-            return true;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -131,7 +131,7 @@ public enum Recyclers {
     }
 
     /**
-     * Wrap the provided recycler so that calls to {@link Recycler#obtain()} and {@link Recycler.V#release()} are protected by
+     * Wrap the provided recycler so that calls to {@link Recycler#obtain()} and {@link Recycler.V#close()} are protected by
      * a lock.
      */
     public static <T> Recycler<T> locked(final Recycler<T> recycler) {
@@ -167,9 +167,9 @@ public enum Recyclers {
                 return new Recycler.V<T>() {
 
                     @Override
-                    public boolean release() throws ElasticsearchException {
+                    public void close() throws ElasticsearchException {
                         synchronized (lock) {
-                            return delegate.release();
+                            delegate.close();
                         }
                     }
 

--- a/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -31,10 +31,9 @@ abstract class AbstractArray implements Releasable {
     }
 
     @Override
-    public boolean release() {
+    public void close() {
         assert !released : "double release";
         released = true;
-        return true; // nothing to release by default
     }
 
 }

--- a/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
@@ -155,19 +155,18 @@ abstract class AbstractBigArray extends AbstractArray {
 
     protected final void releasePage(int page) {
         if (recycler != null) {
-            cache[page].release();
+            cache[page].close();
             cache[page] = null;
         }
     }
 
     @Override
-    public final boolean release() {
-        super.release();
+    public final void close() {
+        super.close();
         if (recycler != null) {
-            Releasables.release(cache);
+            Releasables.close(cache);
             cache = null;
         }
-        return true;
     }
 
 }

--- a/src/main/java/org/elasticsearch/common/util/AbstractHash.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractHash.java
@@ -56,8 +56,7 @@ abstract class AbstractHash extends AbstractPagedHashMap {
     }
 
     @Override
-    public boolean release() {
-        Releasables.release(ids);
-        return true;
+    public void close() {
+        Releasables.close(ids);
     }
 }

--- a/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -96,9 +96,8 @@ public class BigArrays extends AbstractComponent {
         }
 
         @Override
-        public final boolean release() {
-            Releasables.release(releasable);
-            return true;
+        public final void close() {
+            Releasables.close(releasable);
         }
 
     }
@@ -369,7 +368,7 @@ public class BigArrays extends AbstractComponent {
             final ByteArray newArray = newByteArray(size, arr.clearOnResize);
             final byte[] rawArray = ((ByteArrayWrapper) array).array;
             newArray.set(0, rawArray, 0, (int) Math.min(rawArray.length, newArray.size()));
-            array.release();
+            array.close();
             return newArray;
         }
     }
@@ -451,7 +450,7 @@ public class BigArrays extends AbstractComponent {
             for (long i = 0, end = Math.min(size, array.size()); i < end; ++i) {
                 newArray.set(i, array.get(i));
             }
-            array.release();
+            array.close();
             return newArray;
         }
     }
@@ -500,7 +499,7 @@ public class BigArrays extends AbstractComponent {
             for (long i = 0, end = Math.min(size, array.size()); i < end; ++i) {
                 newArray.set(i, array.get(i));
             }
-            array.release();
+            array.close();
             return newArray;
         }
     }
@@ -546,7 +545,7 @@ public class BigArrays extends AbstractComponent {
             for (long i = 0, end = Math.min(size, array.size()); i < end; ++i) {
                 newArray.set(i, array.get(i));
             }
-            array.release();
+            array.close();
             return newArray;
         }
     }
@@ -630,7 +629,7 @@ public class BigArrays extends AbstractComponent {
             for (long i = 0, end = Math.min(size, array.size()); i < end; ++i) {
                 newArray.set(i, array.get(i));
             }
-            array.release();
+            array.close();
             return newArray;
         }
     }

--- a/src/main/java/org/elasticsearch/common/util/DoubleObjectPagedHashMap.java
+++ b/src/main/java/org/elasticsearch/common/util/DoubleObjectPagedHashMap.java
@@ -166,9 +166,8 @@ public class DoubleObjectPagedHashMap<T> extends AbstractPagedHashMap implements
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
-        Releasables.release(keys, values);
-        return true;
+    public void close() throws ElasticsearchException {
+        Releasables.close(keys, values);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/util/LongHash.java
+++ b/src/main/java/org/elasticsearch/common/util/LongHash.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.util;
 
-import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lease.Releasable;
 
 /**
  * Specialized hash table implementation similar to BytesRefHash that maps
@@ -122,15 +122,10 @@ public final class LongHash extends AbstractHash {
     }
 
     @Override
-    public boolean release() {
-        boolean success = false;
-        try {
-            super.release();
-            success = true;
-        } finally {
-            Releasables.release(success, keys);
+    public void close() {
+        try (Releasable releasable = keys) {
+            super.close();
         }
-        return true;
     }
 
 }

--- a/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -166,9 +166,8 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
-        Releasables.release(keys, values);
-        return true;
+    public void close() throws ElasticsearchException {
+        Releasables.close(keys, values);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -163,7 +163,7 @@ public class NettyHttpChannel implements HttpChannel {
             }
         } finally {
             if (!addedReleaseListener && content instanceof Releasable) {
-                ((Releasable) content).release();
+                ((Releasable) content).close();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotDeletionPolicy.java
+++ b/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotDeletionPolicy.java
@@ -24,14 +24,12 @@ import org.apache.lucene.index.IndexDeletionPolicy;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.name.Named;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.IndexShardComponent;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -105,7 +103,7 @@ public class SnapshotDeletionPolicy extends AbstractESDeletionPolicy {
 
     /**
      * Snapshots all the current commits in the index. Make sure to call
-     * {@link SnapshotIndexCommits#release()} to release it.
+     * {@link SnapshotIndexCommits#close()} to release it.
      */
     public SnapshotIndexCommits snapshots() throws IOException {
         synchronized (mutex) {
@@ -122,7 +120,7 @@ public class SnapshotDeletionPolicy extends AbstractESDeletionPolicy {
 
     /**
      * Returns a snapshot of the index (for the last commit point). Make
-     * sure to call {@link SnapshotIndexCommit#release()} in order to release it.
+     * sure to call {@link SnapshotIndexCommit#close()} in order to release it.
      */
     public SnapshotIndexCommit snapshot() throws IOException {
         synchronized (mutex) {
@@ -164,7 +162,7 @@ public class SnapshotDeletionPolicy extends AbstractESDeletionPolicy {
     /**
      * Releases the version provided. Returns <tt>true</tt> if the release was successful.
      */
-    boolean release(long version) {
+    boolean close(long version) {
         synchronized (mutex) {
             SnapshotDeletionPolicy.SnapshotHolder holder = snapshots.get(version);
             if (holder == null) {
@@ -193,12 +191,12 @@ public class SnapshotDeletionPolicy extends AbstractESDeletionPolicy {
         }
 
         @Override
-        public boolean release() {
+        public void close() {
             if (released) {
-                return false;
+                return;
             }
             released = true;
-            return ((SnapshotIndexCommit) delegate).release();
+            ((SnapshotIndexCommit) delegate).close();
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotIndexCommit.java
+++ b/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotIndexCommit.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 /**
- * A snapshot index commit point. While this is held and {@link #release()}
+ * A snapshot index commit point. While this is held and {@link #close()}
  * was not called, no files will be deleted that relates to this commit point
  * ({@link #getFileNames()}).
  *
@@ -57,8 +57,8 @@ public class SnapshotIndexCommit extends IndexCommitDelegate implements Releasab
      * Releases the current snapshot, returning <code>true</code> if it was
      * actually released.
      */
-    public boolean release() {
-        return deletionPolicy.release(getGeneration());
+    public void close() {
+        deletionPolicy.close(getGeneration());
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotIndexCommits.java
+++ b/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotIndexCommits.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.deletionpolicy;
 
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 
 import java.util.Iterator;
 import java.util.List;
@@ -47,11 +48,7 @@ public class SnapshotIndexCommits implements Iterable<SnapshotIndexCommit>, Rele
         return commits.iterator();
     }
 
-    public boolean release() {
-        boolean result = false;
-        for (SnapshotIndexCommit snapshot : commits) {
-            result |= snapshot.release();
-        }
-        return result;
+    public void close() {
+        Releasables.close(commits);
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -86,7 +86,7 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
      * API is responsible for releasing the returned seacher in a
      * safe manner, preferably in a try/finally block.
      *
-     * @see Searcher#release()
+     * @see Searcher#close()
      */
     Searcher acquireSearcher(String source) throws EngineException;
 
@@ -197,9 +197,8 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
+        public void close() throws ElasticsearchException {
             // nothing to release here...
-            return true;
         }
     }
 
@@ -932,7 +931,7 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
 
         public void release() {
             if (searcher != null) {
-                searcher.release();
+                searcher.close();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -349,14 +349,14 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             try {
                 docIdAndVersion = Versions.loadDocIdAndVersion(searcher.reader(), get.uid());
             } catch (Throwable e) {
-                Releasables.releaseWhileHandlingException(searcher);
+                Releasables.closeWhileHandlingException(searcher);
                 //TODO: A better exception goes here
                 throw new EngineException(shardId(), "Couldn't resolve version", e);
             }
 
             if (get.version() != Versions.MATCH_ANY && docIdAndVersion != null) {
                 if (get.versionType().isVersionConflict(docIdAndVersion.version, get.version())) {
-                    Releasables.release(searcher);
+                    Releasables.close(searcher);
                     Uid uid = Uid.createUid(get.uid().text());
                     throw new VersionConflictEngineException(shardId, uid.type(), uid.id(), docIdAndVersion.version, get.version());
                 }
@@ -366,7 +366,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 // don't release the searcher on this path, it is the responsability of the caller to call GetResult.release
                 return new GetResult(searcher, docIdAndVersion);
             } else {
-                Releasables.release(searcher);
+                Releasables.close(searcher);
                 return GetResult.NOT_EXISTS;
             }
 
@@ -1045,14 +1045,14 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             phase1Snapshot = deletionPolicy.snapshot();
         } catch (Throwable e) {
-            Releasables.releaseWhileHandlingException(onGoingRecoveries);
+            Releasables.closeWhileHandlingException(onGoingRecoveries);
             throw new RecoveryEngineException(shardId, 1, "Snapshot failed", e);
         }
 
         try {
             recoveryHandler.phase1(phase1Snapshot);
         } catch (Throwable e) {
-            Releasables.releaseWhileHandlingException(onGoingRecoveries, phase1Snapshot);
+            Releasables.closeWhileHandlingException(onGoingRecoveries, phase1Snapshot);
             if (closed) {
                 e = new EngineClosedException(shardId, e);
             }
@@ -1063,7 +1063,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             phase2Snapshot = translog.snapshot();
         } catch (Throwable e) {
-            Releasables.releaseWhileHandlingException(onGoingRecoveries, phase1Snapshot);
+            Releasables.closeWhileHandlingException(onGoingRecoveries, phase1Snapshot);
             if (closed) {
                 e = new EngineClosedException(shardId, e);
             }
@@ -1073,7 +1073,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             recoveryHandler.phase2(phase2Snapshot);
         } catch (Throwable e) {
-            Releasables.releaseWhileHandlingException(onGoingRecoveries, phase1Snapshot, phase2Snapshot);
+            Releasables.closeWhileHandlingException(onGoingRecoveries, phase1Snapshot, phase2Snapshot);
             if (closed) {
                 e = new EngineClosedException(shardId, e);
             }
@@ -1090,9 +1090,9 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         } catch (Throwable e) {
             throw new RecoveryEngineException(shardId, 3, "Execution failed", e);
         } finally {
-            Releasables.release(success, onGoingRecoveries);
+            Releasables.close(success, onGoingRecoveries);
             rwl.writeLock().unlock();
-            Releasables.release(success, phase1Snapshot, phase2Snapshot, phase3Snapshot);
+            Releasables.close(success, phase1Snapshot, phase2Snapshot, phase3Snapshot);
         }
     }
 
@@ -1114,7 +1114,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 }
                 return stats;
             } finally {
-                searcher.release();
+                searcher.close();
             }
         } finally {
             rwl.readLock().unlock();
@@ -1150,7 +1150,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                     segments.put(info.info.name, segment);
                 }
             } finally {
-                searcher.release();
+                searcher.close();
             }
 
             // now, correlate or add the committed ones...
@@ -1284,7 +1284,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         try {
             return Versions.loadVersion(searcher.reader(), uid);
         } finally {
-            searcher.release();
+            searcher.close();
         }
     }
 
@@ -1457,25 +1457,23 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
+        public void close() throws ElasticsearchException {
             if (!released.compareAndSet(false, true)) {
                 /* In general, searchers should never be released twice or this would break reference counting. There is one rare case
                  * when it might happen though: when the request and the Reaper thread would both try to release it in a very short amount
                  * of time, this is why we only log a warning instead of throwing an exception.
                  */
                 logger.warn("Searcher was released twice", new ElasticsearchIllegalStateException("Double release"));
-                return false;
+                return;
             }
             try {
                 manager.release(searcher);
-                return true;
             } catch (IOException e) {
-                return false;
+                throw new ElasticsearchIllegalStateException("Cannot close", e);
             } catch (AlreadyClosedException e) {
                 /* this one can happen if we already closed the
                  * underlying store / directory and we call into the
                  * IndexWriter to free up pending files. */
-                return false;
             } finally {
                 store.decRef();
             }
@@ -1566,7 +1564,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                     }
                 } finally {
                     // no need to release the fullSearcher, nothing really is done...
-                    Releasables.release(currentSearcher);
+                    Releasables.close(currentSearcher);
                     if (newSearcher != null && closeNewSearcher) {
                         IOUtils.closeWhileHandlingException(newSearcher.getIndexReader()); // ignore
                     }
@@ -1595,9 +1593,8 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
+        public void close() throws ElasticsearchException {
             endRecovery();
-            return true;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -271,7 +271,7 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent {
                         shardPercolateService.addedQuery(entry.getKey(), previousQuery, entry.getValue());
                     }
                 } finally {
-                    searcher.release();
+                    searcher.close();
                 }
             } catch (Exception e) {
                 throw new PercolatorException(shardId.index(), "failed to load queries from percolator index", e);

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
@@ -114,7 +114,7 @@ public class ChildrenConstantScoreQuery extends Query {
 
         long remaining = parentIds.size();
         if (remaining == 0) {
-            Releasables.release(parentIds);
+            Releasables.close(parentIds);
             return Queries.newMatchNoDocsQuery().createWeight(searcher);
         }
 
@@ -205,9 +205,8 @@ public class ChildrenConstantScoreQuery extends Query {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            Releasables.release(parentIds);
-            return true;
+        public void close() throws ElasticsearchException {
+            Releasables.close(parentIds);
         }
 
         private final class ParentDocIdIterator extends FilteredDocIdSetIterator {

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -169,7 +169,7 @@ public class ChildrenQuery extends Query {
                     scores = maxCollector.scores;
                     occurrences = null;
                 } finally {
-                    Releasables.release(maxCollector.parentIdsIndex);
+                    Releasables.close(maxCollector.parentIdsIndex);
                 }
                 break;
             case SUM:
@@ -180,7 +180,7 @@ public class ChildrenQuery extends Query {
                     scores = sumCollector.scores;
                     occurrences = null;
                 } finally {
-                    Releasables.release(sumCollector.parentIdsIndex);
+                    Releasables.close(sumCollector.parentIdsIndex);
                 }
                 break;
             case AVG:
@@ -191,7 +191,7 @@ public class ChildrenQuery extends Query {
                     scores = avgCollector.scores;
                     occurrences = avgCollector.occurrences;
                 } finally {
-                    Releasables.release(avgCollector.parentIdsIndex);
+                    Releasables.close(avgCollector.parentIdsIndex);
                 }
                 break;
             default:
@@ -200,7 +200,7 @@ public class ChildrenQuery extends Query {
 
         int size = (int) parentIds.size();
         if (size == 0) {
-            Releasables.release(parentIds, scores, occurrences);
+            Releasables.close(parentIds, scores, occurrences);
             return Queries.newMatchNoDocsQuery().createWeight(searcher);
         }
 
@@ -290,9 +290,8 @@ public class ChildrenQuery extends Query {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            Releasables.release(parentIds, scores, occurrences);
-            return true;
+        public void close() throws ElasticsearchException {
+            Releasables.close(parentIds, scores, occurrences);
         }
 
         private class ParentScorer extends Scorer {

--- a/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
@@ -91,12 +91,11 @@ public class CustomQueryWrappingFilter extends NoCacheFilter implements Releasab
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    public void close() throws ElasticsearchException {
         // We need to clear the docIdSets, otherwise this is leaved unused
         // DocIdSets around and can potentially become a memory leak.
         docIdSets = null;
         searcher = null;
-        return true;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
@@ -103,7 +103,7 @@ public class ParentConstantScoreQuery extends Query {
         indexSearcher.search(parentQuery, collector);
 
         if (parentIds.size() == 0) {
-            Releasables.release(parentIds);
+            Releasables.close(parentIds);
             return Queries.newMatchNoDocsQuery().createWeight(searcher);
         }
 
@@ -180,9 +180,8 @@ public class ParentConstantScoreQuery extends Query {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            Releasables.release(parentIds);
-            return true;
+        public void close() throws ElasticsearchException {
+            Releasables.close(parentIds);
         }
 
         private final class ChildrenDocIdIterator extends FilteredDocIdSetIterator {

--- a/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -157,7 +157,7 @@ public class ParentQuery extends Query {
         } finally {
             if (releaseCollectorResource) {
                 // either if we run into an exception or if we return early
-                Releasables.release(collector.parentIds, collector.scores);
+                Releasables.close(collector.parentIds, collector.scores);
             }
         }
         searchContext.addReleasable(childWeight);
@@ -276,9 +276,8 @@ public class ParentQuery extends Query {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            Releasables.release(parentIds, scores, parentIdsIndexCache);
-            return true;
+        public void close() throws ElasticsearchException {
+            Releasables.close(parentIds, scores, parentIdsIndexCache);
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/search/child/TopChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/TopChildrenQuery.java
@@ -246,10 +246,10 @@ public class TopChildrenQuery extends Query {
                 ParentDoc[] _parentDocs = value.v().values().toArray(ParentDoc.class);
                 Arrays.sort(_parentDocs, PARENT_DOC_COMP);
                 parentDocs.v().put(keys[i], _parentDocs);
-                Releasables.release(value);
+                Releasables.close(value);
             }
         }
-        Releasables.release(parentDocsPerReader);
+        Releasables.close(parentDocsPerReader);
         return parentHitsResolved;
     }
 
@@ -321,9 +321,8 @@ public class TopChildrenQuery extends Query {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            Releasables.release(parentDocs);
-            return true;
+        public void close() throws ElasticsearchException {
+            Releasables.close(parentDocs);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -495,7 +495,7 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
         try {
             return new DocsStats(searcher.reader().numDocs(), searcher.reader().numDeletedDocs());
         } finally {
-            searcher.release();
+            searcher.close();
         }
     }
 
@@ -585,7 +585,7 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
                 completionStats.add(completionPostingsFormat.completionStats(currentSearcher.reader(), fields));
             }
         } finally {
-            currentSearcher.release();
+            currentSearcher.close();
         }
         return completionStats;
     }

--- a/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotAndRestoreService.java
@@ -90,7 +90,7 @@ public class IndexShardSnapshotAndRestoreService extends AbstractIndexShardCompo
                     logger.debug(sb.toString());
                 }
             } finally {
-                snapshotIndexCommit.release();
+                snapshotIndexCommit.close();
             }
         } catch (SnapshotFailedEngineException e) {
             throw e;

--- a/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorService.java
+++ b/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorService.java
@@ -77,7 +77,7 @@ public class ShardTermVectorService extends AbstractIndexShardComponent {
         } catch (Throwable ex) {
             throw new ElasticsearchException("failed to execute term vector request", ex);
         } finally {
-            searcher.release();
+            searcher.close();
         }
         return termVectorResponse;
     }

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsChannelSnapshot.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsChannelSnapshot.java
@@ -138,8 +138,7 @@ public class FsChannelSnapshot implements Translog.Snapshot {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    public void close() throws ElasticsearchException {
         raf.decreaseRefCount(true);
-        return true;
     }
 }

--- a/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
@@ -189,7 +189,7 @@ public class IndicesFilterCache extends AbstractComponent implements RemovalList
                             }
                             schedule();
                         } finally {
-                            keys.release();
+                            keys.close();
                         }
                     }
                 });

--- a/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -194,7 +194,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
             } catch (Exception e) {
                 logger.warn("failed to purge", e);
             } finally {
-                searcher.release();
+                searcher.close();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/percolator/MultiDocumentPercolatorIndex.java
+++ b/src/main/java/org/elasticsearch/percolator/MultiDocumentPercolatorIndex.java
@@ -120,14 +120,13 @@ class MultiDocumentPercolatorIndex implements PercolatorIndex {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
+        public void close() throws ElasticsearchException {
             try {
                 searcher.getIndexReader().close();
                 rootDocMemoryIndex.reset();
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to close IndexReader in percolator with nested doc", e);
             }
-            return true;
         }
 
     }

--- a/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -227,7 +227,7 @@ public class PercolatorService extends AbstractComponent {
             indexShard.readAllowed();
             return action.doPercolate(request, context);
         } finally {
-            context.release();
+            context.close();
             shardPercolateService.postPercolate(System.nanoTime() - startTime);
         }
     }
@@ -475,7 +475,7 @@ public class PercolatorService extends AbstractComponent {
             } catch (Throwable e) {
                 logger.warn("failed to execute", e);
             } finally {
-                percolatorSearcher.release();
+                percolatorSearcher.close();
             }
             return new PercolateShardResponse(count, context, request.index(), request.shardId());
         }
@@ -586,7 +586,7 @@ public class PercolatorService extends AbstractComponent {
                 logger.debug("failed to execute", e);
                 throw new PercolateException(context.indexShard().shardId(), "failed to execute", e);
             } finally {
-                percolatorSearcher.release();
+                percolatorSearcher.close();
             }
         }
     };
@@ -620,7 +620,7 @@ public class PercolatorService extends AbstractComponent {
                 logger.debug("failed to execute", e);
                 throw new PercolateException(context.indexShard().shardId(), "failed to execute", e);
             } finally {
-                percolatorSearcher.release();
+                percolatorSearcher.close();
             }
         }
     };
@@ -764,7 +764,7 @@ public class PercolatorService extends AbstractComponent {
                 logger.debug("failed to execute", e);
                 throw new PercolateException(context.indexShard().shardId(), "failed to execute", e);
             } finally {
-                percolatorSearcher.release();
+                percolatorSearcher.close();
             }
         }
 

--- a/src/main/java/org/elasticsearch/percolator/SingleDocumentPercolatorIndex.java
+++ b/src/main/java/org/elasticsearch/percolator/SingleDocumentPercolatorIndex.java
@@ -90,14 +90,13 @@ class SingleDocumentPercolatorIndex implements PercolatorIndex {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
+        public void close() throws ElasticsearchException {
             try {
                 searcher.getIndexReader().close();
                 memoryIndex.reset();
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to close percolator in-memory index", e);
             }
-            return true;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -532,7 +532,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             }
             context.keepAlive(keepAlive);
         } catch (Throwable e) {
-            context.release();
+            context.close();
             throw ExceptionsHelper.convertToRuntime(e);
         }
 
@@ -545,7 +545,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             return;
         }
         context.indexShard().searchService().onFreeContext(context);
-        context.release();
+        context.close();
     }
 
     private void freeContext(SearchContext context) {
@@ -553,7 +553,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         if (removed != null) {
             removed.indexShard().searchService().onFreeContext(removed);
         }
-        context.release();
+        context.close();
     }
 
     public void freeAllScrollContexts() {

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.XCollector;
@@ -105,8 +106,7 @@ public class AggregationPhase implements SearchPhase {
         }
 
         Aggregator[] aggregators = context.aggregations().aggregators();
-        boolean success = false;
-        try {
+        try (Releasable releasable = Releasables.wrap(aggregators)) {
             List<Aggregator> globals = new ArrayList<>();
             for (int i = 0; i < aggregators.length; i++) {
                 if (aggregators[i] instanceof GlobalAggregator) {
@@ -135,9 +135,6 @@ public class AggregationPhase implements SearchPhase {
                 aggregations.add(aggregator.buildAggregation(0));
             }
             context.queryResult().aggregations(new InternalAggregations(aggregations));
-            success = true;
-        } finally {
-            Releasables.release(success, aggregators);
         }
 
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -174,15 +174,10 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
 
     /** Called upon release of the aggregator. */
     @Override
-    public boolean release() {
-        boolean success = false;
-        try {
+    public void close() {
+        try (Releasable releasable = Releasables.wrap(subAggregators)) {
             doRelease();
-            success = true;
-        } finally {
-            Releasables.release(success, subAggregators);
         }
-        return true;
     }
 
     /** Release instance-specific data. */

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -157,7 +157,7 @@ public class AggregatorFactories {
                         }
 
                     };
-                    Releasables.release(Iterables.concat(aggregatorsIter, Collections.singleton(aggregators)));
+                    Releasables.close(Iterables.concat(aggregatorsIter, Collections.singleton(aggregators)));
                 }
             };
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -111,15 +111,10 @@ public abstract class BucketsAggregator extends Aggregator {
     }
 
     @Override
-    public final boolean release() {
-        boolean success = false;
-        try {
-            super.release();
-            success = true;
-        } finally {
-            Releasables.release(success, docCounts);
+    public final void close() {
+        try (Releasable releasable = docCounts) {
+            super.close();
         }
-        return true;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -133,7 +133,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds);
+        Releasables.close(bucketOrds);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -219,7 +219,7 @@ public class InternalGeoHashGrid extends InternalAggregation implements GeoHashG
             List<Bucket> sameCellBuckets = cursor.value;
             ordered.insertWithOverflow(sameCellBuckets.get(0).reduce(sameCellBuckets, reduceContext.bigArrays()));
         }
-        buckets.release();
+        buckets.close();
         Bucket[] list = new Bucket[ordered.size()];
         for (int i = ordered.size() - 1; i >= 0; i--) {
             list[i] = ordered.pop();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -135,7 +135,7 @@ public class HistogramAggregator extends BucketsAggregator {
 
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds);
+        Releasables.close(bucketOrds);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -344,7 +344,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
                 reducedBuckets.add(bucket);
             }
         }
-        bucketsByKey.release();
+        bucketsByKey.close();
 
         // adding empty buckets in needed
         if (minDocCount == 0) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -110,7 +110,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds, termsAggFactory);
+        Releasables.close(bucketOrds, termsAggFactory);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -116,7 +116,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
 
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds, termsAggFactory);
+        Releasables.close(bucketOrds, termsAggFactory);
     }
 
     /**
@@ -143,7 +143,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
             final long maxOrd = ordinals.getMaxOrd();
             if (ordinalToBucket == null || ordinalToBucket.size() < maxOrd) {
                 if (ordinalToBucket != null) {
-                    ordinalToBucket.release();
+                    ordinalToBucket.close();
                 }
                 ordinalToBucket = context().bigArrays().newLongArray(BigArrays.overSize(maxOrd), false);
             }
@@ -176,7 +176,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
 
         @Override
         public void doRelease() {
-            Releasables.release(bucketOrds, termsAggFactory, ordinalToBucket);
+            Releasables.close(bucketOrds, termsAggFactory, ordinalToBucket);
         }
 
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -204,14 +204,13 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    public void close() throws ElasticsearchException {
         try {
             if (termsEnum instanceof Releasable) {
-                ((Releasable) termsEnum).release();
+                ((Releasable) termsEnum).close();
             }
         } finally {
             termsEnum = null;
         }
-        return true;
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -153,7 +153,7 @@ public class DoubleTerms extends InternalTerms {
                 ordered.insertWithOverflow(b);
             }
         }
-        buckets.release();
+        buckets.close();
         InternalTerms.Bucket[] list = new InternalTerms.Bucket[ordered.size()];
         for (int i = ordered.size() - 1; i >= 0; i--) {
             list[i] = (Bucket) ordered.pop();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -140,7 +140,7 @@ public class DoubleTermsAggregator extends BucketsAggregator {
 
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds);
+        Releasables.close(bucketOrds);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -149,7 +149,7 @@ public class LongTerms extends InternalTerms {
                 ordered.insertWithOverflow(b);
             }
         }
-        buckets.release();
+        buckets.close();
         InternalTerms.Bucket[] list = new InternalTerms.Bucket[ordered.size()];
         for (int i = ordered.size() - 1; i >= 0; i--) {
             list[i] = (Bucket) ordered.pop();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -140,7 +140,7 @@ public class LongTermsAggregator extends BucketsAggregator {
 
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds);
+        Releasables.close(bucketOrds);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -250,7 +250,7 @@ public class StringTermsAggregator extends BucketsAggregator {
 
     @Override
     public void doRelease() {
-        Releasables.release(bucketOrds);
+        Releasables.close(bucketOrds);
     }
 
     /**
@@ -276,7 +276,7 @@ public class StringTermsAggregator extends BucketsAggregator {
             final long maxOrd = ordinals.getMaxOrd();
             if (ordinalToBucket == null || ordinalToBucket.size() < maxOrd) {
                 if (ordinalToBucket != null) {
-                    ordinalToBucket.release();
+                    ordinalToBucket.close();
                 }
                 ordinalToBucket = context().bigArrays().newLongArray(BigArrays.overSize(maxOrd), false);
             }
@@ -308,7 +308,7 @@ public class StringTermsAggregator extends BucketsAggregator {
 
         @Override
         public void doRelease() {
-            Releasables.release(bucketOrds, ordinalToBucket);
+            Releasables.close(bucketOrds, ordinalToBucket);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -115,7 +115,7 @@ public class AvgAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(counts, sums);
+        Releasables.close(counts, sums);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -119,7 +119,7 @@ public class CardinalityAggregator extends MetricsAggregator.SingleValue {
         if (collector != null) {
             try {
                 collector.postCollect();
-                collector.release();
+                collector.close();
             } finally {
                 collector = null;
             }
@@ -155,7 +155,7 @@ public class CardinalityAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     protected void doRelease() {
-        Releasables.release(counts, collector);
+        Releasables.close(counts, collector);
     }
 
     private static interface Collector extends Releasable {
@@ -190,8 +190,8 @@ public class CardinalityAggregator extends MetricsAggregator.SingleValue {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            return true;
+        public void close() throws ElasticsearchException {
+            // no-op
         }
 
     }
@@ -249,9 +249,7 @@ public class CardinalityAggregator extends MetricsAggregator.SingleValue {
             }
 
             final org.elasticsearch.common.hash.MurmurHash3.Hash128 hash = new org.elasticsearch.common.hash.MurmurHash3.Hash128();
-            final LongArray hashes = bigArrays.newLongArray(maxOrd, false);
-            boolean success = false;
-            try {
+            try (LongArray hashes = bigArrays.newLongArray(maxOrd, false)) {
                 for (int ord = allVisitedOrds.nextSetBit(0); ord != -1; ord = ord + 1 < maxOrd ? allVisitedOrds.nextSetBit(ord + 1) : -1) {
                     final BytesRef value = values.getValueByOrd(ord);
                     org.elasticsearch.common.hash.MurmurHash3.hash128(value.bytes, value.offset, value.length, 0, hash);
@@ -266,16 +264,12 @@ public class CardinalityAggregator extends MetricsAggregator.SingleValue {
                         }
                     }
                 }
-                success = true;
-            } finally {
-                Releasables.release(success, hashes);
             }
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
-            Releasables.release(visitedOrds);
-            return true;
+        public void close() throws ElasticsearchException {
+            Releasables.close(visitedOrds);
         }
 
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -116,6 +116,6 @@ public class MaxAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(maxes);
+        Releasables.close(maxes);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -115,6 +115,6 @@ public class MinAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(mins);
+        Releasables.close(mins);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -93,7 +93,7 @@ public class PercentilesAggregator extends MetricsAggregator.MultiValue {
 
     @Override
     protected void doRelease() {
-        estimator.release();
+        estimator.close();
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigest.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigest.java
@@ -47,9 +47,8 @@ public class TDigest extends PercentilesEstimator {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
-        states.release();
-        return true;
+    public void close() throws ElasticsearchException {
+        states.close();
     }
 
     public void offer(double value, long bucketOrd) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -157,6 +157,6 @@ public class StatsAggegator extends MetricsAggregator.MultiValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(counts, maxes, mins, sums);
+        Releasables.close(counts, maxes, mins, sums);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -156,7 +156,7 @@ public class ExtendedStatsAggregator extends MetricsAggregator.MultiValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(counts, maxes, mins, sumOfSqrs, sums);
+        Releasables.close(counts, maxes, mins, sumOfSqrs, sums);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -110,6 +110,6 @@ public class SumAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(sums);
+        Releasables.close(sums);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -93,7 +93,7 @@ public class ValueCountAggregator extends MetricsAggregator.SingleValue {
 
     @Override
     public void doRelease() {
-        Releasables.release(counts);
+        Releasables.close(counts);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Bytes> {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/CountDateHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/CountDateHistogramFacetExecutor.java
@@ -70,7 +70,7 @@ public class CountDateHistogramFacetExecutor extends FacetExecutor {
                 countEntries[entryIndex++] = new InternalCountDateHistogramFacet.CountEntry(keys[i], values[i]);
             }
         }
-        counts.release();
+        counts.close();
         return new InternalCountDateHistogramFacet(facetName, comparatorType, countEntries);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalCountDateHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalCountDateHistogramFacet.java
@@ -156,7 +156,7 @@ public class InternalCountDateHistogramFacet extends InternalDateHistogramFacet 
                 countEntries[entriesIndex++] = new CountEntry(keys[i], values[i]);
             }
         }
-        counts.release();
+        counts.close();
 
         Arrays.sort(countEntries, comparatorType.comparator());
 

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalFullDateHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/InternalFullDateHistogramFacet.java
@@ -189,7 +189,7 @@ public class InternalFullDateHistogramFacet extends InternalDateHistogramFacet {
             ordered.add(value);
         }
 
-        map.release();
+        map.close();
 
         // just initialize it as already ordered facet
         InternalFullDateHistogramFacet ret = new InternalFullDateHistogramFacet(getName());

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueDateHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueDateHistogramFacetExecutor.java
@@ -73,7 +73,7 @@ public class ValueDateHistogramFacetExecutor extends FacetExecutor {
             }
         }
 
-        entries.release();
+        entries.close();
         return new InternalFullDateHistogramFacet(facetName, comparatorType, entries1);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueScriptDateHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/ValueScriptDateHistogramFacetExecutor.java
@@ -74,7 +74,7 @@ public class ValueScriptDateHistogramFacetExecutor extends FacetExecutor {
             }
         }
 
-        entries.release();
+        entries.close();
         return new InternalFullDateHistogramFacet(facetName, comparatorType, entries1);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/histogram/CountHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/CountHistogramFacetExecutor.java
@@ -67,7 +67,7 @@ public class CountHistogramFacetExecutor extends FacetExecutor {
                 entries[entryIndex++] = new InternalCountHistogramFacet.CountEntry(keys[i], values[i]);
             }
         }
-        counts.release();
+        counts.close();
         return new InternalCountHistogramFacet(facetName, comparatorType, entries);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/histogram/FullHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/FullHistogramFacetExecutor.java
@@ -68,7 +68,7 @@ public class FullHistogramFacetExecutor extends FacetExecutor {
                 fullEntries.add((InternalFullHistogramFacet.FullEntry) values[i]);
             }
         }
-        entries.release();
+        entries.close();
         return new InternalFullHistogramFacet(facetName, comparatorType, fullEntries);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/histogram/InternalCountHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/InternalCountHistogramFacet.java
@@ -155,7 +155,7 @@ public class InternalCountHistogramFacet extends InternalHistogramFacet {
                 entries[entryIndex++] = new CountEntry(keys[i], values[i]);
             }
         }
-        counts.release();
+        counts.close();
 
         Arrays.sort(entries, comparatorType.comparator());
 

--- a/src/main/java/org/elasticsearch/search/facet/histogram/InternalFullHistogramFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/InternalFullHistogramFacet.java
@@ -186,7 +186,7 @@ public class InternalFullHistogramFacet extends InternalHistogramFacet {
             ordered.add(value);
         }
 
-        map.release();
+        map.close();
 
         // just initialize it as already ordered facet
         InternalFullHistogramFacet ret = new InternalFullHistogramFacet(getName());

--- a/src/main/java/org/elasticsearch/search/facet/histogram/ScriptHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/ScriptHistogramFacetExecutor.java
@@ -71,7 +71,7 @@ public class ScriptHistogramFacetExecutor extends FacetExecutor {
             }
         }
 
-        entries.release();
+        entries.close();
         return new InternalFullHistogramFacet(facetName, comparatorType, entries1);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/histogram/ValueHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/ValueHistogramFacetExecutor.java
@@ -70,7 +70,7 @@ public class ValueHistogramFacetExecutor extends FacetExecutor {
                 entries1.add(value);
             }
         }
-        entries.release();
+        entries.close();
         return new InternalFullHistogramFacet(facetName, comparatorType, entries1);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/histogram/ValueScriptHistogramFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/histogram/ValueScriptHistogramFacetExecutor.java
@@ -75,7 +75,7 @@ public class ValueScriptHistogramFacetExecutor extends FacetExecutor {
             }
         }
 
-        entries.release();
+        entries.close();
         return new InternalFullHistogramFacet(facetName, comparatorType, entries1);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/terms/doubles/InternalDoubleTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/doubles/InternalDoubleTermsFacet.java
@@ -201,7 +201,7 @@ public class InternalDoubleTermsFacet extends InternalTermsFacet {
         first.missing = missing;
         first.total = total;
 
-        aggregated.release();
+        aggregated.close();
 
         return first;
     }

--- a/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/doubles/TermsDoubleFacetExecutor.java
@@ -101,7 +101,7 @@ public class TermsDoubleFacetExecutor extends FacetExecutor {
     @Override
     public InternalFacet buildFacet(String facetName) {
         if (facets.v().isEmpty()) {
-            facets.release();
+            facets.close();
             return new InternalDoubleTermsFacet(facetName, comparatorType, size, ImmutableList.<InternalDoubleTermsFacet.DoubleEntry>of(), missing, total);
         } else {
             final boolean[] states = facets.v().allocated;
@@ -118,7 +118,7 @@ public class TermsDoubleFacetExecutor extends FacetExecutor {
                 for (int i = ordered.size() - 1; i >= 0; i--) {
                     list[i] = (InternalDoubleTermsFacet.DoubleEntry) ordered.pop();
                 }
-                facets.release();
+                facets.close();
                 return new InternalDoubleTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
             } else {
                 BoundedTreeSet<InternalDoubleTermsFacet.DoubleEntry> ordered = new BoundedTreeSet<>(comparatorType.comparator(), shardSize);
@@ -127,7 +127,7 @@ public class TermsDoubleFacetExecutor extends FacetExecutor {
                         ordered.add(new InternalDoubleTermsFacet.DoubleEntry(keys[i], values[i]));
                     }
                 }
-                facets.release();
+                facets.close();
                 return new InternalDoubleTermsFacet(facetName, comparatorType, size, ordered, missing, total);
             }
         }

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/InternalLongTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/InternalLongTermsFacet.java
@@ -202,7 +202,7 @@ public class InternalLongTermsFacet extends InternalTermsFacet {
         first.missing = missing;
         first.total = total;
 
-        aggregated.release();
+        aggregated.close();
 
         return first;
     }

--- a/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/longs/TermsLongFacetExecutor.java
@@ -100,7 +100,7 @@ public class TermsLongFacetExecutor extends FacetExecutor {
     @Override
     public InternalFacet buildFacet(String facetName) {
         if (facets.v().isEmpty()) {
-            facets.release();
+            facets.close();
             return new InternalLongTermsFacet(facetName, comparatorType, size, ImmutableList.<InternalLongTermsFacet.LongEntry>of(), missing, total);
         } else {
             LongIntOpenHashMap facetEntries  = facets.v();
@@ -118,7 +118,7 @@ public class TermsLongFacetExecutor extends FacetExecutor {
                 for (int i = ordered.size() - 1; i >= 0; i--) {
                     list[i] = (InternalLongTermsFacet.LongEntry) ordered.pop();
                 }
-                facets.release();
+                facets.close();
                 return new InternalLongTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
             } else {
                 BoundedTreeSet<InternalLongTermsFacet.LongEntry> ordered = new BoundedTreeSet<>(comparatorType.comparator(), shardSize);
@@ -127,7 +127,7 @@ public class TermsLongFacetExecutor extends FacetExecutor {
                         ordered.add(new InternalLongTermsFacet.LongEntry(keys[i], values[i]));
                     }
                 }
-                facets.release();
+                facets.close();
                 return new InternalLongTermsFacet(facetName, comparatorType, size, ordered, missing, total);
             }
         }

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/InternalStringTermsFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/InternalStringTermsFacet.java
@@ -218,7 +218,7 @@ public class InternalStringTermsFacet extends InternalTermsFacet {
         first.missing = missing;
         first.total = total;
 
-        aggregated.release();
+        aggregated.close();
 
         return first;
     }

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/ScriptTermsStringFieldFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/ScriptTermsStringFieldFacetExecutor.java
@@ -80,7 +80,7 @@ public class ScriptTermsStringFieldFacetExecutor extends FacetExecutor {
     @Override
     public InternalFacet buildFacet(String facetName) {
         if (facets.v().isEmpty()) {
-            facets.release();
+            facets.close();
             return new InternalStringTermsFacet(facetName, comparatorType, size, ImmutableList.<InternalStringTermsFacet.TermEntry>of(), missing, total);
         } else {
             final boolean[] states = facets.v().allocated;
@@ -98,7 +98,7 @@ public class ScriptTermsStringFieldFacetExecutor extends FacetExecutor {
                 for (int i = ordered.size() - 1; i >= 0; i--) {
                     list[i] = ((InternalStringTermsFacet.TermEntry) ordered.pop());
                 }
-                facets.release();
+                facets.close();
                 return new InternalStringTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
             } else {
                 BoundedTreeSet<InternalStringTermsFacet.TermEntry> ordered = new BoundedTreeSet<>(comparatorType.comparator(), shardSize);
@@ -108,7 +108,7 @@ public class ScriptTermsStringFieldFacetExecutor extends FacetExecutor {
                         ordered.add(new InternalStringTermsFacet.TermEntry(key, values[i]));
                     }
                 }
-                facets.release();
+                facets.close();
                 return new InternalStringTermsFacet(facetName, comparatorType, size, ordered, missing, total);
             }
         }

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetExecutor.java
@@ -151,7 +151,7 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
                 list[i] = (InternalStringTermsFacet.TermEntry) ordered.pop();
             }
 
-            Releasables.release(aggregators);
+            Releasables.close(aggregators);
 
             return new InternalStringTermsFacet(facetName, comparatorType, size, Arrays.asList(list), missing, total);
         }
@@ -189,7 +189,7 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
             }
         }
 
-        Releasables.release(aggregators);
+        Releasables.close(aggregators);
 
         return new InternalStringTermsFacet(facetName, comparatorType, size, ordered, missing, total);
     }
@@ -210,7 +210,7 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
                 if (current.values.ordinals().getNumOrds() > 0) {
                     aggregators.add(current);
                 } else {
-                    Releasables.release(current);
+                    Releasables.close(current);
                 }
             }
             values = indexFieldData.load(context).getBytesValues(false);
@@ -238,7 +238,7 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
                 if (current.values.ordinals().getNumOrds() > 0) {
                     aggregators.add(current);
                 } else {
-                    Releasables.release(current);
+                    Releasables.close(current);
                 }
                 current = null;
             }
@@ -287,9 +287,8 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
         }
 
         @Override
-        public boolean release() {
-            Releasables.release(counts);
-            return true;
+        public void close() {
+            Releasables.close(counts);
         }
 
     }

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/doubles/InternalTermsStatsDoubleFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/doubles/InternalTermsStatsDoubleFacet.java
@@ -211,7 +211,7 @@ public class InternalTermsStatsDoubleFacet extends InternalTermsStatsFacet {
         if (requiredSize == 0) { // all terms
             DoubleEntry[] entries1 = map.v().values().toArray(DoubleEntry.class);
             Arrays.sort(entries1, comparatorType.comparator());
-            map.release();
+            map.close();
             return new InternalTermsStatsDoubleFacet(getName(), comparatorType, requiredSize, Arrays.asList(entries1), missing);
         } else {
             Object[] values = map.v().values;
@@ -224,7 +224,7 @@ public class InternalTermsStatsDoubleFacet extends InternalTermsStatsFacet {
                 }
                 ordered.add(value);
             }
-            map.release();
+            map.close();
             return new InternalTermsStatsDoubleFacet(getName(), comparatorType, requiredSize, ordered, missing);
         }
     }

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/doubles/TermsStatsDoubleFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/doubles/TermsStatsDoubleFacetExecutor.java
@@ -74,7 +74,7 @@ public class TermsStatsDoubleFacetExecutor extends FacetExecutor {
     @Override
     public InternalFacet buildFacet(String facetName) {
         if (entries.v().isEmpty()) {
-            entries.release();
+            entries.close();
             return new InternalTermsStatsDoubleFacet(facetName, comparatorType, size, ImmutableList.<InternalTermsStatsDoubleFacet.DoubleEntry>of(), missing);
         }
         if (size == 0) { // all terms
@@ -87,7 +87,7 @@ public class TermsStatsDoubleFacetExecutor extends FacetExecutor {
                     doubleEntries.add((InternalTermsStatsDoubleFacet.DoubleEntry) values[i]);
                 }
             }
-            entries.release();
+            entries.close();
             return new InternalTermsStatsDoubleFacet(facetName, comparatorType, 0 /* indicates all terms*/, doubleEntries, missing);
         }
         Object[] values = entries.v().values;
@@ -103,7 +103,7 @@ public class TermsStatsDoubleFacetExecutor extends FacetExecutor {
             ordered.add(value);
         }
 
-        entries.release();
+        entries.close();
         return new InternalTermsStatsDoubleFacet(facetName, comparatorType, size, ordered, missing);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/longs/InternalTermsStatsLongFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/longs/InternalTermsStatsLongFacet.java
@@ -211,7 +211,7 @@ public class InternalTermsStatsLongFacet extends InternalTermsStatsFacet {
         if (requiredSize == 0) { // all terms
             LongEntry[] entries1 = map.v().values().toArray(LongEntry.class);
             Arrays.sort(entries1, comparatorType.comparator());
-            map.release();
+            map.close();
             return new InternalTermsStatsLongFacet(getName(), comparatorType, requiredSize, Arrays.asList(entries1), missing);
         } else {
             Object[] values = map.v().values;
@@ -224,7 +224,7 @@ public class InternalTermsStatsLongFacet extends InternalTermsStatsFacet {
                 }
                 ordered.add(value);
             }
-            map.release();
+            map.close();
             return new InternalTermsStatsLongFacet(getName(), comparatorType, requiredSize, ordered, missing);
         }
     }

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/longs/TermsStatsLongFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/longs/TermsStatsLongFacetExecutor.java
@@ -75,7 +75,7 @@ public class TermsStatsLongFacetExecutor extends FacetExecutor {
     @Override
     public InternalFacet buildFacet(String facetName) {
         if (entries.v().isEmpty()) {
-            entries.release();
+            entries.close();
             return new InternalTermsStatsLongFacet(facetName, comparatorType, size, ImmutableList.<InternalTermsStatsLongFacet.LongEntry>of(), missing);
         }
         if (size == 0) { // all terms
@@ -89,7 +89,7 @@ public class TermsStatsLongFacetExecutor extends FacetExecutor {
                 }
             }
 
-            entries.release();
+            entries.close();
             return new InternalTermsStatsLongFacet(facetName, comparatorType, 0 /* indicates all terms*/, longEntries, missing);
         }
 
@@ -106,7 +106,7 @@ public class TermsStatsLongFacetExecutor extends FacetExecutor {
             }
             ordered.add(value);
         }
-        entries.release();
+        entries.close();
         return new InternalTermsStatsLongFacet(facetName, comparatorType, size, ordered, missing);
     }
 

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/strings/InternalTermsStatsStringFacet.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/strings/InternalTermsStatsStringFacet.java
@@ -216,7 +216,7 @@ public class InternalTermsStatsStringFacet extends InternalTermsStatsFacet {
         if (requiredSize == 0) { // all terms
             StringEntry[] entries1 = map.v().values().toArray(StringEntry.class);
             Arrays.sort(entries1, comparatorType.comparator());
-            map.release();
+            map.close();
             return new InternalTermsStatsStringFacet(getName(), comparatorType, requiredSize, Arrays.asList(entries1), missing);
         } else {
             Object[] values = map.v().values;
@@ -229,7 +229,7 @@ public class InternalTermsStatsStringFacet extends InternalTermsStatsFacet {
                 }
                 ordered.add(value);
             }
-            map.release();
+            map.close();
             return new InternalTermsStatsStringFacet(getName(), comparatorType, requiredSize, ordered, missing);
         }
     }

--- a/src/main/java/org/elasticsearch/search/facet/termsstats/strings/TermsStatsStringFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/termsstats/strings/TermsStatsStringFacetExecutor.java
@@ -77,7 +77,7 @@ public class TermsStatsStringFacetExecutor extends FacetExecutor {
     @Override
     public InternalFacet buildFacet(String facetName) {
         if (entries.v().isEmpty()) {
-            entries.release();
+            entries.close();
             return new InternalTermsStatsStringFacet(facetName, comparatorType, size, ImmutableList.<InternalTermsStatsStringFacet.StringEntry>of(), missing);
         }
         if (size == 0) { // all terms
@@ -105,7 +105,7 @@ public class TermsStatsStringFacetExecutor extends FacetExecutor {
             ordered.add(value);
         }
 
-        entries.release();
+        entries.close();
         return new InternalTermsStatsStringFacet(facetName, comparatorType, size, ordered, missing);
     }
 

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -207,19 +207,18 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    public void close() throws ElasticsearchException {
         if (scanContext != null) {
             scanContext.clear();
         }
         // clear and scope phase we  have
         searcher.release();
-        engineSearcher.release();
-        return true;
+        engineSearcher.close();
     }
 
-    public boolean clearAndRelease() {
+    public void clearAndRelease() {
         clearReleasables();
-        return release();
+        close();
     }
 
     /**
@@ -690,7 +689,7 @@ public class DefaultSearchContext extends SearchContext {
     public void clearReleasables() {
         if (clearables != null) {
             try {
-                Releasables.release(clearables);
+                Releasables.close(clearables);
             } finally {
                 clearables.clear();
             }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -81,7 +81,7 @@ public abstract class SearchContext implements Releasable {
         return current.get();
     }
 
-    public abstract boolean clearAndRelease();
+    public abstract void clearAndRelease();
 
     /**
      * Should be called before executing the main query and after all other parameters have been set.

--- a/src/test/java/org/elasticsearch/benchmark/common/recycler/RecyclerBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/common/recycler/RecyclerBenchmark.java
@@ -58,7 +58,7 @@ public class RecyclerBenchmark {
                     }
                     while (recycles.getAndDecrement() > 0) {
                         final Recycler.V<?> v = recycler.obtain();
-                        v.release();
+                        v.close();
                     }
                 }
             };

--- a/src/test/java/org/elasticsearch/cache/recycler/MockPageCacheRecycler.java
+++ b/src/test/java/org/elasticsearch/cache/recycler/MockPageCacheRecycler.java
@@ -60,7 +60,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
         return new V<T>() {
 
             @Override
-            public boolean release() throws ElasticsearchException {
+            public void close() throws ElasticsearchException {
                 final Throwable t = ACQUIRED_PAGES.remove(v);
                 if (t == null) {
                     throw new IllegalStateException("Releasing a page that has not been acquired");
@@ -73,7 +73,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
                         Array.set(ref, i, (byte) random.nextInt(256));
                     }
                 }
-                return v.release();
+                v.close();
             }
 
             @Override

--- a/src/test/java/org/elasticsearch/common/recycler/AbstractRecyclerTests.java
+++ b/src/test/java/org/elasticsearch/common/recycler/AbstractRecyclerTests.java
@@ -88,7 +88,7 @@ public abstract class AbstractRecyclerTests extends ElasticsearchTestCase {
         assertFalse(o.isRecycled());
         final byte[] b1 = o.v();
         assertFresh(b1);
-        o.release();
+        o.close();
         assertRecycled(b1);
         o = r.obtain();
         final byte[] b2 = o.v();
@@ -99,7 +99,7 @@ public abstract class AbstractRecyclerTests extends ElasticsearchTestCase {
             assertFresh(b2);
             assertNotSame(b1, b2);
         }
-        o.release();
+        o.close();
         r.close();
     }
 
@@ -108,19 +108,19 @@ public abstract class AbstractRecyclerTests extends ElasticsearchTestCase {
         Recycler.V<byte[]> o = r.obtain();
         assertFresh(o.v());
         getRandom().nextBytes(o.v());
-        o.release();
+        o.close();
         o = r.obtain();
         assertRecycled(o.v());
-        o.release();
+        o.close();
         r.close();
     }
 
     public void testDoubleRelease() {
         final Recycler<byte[]> r = newRecycler(limit);
         final Recycler.V<byte[]> v1 = r.obtain();
-        v1.release();
+        v1.close();
         try {
-            v1.release();
+            v1.close();
         } catch (ElasticsearchIllegalStateException e) {
             // impl has protection against double release: ok
             return;
@@ -147,11 +147,11 @@ public abstract class AbstractRecyclerTests extends ElasticsearchTestCase {
         }
         // Recycler size increases on release, not on obtain!
         for (V<byte[]> v: vals) {
-            v.release();
+            v.close();
         }
 
         // release first ref, verify for destruction
-        o.release();
+        o.close();
         assertDead(data);
 
         // close the rest
@@ -168,7 +168,7 @@ public abstract class AbstractRecyclerTests extends ElasticsearchTestCase {
 
         // randomize & return to pool
         getRandom().nextBytes(data);
-        o.release();
+        o.close();
 
         // verify that recycle() ran
         assertRecycled(data);

--- a/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -57,7 +57,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < totalLen; ++i) {
             assertEquals(ref[i], array.get(i));
         }
-        array.release();
+        array.close();
     }
 
     public void testIntArrayGrowth() {
@@ -73,7 +73,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < totalLen; ++i) {
             assertEquals(ref[i], array.get(i));
         }
-        array.release();
+        array.close();
     }
 
     public void testLongArrayGrowth() {
@@ -89,7 +89,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < totalLen; ++i) {
             assertEquals(ref[i], array.get(i));
         }
-        array.release();
+        array.close();
     }
 
     public void testFloatArrayGrowth() {
@@ -105,7 +105,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < totalLen; ++i) {
             assertEquals(ref[i], array.get(i), 0.001d);
         }
-        array.release();
+        array.close();
     }
 
     public void testDoubleArrayGrowth() {
@@ -121,7 +121,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < totalLen; ++i) {
             assertEquals(ref[i], array.get(i), 0.001d);
         }
-        array.release();
+        array.close();
     }
 
     public void testObjectArrayGrowth() {
@@ -141,7 +141,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < totalLen; ++i) {
             assertSame(ref[i], array.get(i));
         }
-        array.release();
+        array.close();
     }
 
     public void testByteArrayFill() {
@@ -162,7 +162,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < len; ++i) {
             assertEquals(array1[i], array2.get(i), 0.001d);
         }
-        array2.release();
+        array2.close();
     }
 
     public void testFloatArrayFill() {
@@ -183,7 +183,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < len; ++i) {
             assertEquals(array1[i], array2.get(i), 0.001d);
         }
-        array2.release();
+        array2.close();
     }
 
     public void testDoubleArrayFill() {
@@ -204,7 +204,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < len; ++i) {
             assertEquals(array1[i], array2.get(i), 0.001d);
         }
-        array2.release();
+        array2.close();
     }
 
     public void testLongArrayFill() {
@@ -225,7 +225,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < len; ++i) {
             assertEquals(array1[i], array2.get(i));
         }
-        array2.release();
+        array2.close();
     }
 
     public void testByteArrayBulkGet() {
@@ -242,7 +242,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
             array2.get(offset, len, ref);
             assertEquals(new BytesRef(array1, offset, len), ref);
         }
-        array2.release();
+        array2.close();
     }
 
     public void testByteArrayBulkSet() {
@@ -257,7 +257,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         for (int i = 0; i < array1.length; ++i) {
             assertEquals(array1[i], array2.get(i));
         }
-        array2.release();
+        array2.close();
     }
 
     public void testByteArrayEquals() {
@@ -268,29 +268,29 @@ public class BigArraysTests extends ElasticsearchTestCase {
         assertTrue(bigArrays.equals(empty1, empty1));
         // equality: both empty
         assertTrue(bigArrays.equals(empty1, empty2));
-        empty1.release();
-        empty2.release();
+        empty1.close();
+        empty2.close();
 
         // not equal: contents differ
         final ByteArray a1 = byteArrayWithBytes(new byte[]{0});
         final ByteArray a2 = byteArrayWithBytes(new byte[]{1});
         assertFalse(bigArrays.equals(a1, a2));
-        a1.release();
-        a2.release();
+        a1.close();
+        a2.close();
 
         // not equal: contents differ
         final ByteArray a3 = byteArrayWithBytes(new byte[]{1,2,3});
         final ByteArray a4 = byteArrayWithBytes(new byte[]{1,1,3});
         assertFalse(bigArrays.equals(a3, a4));
-        a3.release();
-        a4.release();
+        a3.close();
+        a4.close();
 
         // not equal: contents differ
         final ByteArray a5 = byteArrayWithBytes(new byte[]{1,2,3});
         final ByteArray a6 = byteArrayWithBytes(new byte[]{1,2,4});
         assertFalse(bigArrays.equals(a5, a6));
-        a5.release();
-        a6.release();
+        a5.close();
+        a6.close();
     }
 
     public void testByteArrayHashCode() {
@@ -302,7 +302,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         final ByteArray emptyByteArray = byteArrayWithBytes(BytesRef.EMPTY_BYTES);
         final int emptyByteArrayHash = bigArrays.hashCode(emptyByteArray);
         assertEquals(emptyHash, emptyByteArrayHash);
-        emptyByteArray.release();
+        emptyByteArray.close();
 
         // FUN FACT: Arrays.hashCode() and BytesReference.bytesHashCode() are inconsistent for empty byte[]
         // final int emptyHash3 = new BytesArray(BytesRef.EMPTY_BYTES).hashCode();
@@ -315,7 +315,7 @@ public class BigArraysTests extends ElasticsearchTestCase {
         final ByteArray array2 = byteArrayWithBytes(array1);
         final int array2Hash = bigArrays.hashCode(array2);
         assertEquals(array1Hash, array2Hash);
-        array2.release();
+        array2.close();
     }
 
     private ByteArray byteArrayWithBytes(byte[] bytes) {

--- a/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -36,7 +36,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
 
     private void newHash() {
         if (hash != null) {
-            hash.release();
+            hash.close();
         }
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
@@ -83,7 +83,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
                 assertEquals(idToValue[(int) id], spare);
             }
         }
-        hash.release();
+        hash.close();
     }
 
     // START - tests borrowed from LUCENE
@@ -114,7 +114,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
                 }
             }
         }
-        hash.release();
+        hash.close();
     }
 
     /**
@@ -154,7 +154,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
             }
             newHash();
         }
-        hash.release();
+        hash.close();
     }
 
     /**
@@ -195,7 +195,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
             assertAllIn(strings, hash);
             newHash();
         }
-        hash.release();
+        hash.close();
     }
 
     @Test
@@ -231,7 +231,7 @@ public class BytesRefHashTests extends ElasticsearchTestCase {
             assertAllIn(strings, hash);
             newHash();
         }
-        hash.release();
+        hash.close();
     }
 
     private void assertAllIn(Set<String> strings, BytesRefHash hash) {

--- a/src/test/java/org/elasticsearch/common/util/DoubleObjectHashMapTests.java
+++ b/src/test/java/org/elasticsearch/common/util/DoubleObjectHashMapTests.java
@@ -52,7 +52,7 @@ public class DoubleObjectHashMapTests extends ElasticsearchTestCase {
         for (DoubleObjectPagedHashMap.Cursor<Object> cursor : map2) {
             copy.put(cursor.key, cursor.value);
         }
-        map2.release();
+        map2.close();
         assertEquals(map1, copy);
     }
 

--- a/src/test/java/org/elasticsearch/common/util/LongHashTests.java
+++ b/src/test/java/org/elasticsearch/common/util/LongHashTests.java
@@ -64,7 +64,7 @@ public class LongHashTests extends ElasticsearchTestCase {
                 assertEquals(idToValue[(int) id], longHash.key(i));
             }
         }
-        longHash.release();
+        longHash.close();
     }
 
 }

--- a/src/test/java/org/elasticsearch/common/util/LongObjectHashMapTests.java
+++ b/src/test/java/org/elasticsearch/common/util/LongObjectHashMapTests.java
@@ -52,7 +52,7 @@ public class LongObjectHashMapTests extends ElasticsearchTestCase {
         for (LongObjectPagedHashMap.Cursor<Object> cursor : map2) {
             copy.put(cursor.key, cursor.value);
         }
-        map2.release();
+        map2.close();
         assertEquals(map1, copy);
     }
 

--- a/src/test/java/org/elasticsearch/index/deletionpolicy/SnapshotDeletionPolicyTests.java
+++ b/src/test/java/org/elasticsearch/index/deletionpolicy/SnapshotDeletionPolicyTests.java
@@ -91,7 +91,7 @@ public class SnapshotDeletionPolicyTests extends ElasticsearchTestCase {
         assertThat(listCommits(dir).size(), equalTo(2));
 
         // release the commit, add a document and commit, now we should be back to one commit point
-        assertThat(snapshot.release(), equalTo(true));
+        snapshot.close();
         indexWriter.addDocument(testDocument());
         indexWriter.commit();
         assertThat(listCommits(dir).size(), equalTo(1));
@@ -114,13 +114,13 @@ public class SnapshotDeletionPolicyTests extends ElasticsearchTestCase {
         assertThat(listCommits(dir).size(), equalTo(2));
 
         // release one snapshot, we should still have two commit points
-        assertThat(snapshot1.release(), equalTo(true));
+        snapshot1.close();
         indexWriter.addDocument(testDocument());
         indexWriter.commit();
         assertThat(listCommits(dir).size(), equalTo(2));
 
         // release the second snapshot, we should be back to one commit
-        assertThat(snapshot2.release(), equalTo(true));
+        snapshot2.close();
         indexWriter.addDocument(testDocument());
         indexWriter.commit();
         assertThat(listCommits(dir).size(), equalTo(1));
@@ -135,8 +135,8 @@ public class SnapshotDeletionPolicyTests extends ElasticsearchTestCase {
 
         // snapshot the last commit, and release it twice, the seconds should throw an exception
         SnapshotIndexCommit snapshot = deletionPolicy.snapshot();
-        assertThat(snapshot.release(), equalTo(true));
-        assertThat(snapshot.release(), equalTo(false));
+        snapshot.close();
+        snapshot.close();
     }
 
     @Test
@@ -164,13 +164,13 @@ public class SnapshotDeletionPolicyTests extends ElasticsearchTestCase {
         // release the snapshot, add a document and commit
         // we should have 3 commits points since we are holding onto the first two with snapshots
         // and we are using the keep only last
-        assertThat(snapshot.release(), equalTo(true));
+        snapshot.close();
         indexWriter.addDocument(testDocument());
         indexWriter.commit();
         assertThat(listCommits(dir).size(), equalTo(3));
 
         // now release the snapshots, we should be back to a single commit point
-        assertThat(snapshots.release(), equalTo(true));
+        snapshots.close();
         indexWriter.addDocument(testDocument());
         indexWriter.commit();
         assertThat(listCommits(dir).size(), equalTo(1));

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -402,7 +402,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
     public void testSimpleOperations() throws Exception {
         Engine.Searcher searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
-        searchResult.release();
+        searchResult.close();
 
         // create a document
         Document document = testDocumentWithTextField();
@@ -414,7 +414,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // but, we can still get it (in realtime)
         Engine.GetResult getResult = engine.get(new Engine.Get(true, newUid("1")));
@@ -434,7 +434,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
-        searchResult.release();
+        searchResult.close();
 
         // also in non realtime
         getResult = engine.get(new Engine.Get(false, newUid("1")));
@@ -454,7 +454,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // but, we can still get it (in realtime)
         getResult = engine.get(new Engine.Get(true, newUid("1")));
@@ -470,7 +470,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 1));
-        searchResult.release();
+        searchResult.close();
 
         // now delete
         engine.delete(new Engine.Delete("test", "1", newUid("1")));
@@ -480,7 +480,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 1));
-        searchResult.release();
+        searchResult.close();
 
         // but, get should not see it (in realtime)
         getResult = engine.get(new Engine.Get(true, newUid("1")));
@@ -494,7 +494,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // add it back
         document = testDocumentWithTextField();
@@ -507,7 +507,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // refresh and it should be there
         engine.refresh(new Engine.Refresh("test").force(false));
@@ -517,7 +517,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // now flush
         engine.flush(new Engine.Flush());
@@ -541,7 +541,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // refresh and it should be updated
         engine.refresh(new Engine.Refresh("test").force(false));
@@ -550,7 +550,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test1")), 1));
-        searchResult.release();
+        searchResult.close();
 
         engine.close();
     }
@@ -559,7 +559,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
     public void testSearchResultRelease() throws Exception {
         Engine.Searcher searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
-        searchResult.release();
+        searchResult.close();
 
         // create a document
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), Lucene.STANDARD_ANALYZER, B_1, false);
@@ -569,7 +569,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         searchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 0));
-        searchResult.release();
+        searchResult.close();
 
         // refresh and it should be there
         engine.refresh(new Engine.Refresh("test").force(false));
@@ -585,12 +585,12 @@ public class InternalEngineTests extends ElasticsearchTestCase {
         engine.refresh(new Engine.Refresh("test").force(false));
         Engine.Searcher updateSearchResult = engine.acquireSearcher("test");
         MatcherAssert.assertThat(updateSearchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(0));
-        updateSearchResult.release();
+        updateSearchResult.close();
 
         // the non release search result should not see the deleted yet...
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(1));
         MatcherAssert.assertThat(searchResult, EngineSearcherTotalHitsMatcher.engineSearcherTotalHits(new TermQuery(new Term("value", "test")), 1));
-        searchResult.release();
+        searchResult.close();
     }
 
 

--- a/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
@@ -95,8 +95,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean clearAndRelease() {
-        return false;
+    public void clearAndRelease() {
+        // no-op
     }
 
     @Override
@@ -590,8 +590,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
-        return false;
+    public void close() throws ElasticsearchException {
+        // no-op
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
+++ b/src/test/java/org/elasticsearch/index/translog/AbstractSimpleTranslogTests.java
@@ -75,64 +75,64 @@ public abstract class AbstractSimpleTranslogTests {
     public void testTransientTranslog() {
         Translog.Snapshot snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Create("test", "1", new byte[]{1}));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(1));
-        snapshot.release();
+        snapshot.close();
 
         translog.newTransientTranslog(2);
 
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(1));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Index("test", "2", new byte[]{2}));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(2));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(2));
-        snapshot.release();
+        snapshot.close();
 
         translog.makeTransientCurrent();
 
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1)); // now its one, since it only includes "2"
         assertThat(snapshot.estimatedTotalOperations(), equalTo(1));
-        snapshot.release();
+        snapshot.close();
     }
 
     @Test
     public void testSimpleOperations() {
         Translog.Snapshot snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Create("test", "1", new byte[]{1}));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(1));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Index("test", "2", new byte[]{2}));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(2));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(2));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Delete(newUid("3")));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(3));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(3));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.DeleteByQuery(new BytesArray(new byte[]{4}), null));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(4));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(4));
-        snapshot.release();
+        snapshot.close();
 
         snapshot = translog.snapshot();
 
@@ -154,7 +154,7 @@ public abstract class AbstractSimpleTranslogTests {
 
         assertThat(snapshot.hasNext(), equalTo(false));
 
-        snapshot.release();
+        snapshot.close();
 
         long firstId = translog.currentId();
         translog.newTranslog(2);
@@ -163,26 +163,26 @@ public abstract class AbstractSimpleTranslogTests {
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(0));
-        snapshot.release();
+        snapshot.close();
     }
 
     @Test
     public void testSnapshot() {
         Translog.Snapshot snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Create("test", "1", new byte[]{1}));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(1));
-        snapshot.release();
+        snapshot.close();
 
         snapshot = translog.snapshot();
         assertThat(snapshot.hasNext(), equalTo(true));
         Translog.Create create = (Translog.Create) snapshot.next();
         assertThat(create.source().toBytes(), equalTo(new byte[]{1}));
-        snapshot.release();
+        snapshot.close();
 
         Translog.Snapshot snapshot1 = translog.snapshot();
         // we use the translogSize to also navigate to the last position on this snapshot
@@ -194,7 +194,7 @@ public abstract class AbstractSimpleTranslogTests {
         snapshot = translog.snapshot(snapshot1);
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(2));
-        snapshot.release();
+        snapshot.close();
 
         snapshot = translog.snapshot(snapshot1);
         assertThat(snapshot.hasNext(), equalTo(true));
@@ -202,15 +202,15 @@ public abstract class AbstractSimpleTranslogTests {
         assertThat(index.source().toBytes(), equalTo(new byte[]{2}));
         assertThat(snapshot.hasNext(), equalTo(false));
         assertThat(snapshot.estimatedTotalOperations(), equalTo(2));
-        snapshot.release();
-        snapshot1.release();
+        snapshot.close();
+        snapshot1.close();
     }
 
     @Test
     public void testSnapshotWithNewTranslog() {
         Translog.Snapshot snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Create("test", "1", new byte[]{1}));
         Translog.Snapshot actualSnapshot = translog.snapshot();
@@ -223,7 +223,7 @@ public abstract class AbstractSimpleTranslogTests {
 
         snapshot = translog.snapshot(actualSnapshot);
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
-        snapshot.release();
+        snapshot.close();
 
         snapshot = translog.snapshot(actualSnapshot);
         assertThat(snapshot.hasNext(), equalTo(true));
@@ -231,34 +231,34 @@ public abstract class AbstractSimpleTranslogTests {
         assertThat(index.source().toBytes(), equalTo(new byte[]{3}));
         assertThat(snapshot.hasNext(), equalTo(false));
 
-        actualSnapshot.release();
-        snapshot.release();
+        actualSnapshot.close();
+        snapshot.close();
     }
 
     @Test
     public void testSnapshotWithSeekForward() {
         Translog.Snapshot snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(0));
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Create("test", "1", new byte[]{1}));
         snapshot = translog.snapshot();
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
         long lastPosition = snapshot.position();
-        snapshot.release();
+        snapshot.close();
 
         translog.add(new Translog.Create("test", "2", new byte[]{1}));
         snapshot = translog.snapshot();
         snapshot.seekForward(lastPosition);
         MatcherAssert.assertThat(snapshot, TranslogSizeMatcher.translogSize(1));
-        snapshot.release();
+        snapshot.close();
 
         snapshot = translog.snapshot();
         snapshot.seekForward(lastPosition);
         assertThat(snapshot.hasNext(), equalTo(true));
         Translog.Create create = (Translog.Create) snapshot.next();
         assertThat(create.id(), equalTo("2"));
-        snapshot.release();
+        snapshot.close();
     }
 
     private Term newUid(String id) {

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -246,13 +246,13 @@ public class MockBigArrays extends BigArrays {
             return getDelegate().size();
         }
 
-        public boolean release() {
+        public void close() {
             if (!released.compareAndSet(false, true)) {
                 throw new IllegalStateException("Double release");
             }
             ACQUIRED_ARRAYS.remove(this);
             randomizeContent(0, size());
-            return getDelegate().release();
+            getDelegate().close();
         }
 
     }

--- a/src/test/java/org/elasticsearch/test/engine/MockInternalEngine.java
+++ b/src/test/java/org/elasticsearch/test/engine/MockInternalEngine.java
@@ -163,7 +163,7 @@ public final class MockInternalEngine extends InternalEngine implements Engine {
         }
 
         @Override
-        public boolean release() throws ElasticsearchException {
+        public void close() throws ElasticsearchException {
             RuntimeException remove = INFLIGHT_ENGINE_SEARCHERS.remove(this);
             synchronized (lock) {
                 // make sure we only get this once and store the stack of the first caller!
@@ -182,7 +182,7 @@ public final class MockInternalEngine extends InternalEngine implements Engine {
             // problems.
             assert refCount > 0 : "IndexReader#getRefCount() was [" + refCount + "] expected a value > [0] - reader is already closed. Initial refCount was: [" + initialRefCount + "]";
             try {
-                return wrappedSearcher.release();
+                wrappedSearcher.close();
             } catch (RuntimeException ex) {
                 logger.debug("Failed to release searcher", ex);
                 throw ex;


### PR DESCRIPTION
Java7's AutoCloseable allows to manage resources more nicely using
try-with-resources statements. Since the semantics of our Releasable interface
are very close to a Closeable, let's switch to it.
