### PR TITLE
Instantiate facets/aggregations during the QUERY phase.

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -22,10 +22,7 @@ package org.elasticsearch.action.search.type;
 import com.carrotsearch.hppc.IntArrayList;
 import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.search.ReduceSearchPhaseException;
-import org.elasticsearch.action.search.SearchOperationThreading;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.*;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -170,7 +167,11 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
             this.addShardFailure(shardIndex, dfsResult.shardTarget(), t);
             successfulOps.decrementAndGet();
             if (counter.decrementAndGet() == 0) {
-                executeFetchPhase();
+                if (successfulOps.get() == 0) {
+                    listener.onFailure(new SearchPhaseExecutionException("query", "all shards failed", buildShardFailures()));
+                } else {
+                    executeFetchPhase();
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -84,9 +84,7 @@ public abstract class Aggregator implements Releasable, ReaderContextAware {
         assert factories != null : "sub-factories provided to BucketAggregator must not be null, use AggragatorFactories.EMPTY instead";
         this.factories = factories;
         this.subAggregators = factories.createSubAggregators(this, estimatedBucketsCount);
-        // TODO: change it to SEARCH_PHASE, but this would imply allocating the aggregators in the QUERY
-        // phase instead of DFS like it is done today
-        context.searchContext().addReleasable(this, Lifetime.CONTEXT);
+        context.searchContext().addReleasable(this, Lifetime.PHASE);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -89,11 +89,15 @@ public class QueryPhase implements SearchPhase {
     @Override
     public void preProcess(SearchContext context) {
         context.preProcess();
-        facetPhase.preProcess(context);
-        aggregationPhase.preProcess(context);
     }
 
     public void execute(SearchContext searchContext) throws QueryPhaseExecutionException {
+        // Pre-process facets and aggregations as late as possible. In the case of a DFS_Q_T_F
+        // request, preProcess is called on the DFS phase phase, this is why we pre-process them
+        // here to make sure it happens during the QUERY phase
+        facetPhase.preProcess(searchContext);
+        aggregationPhase.preProcess(searchContext);
+
         searchContext.queryResult().searchTimedOut(false);
 
         searchContext.searcher().inStage(ContextIndexSearcher.Stage.MAIN_QUERY);


### PR DESCRIPTION
In case of a DFS_QUERY_THEN_FETCH request, facets and aggregations are currently
instantiated during the DFS phase while they only become useful during the QUERY
phase. By instantiating during the QUERY phase instead, we can make better use
of recycling since objects will have a shorter life out of the recyclers.
