### PR TITLE
Rename readPrimitive*Array()/writePrimitive*Array() methods

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -434,19 +434,19 @@ public abstract class StreamInput extends InputStream {
             case 16:
                 return readShort();
             case 17:
-                return readPrimitiveIntArray();
+                return readIntArray();
             case 18:
-                return readPrimitiveLongArray();
+                return readLongArray();
             case 19:
-                return readPrimitiveFloatArray();
+                return readFloatArray();
             case 20:
-                return readPrimitiveDoubleArray();
+                return readDoubleArray();
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }
     }
 
-    public int[] readPrimitiveIntArray() throws IOException {
+    public int[] readIntArray() throws IOException {
         int length = readVInt();
         int[] values = new int[length];
         for(int i=0; i<length; i++) {
@@ -455,7 +455,7 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
     
-    public long[] readPrimitiveLongArray() throws IOException {
+    public long[] readLongArray() throws IOException {
         int length = readVInt();
         long[] values = new long[length];
         for(int i=0; i<length; i++) {
@@ -464,7 +464,7 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
     
-    public float[] readPrimitiveFloatArray() throws IOException {
+    public float[] readFloatArray() throws IOException {
         int length = readVInt();
         float[] values = new float[length];
         for(int i=0; i<length; i++) {
@@ -473,7 +473,7 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
     
-    public double[] readPrimitiveDoubleArray() throws IOException {
+    public double[] readDoubleArray() throws IOException {
         int length = readVInt();
         double[] values = new double[length];
         for(int i=0; i<length; i++) {

--- a/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -410,43 +410,43 @@ public abstract class StreamOutput extends OutputStream {
             writeShort((Short) value);
         } else if (type == int[].class) {
             writeByte((byte) 17);
-            writePrimitiveIntArray((int[]) value);
+            writeIntArray((int[]) value);
         } else if (type == long[].class) {
             writeByte((byte) 18);
-            writePrimitiveLongArray((long[]) value);
+            writeLongArray((long[]) value);
         } else if (type == float[].class) {
             writeByte((byte) 19);
-            writePrimitiveFloatArray((float[]) value);
+            writeFloatArray((float[]) value);
         } else if (type == double[].class) {
             writeByte((byte) 20);
-            writePrimitiveDoubleArray((double[]) value);
+            writeDoubleArray((double[]) value);
         } else {
             throw new IOException("Can't write type [" + type + "]");
         }
     }
 
-    public void writePrimitiveIntArray(int[] value) throws IOException {
+    public void writeIntArray(int[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeInt(value[i]);
         }
     }
     
-    public void writePrimitiveLongArray(long[] value) throws IOException {
+    public void writeLongArray(long[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeLong(value[i]);
         }
     }
     
-    public void writePrimitiveFloatArray(float[] value) throws IOException {
+    public void writeFloatArray(float[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeFloat(value[i]);
         }
     }
     
-    public void writePrimitiveDoubleArray(double[] value) throws IOException {
+    public void writeDoubleArray(double[] value) throws IOException {
         writeVInt(value.length);
         for (int i=0; i<value.length; i++) {
             writeDouble(value[i]);


### PR DESCRIPTION
Make method names shorter and easier to read.

Closes #5711
