### PR TITLE
Ensure pending merges are updated on segment flushes

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -674,7 +674,15 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
     @Override
     public boolean refreshNeeded() {
-        return dirty;
+        try {
+            // we are either dirty due to a document added or due to a
+            // finished merge - either way we should refresh
+            return dirty || !searcherManager.isSearcherCurrent();
+        } catch (IOException e) {
+            logger.error("failed to access searcher manager", e);
+            failEngine(e);
+            throw new EngineException(shardId, "failed to access searcher manager",e);
+        }
     }
 
     @Override
@@ -706,7 +714,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 // maybeRefresh will only allow one refresh to execute, and the rest will "pass through",
                 // but, we want to make sure not to loose ant refresh calls, if one is taking time
                 synchronized (refreshMutex) {
-                    if (dirty || refresh.force()) {
+                    if (refreshNeeded() || refresh.force()) {
                         // we set dirty to false, even though the refresh hasn't happened yet
                         // as the refresh only holds for data indexed before it. Any data indexed during
                         // the refresh will not be part of it and will set the dirty flag back to true
@@ -926,7 +934,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
     @Override
     public void maybeMerge() throws EngineException {
-        if (!possibleMergeNeeded) {
+        if (!possibleMergeNeeded()) {
             return;
         }
         possibleMergeNeeded = false;

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineIntegrationTest.java
@@ -152,4 +152,5 @@ public class InternalEngineIntegrationTest extends ElasticsearchIntegrationTest 
         assertThat(total, Matchers.equalTo(t));
 
     }
+
 }

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineMergeTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineMergeTests.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.engine.internal;
+
+import com.carrotsearch.randomizedtesting.annotations.Nightly;
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.google.common.base.Predicate;
+import org.apache.lucene.index.LogByteSizeMergePolicy;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.index.merge.policy.LogDocMergePolicyProvider;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+
+/**
+ */
+@ElasticsearchIntegrationTest.ClusterScope(numNodes = 1, scope = ElasticsearchIntegrationTest.Scope.SUITE)
+public class InternalEngineMergeTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    @LuceneTestCase.Slow
+    public void testMergesHappening() throws InterruptedException, IOException, ExecutionException {
+        final int numOfShards = 5;
+        // some settings to keep num segments low
+        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numOfShards)
+                .put(LogDocMergePolicyProvider.MIN_MERGE_DOCS_KEY, 10)
+                .put(LogDocMergePolicyProvider.MERGE_FACTORY_KEY, 5)
+                .put(LogByteSizeMergePolicy.DEFAULT_MIN_MERGE_MB, 0.5)
+                .build()));
+        long id = 0;
+        final int rounds = scaledRandomIntBetween(50, 300);
+        logger.info("Starting rounds [{}] ", rounds);
+        for (int i = 0; i < rounds; ++i) {
+            final int numDocs = scaledRandomIntBetween(100, 1000);
+            BulkRequestBuilder request = client().prepareBulk();
+            for (int j = 0; j < numDocs; ++j) {
+                request.add(Requests.indexRequest("test").type("type1").id(Long.toString(id++)).source(jsonBuilder().startObject().field("l", randomLong()).endObject()));
+            }
+            BulkResponse response = request.execute().actionGet();
+            refresh();
+            assertNoFailures(response);
+            IndicesStatsResponse stats = client().admin().indices().prepareStats("test").setSegments(true).setMerge(true).get();
+            logger.info("index round [{}] - segments {}, total merges {}, current merge {}", i, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());
+        }
+        awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
+                logger.info("numshards {}, segments {}, total merges {}, current merge {}", numOfShards, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());
+                long current = stats.getPrimaries().getMerge().getCurrent();
+                long count = stats.getPrimaries().getSegments().getCount();
+                return count < 50 && current == 0;
+            }
+        });
+        IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
+        logger.info("numshards {}, segments {}, total merges {}, current merge {}", numOfShards, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());
+        long count = stats.getPrimaries().getSegments().getCount();
+        assertThat(count, Matchers.lessThanOrEqualTo(50l));
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -294,9 +294,7 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         protected void randomizeContent(long from, long to) {
-            for (long i = from; i < to; ++i) {
-                set(i, (byte) random.nextInt(1 << 8));
-            }
+            fill(from, to, (byte) random.nextInt(1 << 8));
         }
 
         @Override
@@ -342,9 +340,7 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         protected void randomizeContent(long from, long to) {
-            for (long i = from; i < to; ++i) {
-                set(i, random.nextInt());
-            }
+            fill(from, to, random.nextInt());
         }
 
         @Override
@@ -385,9 +381,7 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         protected void randomizeContent(long from, long to) {
-            for (long i = from; i < to; ++i) {
-                set(i, random.nextLong());
-            }
+            fill(from, to, random.nextLong());
         }
 
         @Override
