### PR TITLE
Switch back to ConcurrentMergeScheduler

### DIFF
--- a/docs/reference/index-modules/merge.asciidoc
+++ b/docs/reference/index-modules/merge.asciidoc
@@ -187,11 +187,7 @@ Defaults to unbounded.
 
 The merge schedule controls the execution of merge operations once they
 are needed (according to the merge policy). The following types are
-supported, with the default being the `SerialMergeScheduler`.
-
-Note, the default is the serial merge scheduler since there is a merge
-thread pool that explicitly schedules merges, and it makes sure that
-merges are serial within a shard, yet concurrent across multiple shards.
+supported, with the default being the `ConcurrentMergeScheduler`.
 
 [float]
 ==== ConcurrentMergeScheduler

--- a/docs/reference/index-modules/merge.asciidoc
+++ b/docs/reference/index-modules/merge.asciidoc
@@ -209,4 +209,16 @@ The maximum number of threads to perform the merge operation. Defaults to
 
 A merge scheduler that simply does each merge sequentially using the
 calling thread (blocking the operations that triggered the merge or the
-index operation).
+index operation). This merge scheduler has a merge thread pool that
+explicitly schedules merges, and it makes sure that merges are serial
+within a shard, yet concurrent across multiple shards.
+
+The scheduler supports the following settings:
+
+`index.merge.scheduler.max_merge_at_once`::
+
+The maximum number of merges a single merge run performs. This setting prevents
+executing unlimited amount of merges in a loop until another shards has a
+chance to get a merge thread from the pool. If this limit is reached the
+merge thread returns to the pool and continues once the the call to a single
+shards is executed. The default is `5`

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/MergeSchedulerModule.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/MergeSchedulerModule.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 public class MergeSchedulerModule extends AbstractModule {
 
     public static final String MERGE_SCHEDULER_TYPE_KEY = "index.merge.scheduler.type";
-    public static final Class<? extends MergeSchedulerProvider> DEFAULT = SerialMergeSchedulerProvider.class;
+    public static final Class<? extends MergeSchedulerProvider> DEFAULT = ConcurrentMergeSchedulerProvider.class;
 
     private final Settings settings;
 


### PR DESCRIPTION
Load tests showed that SerialMS has problems to keep up with
the merges under high load. We should switch back to CMS
until we have a better story to balance merge
threads / efforts across shards on a single node.

Closes #5817
