### PR TITLE
Use unlimited `flush_threshold_ops` for translog

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -11,7 +11,7 @@ parameters:
 |=======================================================================
 |Setting |Description
 |index.translog.flush_threshold_ops |After how many operations to flush.
-Defaults to `5000`.
+Defaults to `unlimited`.
 
 |index.translog.flush_threshold_size |Once the translog hits this size,
 a flush will happen. Defaults to `200mb`.

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -45,6 +45,18 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
  */
 public class TranslogService extends AbstractIndexShardComponent {
 
+    private static final String FLUSH_THRESHOLD_OPS_KEY = "flush_threshold_ops";
+    private static final String FLUSH_THRESHOLD_SIZE_KEY = "flush_threshold_size";
+    private static final String FLUSH_THRESHOLD_PERIOD_KEY = "flush_threshold_period";
+    private static final String FLUSH_THRESHOLD_DISABLE_FLUSH_KEY = "disable_flush";
+    private static final String FLUSH_THRESHOLD_INTERVAL_KEY = "interval";
+
+    public static final String INDEX_TRANSLOG_FLUSH_INTERVAL = "index.translog." + FLUSH_THRESHOLD_INTERVAL_KEY;
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS = "index.translog." + FLUSH_THRESHOLD_OPS_KEY;
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE = "index.translog." + FLUSH_THRESHOLD_SIZE_KEY;
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD =  "index.translog." + FLUSH_THRESHOLD_PERIOD_KEY;
+    public static final String INDEX_TRANSLOG_DISABLE_FLUSH = "index.translog." + FLUSH_THRESHOLD_DISABLE_FLUSH_KEY;
+
     private final ThreadPool threadPool;
     private final IndexSettingsService indexSettingsService;
     private final IndexShard indexShard;
@@ -67,11 +79,11 @@ public class TranslogService extends AbstractIndexShardComponent {
         this.indexShard = indexShard;
         this.translog = translog;
 
-        this.flushThresholdOperations = componentSettings.getAsInt("flush_threshold_ops", componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
-        this.flushThresholdSize = componentSettings.getAsBytesSize("flush_threshold_size", new ByteSizeValue(200, ByteSizeUnit.MB));
-        this.flushThresholdPeriod = componentSettings.getAsTime("flush_threshold_period", TimeValue.timeValueMinutes(30));
-        this.interval = componentSettings.getAsTime("interval", timeValueMillis(5000));
-        this.disableFlush = componentSettings.getAsBoolean("disable_flush", false);
+        this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
+        this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(200, ByteSizeUnit.MB));
+        this.flushThresholdPeriod = componentSettings.getAsTime(FLUSH_THRESHOLD_PERIOD_KEY, TimeValue.timeValueMinutes(30));
+        this.interval = componentSettings.getAsTime(FLUSH_THRESHOLD_INTERVAL_KEY, timeValueMillis(5000));
+        this.disableFlush = componentSettings.getAsBoolean(FLUSH_THRESHOLD_DISABLE_FLUSH_KEY, false);
 
         logger.debug("interval [{}], flush_threshold_ops [{}], flush_threshold_size [{}], flush_threshold_period [{}]", interval, flushThresholdOperations, flushThresholdSize, flushThresholdPeriod);
 
@@ -86,11 +98,7 @@ public class TranslogService extends AbstractIndexShardComponent {
         this.future.cancel(true);
     }
 
-    public static final String INDEX_TRANSLOG_FLUSH_INTERVAL = "index.translog.interval";
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS = "index.translog.flush_threshold_ops";
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE = "index.translog.flush_threshold_size";
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD = "index.translog.flush_threshold_period";
-    public static final String INDEX_TRANSLOG_DISABLE_FLUSH = "index.translog.disable_flush";
+
 
     class ApplySettings implements IndexSettingsService.Listener {
         @Override

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -67,7 +67,7 @@ public class TranslogService extends AbstractIndexShardComponent {
         this.indexShard = indexShard;
         this.translog = translog;
 
-        this.flushThresholdOperations = componentSettings.getAsInt("flush_threshold_ops", componentSettings.getAsInt("flush_threshold", 5000));
+        this.flushThresholdOperations = componentSettings.getAsInt("flush_threshold_ops", componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
         this.flushThresholdSize = componentSettings.getAsBytesSize("flush_threshold_size", new ByteSizeValue(200, ByteSizeUnit.MB));
         this.flushThresholdPeriod = componentSettings.getAsTime("flush_threshold_period", TimeValue.timeValueMinutes(30));
         this.interval = componentSettings.getAsTime("interval", timeValueMillis(5000));


### PR DESCRIPTION
Currently we use 5k operations as a flush threshold. Indexing 5k documents
per second is rather common which would cause the index to be committed on
the lucene level each time the flush logic runs which is 5 seconds by default.
We should rather use a size based threshold similar to the lucene index writer
that doesn't cause such agressive commits which can slow down indexing significantly
especially since they cause the underlying devices to fsync their data.
