### PR TITLE
Improved SearchContext.addReleasable.

### DIFF
--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -125,7 +125,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
             indexShard.deleteByQuery(deleteByQuery);
         } finally {
             SearchContext searchContext = SearchContext.current();
-            searchContext.clearAndRelease();
+            searchContext.release();
             SearchContext.removeCurrent();
         }
         return new PrimaryResponse<>(shardRequest.request, new ShardDeleteByQueryResponse(), null);
@@ -148,7 +148,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
             indexShard.deleteByQuery(deleteByQuery);
         } finally {
             SearchContext searchContext = SearchContext.current();
-            searchContext.clearAndRelease();
+            searchContext.release();
             SearchContext.removeCurrent();
         }
     }

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQuery.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.Set;
@@ -123,7 +124,7 @@ public class ChildrenConstantScoreQuery extends Query {
                 shortCircuitFilter = new ParentIdsFilter(parentType, nonNestedDocsFilter, parentIds);
             }
             final ParentWeight parentWeight = new ParentWeight(parentFilter, shortCircuitFilter, parentIds);
-            searchContext.addReleasable(parentWeight);
+            searchContext.addReleasable(parentWeight, Lifetime.COLLECTION);
             releaseParentIds = false;
             return parentWeight;
         } finally {

--- a/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ChildrenQuery.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -219,7 +220,7 @@ public class ChildrenQuery extends Query {
             parentFilter = new ApplyAcceptedDocsFilter(this.parentFilter);
         }
         ParentWeight parentWeight = new ParentWeight(rewrittenChildQuery.createWeight(searcher), parentFilter, size, parentIds, scores, occurrences);
-        searchContext.addReleasable(parentWeight);
+        searchContext.addReleasable(parentWeight, Lifetime.COLLECTION);
         return parentWeight;
     }
 

--- a/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/child/CustomQueryWrappingFilter.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.docset.DocIdSets;
 import org.elasticsearch.common.lucene.search.NoCacheFilter;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.IdentityHashMap;
@@ -66,7 +67,7 @@ public class CustomQueryWrappingFilter extends NoCacheFilter implements Releasab
             IndexSearcher searcher = searchContext.searcher();
             docIdSets = new IdentityHashMap<>();
             this.searcher = searcher;
-            searchContext.addReleasable(this);
+            searchContext.addReleasable(this, Lifetime.COLLECTION);
 
             final Weight weight = searcher.createNormalizedWeight(query);
             for (final AtomicReaderContext leaf : searcher.getTopReaderContext().leaves()) {

--- a/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentConstantScoreQuery.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.Set;
@@ -104,7 +105,7 @@ public class ParentConstantScoreQuery extends Query {
             }
 
             final ChildrenWeight childrenWeight = new ChildrenWeight(childrenFilter, parentIds);
-            searchContext.addReleasable(childrenWeight);
+            searchContext.addReleasable(childrenWeight, Lifetime.COLLECTION);
             releaseParentIds = false;
             return childrenWeight;
         } finally {

--- a/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/ParentQuery.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.Set;
@@ -156,7 +157,7 @@ public class ParentQuery extends Query {
                 Releasables.release(collector.parentIds, collector.scores);
             }
         }
-        searchContext.addReleasable(childWeight);
+        searchContext.addReleasable(childWeight, Lifetime.COLLECTION);
         return childWeight;
     }
 

--- a/src/main/java/org/elasticsearch/index/search/child/TopChildrenQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/child/TopChildrenQuery.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -168,7 +169,7 @@ public class TopChildrenQuery extends Query {
         }
 
         ParentWeight parentWeight =  new ParentWeight(rewrittenChildQuery.createWeight(searcher), parentDocs);
-        searchContext.addReleasable(parentWeight);
+        searchContext.addReleasable(parentWeight, Lifetime.COLLECTION);
         return parentWeight;
     }
 

--- a/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -23,12 +23,11 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.*;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.percolate.PercolateShardRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.HashedBytesRef;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.util.BigArrays;
@@ -207,18 +206,15 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    protected void doRelease() {
         try {
             if (docSearcher != null) {
                 IndexReader indexReader = docSearcher.reader();
                 fieldDataService.clear(indexReader);
                 indexService.cache().clear(indexReader);
-                return docSearcher.release();
-            } else {
-                return false;
             }
         } finally {
-            engineSearcher.release();
+            Releasables.release(docSearcher, engineSearcher);
         }
     }
 
@@ -295,11 +291,6 @@ public class PercolateContext extends SearchContext {
     }
 
     // Unused:
