### PR TITLE
Separate benchmark API endpoints

### DIFF
--- a/rest-api-spec/api/benchmark.abort.json
+++ b/rest-api-spec/api/benchmark.abort.json
@@ -1,0 +1,20 @@
+{
+    "benchmark.abort" : {
+        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html",
+        "methods": ["POST"],
+        "url": {
+            "path": "/_bench/abort/{name}",
+            "paths": [
+                "/_bench/abort/{name}"
+            ],
+            "parts": {
+                "name": {
+                    "type" : "string",
+                    "description" : "A benchmark name"
+                }
+            },
+            "params": {}
+        },
+        "body": null
+    }
+}

--- a/rest-api-spec/api/benchmark.list.json
+++ b/rest-api-spec/api/benchmark.list.json
@@ -1,0 +1,27 @@
+{
+    "benchmark.list" : {
+        "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html",
+        "methods": ["GET"],
+        "url": {
+            "path": "/_bench",
+            "paths": [
+                "/_bench",
+                "/{index}/_bench",
+                "/{index}/{type}/_bench"
+            ],
+            "parts": {
+                "index": {
+                    "type" : "list",
+                    "description" : "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"
+                },
+                "type": {
+                    "type" : "string",
+                    "required" : true,
+                    "description" : "The name of the document type"
+                }
+            },
+            "params": {}
+        },
+        "body": null
+    }
+}

--- a/rest-api-spec/api/benchmark.submit.json
+++ b/rest-api-spec/api/benchmark.submit.json
@@ -1,14 +1,13 @@
 {
-    "bench" : {
+    "benchmark.submit" : {
         "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html",
-        "methods": ["GET", "PUT", "POST"],
+        "methods": ["PUT"],
         "url": {
             "path": "/_bench",
             "paths": [
                 "/_bench",
                 "/{index}/_bench",
-                "/{index}/{type}/_bench",
-                "/_bench/abort/{name}"
+                "/{index}/{type}/_bench"
             ],
             "parts": {
                 "index": {
@@ -22,10 +21,6 @@
                 }
             },
             "params": {
-                "wait_for_completion": {
-                    "type": "boolean",
-                    "description": "Specify whether the caller will wait for the benchmark to complete or return immediately after submission (default: true)"
-                },
                 "verbose": {
                     "type": "boolean",
                     "description": "Specify whether to return verbose statistics about each iteration (default: false)"


### PR DESCRIPTION
Separates benchmark API endpoints into separate files according to API
funtionality. This makes it easier for our tests and clients.

Closes #5787
