### PR TITLE
Use loopback when localhost is not resolved

### DIFF
--- a/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -49,11 +49,12 @@ public abstract class NetworkUtils {
     private final static InetAddress localAddress;
 
     static {
-        InetAddress localAddressX = null;
+        InetAddress localAddressX;
         try {
             localAddressX = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            logger.trace("Failed to find local host", e);
+        } catch (Throwable e) {
+            logger.debug("failed to resolve local host, fallback to loopback", e);
+            localAddressX = InetAddress.getLoopbackAddress();
         }
         localAddress = localAddressX;
     }


### PR DESCRIPTION
we use the "local host" address in sevearl places in our networking layer, if local host is not resolved for some reason, still continue and operate but using the loopback interface
