### PR TITLE
Remove RootMapper.validate and validate the routing key up-front.

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -418,9 +418,11 @@ public class MappingMetaData {
     }
 
     public ParseContext createParseContext(@Nullable String id, @Nullable String routing, @Nullable String timestamp) {
+        // We parse the routing even if there is already a routing key in the request in order to make sure that
+        // they are the same
         return new ParseContext(
                 id == null && id().hasPath(),
-                routing == null && routing().hasPath(),
+                routing().hasPath(),
                 timestamp == null && timestamp().hasPath()
         );
     }

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -522,10 +522,6 @@ public class DocumentMapper implements ToXContent {
             for (RootMapper rootMapper : rootMappersOrdered) {
                 rootMapper.postParse(context);
             }
-
-            for (RootMapper rootMapper : rootMappersOrdered) {
-                rootMapper.validate(context);
-            }
         } catch (Throwable e) {
             // if its already a mapper parsing exception, no need to wrap it...
             if (e instanceof MapperParsingException) {

--- a/src/main/java/org/elasticsearch/index/mapper/RootMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/RootMapper.java
@@ -31,8 +31,6 @@ public interface RootMapper extends Mapper {
 
     void postParse(ParseContext context) throws IOException;
 
-    void validate(ParseContext context) throws MapperParsingException;
-
     /**
      * Should the mapper be included in the root {@link org.elasticsearch.index.mapper.object.ObjectMapper}.
      */

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -200,10 +200,6 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return true;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
@@ -125,10 +125,6 @@ public class AnalyzerMapper implements Mapper, InternalMapper, RootMapper {
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/BoostFieldMapper.java
@@ -237,10 +237,6 @@ public class BoostFieldMapper extends NumberFieldMapper<Float> implements Intern
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return true;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -293,10 +293,6 @@ public class IdFieldMapper extends AbstractFieldMapper<String> implements Intern
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return true;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -173,10 +173,6 @@ public class IndexFieldMapper extends AbstractFieldMapper<String> implements Int
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -171,10 +171,6 @@ public class ParentFieldMapper extends AbstractFieldMapper<Uid> implements Inter
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return true;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.codec.postingsformat.PostingsFormatProvider;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 
 import java.io.IOException;
 import java.util.List;
@@ -170,31 +169,6 @@ public class RoutingFieldMapper extends AbstractFieldMapper<String> implements I
             return null;
         }
         return value.toString();
-    }
-
-    @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-        String routing = context.sourceToParse().routing();
-        if (path != null && routing != null) {
-            // we have a path, check if we can validate we have the same routing value as the one in the doc...
-            String value = null;
-            Field field = (Field) context.doc().getField(path);
-            if (field != null) {
-                value = field.stringValue();
-                if (value == null) {
-                    // maybe its a numeric field...
-                    if (field instanceof NumberFieldMapper.CustomNumericField) {
-                        value = ((NumberFieldMapper.CustomNumericField) field).numericAsString();
-                    }
-                }
-            }
-            if (value == null) {
-                value = context.ignoredValue(path);
-            }
-            if (!routing.equals(value)) {
-                throw new MapperParsingException("External routing [" + routing + "] and document path routing [" + value + "] mismatch");
-            }
-        }
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -122,10 +122,6 @@ public class SizeFieldMapper extends IntegerFieldMapper implements RootMapper {
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public void preParse(ParseContext context) throws IOException {
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -249,10 +249,6 @@ public class SourceFieldMapper extends AbstractFieldMapper<byte[]> implements In
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -165,10 +165,6 @@ public class TTLFieldMapper extends LongFieldMapper implements InternalMapper, R
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public void preParse(ParseContext context) throws IOException {
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -180,10 +180,6 @@ public class TimestampFieldMapper extends DateFieldMapper implements InternalMap
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public void preParse(ParseContext context) throws IOException {
         super.parse(context);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -169,10 +169,6 @@ public class TypeFieldMapper extends AbstractFieldMapper<String> implements Inte
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -166,10 +166,6 @@ public class UidFieldMapper extends AbstractFieldMapper<Uid> implements Internal
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return false;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -145,10 +145,6 @@ public class VersionFieldMapper extends AbstractFieldMapper<Long> implements Int
     }
 
     @Override
-    public void validate(ParseContext context) throws MapperParsingException {
-    }
-
-    @Override
     public boolean includeInObject() {
         return false;
     }

--- a/src/test/java/org/elasticsearch/cluster/metadata/MappingMetaDataParserTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MappingMetaDataParserTests.java
@@ -43,8 +43,8 @@ public class MappingMetaDataParserTests extends ElasticsearchTestCase {
         md.parse(XContentFactory.xContent(bytes).createParser(bytes), parseContext);
         assertThat(parseContext.id(), equalTo("id"));
         assertThat(parseContext.idResolved(), equalTo(true));
-        assertThat(parseContext.routing(), nullValue());
-        assertThat(parseContext.routingResolved(), equalTo(false));
+        assertThat(parseContext.routing(), equalTo("routing_value"));
+        assertThat(parseContext.routingResolved(), equalTo(true));
         assertThat(parseContext.timestamp(), nullValue());
         assertThat(parseContext.timestampResolved(), equalTo(false));
     }
@@ -106,8 +106,8 @@ public class MappingMetaDataParserTests extends ElasticsearchTestCase {
         md.parse(XContentFactory.xContent(bytes).createParser(bytes), parseContext);
         assertThat(parseContext.id(), nullValue());
         assertThat(parseContext.idResolved(), equalTo(false));
-        assertThat(parseContext.routing(), nullValue());
-        assertThat(parseContext.routingResolved(), equalTo(false));
+        assertThat(parseContext.routing(), equalTo("routing_value"));
+        assertThat(parseContext.routingResolved(), equalTo(true));
         assertThat(parseContext.timestamp(), equalTo("1"));
         assertThat(parseContext.timestampResolved(), equalTo(true));
     }
@@ -160,8 +160,8 @@ public class MappingMetaDataParserTests extends ElasticsearchTestCase {
         md.parse(XContentFactory.xContent(bytes).createParser(bytes), parseContext);
         assertThat(parseContext.id(), equalTo("id"));
         assertThat(parseContext.idResolved(), equalTo(true));
-        assertThat(parseContext.routing(), nullValue());
-        assertThat(parseContext.routingResolved(), equalTo(false));
+        assertThat(parseContext.routing(), equalTo("routing_value"));
+        assertThat(parseContext.routingResolved(), equalTo(true));
         assertThat(parseContext.timestamp(), nullValue());
         assertThat(parseContext.timestampResolved(), equalTo(false));
     }
@@ -202,8 +202,8 @@ public class MappingMetaDataParserTests extends ElasticsearchTestCase {
         md.parse(XContentFactory.xContent(bytes).createParser(bytes), parseContext);
         assertThat(parseContext.id(), nullValue());
         assertThat(parseContext.idResolved(), equalTo(false));
-        assertThat(parseContext.routing(), nullValue());
-        assertThat(parseContext.routingResolved(), equalTo(false));
+        assertThat(parseContext.routing(), equalTo("routing_value"));
+        assertThat(parseContext.routingResolved(), equalTo(true));
         assertThat(parseContext.timestamp(), equalTo("1"));
         assertThat(parseContext.timestampResolved(), equalTo(true));
     }

--- a/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
@@ -235,6 +235,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
+                        .startObject("routing_field").field("type", "string").field("index", randomBoolean() ? "no" : "not_analyzed").field("doc_values", randomBoolean() ? "yes" : "no").endObject()
                         .endObject().endObject())
                 .execute().actionGet();
         ensureGreen();
@@ -303,12 +304,6 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareCreate("test")
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
-                        .startObject("properties")
-                            .startObject("routing_field")
-                                .field("type", "long")
-                                .field("doc_values", false) // TODO this test fails with doc values https://github.com/elasticsearch/elasticsearch/pull/5858
-                            .endObject()
-                        .endObject()
                         .endObject().endObject())
                 .execute().actionGet();
         ensureGreen();


### PR DESCRIPTION
RootMapper.validate was only used by the routing field mapper, which makes
buggy assumptions about how fields are indexed. For example, it assumes that
the index representation of a field is the same as its external representation.

Close #5844
