### PR TITLE
Raise node disconnected even if the transport is stopped

### DIFF
--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -96,7 +96,25 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
 
     @Override
     protected void doStop() throws ElasticsearchException {
-        transport.stop();
+        try {
+            transport.stop();
+        } finally {
+            // in case the transport is not connected to our local node (thus cleaned on node disconnect)
+            // make sure to clean any leftover on going handles
+            for (Map.Entry<Long, RequestHolder> entry : clientHandlers.entrySet()) {
+                final RequestHolder holderToNotify = clientHandlers.remove(entry.getKey());
+                if (holderToNotify != null) {
+                    // callback that an exception happened, but on a different thread since we don't
+                    // want handlers to worry about stack overflows
+                    threadPool.generic().execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            holderToNotify.handler().handleException(new TransportException("transport stopped, action: " + holderToNotify.action()));
+                        }
+                    });
+                }
+            }
+        }
     }
 
     @Override
@@ -300,7 +318,6 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                         }
                     });
                 }
-                // node got disconnected, raise disconnection on possible ongoing handlers
                 for (Map.Entry<Long, RequestHolder> entry : clientHandlers.entrySet()) {
                     RequestHolder holder = entry.getValue();
                     if (holder.node().equals(node)) {


### PR DESCRIPTION
during the stop process, we raise network disconnect, so it is valid to raise then while we are in stop mode, and actually, we should not miss any events in such a case.
Typically, this is not a problem, since its during the normal shutdown process on the JVM, but when running a reused cluster within the JVM (like in our test infra with the shared cluster), we should properly raise those node disconnects
