### PR TITLE
Update index_.asciidoc

### DIFF
--- a/docs/java-api/index_.asciidoc
+++ b/docs/java-api/index_.asciidoc
@@ -100,7 +100,7 @@ Elasticsearch provides built-in helpers to generate JSON content.
 --------------------------------------------------
 import static org.elasticsearch.common.xcontent.XContentFactory.*;
 
-XContentBuilder builder = jsonBuilder()
+XContentBuilder builder = XContentFactory.jsonBuilder()
     .startObject()
         .field("user", "kimchy")
         .field("postDate", new Date())
@@ -133,7 +133,7 @@ twitter, under a type called tweet, with id valued 1:
 import static org.elasticsearch.common.xcontent.XContentFactory.*;
 
 IndexResponse response = client.prepareIndex("twitter", "tweet", "1")
-        .setSource(jsonBuilder()
+        .setSource(XContentFactory.jsonBuilder()
                     .startObject()
                         .field("user", "kimchy")
                         .field("postDate", new Date())


### PR DESCRIPTION
The 2 code examples referencing jsonBuilder() on this page are missing the class reference, should be XContentFactory.jsonBuilder().startObject()...., instead of jsonBuilder().startObject()....
