### PR TITLE
Fix snapshot status with empty repository

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequest.java
@@ -34,11 +34,11 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class SnapshotsStatusRequest extends MasterNodeOperationRequest<SnapshotsStatusRequest> {
 
-    private String repository;
+    private String repository = "_all";
 
     private String[] snapshots = Strings.EMPTY_ARRAY;
 
-    SnapshotsStatusRequest() {
+    public SnapshotsStatusRequest() {
     }
 
     /**

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -87,7 +87,8 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeOperation
         ImmutableList<SnapshotMetaData.Entry> currentSnapshots = snapshotsService.currentSnapshots(request.repository(), request.snapshots());
 
         if (currentSnapshots.isEmpty()) {
-            buildResponse(request, currentSnapshots, null);
+            listener.onResponse(buildResponse(request, currentSnapshots, null));
+            return;
         }
 
         Set<String> nodesIds = newHashSet();

--- a/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -447,4 +447,9 @@ public interface ClusterAdminClient {
      */
     SnapshotsStatusRequestBuilder prepareSnapshotStatus(String repository);
 
+    /**
+     * Get snapshot status.
+     */
+    SnapshotsStatusRequestBuilder prepareSnapshotStatus();
+
 }

--- a/src/main/java/org/elasticsearch/client/support/AbstractClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClusterAdminClient.java
@@ -419,4 +419,9 @@ public abstract class AbstractClusterAdminClient implements InternalClusterAdmin
     public SnapshotsStatusRequestBuilder prepareSnapshotStatus(String repository) {
         return new SnapshotsStatusRequestBuilder(this, repository);
     }
+
+    @Override
+    public SnapshotsStatusRequestBuilder prepareSnapshotStatus() {
+        return new SnapshotsStatusRequestBuilder(this);
+    }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
@@ -49,7 +49,7 @@ public class RestSnapshotsStatusAction extends BaseRestHandler {
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        String repository = request.param("repository");
+        String repository = request.param("repository", "_all");
         String[] snapshots = request.paramAsStringArray("snapshot", Strings.EMPTY_ARRAY);
         if (snapshots.length == 1 && "_all".equalsIgnoreCase(snapshots[0])) {
             snapshots = Strings.EMPTY_ARRAY;

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -382,7 +382,7 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
         if (snapshotMetaData == null || snapshotMetaData.entries().isEmpty()) {
             return ImmutableList.of();
         }
-        if (repository == null) {
+        if ("_all".equals(repository)) {
             return snapshotMetaData.entries();
         }
         if (snapshotMetaData.entries().size() == 1) {


### PR DESCRIPTION
The snapshot status command with empty repository should return current status of currently running snapshots in all repositories.

Fixes #5790
