### PR TITLE
add ipv6 field support

### DIFF
--- a/src/main/java/org/apache/lucene/analysis/BigNumericTokenStream.java
+++ b/src/main/java/org/apache/lucene/analysis/BigNumericTokenStream.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.analysis;
+
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.*;
+
+import java.math.BigInteger;
+
+
+/**
+ * Modified from {@link NumericTokenStream} to support {@link java.math.BigInteger}
+ */
+public final class BigNumericTokenStream extends TokenStream {
+    public static final String TOKEN_TYPE_FULL_PREC  = "fullPrecNumeric";
+
+    public static final String TOKEN_TYPE_LOWER_PREC = "lowerPrecNumeric";
+
+    public interface NumericTermAttribute extends Attribute {
+        int getShift();
+        BigInteger getRawValue();
+        int getValueSize();
+        void init(BigInteger value, int valueSize, int precisionStep, int shift);
+        void setShift(int shift);
+        int incShift();
+    }
+
+    // just a wrapper to prevent adding CTA
+    private static final class NumericAttributeFactory extends AttributeFactory {
+        private final AttributeFactory delegate;
+
+        NumericAttributeFactory(AttributeFactory delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public AttributeImpl createAttributeInstance(Class<? extends Attribute> attClass) {
+            if (CharTermAttribute.class.isAssignableFrom(attClass))
+                throw new IllegalArgumentException("NumericTokenStream does not support CharTermAttribute.");
+            return delegate.createAttributeInstance(attClass);
+        }
+    }
+
+    public static final class NumericTermAttributeImpl extends AttributeImpl implements NumericTermAttribute,TermToBytesRefAttribute {
+        private BigInteger value;
+        private int valueSize = 0, shift = 0, precisionStep = 0;
+        private BytesRef bytes = new BytesRef();
+
+        public NumericTermAttributeImpl() {}
+
+        @Override
+        public BytesRef getBytesRef() {
+            return bytes;
+        }
+
+        @Override
+        public int fillBytesRef() {
+            return BigNumericUtils.bigIntToPrefixCoded(value, shift, bytes, valueSize);
+        }
+
+        @Override
+        public int getShift() { return shift; }
+        @Override
+        public void setShift(int shift) { this.shift = shift; }
+        @Override
+        public int incShift() {
+            return (shift += precisionStep);
+        }
+
+        @Override
+        public BigInteger getRawValue() { return value; }
+        @Override
+        public int getValueSize() { return valueSize; }
+
+        @Override
+        public void init(BigInteger value, int valueSize, int precisionStep, int shift) {
+            this.value = value;
+            this.valueSize = valueSize;
+            this.precisionStep = precisionStep;
+            this.shift = shift;
+        }
+
+        @Override
+        public void clear() {
+        }
+
+        @Override
+        public void reflectWith(AttributeReflector reflector) {
+            fillBytesRef();
+            reflector.reflect(TermToBytesRefAttribute.class, "bytes", BytesRef.deepCopyOf(bytes));
+            reflector.reflect(NumericTermAttribute.class, "shift", shift);
+            reflector.reflect(NumericTermAttribute.class, "rawValue", getRawValue());
+            reflector.reflect(NumericTermAttribute.class, "valueSize", valueSize);
+        }
+
+        @Override
+        public void copyTo(AttributeImpl target) {
+            final NumericTermAttribute a = (NumericTermAttribute) target;
+            a.init(value, valueSize, precisionStep, shift);
+        }
+    }
+
+    public BigNumericTokenStream() {
+        this(AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY, NumericUtils.PRECISION_STEP_DEFAULT, BigNumericUtils.VALUE_SIZE_DEFAULT);
+    }
+
+
+    public BigNumericTokenStream(final int precisionStep) {
+        this(AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY, precisionStep, BigNumericUtils.VALUE_SIZE_DEFAULT);
+    }
+
+    public BigNumericTokenStream(final int precisionStep, final int valSize) {
+        this(AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY, precisionStep, valSize);
+    }
+
+    public BigNumericTokenStream(AttributeFactory factory, final int precisionStep, final int valSize) {
+        super(new NumericAttributeFactory(factory));
+        if (precisionStep < 1)
+            throw new IllegalArgumentException("precisionStep must be >=1");
+        this.precisionStep = precisionStep;
+        this.valSize = valSize;
+        numericAtt.setShift(-precisionStep);
+    }
+
+    public BigNumericTokenStream setBigIntValue(final BigInteger value) {
+        numericAtt.init(value, valSize, precisionStep, -precisionStep);
+        return this;
+    }
+
+    @Override
+    public void reset() {
+        if (valSize == 0)
+            throw new IllegalStateException("call set???Value() before usage");
+        numericAtt.setShift(-precisionStep);
+    }
+
+    @Override
+    public boolean incrementToken() {
+        if (valSize == 0)
+            throw new IllegalStateException("call set???Value() before usage");
+
+        // this will only clear all other attributes in this TokenStream
+        clearAttributes();
+
+        final int shift = numericAtt.incShift();
+        typeAtt.setType((shift == 0) ? TOKEN_TYPE_FULL_PREC : TOKEN_TYPE_LOWER_PREC);
+        posIncrAtt.setPositionIncrement((shift == 0) ? 1 : 0);
+        return (shift < valSize);
+    }
+
+    /** Returns the precision step. */
+    public int getPrecisionStep() {
+        return precisionStep;
+    }
+
+    // members
+    private final NumericTermAttribute numericAtt = addAttribute(NumericTermAttribute.class);
+    private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
+    private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
+
+    private int valSize = 0; // valSize==0 means not initialized
+    private final int precisionStep;
+}

--- a/src/main/java/org/apache/lucene/search/BigNumericRangeFilter.java
+++ b/src/main/java/org/apache/lucene/search/BigNumericRangeFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.math.BigInteger;
+
+/**
+ * Copies from {@link org.apache.lucene.search.BigNumericRangeFilter} to support {@link java.math.BigInteger}
+ */
+public final class BigNumericRangeFilter<T extends Number> extends MultiTermQueryWrapperFilter<BigNumericRangeQuery<T>> {
+
+    private BigNumericRangeFilter(final BigNumericRangeQuery<T> query) {
+        super(query);
+    }
+
+    public static BigNumericRangeFilter<BigInteger> newBigIntegerRange(final String field, final int precisionStep,
+                                                                      BigInteger min, BigInteger max, final boolean minInclusive, final boolean maxInclusive, final int valueSize
+    ) {
+        return new BigNumericRangeFilter<BigInteger>(
+                BigNumericRangeQuery.newBigIntegerRange(field, precisionStep, min, max, minInclusive, maxInclusive, valueSize)
+        );
+    }
+}

--- a/src/main/java/org/apache/lucene/search/BigNumericRangeQuery.java
+++ b/src/main/java/org/apache/lucene/search/BigNumericRangeQuery.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.search;
+
+import org.apache.lucene.index.FilteredTermsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.*;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Comparator;
+import java.util.LinkedList;
+
+/**
+ * Copies from {@link org.apache.lucene.search.NumericRangeQuery} to support {@link java.math.BigInteger}
+ */
+public class BigNumericRangeQuery<T extends Number> extends MultiTermQuery {
+    private BigNumericRangeQuery(final String field, final int precisionStep, final BigNumericUtils.BigNumericType dataType,
+                              T min, T max, final boolean minInclusive, final boolean maxInclusive, final int valueSize
+    ) {
+        super(field);
+        if (precisionStep < 1)
+            throw new IllegalArgumentException("precisionStep must be >=1");
+        this.precisionStep = precisionStep;
+        this.dataType = dataType;
+        this.min = min;
+        this.max = max;
+        this.minInclusive = minInclusive;
+        this.maxInclusive = maxInclusive;
+        this.valueSize = valueSize;
+    }
+
+
+    public static BigNumericRangeQuery<BigInteger> newBigIntegerRange(final String field, final int precisionStep,
+                                                                      BigInteger min, BigInteger max, final boolean minInclusive, final boolean maxInclusive, final int valueSize
+    ) {
+        return new BigNumericRangeQuery<BigInteger>(field, precisionStep, BigNumericUtils.BigNumericType.BIG_INT, min, max, minInclusive, maxInclusive, valueSize);
+    }
+
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected TermsEnum getTermsEnum(final Terms terms, AttributeSource atts) throws IOException {
+        // very strange: java.lang.Number itself is not Comparable, but all subclasses used here are
+        if (min != null && max != null && ((Comparable<T>) min).compareTo(max) > 0) {
+            return TermsEnum.EMPTY;
+        }
+        return new NumericRangeTermsEnum(terms.iterator(null));
+    }
+
+    /** Returns <code>true</code> if the lower endpoint is inclusive */
+    public boolean includesMin() { return minInclusive; }
+
+    /** Returns <code>true</code> if the upper endpoint is inclusive */
+    public boolean includesMax() { return maxInclusive; }
+
+    /** Returns the lower value of this range query */
+    public T getMin() { return min; }
+
+    /** Returns the upper value of this range query */
+    public T getMax() { return max; }
+
+    /** Returns the precision step. */
+    public int getPrecisionStep() { return precisionStep; }
+
+    @Override
+    public String toString(final String field) {
+        final StringBuilder sb = new StringBuilder();
+        if (!getField().equals(field)) sb.append(getField()).append(':');
+        return sb.append(minInclusive ? '[' : '{')
+                .append((min == null) ? "*" : min.toString())
+                .append(" TO ")
+                .append((max == null) ? "*" : max.toString())
+                .append(maxInclusive ? ']' : '}')
+                .append(ToStringUtils.boost(getBoost()))
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        BigNumericRangeQuery that = (BigNumericRangeQuery) o;
+
+        if (maxInclusive != that.maxInclusive) return false;
+        if (minInclusive != that.minInclusive) return false;
+        if (precisionStep != that.precisionStep) return false;
+        if (valueSize != that.valueSize) return false;
+        if (max != null ? !max.equals(that.max) : that.max != null) return false;
+        if (min != null ? !min.equals(that.min) : that.min != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + precisionStep;
+        result = 31 * result + (min != null ? min.hashCode() : 0);
+        result = 31 * result + (max != null ? max.hashCode() : 0);
+        result = 31 * result + (minInclusive ? 1 : 0);
+        result = 31 * result + (maxInclusive ? 1 : 0);
+        result = 31 * result + valueSize;
+        return result;
+    }
+
+    final int precisionStep;
+    final BigNumericUtils.BigNumericType dataType;
+    final T min, max;
+    final boolean minInclusive,maxInclusive;
+    final int valueSize;
+
+
+    static final BigInteger MINUS_ONE = BigInteger.valueOf(-1);
+
+
+    private final class NumericRangeTermsEnum extends FilteredTermsEnum {
+
+        private BytesRef currentLowerBound, currentUpperBound;
+
+        private final LinkedList<BytesRef> rangeBounds = new LinkedList<BytesRef>();
+        private final Comparator<BytesRef> termComp;
+
+        NumericRangeTermsEnum(final TermsEnum tenum) {
+            super(tenum);
+            switch (dataType) {
+                case BIG_INT:
+                    BigInteger minBound = min == null? MINUS_ONE.shiftLeft(valueSize - 1) : (BigInteger) min;  // min value is -2 ^ (valueSize -1)
+                    if (!minInclusive) {
+                        minBound = minBound.add(BigInteger.ONE);
+                    }
+                    BigInteger maxBound = max == null ? BigInteger.ONE.shiftLeft(valueSize - 1).subtract(BigInteger.ONE) : (BigInteger) max;  // max value is 2 ^ (valueSize -1) - 1
+                    if (!maxInclusive) {
+                        maxBound = maxBound.subtract(BigInteger.ONE);
+                    }
+
+                    BigNumericUtils.splitRange(new BigNumericUtils.BigIntegerRangeBuilder() {
+                        @Override
+                        public final void addRange(BytesRef minPrefixCoded, BytesRef maxPrefixCoded) {
+                            rangeBounds.add(minPrefixCoded);
+                            rangeBounds.add(maxPrefixCoded);
+                        }
+                    }, valueSize, precisionStep, minBound, maxBound);
+                    break;
+                default:
+                    // should never happen
+                    throw new IllegalArgumentException("Invalid NumericType");
+            }
+
+            termComp = getComparator();
+        }
+
+        private void nextRange() {
+            assert rangeBounds.size() % 2 == 0;
+
+            currentLowerBound = rangeBounds.removeFirst();
+            assert currentUpperBound == null || termComp.compare(currentUpperBound, currentLowerBound) <= 0 :
+                    "The current upper bound must be <= the new lower bound";
+
+            currentUpperBound = rangeBounds.removeFirst();
+        }
+
+        @Override
+        protected final BytesRef nextSeekTerm(BytesRef term) {
+            while (rangeBounds.size() >= 2) {
+                nextRange();
+
+                // if the new upper bound is before the term parameter, the sub-range is never a hit
+                if (term != null && termComp.compare(term, currentUpperBound) > 0)
+                    continue;
+                // never seek backwards, so use current term if lower bound is smaller
+                return (term != null && termComp.compare(term, currentLowerBound) > 0) ?
+                        term : currentLowerBound;
+            }
+
+            // no more sub-range enums available
+            assert rangeBounds.isEmpty();
+            currentLowerBound = currentUpperBound = null;
+            return null;
+        }
+
+        @Override
+        protected final AcceptStatus accept(BytesRef term) {
+            while (currentUpperBound == null || termComp.compare(term, currentUpperBound) > 0) {
+                if (rangeBounds.isEmpty())
+                    return AcceptStatus.END;
+                // peek next sub-range, only seek if the current term is smaller than next lower bound
+                if (termComp.compare(term, rangeBounds.getFirst()) < 0)
+                    return AcceptStatus.NO_AND_SEEK;
+                // step forward to next range without seeking, as next lower range bound is less or equal current term
+                nextRange();
+            }
+            return AcceptStatus.YES;
+        }
+
+    }
+
+
+}

--- a/src/main/java/org/apache/lucene/util/BigNumericUtils.java
+++ b/src/main/java/org/apache/lucene/util/BigNumericUtils.java
@@ -1,0 +1,137 @@
+/*
+* Licensed to Elasticsearch under one or more contributor
+* license agreements. See the NOTICE file distributed with
+* this work for additional information regarding copyright
+* ownership. Elasticsearch licenses this file to you under
+* the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.lucene.util;
+
+import java.math.BigInteger;
+
+/**
+ * Copies from {@link org.apache.lucene.util.NumericUtils} to support {@link java.math.BigInteger}
+ */
+public final class BigNumericUtils {
+
+    public static final int VALUE_SIZE_DEFAULT = 128;
+
+    public static enum BigNumericType {
+        BIG_INT
+    }
+
+    private static int getBufferSize(int valueSize) {
+        return (valueSize - 1)/7 + 2;
+    }
+
+    public static int bigIntToPrefixCoded(final BigInteger val, final int shift, final BytesRef bytes, final int valueSize) {
+        bigIntToPrefixCodedBytes(val, shift, bytes, valueSize);
+        return bytes.hashCode();
+    }
+
+    public static void bigIntToPrefixCodedBytes(final BigInteger val, final int shift, final BytesRef bytes, final int valueSize) {
+        if (shift < 0 || shift > valueSize)  // ensure shift is 0..127
+            throw new IllegalArgumentException("Illegal shift value, must be 0.." + valueSize);
+        int nChars = (valueSize - 1 - shift) / 7 + 1;
+        bytes.offset = 0;
+        bytes.length = nChars+1;   // one extra for the byte that contains the shift info
+        if (bytes.bytes.length < bytes.length) {
+            bytes.bytes = new byte[getBufferSize(valueSize)];  // use the max
+        }
+        bytes.bytes[0] = (byte)(shift);
+        BigInteger sortableBits = val.xor(BigInteger.valueOf(-1).shiftLeft(valueSize - 1));
+        sortableBits = sortableBits.shiftRight(shift);
+        while (nChars > 0) {
+            // Store 7 bits per byte for compatibility
+            // with UTF-8 encoding of terms
+            bytes.bytes[nChars--] = sortableBits.and(BigInteger.valueOf(0x7f)).byteValue();
+            sortableBits = sortableBits.shiftRight(7);
+        }
+    }
+
+    public static void splitRange(
+            final BigIntegerRangeBuilder builder, final int valSize,
+            final int precisionStep, BigInteger minBound, BigInteger maxBound
+    ) {
+        if (precisionStep < 1)
+            throw new IllegalArgumentException("precisionStep must be >=1");
+        if (minBound.compareTo(maxBound) > 0) return;
+        for (int shift=0; ; shift += precisionStep) {
+            // calculate new bounds for inner precision
+            final BigInteger diff = BigInteger.valueOf(1L << (shift+precisionStep)) ,
+                    mask = BigInteger.valueOf(((1L<<precisionStep) - 1L) << shift) ;
+            final boolean
+                    hasLower = !minBound.and(mask).equals(BigInteger.ZERO),
+                    hasUpper = !minBound.and(mask).equals(mask);
+            final BigInteger
+                    nextMinBound = (hasLower ? minBound.add(diff) : minBound).and(mask.not()),
+                    nextMaxBound = (hasUpper ? maxBound.subtract(diff) : maxBound).and(mask.not());
+            final boolean
+                    lowerWrapped = nextMinBound.compareTo(minBound) < 0,
+                    upperWrapped = nextMaxBound.compareTo(maxBound) > 0;
+
+            if (shift+precisionStep>=valSize || nextMinBound.compareTo(nextMaxBound) > 0 || lowerWrapped || upperWrapped) {
+                // We are in the lowest precision or the next precision is not available.
+                addRange(builder, valSize, minBound, maxBound, shift);
+                // exit the split recursion loop
+                break;
+            }
+
+            if (hasLower)
+                addRange(builder, valSize, minBound, minBound.or(mask), shift);
+            if (hasUpper)
+                addRange(builder, valSize, maxBound.add(mask.not()), maxBound, shift);
+
+            // recurse to next precision
+            minBound = nextMinBound;
+            maxBound = nextMaxBound;
+        }
+    }
+
+    private static void addRange(
+            final BigIntegerRangeBuilder builder, final int valSize,
+            BigInteger minBound, BigInteger maxBound,
+            final int shift
+    ) {
+        maxBound = maxBound.or(BigInteger.valueOf((1L << shift) - 1L));
+        builder.addRange(minBound, maxBound, shift, valSize);
+    }
+
+
+    public static abstract class BigIntegerRangeBuilder {
+
+        /**
+         * Overwrite this method, if you like to receive the already prefix encoded range bounds.
+         * You can directly build classical (inclusive) range queries from them.
+         */
+        public void addRange(BytesRef minPrefixCoded, BytesRef maxPrefixCoded) {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Overwrite this method, if you like to receive the raw long range bounds.
+         * You can use this for e.g. debugging purposes (print out range bounds).
+         */
+        public void addRange(final BigInteger min, final BigInteger max, final int shift, final int valueSize) {
+            final BytesRef minBytes = new BytesRef(getBufferSize(valueSize)), maxBytes = new BytesRef(getBufferSize(valueSize));
+            bigIntToPrefixCodedBytes(min, shift, minBytes, valueSize);
+            bigIntToPrefixCodedBytes(max, shift, maxBytes, valueSize);
+            addRange(minBytes, maxBytes);
+        }
+
+    }
+
+}
+

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.internal.*;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
+import org.elasticsearch.index.mapper.ip.Ipv6FieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -96,7 +97,8 @@ public class DocumentMapperParser extends AbstractIndexComponent {
                 .put(TypeParsers.MULTI_FIELD_CONTENT_TYPE, TypeParsers.multiFieldConverterTypeParser)
                 .put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser())
                 .put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser())
-                .put(Murmur3FieldMapper.CONTENT_TYPE, new Murmur3FieldMapper.TypeParser());
+                .put(Murmur3FieldMapper.CONTENT_TYPE, new Murmur3FieldMapper.TypeParser())
+                .put(Ipv6FieldMapper.CONTENT_TYPE, new Ipv6FieldMapper.TypeParser());
 
         if (ShapesAvailability.JTS_AVAILABLE) {
             typeParsersBuilder.put(GeoShapeFieldMapper.CONTENT_TYPE, new GeoShapeFieldMapper.TypeParser());

--- a/src/main/java/org/elasticsearch/index/mapper/ip/Ipv6FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/Ipv6FieldMapper.java
@@ -1,0 +1,525 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.ip;
+
+import org.apache.lucene.analysis.*;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.search.BigNumericRangeFilter;
+import org.apache.lucene.search.BigNumericRangeQuery;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.*;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.codec.docvaluesformat.DocValuesFormatProvider;
+import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
+import org.elasticsearch.index.mapper.*;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
+
+/**
+ *
+ */
+public class Ipv6FieldMapper extends NumberFieldMapper<BigInteger> {
+
+    public static final String CONTENT_TYPE = "ipv6";
+
+    private static final int BITS = 129;
+
+
+    public static BigInteger ipv6ToNumber(String addr) {
+        int startIndex=addr.indexOf("::");
+
+        if(startIndex!=-1){
+
+
+            String firstStr=addr.substring(0,startIndex);
+            String secondStr=addr.substring(startIndex+2, addr.length());
+
+
+            BigInteger first=ipv6ToNumber(firstStr);
+
+            int x=countChar(addr, ':');
+
+            first=first.shiftLeft(16*(7-x)).add(ipv6ToNumber(secondStr));
+
+            return first;
+        }
+
+
+        String[] strArr = addr.split(":");
+
+        BigInteger retValue = BigInteger.valueOf(0);
+        for (int i=0;i<strArr.length;i++) {
+            BigInteger bi=new BigInteger(strArr[i], 16);
+            retValue = retValue.shiftLeft(16).add(bi);
+        }
+        return retValue;
+    }
+
+
+    public static String numberToIPv6(BigInteger ipNumber) {
+        String ipString ="";
+        BigInteger a =new BigInteger("FFFF", 16);
+
+        for (int i=0; i<8; i++) {
+            ipString=ipNumber.and(a).toString(16)+":"+ipString;
+
+            ipNumber = ipNumber.shiftRight(16);
+        }
+
+        return ipString.substring(0, ipString.length()-1);
+
+    }
+
+    private static int countChar(String str, char reg){
+        char[] ch=str.toCharArray();
+        int count=0;
+        for(int i=0; i<ch.length; ++i){
+            if(ch[i]==reg){
+                if(ch[i+1]==reg){
+                    ++i;
+                    continue;
+                }
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    public static class Defaults extends NumberFieldMapper.Defaults {
+        public static final String NULL_VALUE = null;
+
+        public static final FieldType FIELD_TYPE = new FieldType(NumberFieldMapper.Defaults.FIELD_TYPE);
+
+        static {
+            FIELD_TYPE.freeze();
+        }
+    }
+
+    private ThreadLocal<BigNumericTokenStream> tokenStream = new ThreadLocal<BigNumericTokenStream>() {
+        @Override
+        protected BigNumericTokenStream initialValue() {
+            return new BigNumericTokenStream(precisionStep, BITS);
+        }
+    };
+
+    private static ThreadLocal<BigNumericTokenStream> tokenStream4 = new ThreadLocal<BigNumericTokenStream>() {
+        @Override
+        protected BigNumericTokenStream initialValue() {
+            return new BigNumericTokenStream(4, BITS);
+        }
+    };
+
+    private static ThreadLocal<BigNumericTokenStream> tokenStream8 = new ThreadLocal<BigNumericTokenStream>() {
+        @Override
+        protected BigNumericTokenStream initialValue() {
+            return new BigNumericTokenStream(8, BITS);
+        }
+    };
+
+    private static ThreadLocal<BigNumericTokenStream> tokenStreamMax = new ThreadLocal<BigNumericTokenStream>() {
+        @Override
+        protected BigNumericTokenStream initialValue() {
+            return new BigNumericTokenStream(Integer.MAX_VALUE, BITS);
+        }
+    };
+
+
+    protected BigNumericTokenStream popCachedBigStream() {
+        if (precisionStep == 4) {
+            return tokenStream4.get();
+        }
+        if (precisionStep == 8) {
+            return tokenStream8.get();
+        }
+        if (precisionStep == Integer.MAX_VALUE) {
+            return tokenStreamMax.get();
+        }
+        return tokenStream.get();
+    }
+
+
+    public static class Builder extends NumberFieldMapper.Builder<Builder, Ipv6FieldMapper> {
+
+        protected String nullValue = Defaults.NULL_VALUE;
+
+        public Builder(String name) {
+            super(name, new FieldType(Defaults.FIELD_TYPE));
+            builder = this;
+        }
+
+        public Builder nullValue(String nullValue) {
+            this.nullValue = nullValue;
+            return this;
+        }
+
+        @Override
+        public Ipv6FieldMapper build(BuilderContext context) {
+            fieldType.setOmitNorms(fieldType.omitNorms() && boost == 1.0f);
+            Ipv6FieldMapper fieldMapper = new Ipv6FieldMapper(buildNames(context),
+                    precisionStep, boost, fieldType, docValues, nullValue, ignoreMalformed(context), coerce(context),
+                    postingsProvider, docValuesProvider, similarity,
+                    normsLoading, fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            fieldMapper.includeInAll(includeInAll);
+            return fieldMapper;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            Ipv6FieldMapper.Builder builder = new Ipv6FieldMapper.Builder(name);
+            parseNumberField(builder, name, node, parserContext);
+            for (Map.Entry<String, Object> entry : node.entrySet()) {
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    builder.nullValue(propNode.toString());
+                }
+            }
+            return builder;
+        }
+    }
+
+    private String nullValue;
+
+    protected Ipv6FieldMapper(Names names, int precisionStep, float boost, FieldType fieldType, Boolean docValues,
+                              String nullValue, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                              PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider,
+                              SimilarityProvider similarity, Loading normsLoading, @Nullable Settings fieldDataSettings,
+                              Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(names, precisionStep, boost, fieldType, docValues,
+                ignoreMalformed, coerce, new NamedAnalyzer("_ipv6/" + precisionStep, new NumericIpv6Analyzer(precisionStep)),
+                new NamedAnalyzer("_ipv6/max", new NumericIpv6Analyzer(Integer.MAX_VALUE)), postingsProvider, docValuesProvider,
+                similarity, normsLoading, fieldDataSettings, indexSettings, multiFields, copyTo);
+        this.nullValue = nullValue;
+    }
+
+    @Override
+    public FieldType defaultFieldType() {
+        return Defaults.FIELD_TYPE;
+    }
+
+    @Override
+    public FieldDataType defaultFieldDataType() {
+        return new FieldDataType("long");
+    }
+
+    @Override
+    protected int maxPrecisionStep() {
+        return BITS;
+    }
+
+    @Override
+    public BigInteger value(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof BytesRef) {
+            return new BigInteger(((BytesRef) value).bytes);
+        }
+        return ipv6ToNumber(value.toString());
+    }
+
+    /**
+     * IPs should return as a string.
+     */
+    @Override
+    public Object valueForSearch(Object value) {
+        BigInteger val = value(value);
+        if (val == null) {
+            return null;
+        }
+        return numberToIPv6(val);
+    }
+
+    @Override
+    public BytesRef indexedValueForSearch(Object value) {
+        BytesRef bytesRef = new BytesRef();
+        BigNumericUtils.bigIntToPrefixCodedBytes(parseValue(value), 0, bytesRef, BITS); // 0 because of exact match
+        return bytesRef;
+    }
+
+    private BigInteger parseValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof BytesRef) {
+            return ipv6ToNumber(((BytesRef) value).utf8ToString());
+        }
+        return ipv6ToNumber(value.toString());
+    }
+
+    @Override
+    public Query fuzzyQuery(String value, Fuzziness fuzziness, int prefixLength, int maxExpansions, boolean transpositions) {
+        BigInteger iValue = ipv6ToNumber(value);
+        BigInteger iSim = ipv6ToNumber(fuzziness.asString());
+        return BigNumericRangeQuery.newBigIntegerRange(names.indexName(), precisionStep,
+                iValue.subtract(iSim),
+                iValue.add(iSim),
+                true, true, BITS);
+    }
+
+    @Override
+    public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
+        return BigNumericRangeQuery.newBigIntegerRange(names.indexName(), precisionStep,
+                parseValue(lowerTerm), parseValue(upperTerm), includeLower, includeUpper, BITS);
+    }
+
+    @Override
+    public Filter rangeFilter(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
+        return BigNumericRangeFilter.newBigIntegerRange(names.indexName(), precisionStep,
+                parseValue(lowerTerm), parseValue(upperTerm), includeLower, includeUpper, BITS);
+    }
+
+    @Override
+    public Filter rangeFilter(IndexFieldDataService fieldData, Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context) {
+        throw new UnsupportedOperationException();
+//        return NumericRangeFieldDataFilter.newLongRange((IndexNumericFieldData) fieldData.getForField(this),
+//                lowerTerm == null ? null : parseValue(lowerTerm),
+//                upperTerm == null ? null : parseValue(upperTerm),
+//                includeLower, includeUpper);
+    }
+
+    @Override
+    public Filter nullValueFilter() {
+        if (nullValue == null) {
+            return null;
+        }
+        final BigInteger value = ipv6ToNumber(nullValue);
+        return BigNumericRangeFilter.newBigIntegerRange(names.indexName(), precisionStep,
+                value, value, true, true, BITS);
+    }
+
+    @Override
+    protected void innerParseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        String ipAsString;
+        if (context.externalValueSet()) {
+            ipAsString = (String) context.externalValue();
+            if (ipAsString == null) {
+                ipAsString = nullValue;
+            }
+        } else {
+            if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
+                ipAsString = nullValue;
+            } else {
+                ipAsString = context.parser().text();
+            }
+        }
+
+        if (ipAsString == null) {
+            return;
+        }
+        if (context.includeInAll(includeInAll, this)) {
+            context.allEntries().addText(names.fullName(), ipAsString, boost);
+        }
+
+        final BigInteger value = ipv6ToNumber(ipAsString);
+        if (fieldType.indexed() || fieldType.stored()) {
+            CustomBigIntegerNumericField field = new CustomBigIntegerNumericField(this, value, fieldType);
+            field.setBoost(boost);
+            fields.add(field);
+        }
+        if (hasDocValues()) {
+//            addDocValue(context, value);
+        }
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
+        super.merge(mergeWith, mergeContext);
+        if (!this.getClass().equals(mergeWith.getClass())) {
+            return;
+        }
+        if (!mergeContext.mergeFlags().simulate()) {
+            this.nullValue = ((Ipv6FieldMapper) mergeWith).nullValue;
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || precisionStep != Defaults.PRECISION_STEP) {
+            builder.field("precision_step", precisionStep);
+        }
+        if (includeDefaults || nullValue != null) {
+            builder.field("null_value", nullValue);
+        }
+        if (includeInAll != null) {
+            builder.field("include_in_all", includeInAll);
+        } else if (includeDefaults) {
+            builder.field("include_in_all", false);
+        }
+
+    }
+
+    public static class CustomBigIntegerNumericField extends CustomNumericField {
+
+        private final BigInteger number;
+
+        private final Ipv6FieldMapper mapper;
+
+        public CustomBigIntegerNumericField(Ipv6FieldMapper mapper, BigInteger number, FieldType fieldType) {
+            super(mapper, number, fieldType);
+            this.mapper = mapper;
+            this.number = number;
+        }
+
+        @Override
+        public TokenStream tokenStream(Analyzer analyzer) throws IOException {
+            if (fieldType().indexed()) {
+                return mapper.popCachedBigStream().setBigIntValue(number);
+            }
+            return null;
+        }
+
+        @Override
+        public String numericAsString() {
+            return number.toString();
+        }
+    }
+
+    public static class NumericIpv6Analyzer extends Analyzer {
+
+        private final int precisionStep;
+
+        public NumericIpv6Analyzer(int precisionStep) {
+            this.precisionStep = precisionStep;
+        }
+
+        @Override
+        protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
+            try {
+                // LUCENE 4 UPGRADE: in reusableTokenStream the buffer size was char[120]
+                // Not sure if this is intentional or not
+                return new TokenStreamComponents(createNumericTokenizer(reader, new char[32]));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create numeric tokenizer", e);
+            }
+        }
+
+        protected NumericIpv6Tokenizer createNumericTokenizer(Reader reader, char[] buffer) throws IOException {
+            return new NumericIpv6Tokenizer(reader, precisionStep, buffer);
+        }
+    }
+
+    public static class NumericIpv6Tokenizer extends Tokenizer {
+
+        /** Make this tokenizer get attributes from the delegate token stream. */
+        private static final AttributeSource.AttributeFactory delegatingAttributeFactory(final AttributeSource source) {
+            return new AttributeFactory() {
+                @Override
+                public AttributeImpl createAttributeInstance(Class<? extends Attribute> attClass) {
+                    return (AttributeImpl) source.addAttribute(attClass);
+                }
+            };
+        }
+
+        private final BigNumericTokenStream numericTokenStream;
+        private final char[] buffer;
+        private boolean started;
+
+        public NumericIpv6Tokenizer(Reader reader, int precisionStep, char[] buffer) throws IOException {
+            this(reader, new BigNumericTokenStream(precisionStep, BITS), buffer);
+        }
+
+        protected NumericIpv6Tokenizer(Reader reader, BigNumericTokenStream numericTokenStream, char[] buffer) throws IOException {
+            super(delegatingAttributeFactory(numericTokenStream), reader);
+            this.numericTokenStream = numericTokenStream;
+            // Add attributes from the numeric token stream, this works fine because the attribute factory delegates to numericTokenStream
+            for (Iterator<Class<? extends Attribute>> it = numericTokenStream.getAttributeClassesIterator(); it.hasNext();) {
+                addAttribute(it.next());
+            }
+            this.buffer = buffer;
+            started = true;
+        }
+
+        @Override
+        public void reset() throws IOException {
+            super.reset();
+            started = false;
+        }
+
+        @Override
+        public final boolean incrementToken() throws IOException {
+            if (!started) {
+                // reset() must be idempotent, this is why we read data in incrementToken
+                final int len = Streams.readFully(input, buffer);
+                if (len == buffer.length && input.read() != -1) {
+                    throw new IOException("Cannot read numeric data larger than " + buffer.length + " chars");
+                }
+                setValue(numericTokenStream, new String(buffer, 0, len));
+                numericTokenStream.reset();
+                started = true;
+            }
+            return numericTokenStream.incrementToken();
+        }
+
+        @Override
+        public void end() throws IOException {
+            super.end();
+            numericTokenStream.end();
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            numericTokenStream.close();
+        }
+
+        protected void setValue(BigNumericTokenStream tokenStream, String value) {
+            tokenStream.setBigIntValue(ipv6ToNumber(value));
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/ip/Ipv6IntegrationTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/ip/Ipv6IntegrationTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.ip;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.RangeFilterBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static org.hamcrest.Matchers.*;
+
+/**
+ *
+ */
+public class Ipv6IntegrationTest extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testIndexIpv6() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                    .startObject("ipv6")
+                        .field("type", "ipv6")
+                        .field("precision_step", randomIntBetween(4, 8))
+                    .endObject()
+                .endObject()
+                .endObject().endObject().string();
+
+        createIndex("test");
+        admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
+
+        BigInteger ip1 = getRandomIp();
+
+        XContentBuilder doc1 = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("ipv6", Ipv6FieldMapper.numberToIPv6(ip1))
+                .endObject();
+
+
+        index("test", "type", "1", doc1);
+
+        refresh();
+        RangeQueryBuilder rangeQueryBuilder;
+        RangeFilterBuilder rangeFilterBuilder;
+        SearchResponse searchResponse;
+
+        // test term query
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(QueryBuilders.termQuery("ipv6", Ipv6FieldMapper.numberToIPv6(ip1))).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+
+        // test term query not match
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(QueryBuilders.termQuery("ipv6", Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)))).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+
+        // test in range
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.subtract(BigInteger.ONE)))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)))
+                .includeLower(true)
+                .includeUpper(true);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+
+
+        // test not in range
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.valueOf(10l))))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.valueOf(20l))))
+                .includeLower(true)
+                .includeUpper(true);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+
+        // test is lower bound
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)))
+                .includeLower(true)
+                .includeUpper(true);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+
+        // test is lower bound but exclude lower bound
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)))
+                .includeLower(false)
+                .includeUpper(true);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+
+        // test is upper bound
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.subtract(BigInteger.ONE)))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1))
+                .includeLower(true)
+                .includeUpper(true);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+
+        // test is upper bound but exclude upper bound
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.subtract(BigInteger.ONE)))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1))
+                .includeLower(true)
+                .includeUpper(false);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+
+        // test no lower bound and in range
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)));
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+
+        // test no lower bound and not in range
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.subtract(BigInteger.ONE)));
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+
+        // test no upper bound and in range
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.subtract(BigInteger.ONE)));
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+
+        // test no upper bound and not in range
+        rangeQueryBuilder = QueryBuilders.rangeQuery("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)));
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(rangeQueryBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+
+        // test filter
+        rangeFilterBuilder = FilterBuilders.rangeFilter("ipv6")
+                .from(Ipv6FieldMapper.numberToIPv6(ip1.subtract(BigInteger.ONE)))
+                .to(Ipv6FieldMapper.numberToIPv6(ip1.add(BigInteger.ONE)))
+                .includeLower(true)
+                .includeUpper(true);
+        searchResponse = client().prepareSearch("test").setTypes("type").setQuery(QueryBuilders.matchAllQuery()).setPostFilter(rangeFilterBuilder).get();
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+    }
+
+    public BigInteger getRandomIp() {
+        BigInteger max = BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE);
+        BigInteger bigInteger;
+        do {
+            bigInteger = new BigInteger(129, getRandom());
+        } while (bigInteger.compareTo(max) >= 0);
+        return bigInteger;
+    }
+
+
+}


### PR DESCRIPTION
What I've done is copied the `NumericTokenStream`, `NumericRangeFilter`, `NumericRangeQuery` and `NumericUtils` from lucene and change those to support `BigInteger`

the term query and range query/filter are both working, but there are still other things like field data need to do

@kimchy @jpountz @dadoonet can you have a quick look just to make sure I've done the correct thing so far?

closes #3714
