### PR TITLE
Properly quote $JAVA in bin/plugin

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -45,5 +45,5 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-exec $JAVA $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $args
+exec "$JAVA" $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $args
 


### PR DESCRIPTION
The all new Oracle Java 7 on OSX has
JAVA_HOME=/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home
Note the happy space in "Internet Plug-Ins" - it gives plugin
major agida...
