### PR TITLE
Improve terms aggregation to perform the segment ordinal to global ordinal lookup post segment collection

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/InternalGlobalOrdinalsBuilder.java
@@ -126,7 +126,7 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
 
     }
 
-    private static abstract class GlobalOrdinalMapping implements Ordinals.Docs {
+    public static abstract class GlobalOrdinalMapping implements Ordinals.Docs {
 
         protected final Ordinals.Docs segmentOrdinals;
         private final long memorySizeInBytes;
@@ -172,7 +172,7 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
             return currentGlobalOrd = getGlobalOrd(segmentOrd);
         }
 
-        protected abstract long getGlobalOrd(long segmentOrd);
+        public abstract long getGlobalOrd(long segmentOrd);
 
     }
 
@@ -288,7 +288,7 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
             }
 
             @Override
-            protected long getGlobalOrd(long segmentOrd) {
+            public long getGlobalOrd(long segmentOrd) {
                 return segmentOrd + segmentOrdToGlobalOrdLookup.get(segmentOrd);
             }
         }
@@ -322,7 +322,7 @@ public class InternalGlobalOrdinalsBuilder extends AbstractIndexComponent implem
             }
 
             @Override
-            protected long getGlobalOrd(long segmentOrd) {
+            public long getGlobalOrd(long segmentOrd) {
                 return segmentOrd + segmentOrdToGlobalOrdLookup.get((int) segmentOrd);
             }
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -97,7 +97,7 @@ public abstract class BucketsAggregator extends Aggregator {
     /**
      * Utility method to increment the doc counts of the given bucket (identified by the bucket ordinal)
      */
-    protected final void incrementBucketDocCount(int inc, long bucketOrd) throws IOException {
+    protected final void incrementBucketDocCount(long inc, long bucketOrd) throws IOException {
         docCounts = bigArrays.grow(docCounts, bucketOrd + 1);
         docCounts.increment(bucketOrd, inc);
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -78,11 +78,8 @@ public abstract class BucketsAggregator extends Aggregator {
         }
     }
 
-    /**
-     * Initializes the docCounts to the specified size.
-     */
-    public void initializeDocCounts(long maxOrd) {
-        docCounts = bigArrays.grow(docCounts, maxOrd);
+    public LongArray getDocCounts() {
+        return docCounts;
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -176,9 +176,9 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
 
     }
 
-    // I think this class should be merged in with the main class, since this class just resolves
-    // the global ordinals post collect phase when going to the next segment instead of resolving global ords on the fly.
-    // and then the decision of post collect or on the fly global ord resolving can be made on a per segment basis.
+    /**
+     * Variant of {@link GlobalOrdinalsStringTermsAggregator} that
+     */
     public static class LowCardinality extends GlobalOrdinalsStringTermsAggregator {
 
         private Ordinals.Docs segmentOrdinals;
@@ -186,7 +186,6 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
 
         public LowCardinality(String name, AggregatorFactories factories, ValuesSource.Bytes.WithOrdinals.FieldData valuesSource, long estimatedBucketCount, InternalOrder order, int requiredSize, int shardSize, long minDocCount, AggregationContext aggregationContext, Aggregator parent) {
             super(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
-            assert factories == AggregatorFactories.EMPTY : LowCardinality.class.getSimpleName() + " can only be used as a leaf aggregation";
         }
 
         @Override
@@ -227,7 +226,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         }
 
         private void mapSegmentCountsToGlobalCounts() {
-            if (globalOrdinals instanceof GlobalOrdinalMapping) {
+            if (segmentOrdinals.getMaxOrd() != globalOrdinals.getMaxOrd()) {
                 // There is no public method in Ordinals.Docs that allows for this mapping...
                 // This is the cleanest way I can think of so far
                 GlobalOrdinalMapping mapping = (GlobalOrdinalMapping) globalOrdinals;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.search.aggregations.*;
@@ -39,8 +40,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
-                    InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
-                    AggregationContext aggregationContext, Aggregator parent) {
+                              long maxOrd, InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              AggregationContext aggregationContext, Aggregator parent) {
                 return new StringTermsAggregator(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, includeExclude, aggregationContext, parent);
             }
 
@@ -54,8 +55,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
-                    InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
-                    AggregationContext aggregationContext, Aggregator parent) {
+                              long maxOrd, InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              AggregationContext aggregationContext, Aggregator parent) {
                 if (includeExclude != null) {
                     throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
                 }
@@ -72,12 +73,12 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
-                              InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              long maxOrd, InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
                               AggregationContext aggregationContext, Aggregator parent) {
                 if (includeExclude != null) {
                     throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
                 }
-                return new GlobalOrdinalsStringTermsAggregator(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+                return new GlobalOrdinalsStringTermsAggregator(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, maxOrd, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
             }
 
             @Override
@@ -90,12 +91,12 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
-                              InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              long maxOrd, InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
                               AggregationContext aggregationContext, Aggregator parent) {
                 if (includeExclude != null) {
                     throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
                 }
-                return new GlobalOrdinalsStringTermsAggregator.WithHash(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+                return new GlobalOrdinalsStringTermsAggregator.WithHash(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, maxOrd, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
             }
 
             @Override
@@ -107,7 +108,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
-                              InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              long maxOrd, InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
                               AggregationContext aggregationContext, Aggregator parent) {
                 if (includeExclude != null) {
                     throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
@@ -115,7 +116,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 if (factories != AggregatorFactories.EMPTY) {
                     throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode can only be used as a leaf aggregation");
                 }
-                return new GlobalOrdinalsStringTermsAggregator.LowCardinality(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+                return new GlobalOrdinalsStringTermsAggregator.LowCardinality(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, maxOrd, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
             }
 
             @Override
@@ -140,8 +141,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         }
 
         abstract Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
-                InternalOrder order, int requiredSize, int shardSize, long minDocCount,
-                IncludeExclude includeExclude, AggregationContext aggregationContext, Aggregator parent);
+                                   long maxOrd, InternalOrder order, int requiredSize, int shardSize, long minDocCount,
+                                   IncludeExclude includeExclude, AggregationContext aggregationContext, Aggregator parent);
 
         abstract boolean needsGlobalOrdinals();
 
@@ -220,6 +221,18 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 execution = ExecutionMode.MAP;
             }
 
+            final long maxOrd;
+            final double ratio;
+            if (execution == null || execution.needsGlobalOrdinals()) {
+                ValuesSource.Bytes.WithOrdinals valueSourceWithOrdinals = (ValuesSource.Bytes.WithOrdinals) valuesSource;
+                IndexSearcher indexSearcher = aggregationContext.searchContext().searcher();
+                maxOrd = valueSourceWithOrdinals.maxOrd(indexSearcher);
+                ratio = maxOrd / ((double) indexSearcher.getIndexReader().numDocs());
+            } else {
+                maxOrd = -1;
+                ratio = -1;
+            }
+
             // Let's try to use a good default
             if (execution == null) {
                 // if there is a parent bucket aggregator the number of instances of this aggregator is going
@@ -228,12 +241,23 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 if (hasParentBucketAggregator(parent)) {
                     execution = ExecutionMode.GLOBAL_ORDINALS_HASH;
                 } else {
-                    execution = ExecutionMode.GLOBAL_ORDINALS;
+                    if (factories == AggregatorFactories.EMPTY) {
+                        if (ratio <= 0.5 && maxOrd <= 2048) {
+                            // 0.5: At least we need reduce the number of global ordinals look-ups by half
+                            // 2048: GLOBAL_ORDINALS_LOW_CARDINALITY has additional memory usage, which directly linked to maxOrd, so we need to limit.
+                            execution = ExecutionMode.GLOBAL_ORDINALS_LOW_CARDINALITY;
+                        } else {
+                            execution = ExecutionMode.GLOBAL_ORDINALS;
+                        }
+                    } else {
+                        execution = ExecutionMode.GLOBAL_ORDINALS;
+                    }
                 }
             }
+
             assert execution != null;
             valuesSource.setNeedsGlobalOrdinals(execution.needsGlobalOrdinals());
-            return execution.create(name, factories, valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, includeExclude, aggregationContext, parent);
+            return execution.create(name, factories, valuesSource, estimatedBucketCount, maxOrd, order, requiredSize, shardSize, minDocCount, includeExclude, aggregationContext, parent);
         }
 
         if (includeExclude != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -102,6 +102,23 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             boolean needsGlobalOrdinals() {
                 return true;
             }
+        },
+        GLOBAL_ORDINALS_LOW_CARDINALITY(new ParseField("global_ordinals_low_cardinality")) {
+
+            @Override
+            Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource, long estimatedBucketCount,
+                              InternalOrder order, int requiredSize, int shardSize, long minDocCount, IncludeExclude includeExclude,
+                              AggregationContext aggregationContext, Aggregator parent) {
+                if (includeExclude != null) {
+                    throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
+                }
+                return new GlobalOrdinalsStringTermsAggregator.LowCardinality(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
+            }
+
+            @Override
+            boolean needsGlobalOrdinals() {
+                return true;
+            }
         };
 
         public static ExecutionMode fromString(String value) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -112,6 +112,9 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 if (includeExclude != null) {
                     throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode cannot filter terms.");
                 }
+                if (factories != AggregatorFactories.EMPTY) {
+                    throw new ElasticsearchIllegalArgumentException("The `" + this + "` execution mode can only be used as a leaf aggregation");
+                }
                 return new GlobalOrdinalsStringTermsAggregator.LowCardinality(name, factories, (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, estimatedBucketCount, order, requiredSize, shardSize, minDocCount, aggregationContext, parent);
             }
 

--- a/src/test/java/org/elasticsearch/benchmark/search/aggregations/GlobalOrdinalsBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/search/aggregations/GlobalOrdinalsBenchmark.java
@@ -186,7 +186,7 @@ public class GlobalOrdinalsBenchmark {
                     fieldName = fieldName + ".doc_values";
                     name = name + "_doc_values"; // can't have . in agg name
                 }
-                stats.add(terms(name, fieldName, "global_ordinals"));
+                stats.add(terms(name, fieldName, "global_ordinals_low_cardinality"));
             }
         }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsTests.java
@@ -147,7 +147,8 @@ public class StringTermsTests extends ElasticsearchIntegrationTest {
     public void singleValueField_withGlobalOrdinals() throws Exception {
         ExecutionMode[] executionModes = new ExecutionMode[] {
                 ExecutionMode.GLOBAL_ORDINALS,
-                ExecutionMode.GLOBAL_ORDINALS_HASH
+                ExecutionMode.GLOBAL_ORDINALS_HASH,
+                ExecutionMode.GLOBAL_ORDINALS_LOW_CARDINALITY
         };
         for (ExecutionMode executionMode : executionModes) {
             logger.info("Execution mode:" + executionMode);


### PR DESCRIPTION
In case when there are not too many unique values it is better to do the segment ordinal to global ordinal lookup after segment results have been processed.
