### PR TITLE
Use Lucene's defaults for CMS settings

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/EnableMergeScheduler.java
+++ b/src/main/java/org/elasticsearch/index/merge/EnableMergeScheduler.java
@@ -83,4 +83,9 @@ public class EnableMergeScheduler extends MergeScheduler {
         // the clone will just be the identity.
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "EnableMergeScheduler(" + mergeScheduler + ")";
+    }
 }

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.merge.scheduler;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergeScheduler;
@@ -52,9 +53,8 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
     public ConcurrentMergeSchedulerProvider(ShardId shardId, @IndexSettings Settings indexSettings, ThreadPool threadPool) {
         super(shardId, indexSettings, threadPool);
 
-        // TODO LUCENE MONITOR this will change in Lucene 4.0
-        this.maxThreadCount = componentSettings.getAsInt("max_thread_count", Math.max(1, Math.min(3, Runtime.getRuntime().availableProcessors() / 2)));
-        this.maxMergeCount = componentSettings.getAsInt("max_merge_count", maxThreadCount + 2);
+        this.maxThreadCount = ConcurrentMergeScheduler.DEFAULT_MAX_THREAD_COUNT;
+        this.maxMergeCount = ConcurrentMergeScheduler.DEFAULT_MAX_MERGE_COUNT;
         logger.debug("using [concurrent] merge scheduler with max_thread_count[{}]", maxThreadCount);
     }
 

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -53,8 +53,8 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
     public ConcurrentMergeSchedulerProvider(ShardId shardId, @IndexSettings Settings indexSettings, ThreadPool threadPool) {
         super(shardId, indexSettings, threadPool);
 
-        this.maxThreadCount = ConcurrentMergeScheduler.DEFAULT_MAX_THREAD_COUNT;
-        this.maxMergeCount = ConcurrentMergeScheduler.DEFAULT_MAX_MERGE_COUNT;
+        this.maxThreadCount = componentSettings.getAsInt("max_thread_count", ConcurrentMergeScheduler.DEFAULT_MAX_THREAD_COUNT);
+        this.maxMergeCount = componentSettings.getAsInt("max_merge_count", ConcurrentMergeScheduler.DEFAULT_MAX_MERGE_COUNT);
         logger.debug("using [concurrent] merge scheduler with max_thread_count[{}]", maxThreadCount);
     }
 


### PR DESCRIPTION
#5882

Lucene changed the settings a while back to be more conservative but ES has the old hardwired defaults.
