### PR TITLE
Create an endpoint for analyzer config

### DIFF
--- a/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
@@ -50,3 +50,62 @@ index :
                 escaped_tags : [xxx, yyy]
                 read_ahead : 1024
 --------------------------------------------------
+
+[float]
+[[fetching-analyzers-as-custom]]
+=== Fetching Analyzers as Custom
+coming[1.2.0]
+While the builtin analyzers are reasonably customizable they don't allow for
+inserting additional analyzers.  To do that the analyzer must be rebuilt as a
+custom analyzer.  The _analyzer endpoint provides a starting point for this
+process:
+
+[source,js]
+--------------------------------------------------
+$ curl 'http://localhost:9200/_analyzer/standard,arabic'
+--------------------------------------------------
+
+Which returns:
+[source,js]
+--------------------------------------------------
+{
+  "analyzer": {
+    "custom_arabic": {
+      "tokenizer": "standard",
+      "type": "custom",
+      "filter": [
+        "standard",
+        "lowercase",
+        "arabic_stop",
+        "arabic_normalization",
+        "arabic_stem"
+      ]
+    },
+    "custom_standard": {
+      "tokenizer": "standard",
+      "type": "custom",
+      "filter": [
+        "standard",
+        "lowercase"
+      ]
+    }
+  },
+  "filter": {
+    "arabic_stemmer": {
+      "language": "arabic",
+      "type": "stemmer"
+    },
+    "arabic_stop": {
+      "type": "stop",
+      "stopwords": [
+        "فان",
+.... snip ....
+        "ان"
+      ]
+    }
+  }
+}
+--------------------------------------------------
+
+Which is a copy of the analysis configuration required to build the standard
+and arabic analyzers.

--- a/docs/reference/analysis/tokenfilters/normalization-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/normalization-tokenfilter.asciidoc
@@ -4,12 +4,13 @@
 There are several token filters available which try to normalize special
 characters of a certain language.
 
-You can currently choose between `arabic_normalization` and
-`persian_normalization` normalization in your token filter
-configuration. For more information check the
-http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/ar/ArabicNormalizer.html[ArabicNormalizer]
-or the
-http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/fa/PersianNormalizer.html[PersianNormalizer]
-documentation.
+The following normalizers are supported:
+http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/ar/ArabicNormalizer.html[arabic],
+http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/de/GermanNormalizationFilter.html[german],
+http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/hi/HindiNormalizer.html[hindi],
+http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/in/IndicNormalizer.html[indic],
+http://lucene.apache.org/core/4_3_1/analyzers-common/org/apache/lucene/analysis/fa/PersianNormalizer.html[persian].
 
-*Note:* These filters are available since `0.90.2`
+*Note:* Arabic and Persian filters have been available since `0.90.2`.
+
+*Note:* German, Hindi, and Indic filters have been available since `1.2.0`.

