### PR TITLE
Test: Start nodes using node.bench true to enable benchmark api

### DIFF
--- a/dev-tools/build_release.py
+++ b/dev-tools/build_release.py
@@ -399,7 +399,7 @@ def smoke_test_release(release, files, expected_hash, plugins):
     else:
       background = '-d'
     print('  Starting elasticsearch deamon from [%s]' % os.path.join(tmp_dir, 'elasticsearch-%s' % release))
-    run('%s; %s -Des.node.name=smoke_tester -Des.cluster.name=prepare_release -Des.discovery.zen.ping.multicast.enabled=false %s'
+    run('%s; %s -Des.node.name=smoke_tester -Des.cluster.name=prepare_release -Des.discovery.zen.ping.multicast.enabled=false -Des.node.bench=true %s'
          % (java_exe(), es_run_path, background))
     conn = HTTPConnection('127.0.0.1', 9200, 20);
     wait_for_node_startup()

--- a/rest-api-spec/test/abort_benchmark/10_basic.yaml
+++ b/rest-api-spec/test/abort_benchmark/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test benchmark abort":
 
   - skip:
-        version:     "0 - 9999"
-        reason:      Disabled until nodes run with node.bench set to true
+        features:    "benchmark"
 
   - do:
         abort_benchmark:

--- a/rest-api-spec/test/benchmark/10_basic.yaml
+++ b/rest-api-spec/test/benchmark/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test benchmark submit":
 
   - skip:
-        version:     "0 - 9999"
-        reason:      Disabled until nodes run with node.bench set to true
+        features:    "benchmark"
 
   - do:
       indices.create:
@@ -30,5 +29,5 @@
                             "query":
                                 "match": { "_all": "*" }
 
-  - match: { status: complete }
+  - match: { status: COMPLETE }
 

--- a/rest-api-spec/test/list_benchmarks/10_basic.yaml
+++ b/rest-api-spec/test/list_benchmarks/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test benchmark list":
 
   - skip:
-        version:     "0 - 9999"
-        reason:      Disabled until nodes run with node.bench set to true
+        features:    "benchmark"
 
   - do:
         list_benchmarks: {}

--- a/src/test/java/org/elasticsearch/action/bench/BenchmarkNegativeTest.java
+++ b/src/test/java/org/elasticsearch/action/bench/BenchmarkNegativeTest.java
@@ -25,10 +25,12 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import org.junit.Test;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+
 /**
  * Tests for negative situations where we cannot run benchmarks
  */
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+@ClusterScope(scope = Scope.SUITE, enableRandomBenchNodes = false)
 public class BenchmarkNegativeTest extends ElasticsearchIntegrationTest {
 
     private static final String INDEX_NAME = "test_index";

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1119,6 +1119,12 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         int numClientNodes() default TestCluster.DEFAULT_NUM_CLIENT_NODES;
 
         /**
+         * Returns whether the ability to randomly have benchmark (client) nodes as part of the cluster needs to be enabled.
+         * Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_ENABLE_RANDOM_BENCH_NODES}.
+         */
+        boolean enableRandomBenchNodes() default TestCluster.DEFAULT_ENABLE_RANDOM_BENCH_NODES;
+
+        /**
          * Returns the transport client ratio. By default this returns <code>-1</code> which means a random
          * ratio in the interval <code>[0..1]</code> is used.
          */
@@ -1219,6 +1225,11 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         return annotation == null ? TestCluster.DEFAULT_NUM_CLIENT_NODES : annotation.numClientNodes();
     }
 
+    private boolean enableRandomBenchNodes() {
+        ClusterScope annotation = getAnnotation(this.getClass());
+        return annotation == null ? TestCluster.DEFAULT_ENABLE_RANDOM_BENCH_NODES : annotation.enableRandomBenchNodes();
+    }
+
     private boolean randomDynamicTemplates() {
         ClusterScope annotation = getAnnotation(this.getClass());
         return annotation == null ? true : annotation.randomDynamicTemplates();
@@ -1255,7 +1266,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         }
 
         int numClientNodes = getNumClientNodes();
-        return new TestCluster(currentClusterSeed, minNumDataNodes, maxNumDataNodes, clusterName(scope.name(), ElasticsearchTestCase.CHILD_VM_ID, currentClusterSeed), nodeSettingsSource, numClientNodes);
+        boolean enableRandomBenchNodes = enableRandomBenchNodes();
+        return new TestCluster(currentClusterSeed, minNumDataNodes, maxNumDataNodes, clusterName(scope.name(), ElasticsearchTestCase.CHILD_VM_ID, currentClusterSeed), nodeSettingsSource, numClientNodes, enableRandomBenchNodes);
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -47,6 +47,7 @@ public final class ExternalTestCluster extends ImmutableTestCluster {
     private final InetSocketAddress[] httpAddresses;
 
     private final int numDataNodes;
+    private final int numBenchNodes;
 
     public ExternalTestCluster(TransportAddress... transportAddresses) {
         this.client = new TransportClient(ImmutableSettings.settingsBuilder().put("client.transport.ignore_cluster_name", true))
@@ -55,14 +56,19 @@ public final class ExternalTestCluster extends ImmutableTestCluster {
         NodesInfoResponse nodeInfos = this.client.admin().cluster().prepareNodesInfo().clear().setSettings(true).setHttp(true).get();
         httpAddresses = new InetSocketAddress[nodeInfos.getNodes().length];
         int dataNodes = 0;
+        int benchNodes = 0;
         for (int i = 0; i < nodeInfos.getNodes().length; i++) {
             NodeInfo nodeInfo = nodeInfos.getNodes()[i];
             httpAddresses[i] = ((InetSocketTransportAddress) nodeInfo.getHttp().address().publishAddress()).address();
             if (nodeInfo.getSettings().getAsBoolean("node.data", true)) {
                 dataNodes++;
             }
+            if (nodeInfo.getSettings().getAsBoolean("node.bench", false)) {
+                benchNodes++;
+            }
         }
         this.numDataNodes = dataNodes;
+        this.numBenchNodes = benchNodes;
         logger.info("Setup ExternalTestCluster [{}] made of [{}] nodes", nodeInfos.getClusterName().value(), size());
     }
 
@@ -84,6 +90,11 @@ public final class ExternalTestCluster extends ImmutableTestCluster {
     @Override
     public int numDataNodes() {
         return numDataNodes;
+    }
+
+    @Override
+    public int numBenchNodes() {
+        return numBenchNodes;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/ImmutableTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ImmutableTestCluster.java
@@ -101,6 +101,11 @@ public abstract class ImmutableTestCluster implements Iterable<Client> {
     public abstract int numDataNodes();
 
     /**
+     * Returns the number of bench nodes in the cluster.
+     */
+    public abstract int numBenchNodes();
+
+    /**
      * Returns the http addresses of the nodes within the cluster.
      * Can be used to run REST tests against the test cluster.
      */

--- a/src/test/java/org/elasticsearch/test/rest/support/Features.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/Features.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test.rest.support;
 
 import com.google.common.collect.Lists;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.util.List;
 
@@ -44,17 +45,13 @@ public final class Features {
      */
     public static boolean areAllSupported(List<String> features) {
         for (String feature : features) {
+            if ("benchmark".equals(feature) && ElasticsearchIntegrationTest.immutableCluster().numBenchNodes() > 0) {
+                continue;
+            }
             if (!SUPPORTED.contains(feature)) {
                 return false;
             }
         }
         return true;
-    }
-
-    /**
-     * Returns all the supported features
-     */
-    public static List<String> getSupported() {
-        return SUPPORTED;
     }
 }

--- a/src/test/java/org/elasticsearch/tribe/TribeTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeTests.java
@@ -58,7 +58,7 @@ public class TribeTests extends ElasticsearchIntegrationTest {
     public static void setupSecondCluster() throws Exception {
         ElasticsearchIntegrationTest.beforeClass();
         // create another cluster
-        cluster2 = new TestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()), 0);
+        cluster2 = new TestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()), 0, false);
         cluster2.beforeTest(getRandom(), 0.1);
         cluster2.ensureAtLeastNumDataNodes(2);
     }


### PR DESCRIPTION
Enabling benchmark apis is required to run our REST tests for it. Added the parameter to node creation in `TestCluster` as well in the release script, when starting the node to run the smoke tests against.

Closes #5910
