### PR TITLE
Update datehistogram-aggregation.asciidoc

### DIFF
--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -82,6 +82,28 @@ factor can be set to 1000.
 Specific offsets can be provided for pre rounding and post rounding. The `pre_offset` for pre rounding, and
 `post_offset` for post rounding. The format is the date time format (`1h`, `1d`, etc...).
 
+=== Hits
+
+The date histogram is a bucket aggregation and therefore returns the bucketed matching documents in the `hits` property
+of the response. This can optionally be suppressed by specifying a `search_type` of `count` in the URI. 
+Here is an example:
+
+[source,js]
+--------------------------------------------------
+$ curl -XGET 'http://localhost:9200/twitter/tweet/_search?search_type=count' -d '{
+    "aggs" : {
+        "tweets_per_minute" : {
+            "date_histogram" : {
+                "field" : "timestamp",
+                "interval" : "1M",
+                "format" : "yyyy-MM-dd" <1>
+            }
+        }
+    }
+}
+'
+--------------------------------------------------
+
 ==== Keys
 
 Since internally, dates are represented as 64bit numbers, these numbers are returned as the bucket keys (each key


### PR DESCRIPTION
Docs really need to explain how to suppress the hits portion of the response to shrink it down and speed it up. I had to do a lot of digging to figure out how and actual found it based on how to do it in facets. Although this probably effects all the various bucket aggregations. Perhaps the change should be made somewhere else in the docs. But made it here since this was where I needed it and tested it.

Hope this is helpful. Thanks!