--- a/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
+++ b/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
@@ -417,6 +417,7 @@ public class AnalysisModule extends AbstractModule {
         public void processCharFilters(CharFiltersBindings charFiltersBindings) {
             charFiltersBindings.processCharFilter("html_strip", HtmlStripCharFilterFactory.class);
             charFiltersBindings.processCharFilter("pattern_replace", PatternReplaceCharFilterFactory.class);
+            charFiltersBindings.processCharFilter("persian", PersianCharFilterFactory.class);
         }
 
         @Override
@@ -503,13 +504,14 @@ public class AnalysisModule extends AbstractModule {
             tokenFiltersBindings.processTokenFilter("stemmer_override", StemmerOverrideTokenFilterFactory.class);
 
             tokenFiltersBindings.processTokenFilter("arabic_normalization", ArabicNormalizationFilterFactory.class);
+            tokenFiltersBindings.processTokenFilter("german_normalization", GermanNormalizationFilterFactory.class);
+            tokenFiltersBindings.processTokenFilter("hindi_normalization", HindiNormalizationFilterFactory.class);
+            tokenFiltersBindings.processTokenFilter("indic_normalization", IndicNormalizationFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("persian_normalization", PersianNormalizationFilterFactory.class);
 
             tokenFiltersBindings.processTokenFilter("hunspell", HunspellTokenFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("cjk_bigram", CJKBigramFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("cjk_width", CJKWidthFilterFactory.class);
-
-
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/analysis/BuiltinAsCustom.java
+++ b/src/main/java/org/elasticsearch/index/analysis/BuiltinAsCustom.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Builds custom analyzer configuration required to reproduce a built in
+ * analyzer. Plugins that define builtin analyzers should implement this so
+ * users can get the configuration require to rebuild the builtin analyzer as a
+ * custom analyzer via the _analyze endpoint.
+ */
+public interface BuiltinAsCustom {
+    /**
+     * Builds custom analyzer configuration required to reproduce a built in
+     * analyzer.
+     * 
+     * @param builder
+     *            sync for the configuration
+     * @param name
+     *            name of the analyzer
+     * @return did we recognize the name and build an analyzer?
+     * @throws IOException
+     *             if the builder throws it
+     */
+    public abstract boolean build(XContentBuilder builder, String name) throws IOException;
+}

--- a/src/main/java/org/elasticsearch/index/analysis/BuiltinAsCustomModule.java
+++ b/src/main/java/org/elasticsearch/index/analysis/BuiltinAsCustomModule.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
+
+/**
+ * Module loading default implementation of BuiltinAsCustom.
+ */
+public class BuiltinAsCustomModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder<BuiltinAsCustom> multibinder = Multibinder.newSetBinder(binder(), BuiltinAsCustom.class);
+        multibinder.addBinding().to(StandardBuiltinAsCustom.class);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/GermanNormalizationFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/GermanNormalizationFilterFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.de.GermanNormalizationFilter;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+/**
+ *
+ */
+public class GermanNormalizationFilterFactory extends AbstractTokenFilterFactory {
+
+    @Inject
+    public GermanNormalizationFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new GermanNormalizationFilter(tokenStream);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/HindiNormalizationFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/HindiNormalizationFilterFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.hi.HindiNormalizationFilter;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+/**
+ *
+ */
+public class HindiNormalizationFilterFactory extends AbstractTokenFilterFactory {
+
+    @Inject
+    public HindiNormalizationFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new HindiNormalizationFilter(tokenStream);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/IndicNormalizationFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/IndicNormalizationFilterFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.in.IndicNormalizationFilter;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+/**
+ *
+ */
+public class IndicNormalizationFilterFactory extends AbstractTokenFilterFactory {
+
+    @Inject
+    public IndicNormalizationFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new IndicNormalizationFilter(tokenStream);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/PersianCharFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PersianCharFilterFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.fa.PersianCharFilter;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+import java.io.Reader;
+
+@AnalysisSettingsRequired
+public class PersianCharFilterFactory extends AbstractCharFilterFactory {
+    @Inject
+    public PersianCharFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name) {
+        super(index, indexSettings, name);
+    }
+
+    @Override
+    public Reader create(Reader tokenStream) {
+        return new PersianCharFilter(tokenStream);
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/StandardBuiltinAsCustom.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StandardBuiltinAsCustom.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.ar.ArabicAnalyzer;
+import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
+import org.apache.lucene.analysis.br.BrazilianAnalyzer;
+import org.apache.lucene.analysis.ca.CatalanAnalyzer;
+import org.apache.lucene.analysis.cjk.CJKAnalyzer;
+import org.apache.lucene.analysis.cz.CzechAnalyzer;
+import org.apache.lucene.analysis.da.DanishAnalyzer;
+import org.apache.lucene.analysis.de.GermanAnalyzer;
+import org.apache.lucene.analysis.el.GreekAnalyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.es.SpanishAnalyzer;
+import org.apache.lucene.analysis.eu.BasqueAnalyzer;
+import org.apache.lucene.analysis.fa.PersianAnalyzer;
+import org.apache.lucene.analysis.fi.FinnishAnalyzer;
+import org.apache.lucene.analysis.fr.FrenchAnalyzer;
+import org.apache.lucene.analysis.gl.GalicianAnalyzer;
+import org.apache.lucene.analysis.hi.HindiAnalyzer;
+import org.apache.lucene.analysis.hu.HungarianAnalyzer;
+import org.apache.lucene.analysis.hy.ArmenianAnalyzer;
+import org.apache.lucene.analysis.id.IndonesianAnalyzer;
+import org.apache.lucene.analysis.it.ItalianAnalyzer;
+import org.apache.lucene.analysis.nl.DutchAnalyzer;
+import org.apache.lucene.analysis.no.NorwegianAnalyzer;
+import org.apache.lucene.analysis.pt.PortugueseAnalyzer;
+import org.apache.lucene.analysis.ro.RomanianAnalyzer;
+import org.apache.lucene.analysis.ru.RussianAnalyzer;
+import org.apache.lucene.analysis.sv.SwedishAnalyzer;
+import org.apache.lucene.analysis.th.ThaiAnalyzer;
+import org.apache.lucene.analysis.tr.TurkishAnalyzer;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Spits out custom analyzer configuration required to reproduce builtin analyzers.
+ */
+public class StandardBuiltinAsCustom implements BuiltinAsCustom {
+    @Override
+    public boolean build(XContentBuilder builder, String name) throws IOException {
+        if ("standard".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "standard", "standard", "standard", "lowercase");
+            return true;
+        }
+        if ("simple".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "simple", "lowercase");
+            return true;
+        }
+        if ("keyword".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "keyword", "keyword");
+            return true;
+        }
+        if ("whitespace".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "whitespace", "whitespace");
+            return true;
+        }
+        if ("stop".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "stop", "lowercase", "stop");
+            builder.startObject("filter");
+            buildStop(builder, "english", EnglishAnalyzer.getDefaultStopSet());
+            builder.endObject();
+            return true;
+        }
+        if ("snowball".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "snowball", "standard", "standard", "possessive_english_stemmer", "lowercase", "english_stop",
+                    "english_snowball");
+            builder.startObject("filter");
+            buildStemmer(builder, "possessive_english");
+            buildStop(builder, "english", EnglishAnalyzer.getDefaultStopSet());
+            builder.startObject("english_snowball");
+            builder.field("type", "snowball");
+            builder.field("language", "English");
+            builder.endObject();
+            builder.endObject();
+            return true;
+        }
+        if ("arabic".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "arabic", "standard", "standard", "lowercase", "arabic_stop", "arabic_normalization", "arabic_stem");
+            builder.startObject("filter");
+            buildStop(builder, "arabic", ArabicAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "arabic");
+            builder.endObject();
+            return true;
+        }
+        if ("armenian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "armenian", ArmenianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("basque".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "basque", BasqueAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("brazilian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "brazilian", BrazilianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("bulgarian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "bulgarian", BulgarianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("catalan".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "catalan", "standard", "standard", "catalan_elision", "lowercase", "catalan_stop", "catalan_stemmer");
+            builder.startObject("filter");
+            // The default articles are private.....
+            buildElision(builder, "catalan", "d", "l", "m", "n", "s", "t");
+            buildStop(builder, "catalan", CatalanAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "catalan");
+            builder.endObject();
+            return true;
+        }
+        if ("chinese".equalsIgnoreCase(name)) {
+            throw new IllegalArgumentException(
+                    "The chinese analyzer is deprecated.  Use the Standard analyzer or the smart Chinese plugin instead.");
+        }
+        if ("cjk".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "cjk", "standard", "cjk_width", "lowercase", "cjk_bigram", "cjk_stop");
+            builder.startObject("filter");
+            buildStop(builder, "cjk", CJKAnalyzer.getDefaultStopSet());
+            builder.endObject();
+            return true;
+        }
+        if ("czech".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "czech", CzechAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("danish".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "danish", DanishAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("dutch".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "dutch", "standard", "standard", "lowercase", "dutch_stop", "dutch_stemmer_override", "dutch_stemmer");
+            builder.startObject("filter");
+            buildStop(builder, "dutch", DutchAnalyzer.getDefaultStopSet());
+            builder.startObject("dutch_stemmer_override");
+            builder.field("type", "stemmer_override");
+            builder.startArray("rules");
+            // Have to manually specify the rules because they are private in lucene....
+            builder.value("fiets => fiets");
+            builder.value("bromfiets => bromfiets");
+            builder.value("ei => eier");
+            builder.value("kind => kinder");
+            builder.endArray();
+            builder.endObject();
+            buildStemmer(builder, "dutch");
+            builder.endObject();
+            return true;
+        }
+        if ("english".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "english", "standard", "standard", "possessive_english_stemmer", "lowercase", "english_stop", "porter_stem");
+            builder.startObject("filter");
+            buildStemmer(builder, "possessive_english");
+            buildStop(builder, "english", EnglishAnalyzer.getDefaultStopSet());
+            builder.endObject();
+            return true;
+        }
+        if ("finnish".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "finnish", FinnishAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("french".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "french", "standard", "standard", "elision", "lowercase", "french_stop", "light_french_stemmer");
+            builder.startObject("filter");
+            buildStop(builder, "french", FrenchAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "light_french");
+            builder.endObject();
+            return true;
+        }
+        if ("galician".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "galician", GalicianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("german".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "german", "standard", "standard", "lowercase", "german_stop", "german_normalization", "light_german_stemmer");
+            builder.startObject("filter");
+            buildStop(builder, "german", GermanAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "light_german");
+            builder.endObject();
+            return true;
+        }
+        if ("greek".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "greek", "standard", "greek_lowercase", "standard", "greek_stop", "greek_stemmer");
+            builder.startObject("filter");
+            buildLowercase(builder, "greek");
+            buildStop(builder, "greek", GreekAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "greek");
+            builder.endObject();
+            return true;
+        }
+        if ("hindi".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "hindi", "standard", "lowercase", "indic_normalization", "hindi_normalization", "hindi_stop", "hindi_stemmer");
+            builder.startObject("filter");
+            buildStop(builder, "hindi", HindiAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "hindi");
+            builder.endObject();
+            return true;
+        }
+        if ("hungarian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "hungarian", HungarianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("indonesian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "indonesian", IndonesianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("italian".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "italian", "standard", "standard", "italian_elision", "lowercase", "italian_stop", "light_italian_stemmer");
+            builder.startObject("filter");
+            // The default articles are private.....
+            buildElision(builder, "italian", "c", "l", "all", "dall", "dell", "nell", "sull", "coll", "pell", "gl", "agl", "dagl", "degl",
+                    "negl", "sugl", "un", "m", "t", "s", "v", "d");
+            buildStop(builder, "italian", ItalianAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "light_italian");
+            builder.endObject();
+            return true;
+        }
+        if ("norwegian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "norwegian", NorwegianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("persian".equalsIgnoreCase(name)) {
+            // Since Persian uses a char_filter it can't use buildAnalyzer
+            builder.startObject("analyzer");
+            builder.startObject("custom_persian");
+            builder.field("type", "custom");
+            builder.field("tokenizer", "standard");
+            builder.array("filter", "lowercase", "arabic_normalization", "persian_normalization", "persian_stop");
+            builder.array("char_filter", "persian");
+            builder.endObject();
+            builder.endObject();
+            builder.startObject("filter");
+            buildStop(builder, "persian", PersianAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "persian");
+            builder.endObject();
+            builder.startObject("char_filter");
+            builder.startObject("persian");
+            builder.field("type", "persian");
+            builder.endObject();
+            builder.endObject();
+            return true;
+        }
+        if ("portuguese".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "portuguese", PortugueseAnalyzer.getDefaultStopSet(), "light_");
+            return true;
+        }
+        if ("romanian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "romanian", RomanianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("russian".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "russian", RussianAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("spanish".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "spanish", SpanishAnalyzer.getDefaultStopSet(), "light_");
+            return true;
+        }
+        if ("swedish".equalsIgnoreCase(name)) {
+            buildStandardLanguage(builder, "swedish", SwedishAnalyzer.getDefaultStopSet());
+            return true;
+        }
+        if ("turkish".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "turkish", "standard", "turkish_lowercase", "standard", "turkish_stop", "turkish_stemmer");
+            builder.startObject("filter");
+            buildLowercase(builder, "turkish");
+            buildStop(builder, "turkish", TurkishAnalyzer.getDefaultStopSet());
+            buildStemmer(builder, "turkish");
+            builder.endObject();
+            return true;
+        }
+        if ("thai".equalsIgnoreCase(name)) {
+            buildAnalyzer(builder, "thai", "standard", "standard", "lowercase", "thai_word", "thai_stop");
+            builder.startObject("filter");
+            builder.startObject("thai_word");
+            builder.field("type", "thai_word");
+            builder.endObject();
+            buildStop(builder, "thai", ThaiAnalyzer.getDefaultStopSet());
+            builder.endObject();
+            return true;
+        }
+        return false;
+    }
+
+    private void buildAnalyzer(XContentBuilder builder, String name, String tokenizer, String... filters) throws IOException {
+        builder.startObject("analyzer");
+        builder.startObject("custom_" + name);
+        builder.field("type", "custom");
+        builder.field("tokenizer", tokenizer);
+        builder.array("filter", filters);
+        builder.endObject();
+        builder.endObject();
+    }
+
+    private void buildStandardLanguage(XContentBuilder builder, String name, CharArraySet stopSet) throws IOException {
+        buildStandardLanguage(builder, name, stopSet, "");
+    }
+
+    /**
+     * Build a language with the "standard" set of filters.
+     */
+    private void buildStandardLanguage(XContentBuilder builder, String name, CharArraySet stopSet, String stemmerNamePrefix) throws IOException {
+        buildAnalyzer(builder, name, "standard", "standard", "lowercase", name + "_stop", stemmerNamePrefix + name + "_stemmer");
+        builder.startObject("filter");
+        buildStop(builder, name, stopSet);
+        buildStemmer(builder, stemmerNamePrefix + name);
+        builder.endObject();
+    }
+
+    private void buildStop(XContentBuilder builder, String name, CharArraySet set) throws IOException {
+        builder.startObject(name + "_stop");
+        builder.field("type", "stop");
+        builder.startArray("stopwords");
+        for (Object o : set) {
+            builder.value(new String((char[]) o));
+        }
+        builder.endArray();
+        builder.endObject();
+    }
+    
+    private void buildStemmer(XContentBuilder builder, String language) throws IOException {
+        builder.startObject(language + "_stemmer");
+        builder.field("type", "stemmer");
+        builder.field("language", language);
+        builder.endObject();
+    }
+
+    private void buildElision(XContentBuilder builder, String language, String... articles) throws IOException {
+        builder.startObject(language + "_elision");
+        builder.field("type", "elision");
+        builder.field("articles", articles);
+        builder.field("articles_case", true);
+        builder.endObject();
+    }
+
+    private void buildLowercase(XContentBuilder builder, String language) throws IOException {
+        builder.startObject(language + "_lowercase");
+        builder.field("type", "lowercase");
+        builder.field("language", language);
+        builder.endObject();
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
@@ -35,6 +35,7 @@ import org.apache.lucene.analysis.es.SpanishLightStemFilter;
 import org.apache.lucene.analysis.fi.FinnishLightStemFilter;
 import org.apache.lucene.analysis.fr.FrenchLightStemFilter;
 import org.apache.lucene.analysis.fr.FrenchMinimalStemFilter;
+import org.apache.lucene.analysis.gl.GalicianStemFilter;
 import org.apache.lucene.analysis.hi.HindiStemFilter;
 import org.apache.lucene.analysis.hu.HungarianLightStemFilter;
 import org.apache.lucene.analysis.id.IndonesianStemFilter;
@@ -93,6 +94,8 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
             return new SnowballFilter(tokenStream, new FinnishStemmer());
         } else if ("french".equalsIgnoreCase(language)) {
             return new SnowballFilter(tokenStream, new FrenchStemmer());
+        } else if ("galician".equalsIgnoreCase(language)) {
+            return new GalicianStemFilter(tokenStream);
         } else if ("german".equalsIgnoreCase(language)) {
             return new SnowballFilter(tokenStream, new GermanStemmer());
         } else if ("german2".equalsIgnoreCase(language)) {

--- a/src/main/java/org/elasticsearch/index/analysis/ThaiWordTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ThaiWordTokenFilterFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.th.ThaiWordFilter;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.assistedinject.Assisted;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettings;
+
+public class ThaiWordTokenFilterFactory extends AbstractTokenFilterFactory {
+    @Inject
+    public ThaiWordTokenFilterFactory(Index index, @IndexSettings Settings indexSettings, @Assisted String name,
+            @Assisted Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new ThaiWordFilter(version, tokenStream);
+    }
+}

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -64,6 +64,7 @@ import org.elasticsearch.gateway.GatewayModule;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.http.HttpServerModule;
+import org.elasticsearch.index.analysis.BuiltinAsCustomModule;
 import org.elasticsearch.index.search.shape.ShapeModule;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
@@ -185,6 +186,7 @@ public final class InternalNode implements Node {
         modules.add(new RepositoriesModule());
         modules.add(new TribeModule());
         modules.add(new BenchmarkModule());
+        modules.add(new BuiltinAsCustomModule());
 
         injector = modules.createInjector();
 

--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -64,6 +64,7 @@ import org.elasticsearch.rest.action.admin.indices.mapping.get.RestGetMappingAct
 import org.elasticsearch.rest.action.admin.indices.mapping.put.RestPutMappingAction;
 import org.elasticsearch.rest.action.admin.indices.open.RestOpenIndexAction;
 import org.elasticsearch.rest.action.admin.indices.optimize.RestOptimizeAction;
+import org.elasticsearch.rest.action.admin.indices.recovery.RestRecoveryAction;
 import org.elasticsearch.rest.action.admin.indices.refresh.RestRefreshAction;
 import org.elasticsearch.rest.action.admin.indices.segments.RestIndicesSegmentsAction;
 import org.elasticsearch.rest.action.admin.indices.settings.RestGetSettingsAction;
@@ -78,7 +79,7 @@ import org.elasticsearch.rest.action.admin.indices.validate.query.RestValidateQu
 import org.elasticsearch.rest.action.admin.indices.warmer.delete.RestDeleteWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.get.RestGetWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.put.RestPutWarmerAction;
-import org.elasticsearch.rest.action.admin.indices.recovery.RestRecoveryAction;
+import org.elasticsearch.rest.action.analyzer.RestAnalyzerAction;
 import org.elasticsearch.rest.action.bench.RestBenchAction;
 import org.elasticsearch.rest.action.bulk.RestBulkAction;
 import org.elasticsearch.rest.action.cat.*;
@@ -214,6 +215,8 @@ public class RestActionModule extends AbstractModule {
         bind(RestRecoveryAction.class).asEagerSingleton();
         // Benchmark API
         bind(RestBenchAction.class).asEagerSingleton();
+
+        bind(RestAnalyzerAction.class).asEagerSingleton();
 
         // cat API
         Multibinder<AbstractCatAction> catActionMultibinder = Multibinder.newSetBinder(binder(), AbstractCatAction.class);

--- a/src/main/java/org/elasticsearch/rest/action/analyzer/RestAnalyzerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/analyzer/RestAnalyzerAction.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.analyzer;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.analysis.BuiltinAsCustom;
+import org.elasticsearch.rest.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+/**
+ * Rest action exposing json to build builtin analyzers as custom analyzer. To
+ * be used for customizing builtin analyzers.
+ */
+public class RestAnalyzerAction extends BaseRestHandler {
+    private final Set<BuiltinAsCustom> builtinAsCustoms;
+
+    @Inject
+    public RestAnalyzerAction(Settings settings, Client client, RestController controller, Set<BuiltinAsCustom> builtinAsCustoms) {
+        super(settings, client);
+        this.builtinAsCustoms = builtinAsCustoms;
+        controller.registerHandler(GET, "/_analyzer/{name}", this);
+    }
+
+    @Override
+    public void handleRequest(RestRequest request, RestChannel channel) throws Exception {
+        XContentType xContentType = XContentType.fromRestContentType(request.param("format", request.header("Content-Type")));
+        if (xContentType == null) {
+            xContentType = XContentType.JSON;
+        }
+        
+        Map<String, Object> result = new HashMap<String, Object>();
+        for (String name: Strings.splitStringByCommaToArray(request.param("name"))) {
+            name = name.trim();
+            XContentBuilder builder = XContentBuilder.builder(xContentType.xContent());
+            builder.startObject();
+            boolean found = false;
+            for (BuiltinAsCustom builtinAsCustom: builtinAsCustoms) {
+                try {
+                    if (builtinAsCustom.build(builder, name)) {
+                        found = true;
+                        break;
+                    }
+                } catch (IllegalArgumentException e) {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, e.getMessage()));
+                    return;
+                }
+            }
+            if (!found) {
+                channel.sendResponse(new BytesRestResponse(RestStatus.NOT_FOUND, "Could not find configuration to build " + name
+                        + " as a custom analyzer."));
+            }
+            builder.endObject();
+            XContentHelper.update(result, XContentHelper.convertToMap(builder.bytes(), false).v2());
+        }
+        XContentBuilder builder = XContentBuilder.builder(xContentType.xContent());
+        channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder.map(result)));
+    }
+}

