### PR TITLE
Include name of the field that caused a circuit break in the log and exception message

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/RamAccountingTermsEnum.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/RamAccountingTermsEnum.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.FilteredTermsEnum;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.MemoryCircuitBreaker;
-import org.elasticsearch.index.fielddata.AbstractIndexFieldData;
 
 import java.io.IOException;
 
@@ -39,15 +38,18 @@ public final class RamAccountingTermsEnum extends FilteredTermsEnum {
     private final MemoryCircuitBreaker breaker;
     private final TermsEnum termsEnum;
     private final AbstractIndexFieldData.PerValueEstimator estimator;
+    private final String fieldName;
     private long totalBytes;
     private long flushBuffer;
 
 
-    public RamAccountingTermsEnum(TermsEnum termsEnum, MemoryCircuitBreaker breaker, AbstractIndexFieldData.PerValueEstimator estimator) {
+    public RamAccountingTermsEnum(TermsEnum termsEnum, MemoryCircuitBreaker breaker, AbstractIndexFieldData.PerValueEstimator estimator,
+                                  String fieldName) {
         super(termsEnum);
         this.breaker = breaker;
         this.termsEnum = termsEnum;
         this.estimator = estimator;
+        this.fieldName = fieldName;
         this.totalBytes = 0;
         this.flushBuffer = 0;
     }
@@ -65,7 +67,7 @@ public final class RamAccountingTermsEnum extends FilteredTermsEnum {
      * bytes and resetting the buffer.
      */
     public void flush() {
-        breaker.addEstimateBytesAndMaybeBreak(this.flushBuffer);
+        breaker.addEstimateBytesAndMaybeBreak(this.flushBuffer, this.fieldName);
         this.totalBytes += this.flushBuffer;
         this.flushBuffer = 0;
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -99,7 +99,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
         AtomicReader reader = context.reader();
         Terms terms = reader.terms(getFieldNames().indexName());
         PackedArrayAtomicFieldData data = null;
-        PackedArrayEstimator estimator = new PackedArrayEstimator(breakerService.getBreaker(), getNumericType());
+        PackedArrayEstimator estimator = new PackedArrayEstimator(breakerService.getBreaker(), getNumericType(), getFieldNames().fullName());
         if (terms == null) {
             data = PackedArrayAtomicFieldData.empty(reader.maxDoc());
             estimator.adjustForNoTerms(data.getMemorySizeInBytes());
@@ -335,10 +335,12 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
 
         private final MemoryCircuitBreaker breaker;
         private final NumericType type;
+        private final String fieldName;
 
-        public PackedArrayEstimator(MemoryCircuitBreaker breaker, NumericType type) {
+        public PackedArrayEstimator(MemoryCircuitBreaker breaker, NumericType type, String fieldName) {
             this.breaker = breaker;
             this.type = type;
+            this.fieldName = fieldName;
         }
 
         /**
@@ -357,7 +359,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
          */
         @Override
         public TermsEnum beforeLoad(Terms terms) throws IOException {
-            return new RamAccountingTermsEnum(type.wrapTermsEnum(terms.iterator(null)), breaker, this);
+            return new RamAccountingTermsEnum(type.wrapTermsEnum(terms.iterator(null)), breaker, this, this.fieldName);
         }
 
         /**

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -63,7 +63,7 @@ public class PagedBytesIndexFieldData extends AbstractBytesIndexFieldData<PagedB
     public PagedBytesAtomicFieldData loadDirect(AtomicReaderContext context) throws Exception {
         AtomicReader reader = context.reader();
 
-        PagedBytesEstimator estimator = new PagedBytesEstimator(context, breakerService.getBreaker());
+        PagedBytesEstimator estimator = new PagedBytesEstimator(context, breakerService.getBreaker(), getFieldNames().fullName());
         Terms terms = reader.terms(getFieldNames().indexName());
         if (terms == null) {
             PagedBytesAtomicFieldData emptyData = PagedBytesAtomicFieldData.empty(reader.maxDoc());
@@ -133,11 +133,13 @@ public class PagedBytesIndexFieldData extends AbstractBytesIndexFieldData<PagedB
 
         private final AtomicReaderContext context;
         private final MemoryCircuitBreaker breaker;
+        private final String fieldName;
         private long estimatedBytes;
 
-        PagedBytesEstimator(AtomicReaderContext context, MemoryCircuitBreaker breaker) {
+        PagedBytesEstimator(AtomicReaderContext context, MemoryCircuitBreaker breaker, String fieldName) {
             this.breaker = breaker;
             this.context = context;
+            this.fieldName = fieldName;
         }
 
         /**
@@ -210,15 +212,15 @@ public class PagedBytesIndexFieldData extends AbstractBytesIndexFieldData<PagedB
                 if (logger.isTraceEnabled()) {
                     logger.trace("Filter exists, can't circuit break normally, using RamAccountingTermsEnum");
                 }
-                return new RamAccountingTermsEnum(filter(terms, reader), breaker, this);
+                return new RamAccountingTermsEnum(filter(terms, reader), breaker, this, this.fieldName);
             } else {
                 estimatedBytes = this.estimateStringFieldData();
                 // If we weren't able to estimate, wrap in the RamAccountingTermsEnum
                 if (estimatedBytes == 0) {
-                    return new RamAccountingTermsEnum(filter(terms, reader), breaker, this);
+                    return new RamAccountingTermsEnum(filter(terms, reader), breaker, this, this.fieldName);
                 }
 
-                breaker.addEstimateBytesAndMaybeBreak(estimatedBytes);
+                breaker.addEstimateBytesAndMaybeBreak(estimatedBytes, fieldName);
                 return filter(terms, reader);
             }
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -239,7 +239,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<ParentChil
          */
         @Override
         public TermsEnum beforeLoad(Terms terms) throws IOException {
-            return new RamAccountingTermsEnum(filteredEnum, breaker, this);
+            return new RamAccountingTermsEnum(filteredEnum, breaker, this, "parent/child id cache");
         }
 
         /**

--- a/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreakerTests.java
+++ b/src/test/java/org/elasticsearch/common/breaker/MemoryCircuitBreakerTests.java
@@ -49,7 +49,7 @@ public class MemoryCircuitBreakerTests extends ElasticsearchTestCase {
                 public void run() {
                     for (int j = 0; j < BYTES_PER_THREAD; j++) {
                         try {
-                            breaker.addEstimateBytesAndMaybeBreak(1L);
+                            breaker.addEstimateBytesAndMaybeBreak(1L, "test");
                         } catch (CircuitBreakingException e) {
                             if (tripped.get()) {
                                 assertThat("tripped too many times", true, equalTo(false));
@@ -77,19 +77,20 @@ public class MemoryCircuitBreakerTests extends ElasticsearchTestCase {
     @Test
     public void testConstantFactor() throws Exception {
         final MemoryCircuitBreaker breaker = new MemoryCircuitBreaker(new ByteSizeValue(15), 1.6, logger);
+        String field = "myfield";
 
         // add only 7 bytes
         breaker.addWithoutBreaking(7);
 
         try {
             // this won't actually add it because it trips the breaker
-            breaker.addEstimateBytesAndMaybeBreak(3);
+            breaker.addEstimateBytesAndMaybeBreak(3, field);
             fail("should never reach this");
         } catch (CircuitBreakingException cbe) {
         }
 
         // shouldn't throw an exception
-        breaker.addEstimateBytesAndMaybeBreak(2);
+        breaker.addEstimateBytesAndMaybeBreak(2, field);
 
         assertThat(breaker.getUsed(), equalTo(9L));
 
@@ -98,9 +99,10 @@ public class MemoryCircuitBreakerTests extends ElasticsearchTestCase {
 
         try {
             // Adding no bytes still breaks
-            breaker.addEstimateBytesAndMaybeBreak(0);
+            breaker.addEstimateBytesAndMaybeBreak(0, field);
             fail("should never reach this");
         } catch (CircuitBreakingException cbe) {
+            assertThat(cbe.getMessage().contains("field [" + field + "]"), equalTo(true));
         }
     }
 }

--- a/src/test/java/org/elasticsearch/indices/fielddata/breaker/CircuitBreakerServiceTests.java
+++ b/src/test/java/org/elasticsearch/indices/fielddata/breaker/CircuitBreakerServiceTests.java
@@ -83,7 +83,8 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
             // execute a search that loads field data (sorting on the "test" field)
             // again, this time it should trip the breaker
             assertFailures(client.prepareSearch("cb-test").setSource("{\"sort\": \"test\",\"query\":{\"match_all\":{}}}"),
-                        RestStatus.INTERNAL_SERVER_ERROR, containsString("Data too large, data would be larger than limit of [100] bytes"));
+                        RestStatus.INTERNAL_SERVER_ERROR,
+                    containsString("Data too large, data for field [test] would be larger than limit of [100/100b]"));
         } finally {
             // Reset settings
             Settings resetSettings = settingsBuilder()
@@ -134,7 +135,8 @@ public class CircuitBreakerServiceTests extends ElasticsearchIntegrationTest {
             // execute a search that loads field data (sorting on the "test" field)
             // again, this time it should trip the breaker
             assertFailures(client.prepareSearch("ramtest").setSource("{\"sort\": \"test\",\"query\":{\"match_all\":{}}}"),
-                        RestStatus.INTERNAL_SERVER_ERROR, containsString("Data too large, data would be larger than limit of [100] bytes"));
+                        RestStatus.INTERNAL_SERVER_ERROR,
+                    containsString("Data too large, data for field [test] would be larger than limit of [100/100b]"));
         } finally {
             // Reset settings
             Settings resetSettings = settingsBuilder()


### PR DESCRIPTION
Fixes #5718

Now the log message looks like:

```
New used memory 19 [19b] from field [foo] would be larger than configured breaker: 15 [15b], breaking
```

And the exception on the client side looks like:

```
... ElasticsearchException[org.elasticsearch.common.breaker.CircuitBreakingException: Data too large, data for field [plot] would be larger than limit of [10485760/10mb]]; ...
```
