### PR TITLE
Geo: Find out min/max values for correct intersection handling

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -359,7 +359,8 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
         }
         for (int i = 0; i < numHoles; i++) {
             final Edge current = holes[i];
-            final int intersections = intersections(current.coordinate.x, edges);
+            double x = findMinimumXCoord(current);
+            final int intersections = intersections(x, edges);
             final int pos = Arrays.binarySearch(edges, 0, intersections, current, INTERSECTION_ORDER);
             assert pos < 0 : "illegal state: two edges cross the datum at the same position";
             final int index = -(pos+2);
@@ -373,6 +374,18 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
 
             components.get(component).add(points[i]);
         }
+    }
+
+    private static double findMinimumXCoord(Edge current) {
+        double coordinate = current.coordinate.x;
+
+        Edge next = current.next;
+        while (next != null && !current.equals(next)) {
+            coordinate = coordinate >= 0 ? Math.max(next.coordinate.x, coordinate) : Math.min(next.coordinate.x, coordinate);
+            next = next.next;
+        }
+
+        return coordinate;
     }
 
     private static int merge(Edge[] intersections, int offset, int length, Edge[] holes, int numHoles) {

--- a/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/GeoJSONShapeParserTests.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.geo.builders.ShapeBuilder.SPATIAL_CONTEXT;
+import static org.hamcrest.Matchers.instanceOf;
 
 
 /**
@@ -143,6 +144,33 @@ public class GeoJSONShapeParserTests extends ElasticsearchTestCase {
                 holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, holes);
         assertGeometryEquals(jtsGeom(expected), polygonGeoJson);
+    }
+
+    @Test
+    public void testParsePolygonWithHolesBroken() throws Exception {
+        String geoJson = "{ \"type\": \"Polygon\",\"coordinates\": [[[-85.0018514,37.1311314],[-85.0016645,37.1315293],[-85.0016246,37.1317069],[-85.0016526,37.1318183],[-85.0017119,37.1319196],[-85.0019371,37.1321182],[-85.0019972,37.1322115],[-85.0019942,37.1323234],[-85.0019543,37.1324336],[-85.001906,37.1324985],[-85.001834,37.1325497],[-85.0016965,37.1325907],[-85.0016011,37.1325873],[-85.0014816,37.1325353],[-85.0011755,37.1323509],[-85.000955,37.1322802],[-85.0006241,37.1322529],[-85.0000002,37.1322307],[-84.9994,37.1323001],[-84.999109,37.1322864],[-84.998934,37.1322415],[-84.9988639,37.1321888],[-84.9987841,37.1320944],[-84.9987208,37.131954],[-84.998736,37.1316611],[-84.9988091,37.131334],[-84.9989283,37.1311337],[-84.9991943,37.1309198],[-84.9993573,37.1308459],[-84.9995888,37.1307924],[-84.9998746,37.130806],[-85.0000002,37.1308358],[-85.0004984,37.1310658],[-85.0008008,37.1311625],[-85.0009461,37.1311684],[-85.0011373,37.1311515],[-85.0016455,37.1310491],[-85.0018514,37.1311314]],[[-85.0000002,37.1317672],[-85.0001983,37.1317538],[-85.0003378,37.1317582],[-85.0004697,37.131792],[-85.0008048,37.1319439],[-85.0009342,37.1319838],[-85.0010184,37.1319463],[-85.0010618,37.13184],[-85.0010057,37.1315102],[-85.000977,37.1314403],[-85.0009182,37.1313793],[-85.0005366,37.1312209],[-85.000224,37.1311466],[-85.000087,37.1311356],[-85.0000002,37.1311433],[-84.9995021,37.1312336],[-84.9993308,37.1312859],[-84.9992567,37.1313252],[-84.9991868,37.1314277],[-84.9991593,37.1315381],[-84.9991841,37.1316527],[-84.9992329,37.1317117],[-84.9993527,37.1317788],[-84.9994931,37.1318061],[-84.9996815,37.1317979],[-85.0000002,37.1317672]]]}";
+        XContentParser parser = JsonXContent.jsonXContent.createParser(geoJson);
+        parser.nextToken();
+        Shape shape = ShapeBuilder.parse(parser).build();
+        assertThat(shape, instanceOf(JtsGeometry.class));
+        JtsGeometry geometry = (JtsGeometry) shape;
+        assertThat(geometry.getGeom(), instanceOf(Polygon.class));
+    }
+
+    @Test
+    public void testParsePolygonWithHolesWorks() throws Exception {
+        String geoJson = "{\n" +
+                "\"type\":\"Polygon\",\n" +
+                "\"coordinates\":[\n" +
+                "[[-85.0018514,37.1311314],[-84.998998, 37.1311314],[-84.998998, 37.129352],[-85.001851, 37.129352],[-85.0018514,37.1311314]],\n" +
+                "[[-85.0000, 37.1301],[-85.001, 37.1301],[-85.001, 37.1303],[-85.0000, 37.1303],[-85.0000, 37.1301]]]\n" +
+                "}\n";
+        XContentParser parser = JsonXContent.jsonXContent.createParser(geoJson);
+        parser.nextToken();
+        Shape shape = ShapeBuilder.parse(parser).build();
+        assertThat(shape, instanceOf(JtsGeometry.class));
+        JtsGeometry geometry = (JtsGeometry) shape;
+        assertThat(geometry.getGeom(), instanceOf(Polygon.class));
     }
 
     @Test


### PR DESCRIPTION
A multi polygon with holes didnt correctly calculate possible intersections
because it used the first edge instead of the edge with the min/max value of
the longitude (depending if positive/negative)

Closes #5773
