### PR TITLE
Provide more context variables in update scripts

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -234,3 +234,7 @@ It also allows to update the `ttl` of a document using `ctx._ttl` and
 timestamp using `ctx._timestamp`. Note that if the timestamp is not
 updated and not extracted from the `_source` it will be set to the
 update date.
+
+In addition to `_source`, the following variables are available through
+the `ctx` map: `_index`, `_type`, `_id`, `_version`, `_routing`,
+`_parent`, `_timestamp`, `_ttl`.

--- a/src/test/java/org/elasticsearch/update/UpdateTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateTests.java
@@ -462,6 +462,99 @@ public class UpdateTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testContextVariables() throws Exception {
+        createTestIndex();
+
+        // Add child type for testing the _parent context variable
+        client().admin().indices().preparePutMapping("test")
+                .setType("subtype1")
+                .setSource(XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("subtype1")
+                        .startObject("_parent").field("type", "type1").endObject()
+                        .startObject("_timestamp").field("enabled", true).field("store", "yes").endObject()
+                        .startObject("_ttl").field("enabled", true).field("store", "yes").endObject()
+                        .endObject()
+                        .endObject())
+                .execute().actionGet();
+        ensureGreen();
+
+        // Index some documents
+        long timestamp = System.currentTimeMillis();
+        client().prepareIndex()
+                .setIndex("test")
+                .setType("type1")
+                .setId("parentId1")
+                .setTimestamp(String.valueOf(timestamp-1))
+                .setSource("field1", 0, "content", "bar")
+                .execute().actionGet();
+
+        client().prepareIndex()
+                .setIndex("test")
+                .setType("subtype1")
+                .setId("id1")
+                .setParent("parentId1")
+                .setRouting("routing1")
+                .setTimestamp(String.valueOf(timestamp))
+                .setTTL(111211211)
+                .setSource("field1", 1, "content", "foo")
+                .execute().actionGet();
+        long postIndexTs = System.currentTimeMillis();
+
+        // Update the first object and note context variables values
+        Map<String, Object> scriptParams = new HashMap<>();
+        scriptParams.put("delim", "_");
+        UpdateResponse updateResponse = client().prepareUpdate("test", "subtype1", "id1")
+                .setRouting("routing1")
+                .setScript(
+                        "assert ctx._index == \"test\" : \"index should be \\\"test\\\"\"\n" +
+                        "assert ctx._type == \"subtype1\" : \"type should be \\\"subtype1\\\"\"\n" +
+                        "assert ctx._id == \"id1\" : \"id should be \\\"id1\\\"\"\n" +
+                        "assert ctx._version == 1 : \"version should be 1\"\n" +
+                        "assert ctx._parent == \"parentId1\" : \"parent should be \\\"parentId1\\\"\"\n" +
+                        "assert ctx._routing == \"routing1\" : \"routing should be \\\"routing1\\\"\"\n" +
+                        "assert ctx._timestamp == " + timestamp + " : \"timestamp should be " + timestamp + "\"\n" +
+                        "def now = new Date().getTime()\n" +
+                        "assert (111211211 - ctx._ttl) <= (now - " + postIndexTs + ") : \"ttl is not within acceptable range\"\n" +
+                        "ctx._source.content = ctx._source.content + delim + ctx._source.content;\n" +
+                        "ctx._source.field1 += 1;\n",
+                        ScriptService.ScriptType.INLINE)
+                .setScriptParams(scriptParams)
+                .execute().actionGet();
+
+        assertEquals(2, updateResponse.getVersion());
+
+        GetResponse getResponse = client().prepareGet("test", "subtype1", "id1").setRouting("routing1").execute().actionGet();
+        assertEquals(2, getResponse.getSourceAsMap().get("field1"));
+        assertEquals("foo_foo", getResponse.getSourceAsMap().get("content"));
+
+        // Idem with the second object
+        scriptParams = new HashMap<>();
+        scriptParams.put("delim", "_");
+        updateResponse = client().prepareUpdate("test", "type1", "parentId1")
+                .setScript(
+                        "assert ctx._index == \"test\" : \"index should be \\\"test\\\"\"\n" +
+                        "assert ctx._type == \"type1\" : \"type should be \\\"type1\\\"\"\n" +
+                        "assert ctx._id == \"parentId1\" : \"id should be \\\"parentId1\\\"\"\n" +
+                        "assert ctx._version == 1 : \"version should be 1\"\n" +
+                        "assert ctx._parent == null : \"parent should be null\"\n" +
+                        "assert ctx._routing == null : \"routing should be null\"\n" +
+                        "assert ctx._timestamp == " + (timestamp - 1) + " : \"timestamp should be " + (timestamp - 1) + "\"\n" +
+                        "assert ctx._ttl == null : \"ttl should be null\"\n" +
+                        "ctx._source.content = ctx._source.content + delim + ctx._source.content;\n" +
+                        "ctx._source.field1 += 1;\n",
+                        ScriptService.ScriptType.INLINE)
+                .setScriptParams(scriptParams)
+                .execute().actionGet();
+
+        assertEquals(2, updateResponse.getVersion());
+
+        getResponse = client().prepareGet("test", "type1", "parentId1").execute().actionGet();
+        assertEquals(1, getResponse.getSourceAsMap().get("field1"));
+        assertEquals("bar_bar", getResponse.getSourceAsMap().get("content"));
+    }
+
+    @Test
     @Slow
     public void testConcurrentUpdateWithRetryOnConflict() throws Exception {
         final boolean useBulkApi = randomBoolean();


### PR DESCRIPTION
In addition to `_source`, the following variables are available through the `ctx` map: `_index`, `_type`, `_id`,  `_version`, `_routing`, `_parent`, `_timestamp`, `_ttl`.

Some of these fields are more useful still within the context of an Update By Query, see #1607, #2230, #2231.