@@ -428,9 +422,7 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         protected void randomizeContent(long from, long to) {
-            for (long i = from; i < to; ++i) {
-                set(i, (random.nextFloat() - 0.5f) * 1000);
-            }
+            fill(from, to, (random.nextFloat() - 0.5f) * 1000);
         }
 
         @Override
@@ -471,9 +463,7 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         protected void randomizeContent(long from, long to) {
-            for (long i = from; i < to; ++i) {
-                set(i, (random.nextDouble() - 0.5) * 1000);
-            }
+            fill(from, to, (random.nextDouble() - 0.5) * 1000);
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockPageCacheRecycler.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockPageCacheRecycler.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.TestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentMap;
@@ -85,11 +86,21 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
                     throw new IllegalStateException("Releasing a page that has not been acquired");
                 }
                 final T ref = v();
-                for (int i = 0; i < Array.getLength(ref); ++i) {
-                    if (ref instanceof Object[]) {
-                        Array.set(ref, i, null);
-                    } else {
-                        Array.set(ref, i, (byte) random.nextInt(256));
+                if (ref instanceof Object[]) {
+                    Arrays.fill((Object[])ref, 0, Array.getLength(ref), null);
+                } else if (ref instanceof byte[]) {
+                    Arrays.fill((byte[])ref, 0, Array.getLength(ref), (byte) random.nextInt(256));
+                } else if (ref instanceof long[]) {
+                    Arrays.fill((long[])ref, 0, Array.getLength(ref), random.nextLong());
+                } else if (ref instanceof int[]) {
+                    Arrays.fill((int[])ref, 0, Array.getLength(ref), random.nextInt());
+                } else if (ref instanceof double[]) {
+                    Arrays.fill((double[])ref, 0, Array.getLength(ref), random.nextDouble() - 0.5);
+                } else if (ref instanceof float[]) {
+                    Arrays.fill((float[])ref, 0, Array.getLength(ref), random.nextFloat() - 0.5f);
+                } else {
+                    for (int i = 0; i < Array.getLength(ref); ++i) {
+                            Array.set(ref, i, (byte) random.nextInt(256));
                     }
                 }
                 return v.release();
@@ -112,7 +123,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
     public V<byte[]> bytePage(boolean clear) {
         final V<byte[]> page = super.bytePage(clear);
         if (!clear) {
-            random.nextBytes(page.v());
+            Arrays.fill(page.v(), 0, page.v().length, (byte)random.nextInt(1<<8));
         }
         return wrap(page);
     }
@@ -121,9 +132,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
     public V<int[]> intPage(boolean clear) {
         final V<int[]> page = super.intPage(clear);
         if (!clear) {
-            for (int i = 0; i < page.v().length; ++i) {
-                page.v()[i] = random.nextInt();
-            }
+            Arrays.fill(page.v(), 0, page.v().length, random.nextInt());
         }
         return wrap(page);
     }
@@ -132,9 +141,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
     public V<long[]> longPage(boolean clear) {
         final V<long[]> page = super.longPage(clear);
         if (!clear) {
-            for (int i = 0; i < page.v().length; ++i) {
-                page.v()[i] = random.nextLong();
-            }
+            Arrays.fill(page.v(), 0, page.v().length, random.nextLong());
         }
         return wrap(page);
     }
@@ -143,9 +150,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
     public V<double[]> doublePage(boolean clear) {
         final V<double[]> page = super.doublePage(clear);
         if (!clear) {
-            for (int i = 0; i < page.v().length; ++i) {
-                page.v()[i] = random.nextDouble() - 0.5;
-            }
+            Arrays.fill(page.v(), 0, page.v().length, random.nextDouble() - 0.5);
         }
         return wrap(page);
     }

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.percolate.PercolateResponse;
@@ -200,6 +201,12 @@ public class ElasticsearchAssertions {
         assertThat("Expected at least one shard failure, got none",
                 searchResponse.getShardFailures().length, greaterThan(0));
         assertVersionSerializable(searchResponse);
+    }
+
+    public static void assertNoFailures(BulkResponse response) {
+        assertThat("Unexpected ShardFailures: " + response.buildFailureMessage(),
+                response.hasFailures(), is(false));
+        assertVersionSerializable(response);
     }
 
     public static void assertFailures(SearchRequestBuilder searchRequestBuilder, RestStatus restStatus, Matcher<String> reasonMatcher) {
@@ -513,4 +520,5 @@ public class ElasticsearchAssertions {
             MockDirectoryHelper.wrappers.clear();
         }
     }
+
 }


### PR DESCRIPTION
```
Due to the default of `async_merge` to `true` we never run
the merge policy on a segment flush which prevented the
pending merges from being updated and that caused actual
pending merges not to contribute to the merge decision.

This commit removes the `index.async.merge` setting. The setting is 
actually misleading since we take care of this on a different level 
(the merge scheduler) since 1.1.

This commit also adds an additional check when to run a refresh
since solely relying on the dirty flag might leave merges un-refreshed
which can cause search slowdowns and higher memory consumption.
```

Closes #5779
