### PR TITLE
Return valid empty JSON response when no recovery information

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -89,22 +89,23 @@ public class RecoveryResponse extends BroadcastOperationResponse implements ToXC
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-
-        for (String index : shardResponses.keySet()) {
-            List<ShardRecoveryResponse> responses = shardResponses.get(index);
-            if (responses == null || responses.size() == 0) {
-                continue;
-            }
-            builder.startObject(index);
-            builder.startArray("shards");
-            for (ShardRecoveryResponse recoveryResponse : responses) {
-                builder.startObject();
-                recoveryResponse.detailed(this.detailed);
-                recoveryResponse.toXContent(builder, params);
+        if (hasRecoveries()) {
+            for (String index : shardResponses.keySet()) {
+                List<ShardRecoveryResponse> responses = shardResponses.get(index);
+                if (responses == null || responses.size() == 0) {
+                    continue;
+                }
+                builder.startObject(index);
+                builder.startArray("shards");
+                for (ShardRecoveryResponse recoveryResponse : responses) {
+                    builder.startObject();
+                    recoveryResponse.detailed(this.detailed);
+                    recoveryResponse.toXContent(builder, params);
+                    builder.endObject();
+                }
+                builder.endArray();
                 builder.endObject();
             }
-            builder.endArray();
-            builder.endObject();
         }
         return builder;
     }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
@@ -57,12 +57,10 @@ public class RestRecoveryAction extends BaseRestHandler {
         client.admin().indices().recoveries(recoveryRequest, new RestBuilderListener<RecoveryResponse>(channel) {
             @Override
             public RestResponse buildResponse(RecoveryResponse response, XContentBuilder builder) throws Exception {
-                if (response.hasRecoveries()) {
-                    response.detailed(recoveryRequest.detailed());
-                    builder.startObject();
-                    response.toXContent(builder, request);
-                    builder.endObject();
-                }
+                response.detailed(recoveryRequest.detailed());
+                builder.startObject();
+                response.toXContent(builder, request);
+                builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }
         });


### PR DESCRIPTION
This is a fix to send back to the client a valid empty JSON response in
the case when we have no recovery information.

Closes #5743