-    @Override
-    public boolean clearAndRelease() {
-        throw new UnsupportedOperationException();
-    }
-
     @Override
     public void preProcess() {
         throw new UnsupportedOperationException();
@@ -676,16 +667,6 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public FetchSearchResult fetchResult() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addReleasable(Releasable releasable) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clearReleasables() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -69,10 +69,8 @@ import org.elasticsearch.search.dfs.CachedDfSource;
 import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.*;
-import org.elasticsearch.search.internal.DefaultSearchContext;
-import org.elasticsearch.search.internal.InternalScrollSearchRequest;
-import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.search.internal.*;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 import org.elasticsearch.search.query.*;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -575,6 +573,8 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
     }
 
     private void cleanContext(SearchContext context) {
+        assert context == SearchContext.current();
+        context.clearReleasables(Lifetime.SEARCH_PHASE);
         SearchContext.removeCurrent();
     }
 

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -574,7 +574,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
 
     private void cleanContext(SearchContext context) {
         assert context == SearchContext.current();
-        context.clearReleasables(Lifetime.SEARCH_PHASE);
+        context.clearReleasables(Lifetime.PHASE);
         SearchContext.removeCurrent();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -19,12 +19,12 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.ReaderContextAware;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -84,6 +84,9 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
         assert factories != null : "sub-factories provided to BucketAggregator must not be null, use AggragatorFactories.EMPTY instead";
         this.factories = factories;
         this.subAggregators = factories.createSubAggregators(this, estimatedBucketsCount);
+        // TODO: change it to SEARCH_PHASE, but this would imply allocating the aggregators in the QUERY
+        // phase instead of DFS like it is done today
+        context.searchContext().addReleasable(this, Lifetime.SEARCH_CONTEXT);
     }
 
     /**
@@ -175,13 +178,7 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
     /** Called upon release of the aggregator. */
     @Override
     public boolean release() {
-        boolean success = false;
-        try {
-            doRelease();
-            success = true;
-        } finally {
-            Releasables.release(success, subAggregators);
-        }
+        doRelease();
         return true;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -86,7 +86,7 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
         this.subAggregators = factories.createSubAggregators(this, estimatedBucketsCount);
         // TODO: change it to SEARCH_PHASE, but this would imply allocating the aggregators in the QUERY
         // phase instead of DFS like it is done today
-        context.searchContext().addReleasable(this, Lifetime.SEARCH_CONTEXT);
+        context.searchContext().addReleasable(this, Lifetime.CONTEXT);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.ObjectArray;
@@ -28,8 +26,6 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -82,9 +78,6 @@ public class AggregatorFactories {
                     long arraySize = estimatedBucketsCount > 0 ?  estimatedBucketsCount : 1;
                     aggregators = bigArrays.newObjectArray(arraySize);
                     aggregators.set(0, first);
-                    for (long i = 1; i < arraySize; ++i) {
-                        aggregators.set(i, createAndRegisterContextAware(parent.context(), factory, parent, estimatedBucketsCount));
-                    }
                 }
 
                 @Override
@@ -135,29 +128,7 @@ public class AggregatorFactories {
 
                 @Override
                 public void doRelease() {
-                    final Iterable<Aggregator> aggregatorsIter = new Iterable<Aggregator>() {
-
-                        @Override
-                        public Iterator<Aggregator> iterator() {
-                            return new UnmodifiableIterator<Aggregator>() {
-
-                                long i = 0;
-
-                                @Override
-                                public boolean hasNext() {
-                                    return i < aggregators.size();
-                                }
-
-                                @Override
-                                public Aggregator next() {
-                                    return aggregators.get(i++);
-                                }
-
-                            };
-                        }
-
-                    };
-                    Releasables.release(Iterables.concat(aggregatorsIter, Collections.singleton(aggregators)));
+                    Releasables.release(aggregators);
                 }
             };
         }

--- a/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.List;
@@ -97,7 +98,7 @@ public class MatchedQueriesFetchSubPhase implements FetchSubPhase {
             } catch (IOException e) {
                 // ignore
             } finally {
-                SearchContext.current().clearReleasables();
+                SearchContext.current().clearReleasables(Lifetime.COLLECTION);
             }
         }
     }

--- a/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -21,6 +21,8 @@ package org.elasticsearch.search.internal;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.*;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.MinimumScoreCollector;
 import org.elasticsearch.common.lucene.MultiCollector;
 import org.elasticsearch.common.lucene.search.FilteredCollector;
@@ -28,6 +30,7 @@ import org.elasticsearch.common.lucene.search.XCollector;
 import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.search.dfs.CachedDfSource;
+import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +39,7 @@ import java.util.List;
 /**
  * Context-aware extension of {@link IndexSearcher}.
  */
