### PR TITLE
Use segment ordinals as global ordinals if possible

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -128,6 +128,11 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
             BytesValues.WithOrdinals values = afd.getBytesValues(false);
             Ordinals.Docs segmentOrdinals = values.ordinals();
             Ordinals.Docs globalOrdinals = segmentOrdToGlobalOrdLookup.globalOrdinals(segmentOrdinals);
+            if (segmentOrdinals.getMaxOrd() == globalOrdinals.getMaxOrd()) {
+                // This means that a segment contains all the value and in that case segment ordinals
+                // can be used as global ordinals. This will save an extra lookup per hit.
+                return values;
+            }
 
             final BytesValues.WithOrdinals[] bytesValues = new BytesValues.WithOrdinals[atomicReaders.length];
             for (int i = 0; i < bytesValues.length; i++) {

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
@@ -105,7 +105,8 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
         breakerService.getBreaker().addWithoutBreaking(memorySizeInBytes);
 
         if (logger.isDebugEnabled()) {
-            String implName = maxOrd < threshold ? "PackedIntOrdinalMappingSource" : "CompressedOrdinalMappingSource";
+            // this does include the [] from the array in the impl name
+            String implName = segmentOrdToGlobalOrdLookups.getClass().getSimpleName();
             logger.debug(
                     "Global-ordinals[{}][{}][{}] took {} ms",
                     implName,

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
@@ -105,7 +105,7 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
         breakerService.getBreaker().addWithoutBreaking(memorySizeInBytes);
 
         if (logger.isDebugEnabled()) {
-            String implName = segmentOrdToGlobalOrdLookups[0].getClass().getSimpleName();
+            String implName = maxOrd < threshold ? "PackedIntOrdinalMappingSource" : "CompressedOrdinalMappingSource";
             logger.debug(
                     "Global-ordinals[{}][{}][{}] took {} ms",
                     implName,
@@ -280,19 +280,31 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
                 PackedIntOrdinalMappingSource[] sources = new PackedIntOrdinalMappingSource[numSegments];
                 for (int i = 0; i < newSegmentOrdToGlobalOrdDeltas.length; i++) {
                     PackedInts.Reader segmentOrdToGlobalOrdDelta = newSegmentOrdToGlobalOrdDeltas[i];
-                    long ramUsed = segmentOrdToGlobalOrdDelta.ramBytesUsed();
-                    sources[i] = new PackedIntOrdinalMappingSource(segmentOrdToGlobalOrdDelta, ramUsed, maxOrd);
-                    memorySizeInBytesCounter += ramUsed;
+                    if (segmentOrdToGlobalOrdDelta.size() == maxOrd) {
+                        // This means that a segment contains all the value and in that case segment ordinals
+                        // can be used as global ordinals. This will save an extra lookup per hit.
+                        sources[i] = null;
+                    } else {
+                        long ramUsed = segmentOrdToGlobalOrdDelta.ramBytesUsed();
+                        sources[i] = new PackedIntOrdinalMappingSource(segmentOrdToGlobalOrdDelta, ramUsed, maxOrd);
+                        memorySizeInBytesCounter += ramUsed;
+                    }
+
                 }
                 return sources;
             } else {
                 OrdinalMappingSource[] sources = new OrdinalMappingSource[segmentOrdToGlobalOrdDeltas.length];
                 for (int i = 0; i < segmentOrdToGlobalOrdDeltas.length; i++) {
                     MonotonicAppendingLongBuffer segmentOrdToGlobalOrdLookup = segmentOrdToGlobalOrdDeltas[i];
-                    segmentOrdToGlobalOrdLookup.freeze();
-                    long ramUsed = segmentOrdToGlobalOrdLookup.ramBytesUsed();
-                    sources[i] = new CompressedOrdinalMappingSource(segmentOrdToGlobalOrdLookup, ramUsed, maxOrd);
-                    memorySizeInBytesCounter += ramUsed;
+                    if (segmentOrdToGlobalOrdLookup.size() == maxOrd) {
+                        // idem as above
+                        sources[i] = null;
+                    } else {
+                        segmentOrdToGlobalOrdLookup.freeze();
+                        long ramUsed = segmentOrdToGlobalOrdLookup.ramBytesUsed();
+                        sources[i] = new CompressedOrdinalMappingSource(segmentOrdToGlobalOrdLookup, ramUsed, maxOrd);
+                        memorySizeInBytesCounter += ramUsed;
+                    }
                 }
                 return sources;
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -72,6 +72,23 @@ public abstract class BucketsAggregator extends Aggregator {
     }
 
     /**
+     * Same as {@link #collectBucket(int, long)}, but doesn't check if the docCounts needs to be re-sized.
+     */
+    protected final void collectExistingBucket(int doc, long bucketOrd) throws IOException {
+        docCounts.increment(bucketOrd, 1);
+        for (int i = 0; i < collectableSugAggregators.length; i++) {
+            collectableSugAggregators[i].collect(doc, bucketOrd);
+        }
+    }
+
+    /**
+     * Initializes the docCounts to the specified size.
+     */
+    public void initializeDocCounts(long maxOrd) {
+        docCounts = bigArrays.grow(docCounts, maxOrd);
+    }
+
+    /**
      * Utility method to collect the given doc in the given bucket but not to update the doc counts of the bucket
      */
     protected final void collectBucketNoCounts(int doc, long bucketOrd) throws IOException {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -69,6 +69,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
     public void setNextReader(AtomicReaderContext reader) {
         globalValues = valuesSource.globalBytesValues();
         globalOrdinals = globalValues.ordinals();
+        initializeDocCounts(globalOrdinals.getMaxOrd());
     }
 
     @Override
@@ -76,7 +77,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         final int numOrds = globalOrdinals.setDocument(doc);
         for (int i = 0; i < numOrds; i++) {
             final long globalOrd = globalOrdinals.nextOrd();
-            collectBucket(doc, createBucketOrd(globalOrd));
+            collectExistingBucket(doc, createBucketOrd(globalOrd));
         }
     }
 


### PR DESCRIPTION
Use segment ordinals as global ordinals if a segment contains all values for a field on a shard level.

PR for #5854
