### PR TITLE
Add BytesValues#copyShard(BytesRef)

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/BytesValues.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/BytesValues.java
@@ -75,6 +75,13 @@ public abstract class BytesValues {
     }
 
     /**
+     * Similar to {@link #copyShared()}, but allows to specify the ByteRef to copy into.
+     */
+    public void copyShared(BytesRef scratch) {
+        this.scratch.copyBytes(scratch);
+    }
+
+    /**
      * Sets iteration to the specified docID and returns the number of
      * values for this document ID,
      * @param docId document ID

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -145,9 +145,15 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
                     return bytesValues[readerIndex].getValueByOrd(segmentOrd);
                 }
 
+
                 @Override
                 public BytesRef copyShared() {
                     return bytesValues[readerIndex].copyShared();
+                }
+
+                @Override
+                public void copyShared(BytesRef scratch) {
+                    bytesValues[readerIndex].copyShared(scratch);
                 }
 
                 @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -140,6 +140,13 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
         }
 
         @Override
+        public void copyShared(BytesRef scratch) {
+            scratch.bytes = this.scratch.bytes;
+            scratch.offset = this.scratch.offset;
+            scratch.length = this.scratch.length;
+        }
+
+        @Override
         public BytesRef copyShared() {
             // when we fill from the pages bytes, we just reference an existing buffer slice, its enough
             // to create a shallow copy of the bytes to be safe for "reads".

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.index.AtomicReaderContext;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.index.fielddata.BytesValues;
@@ -80,15 +78,6 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         }
     }
 
-    private static void copy(BytesRef from, BytesRef to) {
-        if (to.bytes.length < from.length) {
-            to.bytes = new byte[ArrayUtil.oversize(from.length, RamUsageEstimator.NUM_BYTES_BYTE)];
-        }
-        to.offset = 0;
-        to.length = from.length;
-        System.arraycopy(from.bytes, from.offset, to.bytes, 0, from.length);
-    }
-
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (globalOrdinals == null) { // no context in this reader
@@ -115,7 +104,8 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
             }
             spare.bucketOrd = bucketOrd;
             spare.docCount = bucketDocCount;
-            copy(globalValues.getValueByOrd(termOrd), spare.termBytes);
+            globalValues.getValueByOrd(termOrd);
+            globalValues.copyShared(spare.termBytes);
             spare = (StringTerms.Bucket) ordered.insertWithOverflow(spare);
         }
 


### PR DESCRIPTION
This allows the scratch to be reused externally outside of the FD impl.
