### PR TITLE
Benchmark: Fix for hung clients on cluster without benchmark nodes

### DIFF
--- a/rest-api-spec/test/benchmark.abort/10_basic.yaml
+++ b/rest-api-spec/test/benchmark.abort/10_basic.yaml
@@ -1,0 +1,8 @@
+---
+"Test benchmark abort":
+
+  - do:
+        benchmark.abort:
+            name: my_benchmark
+        catch: request
+

--- a/rest-api-spec/test/benchmark.list/10_basic.yaml
+++ b/rest-api-spec/test/benchmark.list/10_basic.yaml
@@ -1,0 +1,7 @@
+---
+"Test benchmark list":
+
+  - do:
+        benchmark.list: {}
+        catch: request
+

--- a/rest-api-spec/test/benchmark.submit/10_basic.yaml
+++ b/rest-api-spec/test/benchmark.submit/10_basic.yaml
@@ -1,0 +1,32 @@
+---
+"Test benchmark submit":
+
+  - do:
+      indices.create:
+        index: test_1
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+        benchmark.submit:
+            index: test_1
+            body: {
+                    "name": "my_benchmark",
+                    "competitors": [ {
+                        "name": "my_competitor",
+                        "requests": [ {
+                            "query": {
+                                "match": { "_all": "*" }
+                            }
+                        } ]
+                    } ]
+                }
+        catch: request
+
+

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkNodeMissingException.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkNodeMissingException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ *
+ */
+public class BenchmarkNodeMissingException extends ElasticsearchException {
+
+    public BenchmarkNodeMissingException(String msg) {
+        super(msg);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
@@ -55,7 +55,10 @@ public class BenchmarkResponse extends ActionResponse implements Streamable, ToX
     }
 
     /**
-     * Benchmarks can be in one of: RUNNING, COMPLETE, or ABORTED.
+     * Benchmarks can be in one of:
+     *  RUNNING     - executing normally
+     *  COMPLETE    - completed normally
+     *  ABORTED     - aborted
      */
     public static enum State {
         RUNNING((byte) 0),
@@ -131,7 +134,7 @@ public class BenchmarkResponse extends ActionResponse implements Streamable, ToX
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(Fields.STATUS, state.toString().toLowerCase(Locale.ROOT));
+        builder.field(Fields.STATUS, state.toString());
         builder.startObject(Fields.COMPETITORS);
         if (competitionResults != null) {
             for (Map.Entry<String, CompetitionResult> entry : competitionResults.entrySet()) {
@@ -184,7 +187,6 @@ public class BenchmarkResponse extends ActionResponse implements Streamable, ToX
 
     static final class Fields {
         static final XContentBuilderString STATUS = new XContentBuilderString("status");
-        static final XContentBuilderString INDEX = new XContentBuilderString("index");
         static final XContentBuilderString COMPETITORS = new XContentBuilderString("competitors");
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -45,8 +45,10 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.METHOD_NOT_ALLOWED;
+import static org.elasticsearch.rest.RestStatus.SERVICE_UNAVAILABLE;
 import static org.elasticsearch.common.xcontent.json.JsonXContent.contentBuilder;
 
 /**
@@ -104,7 +106,7 @@ public class RestBenchAction extends BaseRestHandler {
                 builder.startObject();
                 response.toXContent(builder, request);
                 builder.endObject();
-                return new BytesRestResponse(RestStatus.OK, builder);
+                return new BytesRestResponse(OK, builder);
             }
         });
     }
@@ -124,7 +126,7 @@ public class RestBenchAction extends BaseRestHandler {
                 builder.startObject();
                 response.toXContent(builder, request);
                 builder.endObject();
-                return new BytesRestResponse(RestStatus.OK, builder);
+                return new BytesRestResponse(OK, builder);
             }
         });
     }
@@ -165,7 +167,7 @@ public class RestBenchAction extends BaseRestHandler {
                 builder.startObject();
                 response.toXContent(builder, request);
                 builder.endObject();
-                return new BytesRestResponse(RestStatus.OK, builder);
+                return new BytesRestResponse(OK, builder);
             }
         });
     }


### PR DESCRIPTION
This is a fix for a bug whereby a cluster that has no nodes started with
-Des.node.bench=true will cause clients to hang if they attempt to
submit a benchmark.

Closes #5754
