### PR TITLE
The clear scroll apis should optionally accepts a scroll_id in the request body.

### DIFF
--- a/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/api/clear_scroll.json
@@ -14,6 +14,8 @@
       },
       "params": {}
     },
-    "body": null
+    "body": {
+      "description": "A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"
+    }
   }
 }

--- a/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/test/scroll/11_clear.yaml
@@ -1,0 +1,35 @@
+---
+"Clear scroll":
+  - do:
+      indices.create:
+          index:  test_scroll
+  - do:
+      index:
+          index:  test_scroll
+          type:   test
+          id:     42
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_scroll
+        search_type: scan
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      clear_scroll:
+        scroll_id: $scroll_id1
+
+  - do:
+      scroll:
+        scroll_id: $scroll_id1
+
+  - length: {hits.hits: 0}

--- a/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
 import java.util.Arrays;
@@ -49,6 +50,9 @@ public class RestClearScrollAction extends BaseRestHandler {
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         String scrollIds = request.param("scroll_id");
+        if (scrollIds == null) {
+            scrollIds = RestActions.getRestContent(request).toUtf8();
+        }
 
         ClearScrollRequest clearRequest = new ClearScrollRequest();
         clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));


### PR DESCRIPTION
PR ofr #5726
