### PR TITLE
Change default merge throttling to 50MB / sec

### DIFF
--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -40,7 +40,7 @@ second. It can be set by setting `indices.store.throttle.type` to
 `merge`, and setting `indices.store.throttle.max_bytes_per_sec` to
 something like `5mb`. The node level settings can be changed dynamically
 using the cluster update settings API. The default is set
-to `20mb` with type `merge`.
+to `50mb` with type `merge`.
 
 If specific index level configuration is needed, regardless of the node
 level settings, it can be set as well using the

--- a/docs/reference/modules/indices.asciidoc
+++ b/docs/reference/modules/indices.asciidoc
@@ -59,7 +59,7 @@ The following settings can be set to manage the recovery policy:
     defaults to `true`.
 
 `indices.recovery.max_bytes_per_sec`::
-    defaults to `20mb`.
+    defaults to `50mb`.
 
 [float]
 [[throttling]]

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -95,7 +95,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         // we limit with 20MB / sec by default with a default type set to merge sice 0.90.1
         this.rateLimitingType = componentSettings.get("throttle.type", StoreRateLimiting.Type.MERGE.name());
         rateLimiting.setType(rateLimitingType);
-        this.rateLimitingThrottle = componentSettings.getAsBytesSize("throttle.max_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB));
+        this.rateLimitingThrottle = componentSettings.getAsBytesSize("throttle.max_bytes_per_sec", new ByteSizeValue(50, ByteSizeUnit.MB));
         rateLimiting.setMaxRate(rateLimitingThrottle);
 
         logger.debug("using indices.store.throttle.type [{}], with index.store.throttle.max_bytes_per_sec [{}]", rateLimitingType, rateLimitingThrottle);

--- a/src/test/java/org/elasticsearch/indices/store/SimpleDistributorTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/SimpleDistributorTests.java
@@ -50,6 +50,7 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testDirectoryToString() throws IOException {
+        cluster().wipeTemplates(); // no random settings please
         createIndexWithStoreType("test", "niofs", "least_used");
         String storeString = getStoreDirectory("test", 0).toString();
         logger.info(storeString);
@@ -58,7 +59,7 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         if (dataPaths.length > 1) {
             assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(niofs(" + dataPaths[1].getAbsolutePath().toLowerCase(Locale.ROOT)));
         }
-        assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
+        assertThat(storeString, endsWith(", type=MERGE, rate=50.0)])"));
 
         createIndexWithStoreType("test", "niofs", "random");
         storeString = getStoreDirectory("test", 0).toString();
@@ -68,7 +69,7 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         if (dataPaths.length > 1) {
             assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(niofs(" + dataPaths[1].getAbsolutePath().toLowerCase(Locale.ROOT)));
         }
-        assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
+        assertThat(storeString, endsWith(", type=MERGE, rate=50.0)])"));
 
         createIndexWithStoreType("test", "mmapfs", "least_used");
         storeString = getStoreDirectory("test", 0).toString();
@@ -78,7 +79,7 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         if (dataPaths.length > 1) {
             assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(mmapfs(" + dataPaths[1].getAbsolutePath().toLowerCase(Locale.ROOT)));
         }
-        assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
+        assertThat(storeString, endsWith(", type=MERGE, rate=50.0)])"));
 
         createIndexWithStoreType("test", "simplefs", "least_used");
         storeString = getStoreDirectory("test", 0).toString();
@@ -88,7 +89,7 @@ public class SimpleDistributorTests extends ElasticsearchIntegrationTest {
         if (dataPaths.length > 1) {
             assertThat(storeString.toLowerCase(Locale.ROOT), containsString("), rate_limited(simplefs(" + dataPaths[1].getAbsolutePath().toLowerCase(Locale.ROOT)));
         }
-        assertThat(storeString, endsWith(", type=MERGE, rate=20.0)])"));
+        assertThat(storeString, endsWith(", type=MERGE, rate=50.0)])"));
 
         createIndexWithStoreType("test", "memory", "least_used");
         storeString = getStoreDirectory("test", 0).toString();


### PR DESCRIPTION
The current setting of 20MB/sec seems to be too conservative given
the capabilities of modern hardware. Even on cloud infrastructure this
seems to be too lowish. A 50MB default should provide better out of the box
performance
