### PR TITLE
Field data diet.

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/AtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/AtomicFieldData.java
@@ -34,11 +34,6 @@ public interface AtomicFieldData<Script extends ScriptDocValues> extends RamUsag
     boolean isMultiValued();
 
     /**
-     * The number of docs in this field data.
-     */
-    int getNumDocs();
-
-    /**
      * An upper limit of the number of unique values in this atomic field data.
      */
     long getNumberUniqueValues();

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefOrdValComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefOrdValComparator.java
@@ -153,7 +153,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
         public PerSegmentComparator(BytesValues.WithOrdinals termsIndex) {
             this.readerOrds = termsIndex.ordinals();
             this.termsIndex = termsIndex;
-            if (readerOrds.getNumOrds() > Long.MAX_VALUE / 4) {
+            if (readerOrds.getMaxOrd() > Long.MAX_VALUE / 4) {
                 throw new IllegalStateException("Current terms index pretends it has more than " + (Long.MAX_VALUE / 4) + " ordinals, which is unsupported by this impl");
             }
         }
@@ -297,7 +297,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
     @Override
     public FieldComparator<BytesRef> setNextReader(AtomicReaderContext context) throws IOException {
         termsIndex = indexFieldData.load(context).getBytesValues(false);
-        assert termsIndex.ordinals() != null && termsIndex.ordinals().ordinals() != null;
+        assert termsIndex.ordinals() != null;
         if (missingValue == null) {
             missingOrd = Ordinals.MISSING_ORDINAL;
         } else {
@@ -305,7 +305,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
             assert consistentInsertedOrd(termsIndex, missingOrd, missingValue);
         }
         FieldComparator<BytesRef> perSegComp = null;
-        assert termsIndex.ordinals() != null && termsIndex.ordinals().ordinals() != null;
+        assert termsIndex.ordinals() != null;
         if (termsIndex.isMultiValued()) {
             perSegComp = new PerSegmentComparator(termsIndex) {
                 @Override
@@ -368,7 +368,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
     }
 
     final protected static long binarySearch(BytesValues.WithOrdinals a, BytesRef key) {
-        return binarySearch(a, key, 1, a.ordinals().getNumOrds());
+        return binarySearch(a, key, Ordinals.MIN_ORDINAL, a.ordinals().getMaxOrd() - 1);
     }
 
     final protected static long binarySearch(BytesValues.WithOrdinals a, BytesRef key, long low, long high) {

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/DocIdOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/DocIdOrdinals.java
@@ -49,18 +49,8 @@ public class DocIdOrdinals implements Ordinals {
     }
 
     @Override
-    public int getNumDocs() {
-        return numDocs;
-    }
-
-    @Override
-    public long getNumOrds() {
-        return numDocs;
-    }
-
-    @Override
     public long getMaxOrd() {
-        return 1L + numDocs;
+        return Ordinals.MIN_ORDINAL + numDocs;
     }
 
     @Override
@@ -68,51 +58,19 @@ public class DocIdOrdinals implements Ordinals {
         return new Docs(this);
     }
 
-    public static class Docs implements Ordinals.Docs {
+    public static class Docs extends Ordinals.AbstractDocs {
 
-        private final DocIdOrdinals parent;
         private final LongsRef longsScratch = new LongsRef(new long[1], 0, 1);
         private int docId = -1;
         private long currentOrdinal = -1;
 
         public Docs(DocIdOrdinals parent) {
-            this.parent = parent;
-        }
-
-        @Override
-        public Ordinals ordinals() {
-            return parent;
-        }
-
-        @Override
-        public int getNumDocs() {
-            return parent.getNumDocs();
-        }
-
-        @Override
-        public long getNumOrds() {
-            return parent.getNumOrds();
-        }
-
-        @Override
-        public long getMaxOrd() {
-            return parent.getMaxOrd();
-        }
-
-        @Override
-        public boolean isMultiValued() {
-            return false;
+            super(parent);
         }
 
         @Override
         public long getOrd(int docId) {
             return currentOrdinal = docId + 1;
-        }
-
-        @Override
-        public LongsRef getOrds(int docId) {
-            longsScratch.longs[0] = currentOrdinal = docId + 1;
-            return longsScratch;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/EmptyOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/EmptyOrdinals.java
@@ -24,13 +24,8 @@ import org.elasticsearch.ElasticsearchIllegalStateException;
 
 /**
  */
-public class EmptyOrdinals implements Ordinals {
-
-    private final int numDocs;
-
-    public EmptyOrdinals(int numDocs) {
-        this.numDocs = numDocs;
-    }
+public enum EmptyOrdinals implements Ordinals {
+    INSTANCE;
 
     @Override
     public long getMemorySizeInBytes() {
@@ -43,16 +38,6 @@ public class EmptyOrdinals implements Ordinals {
     }
 
     @Override
-    public int getNumDocs() {
-        return this.numDocs;
-    }
-
-    @Override
-    public long getNumOrds() {
-        return 0;
-    }
-
-    @Override
     public long getMaxOrd() {
         return 1;
     }
@@ -62,47 +47,16 @@ public class EmptyOrdinals implements Ordinals {
         return new Docs(this);
     }
 
-    public static class Docs implements Ordinals.Docs {
-        private final EmptyOrdinals parent;
+    public static class Docs extends Ordinals.AbstractDocs {
         public static final LongsRef EMPTY_LONGS_REF = new LongsRef();
 
         public Docs(EmptyOrdinals parent) {
-            this.parent = parent;
-        }
-
-        @Override
-        public Ordinals ordinals() {
-            return parent;
-        }
-
-        @Override
-        public int getNumDocs() {
-            return parent.getNumDocs();
-        }
-
-        @Override
-        public long getNumOrds() {
-            return 0;
-        }
-
-        @Override
-        public long getMaxOrd() {
-            return 1;
-        }
-
-        @Override
-        public boolean isMultiValued() {
-            return false;
+            super(parent);
         }
 
         @Override
         public long getOrd(int docId) {
             return 0;
-        }
-
-        @Override
-        public LongsRef getOrds(int docId) {
-            return EMPTY_LONGS_REF;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -162,11 +162,6 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
         }
 
         @Override
-        public int getNumDocs() {
-            return afd.getNumDocs();
-        }
-
-        @Override
         public long getNumberUniqueValues() {
             return afd.getNumberUniqueValues();
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
-import org.apache.lucene.util.LongsRef;
 import org.apache.lucene.util.PriorityQueue;
 import org.apache.lucene.util.packed.AppendingPackedLongBuffer;
 import org.apache.lucene.util.packed.MonotonicAppendingLongBuffer;
@@ -141,51 +140,6 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
         }
 
         @Override
-        public final Ordinals ordinals() {
-            return new Ordinals() {
-                @Override
-                public long getMemorySizeInBytes() {
-                    return memorySizeInBytes;
-                }
-
-                @Override
-                public boolean isMultiValued() {
-                    return GlobalOrdinalMapping.this.isMultiValued();
-                }
-
-                @Override
-                public int getNumDocs() {
-                    return GlobalOrdinalMapping.this.getNumDocs();
-                }
-
-                @Override
-                public long getNumOrds() {
-                    return GlobalOrdinalMapping.this.getNumOrds();
-                }
-
-                @Override
-                public long getMaxOrd() {
-                    return GlobalOrdinalMapping.this.getMaxOrd();
-                }
-
-                @Override
-                public Docs ordinals() {
-                    return GlobalOrdinalMapping.this;
-                }
-            };
-        }
-
-        @Override
-        public final int getNumDocs() {
-            return segmentOrdinals.getNumDocs();
-        }
-
-        @Override
-        public final long getNumOrds() {
-            return maxOrd - Ordinals.MIN_ORDINAL;
-        }
-
-        @Override
         public final long getMaxOrd() {
             return maxOrd;
         }
@@ -209,15 +163,6 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
         public final long getOrd(int docId) {
             long segmentOrd = segmentOrdinals.getOrd(docId);
             return currentGlobalOrd = getGlobalOrd(segmentOrd);
-        }
-
-        @Override
-        public final LongsRef getOrds(int docId) {
-            LongsRef refs = segmentOrdinals.getOrds(docId);
-            for (int i = refs.offset; i < refs.length; i++) {
-                refs.longs[i] = getGlobalOrd(refs.longs[i]);
-            }
-            return refs;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/Ordinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/Ordinals.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.fielddata.ordinals;
 
-import org.apache.lucene.util.LongsRef;
 
 /**
  * A thread safe ordinals abstraction. Ordinals can only be positive integers.
@@ -38,16 +37,6 @@ public interface Ordinals {
      * Is one of the docs maps to more than one ordinal?
      */
     boolean isMultiValued();
-
-    /**
-     * The number of docs in this ordinals.
-     */
-    int getNumDocs();
-
-    /**
-     * The number of ordinals, excluding the {@link #MISSING_ORDINAL} ordinal indicating a missing value.
-     */
-    long getNumOrds();
 
     /**
      * Returns total unique ord count; this includes +1 for
@@ -79,21 +68,6 @@ public interface Ordinals {
     interface Docs {
 
         /**
-         * Returns the original ordinals used to generate this Docs "itereator".
-         */
-        Ordinals ordinals();
-
-        /**
-         * The number of docs in this ordinals.
-         */
-        int getNumDocs();
-
-        /**
-         * The number of ordinals, excluding the "0" ordinal (indicating a missing value).
-         */
-        long getNumOrds();
-
-        /**
          * Returns total unique ord count; this includes +1 for
          * the null ord (always 0).
          */
@@ -109,12 +83,6 @@ public interface Ordinals {
          * <tt>0</tt>.
          */
         long getOrd(int docId);
-
-        /**
-         * Returns an array of ordinals matching the docIds, with 0 length one
-         * for a doc with no ordinals.
-         */
-        LongsRef getOrds(int docId);
 
 
         /**
@@ -145,6 +113,29 @@ public interface Ordinals {
          * @return the current ordinal in the iteration
          */
         long currentOrd();
+    }
+
+    /**
+     * Base implementation of {@link Docs}.
+     */
+    public static abstract class AbstractDocs implements Docs {
+
+        protected final Ordinals ordinals;
+
+        public AbstractDocs(Ordinals ordinals) {
+            this.ordinals = ordinals;
+        }
+
+        @Override
+        public final long getMaxOrd() {
+            return ordinals.getMaxOrd();
+        }
+
+        @Override
+        public final boolean isMultiValued() {
+            return ordinals.isMultiValued();
+        }
+
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/SinglePackedOrdinals.java
@@ -29,17 +29,15 @@ public class SinglePackedOrdinals implements Ordinals {
 
     // ordinals with value 0 indicates no value
     private final PackedInts.Reader reader;
-    private final long numOrds;
     private final long maxOrd;
 
     private long size = -1;
 
     public SinglePackedOrdinals(OrdinalsBuilder builder, float acceptableOverheadRatio) {
         assert builder.getNumMultiValuesDocs() == 0;
-        this.numOrds = builder.getNumOrds();
         this.maxOrd = builder.getNumOrds() + 1;
         // We don't reuse the builder as-is because it might have been built with a higher overhead ratio
-        final PackedInts.Mutable reader = PackedInts.getMutable(builder.maxDoc(), PackedInts.bitsRequired(getNumOrds()), acceptableOverheadRatio);
+        final PackedInts.Mutable reader = PackedInts.getMutable(builder.maxDoc(), PackedInts.bitsRequired(getMaxOrd() - 1), acceptableOverheadRatio);
         PackedInts.copy(builder.getFirstOrdinals(), 0, reader, 0, builder.maxDoc(), 8 * 1024);
         this.reader = reader;
     }
@@ -58,16 +56,6 @@ public class SinglePackedOrdinals implements Ordinals {
     }
 
     @Override
-    public int getNumDocs() {
-        return reader.size();
-    }
-
-    @Override
-    public long getNumOrds() {
-        return numOrds;
-    }
-
-    @Override
     public long getMaxOrd() {
         return maxOrd;
     }
@@ -77,56 +65,21 @@ public class SinglePackedOrdinals implements Ordinals {
         return new Docs(this, reader);
     }
 
-    public static class Docs implements Ordinals.Docs {
+    public static class Docs extends Ordinals.AbstractDocs {
 
-        private final SinglePackedOrdinals parent;
         private final PackedInts.Reader reader;
 
         private final LongsRef longsScratch = new LongsRef(1);
         private long currentOrdinal;
 
         public Docs(SinglePackedOrdinals parent, PackedInts.Reader reader) {
-            this.parent = parent;
+            super(parent);
             this.reader = reader;
-        }
-
-        @Override
-        public Ordinals ordinals() {
-            return parent;
-        }
-
-        @Override
-        public int getNumDocs() {
-            return parent.getNumDocs();
-        }
-
-        @Override
-        public long getNumOrds() {
-            return parent.getNumOrds();
-        }
-
-        @Override
-        public long getMaxOrd() {
-            return parent.getMaxOrd();
-        }
-
-        @Override
-        public boolean isMultiValued() {
-            return false;
         }
 
         @Override
         public long getOrd(int docId) {
             return currentOrdinal = reader.get(docId);
-        }
-
-        @Override
-        public LongsRef getOrds(int docId) {
-            final long ordinal = reader.get(docId);
-            longsScratch.offset = 0;
-            longsScratch.length = (int)Math.min(currentOrdinal, 1);
-            longsScratch.longs[0] = currentOrdinal = ordinal;
-            return longsScratch;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractGeoPointIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractGeoPointIndexFieldData.java
@@ -38,12 +38,6 @@ abstract class AbstractGeoPointIndexFieldData extends AbstractIndexFieldData<Ato
 
     protected static class Empty extends AtomicGeoPointFieldData<ScriptDocValues> {
 
-        private final int numDocs;
-
-        Empty(int numDocs) {
-            this.numDocs = numDocs;
-        }
-
         @Override
         public boolean isMultiValued() {
             return false;
@@ -72,11 +66,6 @@ abstract class AbstractGeoPointIndexFieldData extends AbstractIndexFieldData<Ato
         @Override
         public ScriptDocValues getScriptValues() {
             return ScriptDocValues.EMPTY_GEOPOINTS;
-        }
-
-        @Override
-        public int getNumDocs() {
-            return numDocs;
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVAtomicFieldData.java
@@ -48,11 +48,6 @@ public class BinaryDVAtomicFieldData implements AtomicFieldData<ScriptDocValues.
     }
 
     @Override
-    public int getNumDocs() {
-        return reader.maxDoc();
-    }
-
-    @Override
     public long getNumberUniqueValues() {
         // probably not accurate, but a good upper limit
         return reader.maxDoc();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericAtomicFieldData.java
@@ -145,11 +145,6 @@ final class BinaryDVNumericAtomicFieldData extends AbstractAtomicNumericFieldDat
     }
 
     @Override
-    public int getNumDocs() {
-        return reader.maxDoc();
-    }
-
-    @Override
     public long getNumberUniqueValues() {
         return Long.MAX_VALUE; // no clue
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
@@ -44,11 +44,6 @@ final class BytesBinaryDVAtomicFieldData implements AtomicFieldData<ScriptDocVal
     }
 
     @Override
-    public int getNumDocs() {
-        return reader.maxDoc();
-    }
-
-    @Override
     public long getNumberUniqueValues() {
         return Long.MAX_VALUE;
     }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayAtomicFieldData.java
@@ -29,32 +29,24 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
  */
 public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFieldData {
 
-    public static DoubleArrayAtomicFieldData empty(int numDocs) {
-        return new Empty(numDocs);
+    public static DoubleArrayAtomicFieldData empty() {
+        return new Empty();
     }
-
-    private final int numDocs;
 
     protected long size = -1;
 
-    public DoubleArrayAtomicFieldData(int numDocs) {
+    public DoubleArrayAtomicFieldData() {
         super(true);
-        this.numDocs = numDocs;
     }
 
     @Override
     public void close() {
     }
 
-    @Override
-    public int getNumDocs() {
-        return numDocs;
-    }
-
     static class Empty extends DoubleArrayAtomicFieldData {
 
-        Empty(int numDocs) {
-            super(numDocs);
+        Empty() {
+            super();
         }
 
         @Override
@@ -98,8 +90,8 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
         private final BigDoubleArrayList values;
         private final Ordinals ordinals;
 
-        public WithOrdinals(BigDoubleArrayList values, int numDocs, Ordinals ordinals) {
-            super(numDocs);
+        public WithOrdinals(BigDoubleArrayList values, Ordinals ordinals) {
+            super();
             this.values = values;
             this.ordinals = ordinals;
         }
@@ -111,13 +103,13 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
 
         @Override
         public long getNumberUniqueValues() {
-            return ordinals.getNumOrds();
+            return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
         }
 
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + values.sizeInBytes() + ordinals.getMemorySizeInBytes();
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + values.sizeInBytes() + ordinals.getMemorySizeInBytes();
             }
             return size;
         }
@@ -177,8 +169,8 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
         private final FixedBitSet set;
         private final long numOrds;
 
-        public SingleFixedSet(BigDoubleArrayList values, int numDocs, FixedBitSet set, long numOrds) {
-            super(numDocs);
+        public SingleFixedSet(BigDoubleArrayList values, FixedBitSet set, long numOrds) {
+            super();
             this.values = values;
             this.set = set;
             this.numOrds = numOrds;
@@ -271,8 +263,8 @@ public abstract class DoubleArrayAtomicFieldData extends AbstractAtomicNumericFi
          * Note, here, we assume that there is no offset by 1 from docId, so position 0
          * is the value for docId 0.
          */
-        public Single(BigDoubleArrayList values, int numDocs, long numOrds) {
-            super(numDocs);
+        public Single(BigDoubleArrayList values, long numOrds) {
+            super();
             this.values = values;
             this.numOrds = numOrds;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -81,7 +81,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<DoubleArra
         // TODO: Use an actual estimator to estimate before loading.
         NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker());
         if (terms == null) {
-            data = DoubleArrayAtomicFieldData.empty(reader.maxDoc());
+            data = DoubleArrayAtomicFieldData.empty();
             estimator.afterLoad(null, data.getMemorySizeInBytes());
             return data;
         }
@@ -99,7 +99,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<DoubleArra
             }
             Ordinals build = builder.build(fieldDataType.getSettings());
             if (build.isMultiValued() || CommonSettings.getMemoryStorageHint(fieldDataType) == CommonSettings.MemoryStorageFormat.ORDINALS) {
-                data = new DoubleArrayAtomicFieldData.WithOrdinals(values, reader.maxDoc(), build);
+                data = new DoubleArrayAtomicFieldData.WithOrdinals(values, build);
             } else {
                 Docs ordinals = build.ordinals();
                 final FixedBitSet set = builder.buildDocsWithValuesSet();
@@ -109,7 +109,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<DoubleArra
                 long uniqueValuesArraySize = values.sizeInBytes();
                 long ordinalsSize = build.getMemorySizeInBytes();
                 if (uniqueValuesArraySize + ordinalsSize < singleValuesArraySize) {
-                    data = new DoubleArrayAtomicFieldData.WithOrdinals(values, reader.maxDoc(), build);
+                    data = new DoubleArrayAtomicFieldData.WithOrdinals(values, build);
                     success = true;
                     return data;
                 }
@@ -121,9 +121,9 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<DoubleArra
                 }
                 assert sValues.size() == maxDoc;
                 if (set == null) {
-                    data = new DoubleArrayAtomicFieldData.Single(sValues, maxDoc, ordinals.getNumOrds());
+                    data = new DoubleArrayAtomicFieldData.Single(sValues, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 } else {
-                    data = new DoubleArrayAtomicFieldData.SingleFixedSet(sValues, maxDoc, set, ordinals.getNumOrds());
+                    data = new DoubleArrayAtomicFieldData.SingleFixedSet(sValues, set, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 }
             }
             success = true;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesAtomicFieldData.java
@@ -38,8 +38,8 @@ import java.io.IOException;
  */
 public class FSTBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> {
 
-    public static FSTBytesAtomicFieldData empty(int numDocs) {
-        return new Empty(numDocs);
+    public static FSTBytesAtomicFieldData empty() {
+        return new Empty();
     }
 
     // 0 ordinal in values means no value (its null)
@@ -65,13 +65,8 @@ public class FSTBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<Scr
     }
 
     @Override
-    public int getNumDocs() {
-        return ordinals.getNumDocs();
-    }
-
-    @Override
     public long getNumberUniqueValues() {
-        return ordinals.getNumOrds();
+        return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
     }
 
     @Override
@@ -180,18 +175,13 @@ public class FSTBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<Scr
 
     final static class Empty extends FSTBytesAtomicFieldData {
 
-        Empty(int numDocs) {
-            super(null, new EmptyOrdinals(numDocs));
+        Empty() {
+            super(null, EmptyOrdinals.INSTANCE);
         }
 
         @Override
         public boolean isMultiValued() {
             return false;
-        }
-
-        @Override
-        public int getNumDocs() {
-            return ordinals.getNumDocs();
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FSTBytesIndexFieldData.java
@@ -69,7 +69,7 @@ public class FSTBytesIndexFieldData extends AbstractBytesIndexFieldData<FSTBytes
         // TODO: Use an actual estimator to estimate before loading.
         NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker());
         if (terms == null) {
-            data = FSTBytesAtomicFieldData.empty(reader.maxDoc());
+            data = FSTBytesAtomicFieldData.empty();
             estimator.afterLoad(null, data.getMemorySizeInBytes());
             return data;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayAtomicFieldData.java
@@ -28,32 +28,24 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
  */
 public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFieldData {
 
-    public static FloatArrayAtomicFieldData empty(int numDocs) {
-        return new Empty(numDocs);
+    public static FloatArrayAtomicFieldData empty() {
+        return new Empty();
     }
-
-    private final int numDocs;
 
     protected long size = -1;
 
-    public FloatArrayAtomicFieldData(int numDocs) {
+    public FloatArrayAtomicFieldData() {
         super(true);
-        this.numDocs = numDocs;
     }
 
     @Override
     public void close() {
     }
 
-    @Override
-    public int getNumDocs() {
-        return numDocs;
-    }
-
     static class Empty extends FloatArrayAtomicFieldData {
 
-        Empty(int numDocs) {
-            super(numDocs);
+        Empty() {
+            super();
         }
 
         @Override
@@ -97,8 +89,8 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
         private final Ordinals ordinals;
         private final BigFloatArrayList values;
 
-        public WithOrdinals(BigFloatArrayList values, int numDocs, Ordinals ordinals) {
-            super(numDocs);
+        public WithOrdinals(BigFloatArrayList values, Ordinals ordinals) {
+            super();
             this.values = values;
             this.ordinals = ordinals;
         }
@@ -110,13 +102,13 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
 
         @Override
         public long getNumberUniqueValues() {
-            return ordinals.getNumOrds();
+            return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
         }
 
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + values.sizeInBytes() + ordinals.getMemorySizeInBytes();
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + values.sizeInBytes() + ordinals.getMemorySizeInBytes();
             }
             return size;
         }
@@ -173,8 +165,8 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
         private final FixedBitSet set;
         private final long numOrd;
 
-        public SingleFixedSet(BigFloatArrayList values, int numDocs, FixedBitSet set, long numOrd) {
-            super(numDocs);
+        public SingleFixedSet(BigFloatArrayList values, FixedBitSet set, long numOrd) {
+            super();
             this.values = values;
             this.set = set;
             this.numOrd = numOrd;
@@ -269,8 +261,8 @@ public abstract class FloatArrayAtomicFieldData extends AbstractAtomicNumericFie
          * Note, here, we assume that there is no offset by 1 from docId, so position 0
          * is the value for docId 0.
          */
-        public Single(BigFloatArrayList values, int numDocs, long numOrd) {
-            super(numDocs);
+        public Single(BigFloatArrayList values, long numOrd) {
+            super();
             this.values = values;
             this.numOrd = numOrd;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -79,7 +79,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<FloatArrayA
         // TODO: Use an actual estimator to estimate before loading.
         NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker());
         if (terms == null) {
-            data = FloatArrayAtomicFieldData.empty(reader.maxDoc());
+            data = FloatArrayAtomicFieldData.empty();
             estimator.afterLoad(null, data.getMemorySizeInBytes());
             return data;
         }
@@ -98,7 +98,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<FloatArrayA
             }
             Ordinals build = builder.build(fieldDataType.getSettings());
             if (build.isMultiValued() || CommonSettings.getMemoryStorageHint(fieldDataType) == CommonSettings.MemoryStorageFormat.ORDINALS) {
-                data = new FloatArrayAtomicFieldData.WithOrdinals(values, reader.maxDoc(), build);
+                data = new FloatArrayAtomicFieldData.WithOrdinals(values, build);
             } else {
                 Docs ordinals = build.ordinals();
                 final FixedBitSet set = builder.buildDocsWithValuesSet();
@@ -108,7 +108,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<FloatArrayA
                 long uniqueValuesArraySize = values.sizeInBytes();
                 long ordinalsSize = build.getMemorySizeInBytes();
                 if (uniqueValuesArraySize + ordinalsSize < singleValuesArraySize) {
-                    data = new FloatArrayAtomicFieldData.WithOrdinals(values, reader.maxDoc(), build);
+                    data = new FloatArrayAtomicFieldData.WithOrdinals(values, build);
                     success = true;
                     return data;
                 }
@@ -120,9 +120,9 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<FloatArrayA
                 }
                 assert sValues.size() == maxDoc;
                 if (set == null) {
-                    data = new FloatArrayAtomicFieldData.Single(sValues, maxDoc, ordinals.getNumOrds());
+                    data = new FloatArrayAtomicFieldData.Single(sValues, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 } else {
-                    data = new FloatArrayAtomicFieldData.SingleFixedSet(sValues, maxDoc, set, ordinals.getNumOrds());
+                    data = new FloatArrayAtomicFieldData.SingleFixedSet(sValues, set, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 }
             }
             success = true;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVAtomicFieldData.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
-import org.apache.lucene.index.AtomicReader;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -30,23 +29,16 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 
 final class GeoPointBinaryDVAtomicFieldData extends AtomicGeoPointFieldData<ScriptDocValues> {
 
-    private final AtomicReader reader;
     private final BinaryDocValues values;
 
-    GeoPointBinaryDVAtomicFieldData(AtomicReader reader, BinaryDocValues values) {
+    GeoPointBinaryDVAtomicFieldData(BinaryDocValues values) {
         super();
-        this.reader = reader;
         this.values = values == null ? BinaryDocValues.EMPTY : values;
     }
 
     @Override
     public boolean isMultiValued() {
         return false;
-    }
-
-    @Override
-    public int getNumDocs() {
-        return reader.maxDoc();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
@@ -54,7 +54,7 @@ public class GeoPointBinaryDVIndexFieldData extends DocValuesIndexFieldData impl
     @Override
     public AtomicGeoPointFieldData<ScriptDocValues> load(AtomicReaderContext context) {
         try {
-            return new GeoPointBinaryDVAtomicFieldData(context.reader(), context.reader().getBinaryDocValues(fieldNames.indexName()));
+            return new GeoPointBinaryDVAtomicFieldData(context.reader().getBinaryDocValues(fieldNames.indexName()));
         } catch (IOException e) {
             throw new ElasticsearchIllegalStateException("Cannot load doc values", e);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedAtomicFieldData.java
@@ -33,21 +33,10 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
  */
 public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFieldData<ScriptDocValues> {
 
-    private final int numDocs;
-
     protected long size = -1;
-
-    public GeoPointCompressedAtomicFieldData(int numDocs) {
-        this.numDocs = numDocs;
-    }
 
     @Override
     public void close() {
-    }
-
-    @Override
-    public int getNumDocs() {
-        return numDocs;
     }
 
     @Override
@@ -61,8 +50,8 @@ public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFi
         private final PagedMutable lon, lat;
         private final Ordinals ordinals;
 
-        public WithOrdinals(GeoPointFieldMapper.Encoding encoding, PagedMutable lon, PagedMutable lat, int numDocs, Ordinals ordinals) {
-            super(numDocs);
+        public WithOrdinals(GeoPointFieldMapper.Encoding encoding, PagedMutable lon, PagedMutable lat, Ordinals ordinals) {
+            super();
             this.encoding = encoding;
             this.lon = lon;
             this.lat = lat;
@@ -76,13 +65,13 @@ public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFi
 
         @Override
         public long getNumberUniqueValues() {
-            return ordinals.getNumOrds();
+            return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
         }
 
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + lon.ramBytesUsed() + lat.ramBytesUsed();
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + lon.ramBytesUsed() + lat.ramBytesUsed();
             }
             return size;
         }
@@ -133,8 +122,8 @@ public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFi
         private final FixedBitSet set;
         private final long numOrds;
 
-        public SingleFixedSet(GeoPointFieldMapper.Encoding encoding, PagedMutable lon, PagedMutable lat, int numDocs, FixedBitSet set, long numOrds) {
-            super(numDocs);
+        public SingleFixedSet(GeoPointFieldMapper.Encoding encoding, PagedMutable lon, PagedMutable lat, FixedBitSet set, long numOrds) {
+            super();
             this.encoding = encoding;
             this.lon = lon;
             this.lat = lat;
@@ -155,7 +144,7 @@ public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFi
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + lon.ramBytesUsed() + lat.ramBytesUsed() + RamUsageEstimator.sizeOf(set.getBits());
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + lon.ramBytesUsed() + lat.ramBytesUsed() + RamUsageEstimator.sizeOf(set.getBits());
             }
             return size;
         }
@@ -204,8 +193,8 @@ public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFi
         private final PagedMutable lon, lat;
         private final long numOrds;
 
-        public Single(GeoPointFieldMapper.Encoding encoding, PagedMutable lon, PagedMutable lat, int numDocs, long numOrds) {
-            super(numDocs);
+        public Single(GeoPointFieldMapper.Encoding encoding, PagedMutable lon, PagedMutable lat, long numOrds) {
+            super();
             this.encoding = encoding;
             this.lon = lon;
             this.lat = lat;
@@ -225,7 +214,7 @@ public abstract class GeoPointCompressedAtomicFieldData extends AtomicGeoPointFi
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + (lon.ramBytesUsed() + lat.ramBytesUsed());
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + (lon.ramBytesUsed() + lat.ramBytesUsed());
             }
             return size;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointCompressedIndexFieldData.java
@@ -85,7 +85,7 @@ public class GeoPointCompressedIndexFieldData extends AbstractGeoPointIndexField
         // TODO: Use an actual estimator to estimate before loading.
         NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker());
         if (terms == null) {
-            data = new Empty(reader.maxDoc());
+            data = new Empty();
             estimator.afterLoad(null, data.getMemorySizeInBytes());
             return data;
         }
@@ -121,7 +121,7 @@ public class GeoPointCompressedIndexFieldData extends AbstractGeoPointIndexField
                     lat = lat.resize(build.getMaxOrd());
                     lon = lon.resize(build.getMaxOrd());
                 }
-                data = new GeoPointCompressedAtomicFieldData.WithOrdinals(encoding, lon, lat, reader.maxDoc(), build);
+                data = new GeoPointCompressedAtomicFieldData.WithOrdinals(encoding, lon, lat, build);
             } else {
                 Docs ordinals = build.ordinals();
                 int maxDoc = reader.maxDoc();
@@ -134,9 +134,9 @@ public class GeoPointCompressedIndexFieldData extends AbstractGeoPointIndexField
                 }
                 FixedBitSet set = builder.buildDocsWithValuesSet();
                 if (set == null) {
-                    data = new GeoPointCompressedAtomicFieldData.Single(encoding, sLon, sLat, reader.maxDoc(), ordinals.getNumOrds());
+                    data = new GeoPointCompressedAtomicFieldData.Single(encoding, sLon, sLat, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 } else {
-                    data = new GeoPointCompressedAtomicFieldData.SingleFixedSet(encoding, sLon, sLat, reader.maxDoc(), set, ordinals.getNumOrds());
+                    data = new GeoPointCompressedAtomicFieldData.SingleFixedSet(encoding, sLon, sLat, set, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 }
             }
             success = true;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayAtomicFieldData.java
@@ -31,21 +31,10 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
  */
 public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointFieldData<ScriptDocValues> {
 
-    private final int numDocs;
-
     protected long size = -1;
-
-    public GeoPointDoubleArrayAtomicFieldData(int numDocs) {
-        this.numDocs = numDocs;
-    }
 
     @Override
     public void close() {
-    }
-
-    @Override
-    public int getNumDocs() {
-        return numDocs;
     }
 
     @Override
@@ -58,8 +47,8 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
         private final BigDoubleArrayList lon, lat;
         private final Ordinals ordinals;
 
-        public WithOrdinals(BigDoubleArrayList lon, BigDoubleArrayList lat, int numDocs, Ordinals ordinals) {
-            super(numDocs);
+        public WithOrdinals(BigDoubleArrayList lon, BigDoubleArrayList lat, Ordinals ordinals) {
+            super();
             this.lon = lon;
             this.lat = lat;
             this.ordinals = ordinals;
@@ -72,13 +61,13 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
 
         @Override
         public long getNumberUniqueValues() {
-            return ordinals.getNumOrds();
+            return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
         }
 
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + lon.sizeInBytes() + lat.sizeInBytes();
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + lon.sizeInBytes() + lat.sizeInBytes();
             }
             return size;
         }
@@ -126,8 +115,8 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
         private final FixedBitSet set;
         private final long numOrds;
 
-        public SingleFixedSet(BigDoubleArrayList lon, BigDoubleArrayList lat, int numDocs, FixedBitSet set, long numOrds) {
-            super(numDocs);
+        public SingleFixedSet(BigDoubleArrayList lon, BigDoubleArrayList lat, FixedBitSet set, long numOrds) {
+            super();
             this.lon = lon;
             this.lat = lat;
             this.set = set;
@@ -147,7 +136,7 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + lon.sizeInBytes() + lat.sizeInBytes() + RamUsageEstimator.sizeOf(set.getBits());
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + lon.sizeInBytes() + lat.sizeInBytes() + RamUsageEstimator.sizeOf(set.getBits());
             }
             return size;
         }
@@ -194,8 +183,8 @@ public abstract class GeoPointDoubleArrayAtomicFieldData extends AtomicGeoPointF
         private final BigDoubleArrayList lon, lat;
         private final long numOrds;
 
-        public Single(BigDoubleArrayList lon, BigDoubleArrayList lat, int numDocs, long numOrds) {
-            super(numDocs);
+        public Single(BigDoubleArrayList lon, BigDoubleArrayList lat, long numOrds) {
+            super();
             this.lon = lon;
             this.lat = lat;
             this.numOrds = numOrds;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointDoubleArrayIndexFieldData.java
@@ -66,7 +66,7 @@ public class GeoPointDoubleArrayIndexFieldData extends AbstractGeoPointIndexFiel
         // TODO: Use an actual estimator to estimate before loading.
         NonEstimatingEstimator estimator = new NonEstimatingEstimator(breakerService.getBreaker());
         if (terms == null) {
-            data = new Empty(reader.maxDoc());
+            data = new Empty();
             estimator.afterLoad(null, data.getMemorySizeInBytes());
             return data;
         }
@@ -97,12 +97,12 @@ public class GeoPointDoubleArrayIndexFieldData extends AbstractGeoPointIndexFiel
                 }
                 FixedBitSet set = builder.buildDocsWithValuesSet();
                 if (set == null) {
-                    data = new GeoPointDoubleArrayAtomicFieldData.Single(sLon, sLat, reader.maxDoc(), ordinals.getNumOrds());
+                    data = new GeoPointDoubleArrayAtomicFieldData.Single(sLon, sLat, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 } else {
-                    data = new GeoPointDoubleArrayAtomicFieldData.SingleFixedSet(sLon, sLat, reader.maxDoc(), set, ordinals.getNumOrds());
+                    data = new GeoPointDoubleArrayAtomicFieldData.SingleFixedSet(sLon, sLat, set, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                 }
             } else {
-                data = new GeoPointDoubleArrayAtomicFieldData.WithOrdinals(lon, lat, reader.maxDoc(), build);
+                data = new GeoPointDoubleArrayAtomicFieldData.WithOrdinals(lon, lat, build);
             }
             success = true;
             return data;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVAtomicFieldData.java
@@ -53,11 +53,6 @@ public class NumericDVAtomicFieldData extends AbstractAtomicNumericFieldData {
     }
 
     @Override
-    public int getNumDocs() {
-        return reader.maxDoc();
-    }
-
-    @Override
     public long getNumberUniqueValues() {
         // good upper limit
         return reader.maxDoc();

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayAtomicFieldData.java
@@ -32,33 +32,21 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals;
  */
 public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFieldData {
 
-    public static PackedArrayAtomicFieldData empty(int numDocs) {
-        return new Empty(numDocs);
+    public static PackedArrayAtomicFieldData empty() {
+        return new Empty();
     }
-
-    private final int numDocs;
 
     protected long size = -1;
 
-    public PackedArrayAtomicFieldData(int numDocs) {
+    public PackedArrayAtomicFieldData() {
         super(false);
-        this.numDocs = numDocs;
     }
 
     @Override
     public void close() {
     }
 
-    @Override
-    public int getNumDocs() {
-        return numDocs;
-    }
-
     static class Empty extends PackedArrayAtomicFieldData {
-
-        Empty(int numDocs) {
-            super(numDocs);
-        }
 
         @Override
         public LongValues getLongValues() {
@@ -101,8 +89,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
         private final MonotonicAppendingLongBuffer values;
         private final Ordinals ordinals;
 
-        public WithOrdinals(MonotonicAppendingLongBuffer values, int numDocs, Ordinals ordinals) {
-            super(numDocs);
+        public WithOrdinals(MonotonicAppendingLongBuffer values, Ordinals ordinals) {
+            super();
             this.values = values;
             this.ordinals = ordinals;
         }
@@ -115,14 +103,14 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
         @Override
         public long getMemorySizeInBytes() {
             if (size == -1) {
-                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + RamUsageEstimator.NUM_BYTES_INT/*numDocs*/ + values.ramBytesUsed() + ordinals.getMemorySizeInBytes();
+                size = RamUsageEstimator.NUM_BYTES_INT/*size*/ + values.ramBytesUsed() + ordinals.getMemorySizeInBytes();
             }
             return size;
         }
 
         @Override
         public long getNumberUniqueValues() {
-            return ordinals.getNumOrds();
+            return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
         }
 
         @Override
@@ -181,8 +169,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
         private final long missingValue;
         private final long numOrds;
 
-        public SingleSparse(PackedInts.Mutable values, long minValue, int numDocs, long missingValue, long numOrds) {
-            super(numDocs);
+        public SingleSparse(PackedInts.Mutable values, long minValue, long missingValue, long numOrds) {
+            super();
             this.values = values;
             this.minValue = minValue;
             this.missingValue = missingValue;
@@ -281,8 +269,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
          * Note, here, we assume that there is no offset by 1 from docId, so position 0
          * is the value for docId 0.
          */
-        public Single(PackedInts.Mutable values, long minValue, int numDocs, long numOrds) {
-            super(numDocs);
+        public Single(PackedInts.Mutable values, long minValue, long numOrds) {
+            super();
             this.values = values;
             this.minValue = minValue;
             this.numOrds = numOrds;
@@ -373,8 +361,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
          * Note, here, we assume that there is no offset by 1 from docId, so position 0
          * is the value for docId 0.
          */
-        public PagedSingle(AppendingDeltaPackedLongBuffer values, int numDocs, long numOrds) {
-            super(numDocs);
+        public PagedSingle(AppendingDeltaPackedLongBuffer values, long numOrds) {
+            super();
             this.values = values;
             this.numOrds = numOrds;
         }
@@ -460,8 +448,8 @@ public abstract class PackedArrayAtomicFieldData extends AbstractAtomicNumericFi
         private final FixedBitSet docsWithValue;
         private final long numOrds;
 
-        public PagedSingleSparse(AppendingDeltaPackedLongBuffer values, int numDocs, FixedBitSet docsWithValue, long numOrds) {
-            super(numDocs);
+        public PagedSingleSparse(AppendingDeltaPackedLongBuffer values, FixedBitSet docsWithValue, long numOrds) {
+            super();
             this.values = values;
             this.docsWithValue = docsWithValue;
             this.numOrds = numOrds;

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -101,7 +101,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
         PackedArrayAtomicFieldData data = null;
         PackedArrayEstimator estimator = new PackedArrayEstimator(breakerService.getBreaker(), getNumericType());
         if (terms == null) {
-            data = PackedArrayAtomicFieldData.empty(reader.maxDoc());
+            data = PackedArrayAtomicFieldData.empty();
             estimator.adjustForNoTerms(data.getMemorySizeInBytes());
             return data;
         }
@@ -129,7 +129,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
             CommonSettings.MemoryStorageFormat formatHint = CommonSettings.getMemoryStorageHint(fieldDataType);
 
             if (build.isMultiValued() || formatHint == CommonSettings.MemoryStorageFormat.ORDINALS) {
-                data = new PackedArrayAtomicFieldData.WithOrdinals(values, reader.maxDoc(), build);
+                data = new PackedArrayAtomicFieldData.WithOrdinals(values, build);
             } else {
                 Docs ordinals = build.ordinals();
                 final FixedBitSet docsWithValues = builder.buildDocsWithValuesSet();
@@ -191,9 +191,9 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                             }
                         }
                         if (docsWithValues == null) {
-                            data = new PackedArrayAtomicFieldData.Single(sValues, minValue, reader.maxDoc(), ordinals.getNumOrds());
+                            data = new PackedArrayAtomicFieldData.Single(sValues, minValue, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                         } else {
-                            data = new PackedArrayAtomicFieldData.SingleSparse(sValues, minValue, reader.maxDoc(), missingValue, ordinals.getNumOrds());
+                            data = new PackedArrayAtomicFieldData.SingleSparse(sValues, minValue, missingValue, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                         }
                         break;
                     case PAGED:
@@ -210,13 +210,13 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                         }
                         dpValues.freeze();
                         if (docsWithValues == null) {
-                            data = new PackedArrayAtomicFieldData.PagedSingle(dpValues, reader.maxDoc(), ordinals.getNumOrds());
+                            data = new PackedArrayAtomicFieldData.PagedSingle(dpValues, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                         } else {
-                            data = new PackedArrayAtomicFieldData.PagedSingleSparse(dpValues, reader.maxDoc(), docsWithValues, ordinals.getNumOrds());
+                            data = new PackedArrayAtomicFieldData.PagedSingleSparse(dpValues, docsWithValues, ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL);
                         }
                         break;
                     case ORDINALS:
-                        data = new PackedArrayAtomicFieldData.WithOrdinals(values, reader.maxDoc(), build);
+                        data = new PackedArrayAtomicFieldData.WithOrdinals(values, build);
                         break;
                     default:
                         throw new ElasticsearchException("unknown memory format: " + formatHint);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -35,8 +35,8 @@ import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
  */
 public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> {
 
-    public static PagedBytesAtomicFieldData empty(int numDocs) {
-        return new Empty(numDocs);
+    public static PagedBytesAtomicFieldData empty() {
+        return new Empty();
     }
 
     // 0 ordinal in values means no value (its null)
@@ -65,13 +65,8 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
     }
 
     @Override
-    public int getNumDocs() {
-        return ordinals.getNumDocs();
-    }
-
-    @Override
     public long getNumberUniqueValues() {
-        return ordinals.getNumOrds();
+        return ordinals.getMaxOrd() - Ordinals.MIN_ORDINAL;
     }
 
     @Override
@@ -179,8 +174,8 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
 
     private final static class Empty extends PagedBytesAtomicFieldData {
 
-        Empty(int numDocs) {
-            super(emptyBytes(), 0, new MonotonicAppendingLongBuffer(), new EmptyOrdinals(numDocs));
+        Empty() {
+            super(emptyBytes(), 0, new MonotonicAppendingLongBuffer(), EmptyOrdinals.INSTANCE);
         }
 
         static PagedBytes.Reader emptyBytes() {
@@ -192,11 +187,6 @@ public class PagedBytesAtomicFieldData implements AtomicFieldData.WithOrdinals<S
         @Override
         public boolean isMultiValued() {
             return false;
-        }
-
-        @Override
-        public int getNumDocs() {
-            return ordinals.getNumDocs();
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -26,8 +26,10 @@ import org.apache.lucene.util.packed.MonotonicAppendingLongBuffer;
 import org.elasticsearch.common.breaker.MemoryCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.RamAccountingTermsEnum;
-import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -66,7 +68,7 @@ public class PagedBytesIndexFieldData extends AbstractBytesIndexFieldData<PagedB
         PagedBytesEstimator estimator = new PagedBytesEstimator(context, breakerService.getBreaker());
         Terms terms = reader.terms(getFieldNames().indexName());
         if (terms == null) {
-            PagedBytesAtomicFieldData emptyData = PagedBytesAtomicFieldData.empty(reader.maxDoc());
+            PagedBytesAtomicFieldData emptyData = PagedBytesAtomicFieldData.empty();
             estimator.adjustForNoTerms(emptyData.getMemorySizeInBytes());
             return emptyData;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildAtomicFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildAtomicFieldData.java
@@ -33,7 +33,6 @@ public class ParentChildAtomicFieldData implements AtomicFieldData {
     private final ImmutableOpenMap<String, PagedBytesAtomicFieldData> typeToIds;
     private final long numberUniqueValues;
     private final long memorySizeInBytes;
-    private final int numDocs;
 
     public ParentChildAtomicFieldData(ImmutableOpenMap<String, PagedBytesAtomicFieldData> typeToIds) {
         this.typeToIds = typeToIds;
@@ -47,17 +46,11 @@ public class ParentChildAtomicFieldData implements AtomicFieldData {
             size += cursor.value.getMemorySizeInBytes();
         }
         this.memorySizeInBytes = size;
-        this.numDocs = typeToIds.isEmpty() ? 0 : typeToIds.values().toArray(PagedBytesAtomicFieldData.class)[0].getNumDocs();
     }
 
     @Override
     public boolean isMultiValued() {
         return true;
-    }
-
-    @Override
-    public int getNumDocs() {
-        return numDocs;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetExecutor.java
+++ b/src/main/java/org/elasticsearch/search/facet/terms/strings/TermsStringOrdinalsFacetExecutor.java
@@ -207,7 +207,7 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
             if (current != null) {
                 missing += current.counts.get(0);
                 total += current.total - current.counts.get(0);
-                if (current.values.ordinals().getNumOrds() > 0) {
+                if (current.values.ordinals().getMaxOrd() > Ordinals.MIN_ORDINAL) {
                     aggregators.add(current);
                 } else {
                     Releasables.close(current);
@@ -235,7 +235,7 @@ public class TermsStringOrdinalsFacetExecutor extends FacetExecutor {
                 missing += current.counts.get(0);
                 total += current.total - current.counts.get(0);
                 // if we have values for this one, add it
-                if (current.values.ordinals().getNumOrds() > 0) {
+                if (current.values.ordinals().getMaxOrd() > Ordinals.MIN_ORDINAL) {
                     aggregators.add(current);
                 } else {
                     Releasables.close(current);

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
@@ -67,7 +67,7 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         AtomicReaderContext readerContext = refreshReader();
         AtomicFieldData fieldData = indexFieldData.load(readerContext);
         BytesValues values = fieldData.getBytesValues(randomBoolean());
-        for (int i = 0; i < fieldData.getNumDocs(); ++i) {
+        for (int i = 0; i < readerContext.reader().maxDoc(); ++i) {
             assertThat(values.setDocument(i), greaterThanOrEqualTo(1));
         }
     }
@@ -79,8 +79,6 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         AtomicReaderContext readerContext = refreshReader();
         AtomicFieldData fieldData = indexFieldData.load(readerContext);
         assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
 
         BytesValues bytesValues = fieldData.getBytesValues(randomBoolean());
 
@@ -177,8 +175,6 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         AtomicFieldData fieldData = indexFieldData.load(refreshReader());
         assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
 
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
         BytesValues bytesValues = fieldData
                 .getBytesValues(randomBoolean());
 
@@ -208,8 +204,6 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         IndexFieldData indexFieldData = getForField("value");
         AtomicFieldData fieldData = indexFieldData.load(refreshReader());
         assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
 
         BytesValues bytesValues = fieldData.getBytesValues(randomBoolean());
 
@@ -253,8 +247,6 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         AtomicFieldData fieldData = indexFieldData.load(refreshReader());
         assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
 
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
         BytesValues bytesValues = fieldData.getBytesValues(randomBoolean());
 
         assertThat(bytesValues.isMultiValued(), equalTo(true));
@@ -285,8 +277,6 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         AtomicFieldData fieldData = indexFieldData.load(refreshReader());
         // Some impls (FST) return size 0 and some (PagedBytes) do take size in the case no actual data is loaded
         assertThat(fieldData.getMemorySizeInBytes(), greaterThanOrEqualTo(0l));
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
 
         BytesValues bytesValues = fieldData.getBytesValues(randomBoolean());
 

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
@@ -54,8 +54,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         IndexNumericFieldData indexFieldData = getForField("value");
         AtomicNumericFieldData fieldData = indexFieldData.load(refreshReader());
 
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
         LongValues longValues = fieldData.getLongValues();
 
         assertThat(longValues.isMultiValued(), equalTo(false));
@@ -105,8 +103,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         fillSingleValueWithMissing();
         IndexNumericFieldData indexFieldData = getForField("value");
         AtomicNumericFieldData fieldData = indexFieldData.load(refreshReader());
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
 
         LongValues longValues = fieldData.getLongValues();
 
@@ -184,8 +180,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         IndexNumericFieldData indexFieldData = getForField("value");
         AtomicNumericFieldData fieldData = indexFieldData.load(refreshReader());
 
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
         LongValues longValues = fieldData.getLongValues();
 
         assertThat(longValues.isMultiValued(), equalTo(true));
@@ -221,8 +215,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         IndexNumericFieldData indexFieldData = getForField("value");
         AtomicNumericFieldData fieldData = indexFieldData.load(refreshReader());
 
-        assertThat(fieldData.getNumDocs(), equalTo(3));
-
         LongValues longValues = fieldData.getLongValues();
 
         assertThat(longValues.isMultiValued(), equalTo(true));
@@ -257,8 +249,6 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         fillAllMissing();
         IndexNumericFieldData indexFieldData = getForField("value");
         AtomicNumericFieldData fieldData = indexFieldData.load(refreshReader());
-
-        assertThat(fieldData.getNumDocs(), equalTo(3));
 
         // long values
 

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTests.java
@@ -435,9 +435,8 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
         // First segment
         assertThat(globalOrdinals, instanceOf(GlobalOrdinalsIndexFieldData.class));
         AtomicFieldData.WithOrdinals afd = globalOrdinals.load(topLevelReader.leaves().get(0));
-        assertThat(afd.getNumDocs(), equalTo(3));
         BytesValues.WithOrdinals values = afd.getBytesValues(randomBoolean());
-        Ordinals.Docs ordinals = values.ordinals().ordinals().ordinals();
+        Ordinals.Docs ordinals = afd.getBytesValues(randomBoolean()).ordinals();
         assertThat(ordinals.setDocument(0), equalTo(2));
         long ord = ordinals.nextOrd();
         assertThat(ord, equalTo(4l));
@@ -453,9 +452,8 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
 
         // Second segment
         afd = globalOrdinals.load(topLevelReader.leaves().get(1));
-        assertThat(afd.getNumDocs(), equalTo(4));
         values = afd.getBytesValues(randomBoolean());
-        ordinals = values.ordinals().ordinals().ordinals();
+        ordinals = afd.getBytesValues(randomBoolean()).ordinals();
         assertThat(ordinals.setDocument(0), equalTo(3));
         ord = ordinals.nextOrd();
         assertThat(ord, equalTo(6l));
@@ -491,8 +489,7 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
         // Third segment
         afd = globalOrdinals.load(topLevelReader.leaves().get(2));
         values = afd.getBytesValues(randomBoolean());
-        ordinals = values.ordinals().ordinals().ordinals();
-        assertThat(afd.getNumDocs(), equalTo(1));
+        ordinals = afd.getBytesValues(randomBoolean()).ordinals();
         assertThat(ordinals.setDocument(0), equalTo(3));
         ord = ordinals.nextOrd();
         assertThat(ord, equalTo(1l));

--- a/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
@@ -79,7 +79,6 @@ public class BinaryDVFieldDataTests extends AbstractFieldDataTests {
         AtomicReaderContext reader = refreshReader();
         IndexFieldData indexFieldData = getForField("field");
         AtomicFieldData fieldData = indexFieldData.load(reader);
-        assertThat(fieldData.getNumDocs(), equalTo(4));
 
         BytesValues bytesValues = fieldData.getBytesValues(randomBoolean());
 

--- a/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
@@ -407,7 +407,6 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
             Docs leftOrds = left.ordinals();
             Docs rightOrds = right.ordinals();
             assertEquals(leftOrds.getMaxOrd(), rightOrds.getMaxOrd());
-            assertEquals(leftOrds.getNumOrds(), rightOrds.getNumOrds());
             for (long ord = Ordinals.MIN_ORDINAL; ord < leftOrds.getMaxOrd(); ++ord) {
                 assertEquals(left.getValueByOrd(ord), right.getValueByOrd(ord));
             }
@@ -503,9 +502,8 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
     private static void duelFieldDataBytes(Random random, AtomicReaderContext context, IndexFieldData<?> left, IndexFieldData<?> right, Preprocessor pre) throws Exception {
         AtomicFieldData<?> leftData = random.nextBoolean() ? left.load(context) : left.loadDirect(context);
         AtomicFieldData<?> rightData = random.nextBoolean() ? right.load(context) : right.loadDirect(context);
-        assertThat(leftData.getNumDocs(), equalTo(rightData.getNumDocs()));
 
-        int numDocs = leftData.getNumDocs();
+        int numDocs = context.reader().maxDoc();
         BytesValues leftBytesValues = leftData.getBytesValues(random.nextBoolean());
         BytesValues rightBytesValues = rightData.getBytesValues(random.nextBoolean());
         BytesRef leftSpare = new BytesRef();
@@ -540,9 +538,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
         AtomicNumericFieldData leftData = random.nextBoolean() ? left.load(context) : left.loadDirect(context);
         AtomicNumericFieldData rightData = random.nextBoolean() ? right.load(context) : right.loadDirect(context);
 
-        assertThat(leftData.getNumDocs(), equalTo(rightData.getNumDocs()));
-
-        int numDocs = leftData.getNumDocs();
+        int numDocs = context.reader().maxDoc();
         DoubleValues leftDoubleValues = leftData.getDoubleValues();
         DoubleValues rightDoubleValues = rightData.getDoubleValues();
         for (int i = 0; i < numDocs; i++) {
@@ -568,9 +564,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
         AtomicNumericFieldData leftData = random.nextBoolean() ? left.load(context) : left.loadDirect(context);
         AtomicNumericFieldData rightData = random.nextBoolean() ? right.load(context) : right.loadDirect(context);
 
-        assertThat(leftData.getNumDocs(), equalTo(rightData.getNumDocs()));
-
-        int numDocs = leftData.getNumDocs();
+        int numDocs = context.reader().maxDoc();
         LongValues leftLongValues = leftData.getLongValues();
         LongValues rightLongValues = rightData.getLongValues();
         for (int i = 0; i < numDocs; i++) {
@@ -592,9 +586,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
         AtomicGeoPointFieldData<?> leftData = random.nextBoolean() ? left.load(context) : left.loadDirect(context);
         AtomicGeoPointFieldData<?> rightData = random.nextBoolean() ? right.load(context) : right.loadDirect(context);
 
-        assertThat(leftData.getNumDocs(), equalTo(rightData.getNumDocs()));
-
-        int numDocs = leftData.getNumDocs();
+        int numDocs = context.reader().maxDoc();
         GeoPointValues leftValues = leftData.getGeoPointValues();
         GeoPointValues rightValues = rightData.getGeoPointValues();
         for (int i = 0; i < numDocs; ++i) {

--- a/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTest.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTest.java
@@ -74,8 +74,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(2L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(3L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("10"));
                 assertThat(bytesValues.getValueByOrd(2).utf8ToString(), equalTo("100"));
             }
@@ -87,8 +86,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(1L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(2L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("5"));
             }
             
@@ -100,8 +98,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(2L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(3L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("10"));
                 assertThat(bytesValues.getValueByOrd(2).utf8ToString(), equalTo("100"));
             }
@@ -114,8 +111,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(2L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(3L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("10"));
                 assertThat(bytesValues.getValueByOrd(2).utf8ToString(), equalTo("100"));
             }
@@ -131,8 +127,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(1L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(2L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("100"));
             }
         }
@@ -176,8 +171,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(1L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(2L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("5"));
             }
             {
@@ -188,8 +182,7 @@ public class FilterFieldDataTest extends AbstractFieldDataTests {
                 AtomicFieldData.WithOrdinals<ScriptDocValues.Strings> loadDirect = (WithOrdinals<Strings>) fieldData.loadDirect(context);
                 BytesValues.WithOrdinals bytesValues = loadDirect.getBytesValues(randomBoolean());
                 Docs ordinals = bytesValues.ordinals();
-                assertThat(2L, equalTo(ordinals.getNumOrds()));
-                assertThat(1000, equalTo(ordinals.getNumDocs()));
+                assertThat(3L, equalTo(ordinals.getMaxOrd()));
                 assertThat(bytesValues.getValueByOrd(1).utf8ToString(), equalTo("10"));
                 assertThat(bytesValues.getValueByOrd(2).utf8ToString(), equalTo("5"));
             }

--- a/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
@@ -105,7 +105,6 @@ public class ParentChildFieldDataTests extends AbstractFieldDataTests {
     public void testGetBytesValues() throws Exception {
         IndexFieldData indexFieldData = getForField(childType);
         AtomicFieldData fieldData = indexFieldData.load(refreshReader());
-        assertThat(fieldData.getNumDocs(), equalTo(8));
         assertThat(fieldData.getMemorySizeInBytes(), greaterThan(0l));
 
         BytesValues bytesValues = fieldData.getBytesValues(randomBoolean());

--- a/src/test/java/org/elasticsearch/index/fielddata/ordinals/SingleOrdinalsTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/ordinals/SingleOrdinalsTests.java
@@ -52,7 +52,6 @@ public class SingleOrdinalsTests extends ElasticsearchTestCase {
         assertThat(ords, instanceOf(SinglePackedOrdinals.class));
         Ordinals.Docs docs = ords.ordinals();
 
-        assertThat(controlDocToOrdinal.size(), equalTo(docs.getNumDocs()));
         for (Map.Entry<Integer, Long> entry : controlDocToOrdinal.entrySet()) {
             assertThat(entry.getValue(), equalTo(docs.getOrd(entry.getKey())));
         }


### PR DESCRIPTION
We have lots of unused, or almost unused methods in our field data impls,
especially when dealing with ordinals. Let's nuke them.

This removes:
- `getNumOrds` (same as `getMaxOrd - 1`)
- `getNumDocs` (unused)
- gettting ordinals as a `LongsRef`
- `Ordinals.Docs.ordinals()`
