### PR TITLE
Update setup repositories documentation

### DIFF
--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -4,7 +4,7 @@
 We also have repositories available for APT and YUM based distributions.
 
 We have split the major versions in separate urls to avoid accidental upgrades across major version.
-For all 0.90.x releases use 0.90 as version number, for 1.0.x use 1.0, etc.
+For all 0.90.x releases use 0.90 as version number, for 1.0.x use 1.0, for 1.1.x use 1.1 etc.
 
 [float]
 === APT
@@ -20,7 +20,7 @@ Add the following to your /etc/apt/sources.list to enable the repository
 
 [source,sh]
 --------------------------------------------------
-deb http://packages.elasticsearch.org/elasticsearch/0.90/debian stable main
+deb http://packages.elasticsearch.org/elasticsearch/1.1/debian stable main
 --------------------------------------------------
 
 Run apt-get update and the repository is ready for use.
@@ -40,9 +40,9 @@ Add the following in your /etc/yum.repos.d/ directory
 
 [source,sh]
 --------------------------------------------------
-[elasticsearch-0.90]
-name=Elasticsearch repository for 0.90.x packages
-baseurl=http://packages.elasticsearch.org/elasticsearch/0.90/centos
+[elasticsearch-1.1]
+name=Elasticsearch repository for 1.1.x packages
+baseurl=http://packages.elasticsearch.org/elasticsearch/1.1/centos
 gpgcheck=1
 gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
 enabled=1


### PR DESCRIPTION
Update doc so
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/setup-repositories.html
example is going to 1.1 instead of 0.90
