### PR TITLE
Fix TemplateQueryParser swallows additional parameters

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -68,7 +68,6 @@ public class TemplateQueryParser implements QueryParser {
             final QueryParseContext context = new QueryParseContext(parseContext.index(), parseContext.indexQueryParser);
             context.reset(qSourceParser);
             Query result = context.parseInnerQuery();
-            parser.nextToken();
             return result;
         }
     }

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +37,8 @@ import java.util.Map;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -69,6 +73,42 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
         SearchResponse sr = client().prepareSearch().setQuery(builder)
                 .execute().actionGet();
         assertHitCount(sr, 2);
+    }
+
+    @Test
+    public void testTemplateInBodyWithSize() throws IOException {
+        String request = "{\n" +
+                "    \"size\":0,"+
+                "    \"query\": {\n" +
+                "        \"template\": {\n" +
+                "            \"query\": {\"match_{{template}}\": {}},\n" +
+                "            \"params\" : {\n" +
+                "                \"template\" : \"all\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        SearchResponse sr = client().prepareSearch().setSource(request)
+                .execute().actionGet();
+        assertNoFailures(sr);
+        assertThat(sr.getHits().hits().length, equalTo(0));
+        request = "{\n" +
+                "    \"query\": {\n" +
+                "        \"template\": {\n" +
+                "            \"query\": {\"match_{{template}}\": {}},\n" +
+                "            \"params\" : {\n" +
+                "                \"template\" : \"all\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"size\":0"+
+                "}";
+
+        sr = client().prepareSearch().setSource(request)
+                .execute().actionGet();
+        assertNoFailures(sr);
+        assertThat(sr.getHits().hits().length, equalTo(0));
+
     }
 
     @Test


### PR DESCRIPTION
Request parameters such as "size" and "fields" were ignored when
placed after the template query in the reqest.
