### PR TITLE
Replace InternalSearchResponse#EMPTY with InternalSearchResponse#empty()

### DIFF
--- a/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/test/scroll/11_clear.yaml
@@ -1,9 +1,4 @@
 ---
-setup:
-  - skip:
-      version: 0 - 999
-      reason:  This test some impacts other tests
----
 "Clear scroll":
   - do:
       indices.create:

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -140,7 +140,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
         public void start() {
             if (expectedSuccessfulOps == 0) {
                 // no search shards to search on, bail with empty response (it happens with search across _all with no indices around and consistent with broadcast operations)
-                listener.onResponse(new SearchResponse(InternalSearchResponse.EMPTY, null, 0, 0, System.currentTimeMillis() - startTime, ShardSearchFailure.EMPTY_ARRAY));
+                listener.onResponse(new SearchResponse(InternalSearchResponse.empty(), null, 0, 0, System.currentTimeMillis() - startTime, ShardSearchFailure.EMPTY_ARRAY));
                 return;
             }
             request.beforeStart();

--- a/src/main/java/org/elasticsearch/search/controller/SearchPhaseController.java
+++ b/src/main/java/org/elasticsearch/search/controller/SearchPhaseController.java
@@ -414,7 +414,7 @@ public class SearchPhaseController extends AbstractComponent {
         List<? extends AtomicArray.Entry<? extends FetchSearchResultProvider>> fetchResults = fetchResultsArr.asList();
 
         if (queryResults.isEmpty()) {
-            return InternalSearchResponse.EMPTY;
+            return InternalSearchResponse.empty();
         }
 
         QuerySearchResult firstResult = queryResults.get(0).value.queryResult();

--- a/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
+++ b/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
@@ -40,6 +40,10 @@ import static org.elasticsearch.search.internal.InternalSearchHits.readSearchHit
  */
 public class InternalSearchResponse implements Streamable, ToXContent {
 
+    public static InternalSearchResponse empty() {
+        return new InternalSearchResponse(new InternalSearchHits(new InternalSearchHit[0], 0, 0), null, null, null, false);
+    }
+
     private InternalSearchHits hits;
 
     private InternalFacets facets;
@@ -49,8 +53,6 @@ public class InternalSearchResponse implements Streamable, ToXContent {
     private Suggest suggest;
 
     private boolean timedOut;
-
-    public static final InternalSearchResponse EMPTY = new InternalSearchResponse(new InternalSearchHits(new InternalSearchHit[0], 0, 0), null, null, null, false);
 
     private InternalSearchResponse() {
     }


### PR DESCRIPTION
Each search request should use a new InternalSearchResponse instance even in case when all shards return no hits. The InternalSearchResponse may get modified afterwards, so a new instance required at all times.