--- a/src/test/java/org/elasticsearch/index/analysis/AbstractBuiltinAsCustomTestBase.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AbstractBuiltinAsCustomTestBase.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Splitter;
+import com.google.common.io.Resources;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.*;
+import org.apache.lucene.util._TestUtil;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ElasticsearchTokenStreamTestCase;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base class for testing BuiltinAsCustom implementations. Plugins that define
+ * builtin analyzers should extend this to test their implementation of
+ * BuiltinAsCustom.
+ */
+public abstract class AbstractBuiltinAsCustomTestBase extends ElasticsearchTokenStreamTestCase {
+    private static final int ROUNDS = 20;
+    private static final List<String> EXAMPLES;
+    static {
+        URL resource = Resources.getResource(StandardBuiltinAsCustomTest.class, "builtin_as_custom_examples.txt");
+        Splitter splitter = Splitter.on('\n').trimResults().omitEmptyStrings();
+        try {
+            EXAMPLES = splitter.splitToList(Resources.toString(resource, Charsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected abstract BuiltinAsCustom buildBuiltinAsCustom();
+
+    /**
+     * Implement me in subclasses to add extra examples that must parse the
+     * same.
+     */
+    protected List<String> extraExamples() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Rebuild the builtin analyzer as a custom analyzer and throw a bunch of
+     * strings at both of them to make sure they spit out the same tokens.
+     * 
+     * @param builtinName
+     *            name of builtin analyzer to rebuild as a custom analyzer and
+     *            test
+     * @throws IOException
+     *             if thrown by the analyzers
+     */
+    protected void check(String builtinName) throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(JsonXContent.jsonXContent);
+        builder.startObject().startObject("index").startObject("analysis");
+        buildBuiltinAsCustom().build(builder, builtinName);
+        builder.endObject().endObject().endObject();
+        Settings settings = ImmutableSettings.settingsBuilder().loadFromSource(builder.string()).build();
+        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(settings);
+        Analyzer builtin = analysisService.analyzer(builtinName);
+        Analyzer custom = analysisService.analyzer("custom_" + builtinName);
+
+        // Both exist
+        assertNotNull(builtin);
+        assertNotNull(custom);
+
+        // Sanity checks
+        checkRandomData(random(), builtin, ROUNDS);
+        checkRandomData(random(), custom, ROUNDS);
+
+        // Now test some strings
+        for (String example : EXAMPLES) {
+            checkSame(builtin, custom, example);
+        }
+        for (String example : extraExamples()) {
+            checkSame(builtin, custom, example);
+        }
+        for (int i = 0; i < ROUNDS; i++) {
+            checkSame(builtin, custom, _TestUtil.randomAnalysisString(random(), 1000, false));
+        }
+    }
+
+    private void checkSame(Analyzer builtin, Analyzer custom, String input) throws IOException {
+        TokenStream builtinStream = builtin.tokenStream("dummy", input);
+        TokenStream customStream = custom.tokenStream("dummy", input);
+
+        builtinStream.reset();
+        customStream.reset();
+
+        CharTermAttribute builtinTerm = builtinStream.addAttribute(CharTermAttribute.class);
+        CharTermAttribute customTerm = customStream.addAttribute(CharTermAttribute.class);
+        OffsetAttribute builtinOffset = builtinStream.addAttribute(OffsetAttribute.class);
+        OffsetAttribute customOffset = customStream.addAttribute(OffsetAttribute.class);
+        TypeAttribute builtinType = builtinStream.addAttribute(TypeAttribute.class);
+        TypeAttribute customType = customStream.addAttribute(TypeAttribute.class);
+        PositionIncrementAttribute builtinPositionIncrement = builtinStream.addAttribute(PositionIncrementAttribute.class);
+        PositionIncrementAttribute customPositionIncrement = customStream.addAttribute(PositionIncrementAttribute.class);
+        PositionLengthAttribute builtinPositionLength = builtinStream.addAttribute(PositionLengthAttribute.class);
+        PositionLengthAttribute customPositionLength = customStream.addAttribute(PositionLengthAttribute.class);
+        KeywordAttribute builtinKeywordMarker = builtinStream.addAttribute(KeywordAttribute.class);
+        KeywordAttribute customKeywordMarker = customStream.addAttribute(KeywordAttribute.class);
+
+        while (builtinStream.incrementToken()) {
+            assertTrue("Custom ran out of tokens before builtin", customStream.incrementToken());
+            assertEquals(builtinTerm, customTerm);
+            assertEquals(builtinOffset, customOffset);
+            assertEquals(builtinType, customType);
+            assertEquals(builtinPositionIncrement, customPositionIncrement);
+            assertEquals(builtinPositionLength, customPositionLength);
+            assertEquals(builtinKeywordMarker, customKeywordMarker);
+        }
+
+        assertFalse("Custom still had tokens after builtin", customStream.incrementToken());
+        builtinStream.end();
+        customStream.end();
+        builtinStream.close();
+        customStream.close();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/index/analysis/StandardBuiltinAsCustomTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/StandardBuiltinAsCustomTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class StandardBuiltinAsCustomTest extends AbstractBuiltinAsCustomTestBase {
+    @Override
+    protected BuiltinAsCustom buildBuiltinAsCustom() {
+        return new StandardBuiltinAsCustom();
+    }
+
+    @Test
+    public void keyword() throws IOException {
+        check("keyword");
+    }
+    @Test
+    public void simple() throws IOException {
+        check("simple");
+    }
+    @Test
+    public void whitespace() throws IOException {
+        check("whitespace");
+    }
+    @Test
+    public void stop() throws IOException {
+        check("stop");
+    }
+    @Test
+    public void snowball() throws IOException {
+        check("snowball");
+    }
+    @Test
+    public void standard() throws IOException {
+        check("standard");
+    }
+    @Test
+    public void arabic() throws IOException {
+        check("arabic");
+    }
+    @Test
+    public void armenian() throws IOException {
+        check("armenian");
+    }
+    @Test
+    public void basque() throws IOException {
+        check("basque");
+    }
+    @Test
+    public void brazillian() throws IOException {
+        check("brazilian");
+    }
+    @Test
+    public void bulgarian() throws IOException {
+        check("bulgarian");
+    }
+    @Test
+    public void catalan() throws IOException {
+        check("catalan");
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void chinese() throws IOException {
+        new StandardBuiltinAsCustom().build(XContentBuilder.builder(JsonXContent.jsonXContent), "chinese");
+    }
+    @Test
+    public void cjk() throws IOException {
+        check("cjk");
+    }
+    @Test
+    public void czech() throws IOException {
+        check("czech");
+    }
+    @Test
+    public void danish() throws IOException {
+        check("danish");
+    }
+    @Test
+    public void dutch() throws IOException {
+        check("dutch");
+    }
+    @Test
+    public void english() throws IOException {
+        check("english");
+    }
+    @Test
+    public void finnish() throws IOException {
+        check("finnish");
+    }
+    @Test
+    public void french() throws IOException {
+        check("french");
+    }
+    @Test
+    public void galician() throws IOException {
+        check("galician");
+    }
+    @Test
+    public void german() throws IOException {
+        check("german");
+    }
+    @Test
+    public void greek() throws IOException {
+        check("greek");
+    }
+    @Test
+    public void hindi() throws IOException {
+        check("hindi");
+    }
+    @Test
+    public void hungarian() throws IOException {
+        check("hungarian");
+    }
+    @Test
+    public void indonesian() throws IOException {
+        check("indonesian");
+    }
+    @Test
+    public void italian() throws IOException {
+        check("italian");
+    }
+    @Test
+    public void norwegian() throws IOException {
+        check("norwegian");
+    }
+    @Test
+    public void persian() throws IOException {
+        check("persian");
+    }
+    @Test
+    public void portuguese() throws IOException {
+        check("portuguese");
+    }
+    @Test
+    public void romanian() throws IOException {
+        check("romanian");
+    }
+    @Test
+    public void russian() throws IOException {
+        check("russian");
+    }
+    @Test
+    public void spanish() throws IOException {
+        check("spanish");
+    }
+    @Test
+    public void swedish() throws IOException {
+        check("swedish");
+    }
+    @Test
+    public void turkish() throws IOException {
+        check("turkish");
+    }
+    @Test
+    public void thai() throws IOException {
+        check("thai");
+    }
+}

--- a/src/test/java/org/elasticsearch/index/analysis/builtin_as_custom_examples.txt
+++ b/src/test/java/org/elasticsearch/index/analysis/builtin_as_custom_examples.txt
@@ -1,0 +1,42 @@
+ويمكنني أن أكل الزجاج، فإنه لا يؤذيني
+Ես կարող եմ ուտել ապակի, դա չի խանգարում ինձ
+Beira dut jan daiteke, ez du minik niri
+Consigo comer vidro. Não me machuca.
+Мога да ям стъкло, тя не ме боли
+Puc menjar vidre, que no em fa mal
+我可以吃玻璃，它不会伤害我
+我可以吃玻璃，它不會傷害我
+私はガラスを食べることができ、それは私を傷つけることはありません。
+나는 유리를 먹을 수있는, 그것은 나를 다치게하지 않습니다
+Můžu jíst sklo, to mě bolí
+Jeg kan spise glas, gør det ikke ondt mig
+Ik kan glas eet, doet het me geen pijn
+I can eat glass, it does not hurt me.
+Voin syödä lasia, se ei satuta minua
+Je peux manger verre, ça ne me fait pas de mal
+Podo comer vidro, non me machucar
+Ich kann Glas essen, ist es mir nicht weh
+Μπορώ να φάω το γυαλί, δεν μου κάνει κακό
+मैं कांच खा सकते हैं, यह मुझे चोट नहीं करता है
+Tudok enni üveg, nem fáj nekem
+Aku bisa makan kaca, itu tidak menyakiti saya
+Jeg kan spise glass, gjør det ikke vondt meg
+من می توانم شیشه خوردن، آن را به من صدمه دیده است
+Eu posso comer vidro, ele não me machucar
+Eu pot mânca de sticlă, nu-mi face rău
+Я могу съесть стакан, это не мне больно
+Puedo comer vidrio, que no me duele
+Jag kan äta glas, inte skada mig
+Ben cam yiyebilir, o bana zarar vermez
+
+ฉันสามารถกินแก้วจะไม่ทำร้ายฉัน
+
+
+Stem overrides (Danish):
+kind kinder fiets bromfiets ei eier
+
+Normlization (German, Hindi):
+groß gross वाङ्मय वाङ्‍मय वाङ‍्मय वाङ्‌मय
+
+Elision filters (Italian, Catalan, and French must see these differently):
+l'appariscenza c'era M'Pessoba Puisqu’il


### PR DESCRIPTION
This endpoint provides a starting point for folks that want to customize
the builtin analyzers beyond the customization allowed on the analyzer:
it returns several builtin analyzers as custom analyzers.  From there
customization is just adding or subtracting filters.

Closes #5648
