### PR TITLE
Make writePrimitive*() and readPrimitive*() methods public.

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -446,7 +446,7 @@ public abstract class StreamInput extends InputStream {
         }
     }
 
-    private Object readPrimitiveIntArray() throws IOException {
+    public int[] readPrimitiveIntArray() throws IOException {
         int length = readVInt();
         int[] values = new int[length];
         for(int i=0; i<length; i++) {
@@ -455,7 +455,7 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
     
-    private Object readPrimitiveLongArray() throws IOException {
+    public long[] readPrimitiveLongArray() throws IOException {
         int length = readVInt();
         long[] values = new long[length];
         for(int i=0; i<length; i++) {
@@ -464,7 +464,7 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
     
-    private Object readPrimitiveFloatArray() throws IOException {
+    public float[] readPrimitiveFloatArray() throws IOException {
         int length = readVInt();
         float[] values = new float[length];
         for(int i=0; i<length; i++) {
@@ -473,7 +473,7 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
     
-    private Object readPrimitiveDoubleArray() throws IOException {
+    public double[] readPrimitiveDoubleArray() throws IOException {
         int length = readVInt();
         double[] values = new double[length];
         for(int i=0; i<length; i++) {

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -425,28 +425,28 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
-    private void writePrimitiveIntArray(int[] value) throws IOException {
+    public void writePrimitiveIntArray(int[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeInt(value[i]);
         }
     }
     
-    private void writePrimitiveLongArray(long[] value) throws IOException {
+    public void writePrimitiveLongArray(long[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeLong(value[i]);
         }
     }
     
-    private void writePrimitiveFloatArray(float[] value) throws IOException {
+    public void writePrimitiveFloatArray(float[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeFloat(value[i]);
         }
     }
     
-    private void writePrimitiveDoubleArray(double[] value) throws IOException {
+    public void writePrimitiveDoubleArray(double[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeDouble(value[i]);


### PR DESCRIPTION
These utility methods are useful for client code to read/write arrays of
primitive types.
