### PR TITLE
Fix P/C assertions for rewrite reader

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -147,13 +147,10 @@ public class ChildrenQuery extends Query {
     @Override
     public Weight createWeight(IndexSearcher searcher) throws IOException {
         SearchContext searchContext = SearchContext.current();
-        final Query childQuery;
-        if (rewrittenChildQuery == null) {
-            childQuery = rewrittenChildQuery = searcher.rewrite(originalChildQuery);
-        } else {
-            assert rewriteIndexReader == searcher.getIndexReader() : "not equal, rewriteIndexReader=" + rewriteIndexReader + " searcher.getIndexReader()=" + searcher.getIndexReader();
-            childQuery = rewrittenChildQuery;
-        }
+        assert rewrittenChildQuery != null;
+        assert rewriteIndexReader == searcher.getIndexReader() : "not equal, rewriteIndexReader=" + rewriteIndexReader + " searcher.getIndexReader()=" + searcher.getIndexReader();
+        final Query childQuery = rewrittenChildQuery;
+
         IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
         indexSearcher.setSimilarity(searcher.getSimilarity());
 

--- a/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
@@ -87,29 +87,31 @@ public class ParentConstantScoreQuery extends Query {
 
     @Override
     public Weight createWeight(IndexSearcher searcher) throws IOException {
-        SearchContext searchContext = SearchContext.current();
-        BytesRefHash parentIds = new BytesRefHash(512, searchContext.bigArrays());
-        ParentIdsCollector collector = new ParentIdsCollector(parentType, parentChildIndexFieldData, parentIds);
-
-        final Query parentQuery;
-        if (rewrittenParentQuery != null) {
-            parentQuery = rewrittenParentQuery;
-        } else {
+        final SearchContext searchContext = SearchContext.current();
+        final BytesRefHash parentIds = new BytesRefHash(512, searchContext.bigArrays());
+        boolean releaseParentIds = true;
+        try {
+            ParentIdsCollector collector = new ParentIdsCollector(parentType, parentChildIndexFieldData, parentIds);
+            assert rewrittenParentQuery != null;
             assert rewriteIndexReader == searcher.getIndexReader() : "not equal, rewriteIndexReader=" + rewriteIndexReader + " searcher.getIndexReader()=" + searcher.getIndexReader();
-            parentQuery = rewrittenParentQuery = originalParentQuery.rewrite(searcher.getIndexReader());
-        }
-        IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
-        indexSearcher.setSimilarity(searcher.getSimilarity());
-        indexSearcher.search(parentQuery, collector);
+            final Query parentQuery = rewrittenParentQuery;
+            IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
+            indexSearcher.setSimilarity(searcher.getSimilarity());
+            indexSearcher.search(parentQuery, collector);
 
-        if (parentIds.size() == 0) {
-            Releasables.release(parentIds);
-            return Queries.newMatchNoDocsQuery().createWeight(searcher);
-        }
+            if (parentIds.size() == 0) {
+                return Queries.newMatchNoDocsQuery().createWeight(searcher);
+            }
 
-        ChildrenWeight childrenWeight = new ChildrenWeight(childrenFilter, parentIds);
-        searchContext.addReleasable(childrenWeight);
-        return childrenWeight;
+            final ChildrenWeight childrenWeight = new ChildrenWeight(childrenFilter, parentIds);
+            searchContext.addReleasable(childrenWeight);
+            releaseParentIds = false;
+            return childrenWeight;
+        } finally {
+            if (releaseParentIds) {
+                Releasables.release(parentIds);
+            }
+        }
     }
 
     private final class ChildrenWeight extends Weight implements Releasable {

--- a/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -133,17 +133,13 @@ public class ParentQuery extends Query {
     @Override
     public Weight createWeight(IndexSearcher searcher) throws IOException {
         SearchContext searchContext = SearchContext.current();
-        ParentIdAndScoreCollector collector = new ParentIdAndScoreCollector(searchContext, parentChildIndexFieldData, parentType);
+        final ParentIdAndScoreCollector collector = new ParentIdAndScoreCollector(searchContext, parentChildIndexFieldData, parentType);
         ChildWeight childWeight;
         boolean releaseCollectorResource = true;
         try {
-            final Query parentQuery;
-            if (rewrittenParentQuery == null) {
-                parentQuery = rewrittenParentQuery = searcher.rewrite(originalParentQuery);
-            } else {
-                assert rewriteIndexReader == searcher.getIndexReader() : "not equal, rewriteIndexReader=" + rewriteIndexReader + " searcher.getIndexReader()=" + searcher.getIndexReader();
-                parentQuery = rewrittenParentQuery;
-            }
+            assert rewrittenParentQuery != null;
+            assert rewriteIndexReader == searcher.getIndexReader() : "not equal, rewriteIndexReader=" + rewriteIndexReader + " searcher.getIndexReader()=" + searcher.getIndexReader();
+            final Query  parentQuery = rewrittenParentQuery;
             IndexSearcher indexSearcher = new IndexSearcher(searcher.getIndexReader());
             indexSearcher.setSimilarity(searcher.getSimilarity());
             indexSearcher.search(parentQuery, collector);


### PR DESCRIPTION
Inner queries must be rewritten as soon as a weight is pulled ie. must
be non-null.