-public class ContextIndexSearcher extends IndexSearcher {
+public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     public static enum Stage {
         NA,
@@ -66,10 +69,10 @@ public class ContextIndexSearcher extends IndexSearcher {
         setSimilarity(searcher.searcher().getSimilarity());
     }
 
-    public void release() {
-        if (mainDocIdSetCollector != null) {
-            mainDocIdSetCollector.release();
-        }
+    @Override
+    public boolean release() {
+        Releasables.release(mainDocIdSetCollector);
+        return true;
     }
 
     public void dfSource(CachedDfSource dfSource) {
@@ -129,7 +132,7 @@ public class ContextIndexSearcher extends IndexSearcher {
             }
             return in.createNormalizedWeight(query);
         } catch (Throwable t) {
-            searchContext.clearReleasables();
+            searchContext.clearReleasables(Lifetime.COLLECTION);
             throw new RuntimeException(t);
         }
     }
@@ -187,7 +190,7 @@ public class ContextIndexSearcher extends IndexSearcher {
                 }
             }
         } finally {
-            searchContext.clearReleasables();
+            searchContext.clearReleasables(Lifetime.COLLECTION);
         }
     }
 
@@ -200,7 +203,7 @@ public class ContextIndexSearcher extends IndexSearcher {
             XFilteredQuery filteredQuery = new XFilteredQuery(query, searchContext.aliasFilter());
             return super.explain(filteredQuery, doc);
         } finally {
-            searchContext.clearReleasables();
+            searchContext.clearReleasables(Lifetime.COLLECTION);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -30,7 +30,6 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.search.AndFilter;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -177,8 +176,6 @@ public class DefaultSearchContext extends SearchContext {
 
     private volatile long lastAccessTime = -1;
 
-    private List<Releasable> clearables = null;
-
     private volatile boolean useSlowScroll;
 
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
@@ -207,19 +204,12 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
+    public void doRelease() throws ElasticsearchException {
         if (scanContext != null) {
             scanContext.clear();
         }
         // clear and scope phase we  have
-        searcher.release();
-        engineSearcher.release();
-        return true;
-    }
-
-    public boolean clearAndRelease() {
-        clearReleasables();
-        return release();
+        Releasables.release(searcher, engineSearcher);
     }
 
     /**
@@ -676,25 +666,6 @@ public class DefaultSearchContext extends SearchContext {
 
     public FetchSearchResult fetchResult() {
         return fetchResult;
-    }
-
-    @Override
-    public void addReleasable(Releasable releasable) {
-        if (clearables == null) {
-            clearables = new ArrayList<>();
-        }
-        clearables.add(releasable);
-    }
-
-    @Override
-    public void clearReleasables() {
-        if (clearables != null) {
-            try {
-                Releasables.release(clearables);
-            } finally {
-                clearables.clear();
-            }
-        }
     }
 
     public ScanContext scanContext() {

--- a/src/main/java/org/elasticsearch/search/internal/DocIdSetCollector.java
+++ b/src/main/java/org/elasticsearch/search/internal/DocIdSetCollector.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.docset.ContextDocIdSet;
 import org.elasticsearch.common.lucene.search.XCollector;
 import org.elasticsearch.index.cache.docset.DocSetCache;
@@ -33,7 +34,7 @@ import java.util.List;
 
 /**
  */
-public class DocIdSetCollector extends XCollector {
+public class DocIdSetCollector extends XCollector implements Releasable {
 
     private final DocSetCache docSetCache;
     private final Collector collector;
@@ -53,10 +54,11 @@ public class DocIdSetCollector extends XCollector {
         return docSets;
     }
 
-    public void release() {
+    public boolean release() {
         for (ContextDocIdSet docSet : docSets) {
             docSetCache.release(docSet);
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -18,6 +18,9 @@
  */
 package org.elasticsearch.search.internal;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -27,6 +30,7 @@ import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
@@ -59,6 +63,8 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -81,7 +87,18 @@ public abstract class SearchContext implements Releasable {
         return current.get();
     }
 
-    public abstract boolean clearAndRelease();
+    private Multimap<Lifetime, Releasable> clearables = null;
+
+    public final boolean release() {
+        try {
+            clearReleasables(Lifetime.SEARCH_CONTEXT);
+            return true;
+        } finally {
+            doRelease();
+        }
+    }
+
+    protected abstract void doRelease();
 
     /**
      * Should be called before executing the main query and after all other parameters have been set.
@@ -288,9 +305,29 @@ public abstract class SearchContext implements Releasable {
 
     public abstract FetchSearchResult fetchResult();
 
-    public abstract void addReleasable(Releasable releasable);
+    /**
+     * Schedule the release of a resource. The time when {@link Releasable#release()} will be called on this object
+     * is function of the provided {@link Lifetime}.
+     */
+    public void addReleasable(Releasable releasable, Lifetime lifetime) {
+        if (clearables == null) {
+            clearables = MultimapBuilder.enumKeys(Lifetime.class).arrayListValues().build();
+        }
+        clearables.put(lifetime, releasable);
+    }
 
-    public abstract void clearReleasables();
+    public void clearReleasables(Lifetime lifetime) {
+        if (clearables != null) {
+            List<Collection<Releasable>> releasables = new ArrayList<>();
+            for (Lifetime lc : Lifetime.values()) {
+                if (lc.compareTo(lifetime) > 0) {
+                    break;
+                }
+                releasables.add(clearables.removeAll(lc));
+            }
+            Releasables.release(Iterables.concat(releasables));
+        }
+    }
 
     public abstract ScanContext scanContext();
 
@@ -305,4 +342,22 @@ public abstract class SearchContext implements Releasable {
     public abstract boolean useSlowScroll();
 
     public abstract SearchContext useSlowScroll(boolean useSlowScroll);
+
+    /**
+     * The life time of an object that is used during search execution.
+     */
+    public enum Lifetime {
+        /**
+         * This life time is for objects that only live during collection time.
+         */
+        COLLECTION,
+        /**
+         * This life time is for objects that need to live until the end of the current search phase.
+         */
+        SEARCH_PHASE,
+        /**
+         * This life time is for objects that need to live until the search context they are attached to is destroyed.
+         */
+        SEARCH_CONTEXT;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -91,7 +91,7 @@ public abstract class SearchContext implements Releasable {
 
     public final boolean release() {
         try {
-            clearReleasables(Lifetime.SEARCH_CONTEXT);
+            clearReleasables(Lifetime.CONTEXT);
             return true;
         } finally {
             doRelease();
@@ -354,10 +354,10 @@ public abstract class SearchContext implements Releasable {
         /**
          * This life time is for objects that need to live until the end of the current search phase.
          */
-        SEARCH_PHASE,
+        PHASE,
         /**
          * This life time is for objects that need to live until the search context they are attached to is destroyed.
          */
-        SEARCH_CONTEXT;
+        CONTEXT;
     }
 }

--- a/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/index/search/child/TestSearchContext.java
@@ -26,7 +26,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.docset.DocSetCache;
@@ -92,11 +91,6 @@ public class TestSearchContext extends SearchContext {
         this.indexService = null;
         this.filterCache = null;
         this.indexFieldDataService = null;
-    }
-
-    @Override
-    public boolean clearAndRelease() {
-        return false;
     }
 
     @Override
@@ -557,14 +551,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public void addReleasable(Releasable releasable) {
-    }
-
-    @Override
-    public void clearReleasables() {
-    }
-
-    @Override
     public ScanContext scanContext() {
         return null;
     }
@@ -590,8 +576,8 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean release() throws ElasticsearchException {
-        return false;
+    public void doRelease() throws ElasticsearchException {
+        // no-op
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -33,7 +32,6 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -217,7 +215,6 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_WithSubAggregation() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
@@ -433,7 +430,6 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void script_SingleValue() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
@@ -615,7 +611,6 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void emptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
@@ -756,11 +751,8 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         assertThat(max.getValue(), equalTo(asc ? 4.0 : 2.0));
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMissingSubAggregation() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -776,11 +768,8 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByNonMetricsOrMultiBucketSubAggregation() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -797,11 +786,8 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithUknownMetric() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -819,11 +805,8 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithoutMetric() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -841,7 +824,6 @@ public class DoubleTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedBySingleValueSubAggregationDesc() throws Exception {
         boolean asc = false;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/LongTermsTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -32,7 +31,6 @@ import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -513,7 +511,6 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void script_MultiValued_WithAggregatorInherited_NoExplicitType() throws Exception {
 
@@ -753,11 +750,8 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
         assertThat(max.getValue(), equalTo(asc ? 4.0 : 2.0));
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMissingSubAggregation() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -773,11 +767,8 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByNonMetricsOrMultiBucketSubAggregation() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -794,11 +785,8 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithUknownMetric() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -816,11 +804,8 @@ public class LongTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithoutMetric() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -33,7 +32,6 @@ import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -186,10 +184,8 @@ public class NestedTests extends ElasticsearchIntegrationTest {
         assertThat(stats.getAvg(), equalTo((double) sum / count));
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void onNonNestedField() throws Exception {
-        MockBigArrays.discardNextCheck();
         try {
             client().prepareSearch("idx")
                     .addAggregation(nested("nested").path("value")

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import com.google.common.base.Strings;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -27,12 +26,12 @@ import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCount;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -45,7 +44,6 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
-import static org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -943,11 +941,8 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     }
 
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMissingSubAggregation() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -964,11 +959,8 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByNonMetricsOrMultiBucketSubAggregation() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")
@@ -986,11 +978,8 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithUknownMetric() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
             client().prepareSearch("idx").setTypes("type")
                     .addAggregation(terms("terms")
@@ -1008,11 +997,8 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/5703")
     @Test
     public void singleValuedField_OrderedByMultiValuedSubAggregation_WithoutMetric() throws Exception {
-
-        MockBigArrays.discardNextCheck();
         try {
 
             client().prepareSearch("idx").setTypes("type")

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -45,44 +45,30 @@ public class MockBigArrays extends BigArrays {
      */
     private static final boolean TRACK_ALLOCATIONS = false;
 
-    private static boolean DISCARD = false;
-
     private static ConcurrentMap<Object, Object> ACQUIRED_ARRAYS = new ConcurrentHashMap<>();
 
-    /**
-     * Discard the next check that all arrays should be released. This can be useful if for a specific test, the cost to make
-     * sure the array is released is higher than the cost the user would experience if the array would not be released.
-     */
-    public static void discardNextCheck() {
-        DISCARD = true;
-    }
-
     public static void ensureAllArraysAreReleased() throws Exception {
-        if (DISCARD) {
-            DISCARD = false;
-        } else {
-            final Map<Object, Object> masterCopy = Maps.newHashMap(ACQUIRED_ARRAYS);
-            if (masterCopy.isEmpty()) {
-                return;
+        final Map<Object, Object> masterCopy = Maps.newHashMap(ACQUIRED_ARRAYS);
+        if (masterCopy.isEmpty()) {
+            return;
+        }
+        // not empty, we might be executing on a shared cluster that keeps on obtaining
+        // and releasing arrays, lets make sure that after a reasonable timeout, all master
+        // copy (snapshot) have been released
+        boolean success = ElasticsearchTestCase.awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                return Sets.intersection(masterCopy.keySet(), ACQUIRED_ARRAYS.keySet()).isEmpty();
             }
-            // not empty, we might be executing on a shared cluster that keeps on obtaining
-            // and releasing arrays, lets make sure that after a reasonable timeout, all master
-            // copy (snapshot) have been released
-            boolean success = ElasticsearchTestCase.awaitBusy(new Predicate<Object>() {
-                @Override
-                public boolean apply(Object input) {
-                    return Sets.intersection(masterCopy.keySet(), ACQUIRED_ARRAYS.keySet()).isEmpty();
-                }
-            });
-            if (success) {
-                return;
-            }
-            masterCopy.keySet().retainAll(ACQUIRED_ARRAYS.keySet());
-            ACQUIRED_ARRAYS.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on
-            if (!masterCopy.isEmpty()) {
-                final Object cause = masterCopy.entrySet().iterator().next().getValue();
-                throw new RuntimeException(masterCopy.size() + " arrays have not been released", cause instanceof Throwable ? (Throwable) cause : null);
-            }
+        });
+        if (success) {
+            return;
+        }
+        masterCopy.keySet().retainAll(ACQUIRED_ARRAYS.keySet());
+        ACQUIRED_ARRAYS.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on
+        if (!masterCopy.isEmpty()) {
+            final Object cause = masterCopy.entrySet().iterator().next().getValue();
+            throw new RuntimeException(masterCopy.size() + " arrays have not been released", cause instanceof Throwable ? (Throwable) cause : null);
         }
     }
 


### PR DESCRIPTION
For resources that have their life time effectively defined by the search
context they are attached to, it is convenient to use the search context to
schedule the release of such resources.

This commit changes aggregations to use this mechanism and also introduces
a `Lifetime` object that can be used to define how long the object should
live:
- COLLECTION: if the object only needs to live during collection time and is
  what SearchContext.addReleasable would have chosen before this change
  (used for p/c queries),
- PHASE for resources that only need to live during the current search
  phase (DFS, QUERY or FETCH),
- CONTEXT for resources that need to live until the context is
  destroyed.

Aggregators are currently registed with CONTEXT. The reason is that when
using the DFS_QUERY_THEN_FETCH search type, they are allocated during the DFS
phase but only used during the QUERY phase. However we should fix it in order
to only allocate them during the QUERY phase and use PHASE as a life
time.

Close #5703
