### PR TITLE
Remove clear on mock page/array

### DIFF
--- a/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
+++ b/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
@@ -40,18 +40,16 @@ public class PagedBytesReferenceTest extends ElasticsearchTestCase {
 
     private static final int PAGE_SIZE = BigArrays.BYTE_PAGE_SIZE;
 
-    private MockBigArrays bigarrays;
+    private BigArrays bigarrays;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        bigarrays = new MockBigArrays(ImmutableSettings.EMPTY, null);
+        bigarrays = new BigArrays(ImmutableSettings.EMPTY, null);
     }
 
     @After
     public void tearDown() throws Exception {
-        // necessary since we currently never release BigArrays
-        MockBigArrays.reset();
         super.tearDown();
     }
 

--- a/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
@@ -346,8 +346,9 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
     static SearchContext createSearchContext(String indexName, String parentType, String childType) throws IOException {
         final Index index = new Index(indexName);
         final CacheRecycler cacheRecycler = new CacheRecycler(ImmutableSettings.EMPTY);
-        final PageCacheRecycler pageCacheRecycler = new PageCacheRecycler(ImmutableSettings.EMPTY, new ThreadPool());
-        final BigArrays bigArrays = new MockBigArrays(ImmutableSettings.EMPTY, pageCacheRecycler);
+        ThreadPool threadPool = new ThreadPool();
+        final PageCacheRecycler pageCacheRecycler = new PageCacheRecycler(ImmutableSettings.EMPTY, threadPool);
+        final BigArrays bigArrays = new BigArrays(ImmutableSettings.EMPTY, pageCacheRecycler);
         Settings settings = ImmutableSettings.EMPTY;
         MapperService mapperService = MapperTestUtils.newMapperService(index, settings);
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(index, new DummyCircuitBreakerService());
@@ -358,7 +359,6 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
                 childType, new CompressedString(PutMappingRequest.buildFromSimplifiedDef(childType, "_parent", "type=" + parentType).string()), true
         );
 
-        ThreadPool threadPool = new ThreadPool();
         NodeSettingsService nodeSettingsService = new NodeSettingsService(settings);
         IndicesFilterCache indicesFilterCache = new IndicesFilterCache(settings, threadPool, cacheRecycler, nodeSettingsService);
         WeightedFilterCache filterCache = new WeightedFilterCache(index, settings, indicesFilterCache);

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -128,20 +128,9 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
         return new File(uri);
     }
 
-    @Before
-    public void resetPageTracking() {
-        MockPageCacheRecycler.reset();
-    }
-
     @After
     public void ensureAllPagesReleased() throws Exception {
         MockPageCacheRecycler.ensureAllPagesAreReleased();
-    }
-
-    @Before
-    public void resetArrayTracking() {
-        // useful if there are tests that use MockBigArrays but don't inherit from ElasticsearchTestCase
-        MockBigArrays.reset();
     }
 
     @After

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -57,10 +57,6 @@ public class MockBigArrays extends BigArrays {
         DISCARD = true;
     }
 
-    public static void reset() {
-        ACQUIRED_ARRAYS.clear();
-    }
-
     public static void ensureAllArraysAreReleased() throws Exception {
         if (DISCARD) {
             DISCARD = false;
@@ -82,6 +78,7 @@ public class MockBigArrays extends BigArrays {
                 return;
             }
             masterCopy.keySet().retainAll(ACQUIRED_ARRAYS.keySet());
+            ACQUIRED_ARRAYS.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on
             if (!masterCopy.isEmpty()) {
                 final Object cause = masterCopy.entrySet().iterator().next().getValue();
                 throw new RuntimeException(masterCopy.size() + " arrays have not been released", cause instanceof Throwable ? (Throwable) cause : null);

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockPageCacheRecycler.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockPageCacheRecycler.java
@@ -40,10 +40,6 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
 
     private static final ConcurrentMap<Object, Throwable> ACQUIRED_PAGES = Maps.newConcurrentMap();
 
-    public static void reset() {
-        ACQUIRED_PAGES.clear();
-    }
-
     public static void ensureAllPagesAreReleased() throws Exception {
         final Map<Object, Throwable> masterCopy = Maps.newHashMap(ACQUIRED_PAGES);
         if (masterCopy.isEmpty()) {
@@ -62,6 +58,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
             return;
         }
         masterCopy.keySet().retainAll(ACQUIRED_PAGES.keySet());
+        ACQUIRED_PAGES.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on
         if (!masterCopy.isEmpty()) {
             final Throwable t = masterCopy.entrySet().iterator().next().getValue();
             throw new RuntimeException(masterCopy.size() + " pages have not been released", t);


### PR DESCRIPTION
since we use a shared cluster, calling clear on the mock array / page recycler can cause removing a valid on going reference, and then when its released, the release will fail because it can't be found.
There is no real reason to call clear, checking if pages/arrays have been released takes the snapshot behavior here into account.
This change also makes sure we don't use the mock classes in places where we don't really release.

Note, with this change DoubleTermsTests fails, since it causes failures when creating aggs in the pre process phase, causing obtained arrays not to be released. This needs to be fixed before pulling this change in.
