### PR TITLE
Make Create/Update/Delete classes less mutable

### DIFF
--- a/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -185,9 +185,7 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     protected PrimaryResponse<DeleteResponse, DeleteRequest> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) {
         DeleteRequest request = shardRequest.request;
         IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.request.index()).shardSafe(shardRequest.shardId);
-        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version())
-                .versionType(request.versionType())
-                .origin(Engine.Operation.Origin.PRIMARY);
+        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version(), request.versionType(), Engine.Operation.Origin.PRIMARY);
         indexShard.delete(delete);
         // update the request with teh version so it will go to the replicas
         request.versionType(delete.versionType().versionTypeForReplicationAndRecovery());
@@ -211,8 +209,7 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     protected void shardOperationOnReplica(ReplicaOperationRequest shardRequest) {
         DeleteRequest request = shardRequest.request;
         IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.request.index()).shardSafe(shardRequest.shardId);
-        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version()).versionType(request.versionType())
-                .origin(Engine.Operation.Origin.REPLICA);
+        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version(), request.versionType(), Engine.Operation.Origin.REPLICA);
 
         indexShard.delete(delete);
 

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
@@ -93,8 +93,7 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
     protected PrimaryResponse<ShardDeleteResponse, ShardDeleteRequest> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) {
         ShardDeleteRequest request = shardRequest.request;
         IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.request.index()).shardSafe(shardRequest.shardId);
-        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version())
-                .origin(Engine.Operation.Origin.PRIMARY);
+        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version(), VersionType.INTERNAL, Engine.Operation.Origin.PRIMARY);
         indexShard.delete(delete);
         // update the version to happen on the replicas
         request.version(delete.version());
@@ -116,11 +115,10 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
     protected void shardOperationOnReplica(ReplicaOperationRequest shardRequest) {
         ShardDeleteRequest request = shardRequest.request;
         IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.request.index()).shardSafe(shardRequest.shardId);
-        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version())
-                .origin(Engine.Operation.Origin.REPLICA);
+        Engine.Delete delete = indexShard.prepareDelete(request.type(), request.id(), request.version(), VersionType.INTERNAL, Engine.Operation.Origin.REPLICA);
 
         // IndexDeleteAction doesn't support version type at the moment. Hard coded for the INTERNAL version
-        delete.versionType(VersionType.INTERNAL.versionTypeForReplicationAndRecovery());
+        delete = new Engine.Delete(delete, VersionType.INTERNAL.versionTypeForReplicationAndRecovery());
 
         assert delete.versionType().validateVersion(delete.version());
 

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -119,8 +119,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
                 indexShard.acquireSearcher("delete_by_query"), indexService, indexShard, scriptService, cacheRecycler,
                 pageCacheRecycler, bigArrays));
         try {
-            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.source(), request.filteringAliases(), request.types())
-                    .origin(Engine.Operation.Origin.PRIMARY);
+            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.source(), request.filteringAliases(), Engine.Operation.Origin.PRIMARY, request.types());
             SearchContext.current().parsedQuery(new ParsedQuery(deleteByQuery.query(), ImmutableMap.<String, Filter>of()));
             indexShard.deleteByQuery(deleteByQuery);
         } finally {
@@ -142,8 +141,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
                 indexShard.acquireSearcher("delete_by_query", IndexShard.Mode.WRITE), indexService, indexShard, scriptService,
                 cacheRecycler, pageCacheRecycler, bigArrays));
         try {
-            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.source(), request.filteringAliases(), request.types())
-                    .origin(Engine.Operation.Origin.REPLICA);
+            Engine.DeleteByQuery deleteByQuery = indexShard.prepareDeleteByQuery(request.source(), request.filteringAliases(), Engine.Operation.Origin.REPLICA, request.types());
             SearchContext.current().parsedQuery(new ParsedQuery(deleteByQuery.query(), ImmutableMap.<String, Filter>of()));
             indexShard.deleteByQuery(deleteByQuery);
         } finally {

--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -191,10 +191,7 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
         boolean created;
         Engine.IndexingOperation op;
         if (request.opType() == IndexRequest.OpType.INDEX) {
-            Engine.Index index = indexShard.prepareIndex(sourceToParse)
-                    .version(request.version())
-                    .versionType(request.versionType())
-                    .origin(Engine.Operation.Origin.PRIMARY);
+            Engine.Index index = indexShard.prepareIndex(sourceToParse, request.version(), request.versionType(), Engine.Operation.Origin.PRIMARY);
             if (index.parsedDoc().mappingsModified()) {
                 mappingUpdatedAction.updateMappingOnMaster(request.index(), request.type(), indexMetaData.getUUID(), false);
             }
@@ -203,10 +200,8 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
             op = index;
             created = index.created();
         } else {
-            Engine.Create create = indexShard.prepareCreate(sourceToParse)
-                    .version(request.version())
-                    .versionType(request.versionType())
-                    .origin(Engine.Operation.Origin.PRIMARY);
+            Engine.Create create = indexShard.prepareCreate(sourceToParse,
+                    request.version(), request.versionType(), Engine.Operation.Origin.PRIMARY);
             if (create.parsedDoc().mappingsModified()) {
                 mappingUpdatedAction.updateMappingOnMaster(request.index(), request.type(), indexMetaData.getUUID(), false);
             }
@@ -240,14 +235,11 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
         SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, request.source()).type(request.type()).id(request.id())
                 .routing(request.routing()).parent(request.parent()).timestamp(request.timestamp()).ttl(request.ttl());
         if (request.opType() == IndexRequest.OpType.INDEX) {
-            Engine.Index index = indexShard.prepareIndex(sourceToParse)
-                    .version(request.version()).versionType(request.versionType())
-                    .origin(Engine.Operation.Origin.REPLICA);
+            Engine.Index index = indexShard.prepareIndex(sourceToParse, request.version(), request.versionType(), Engine.Operation.Origin.REPLICA);
             indexShard.index(index);
         } else {
-            Engine.Create create = indexShard.prepareCreate(sourceToParse)
-                    .version(request.version()).versionType(request.versionType())
-                    .origin(Engine.Operation.Origin.REPLICA);
+            Engine.Create create = indexShard.prepareCreate(sourceToParse,
+                    request.version(), request.versionType(), Engine.Operation.Origin.REPLICA);
             indexShard.create(create);
         }
         if (request.refresh()) {

--- a/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -376,270 +376,147 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         Origin origin();
     }
 
-    static interface IndexingOperation extends Operation {
+    static abstract class IndexingOperation implements Operation {
 
-        ParsedDocument parsedDoc();
-
-        List<Document> docs();
-
-        DocumentMapper docMapper();
-    }
-
-    static class Create implements IndexingOperation {
         private final DocumentMapper docMapper;
         private final Term uid;
         private final ParsedDocument doc;
-        private long version = Versions.MATCH_ANY;
-        private VersionType versionType = VersionType.INTERNAL;
-        private Origin origin = Origin.PRIMARY;
+        private long version;
+        private final VersionType versionType;
+        private final Origin origin;
 
-        private long startTime;
+        private final long startTime;
         private long endTime;
 
-        public Create(DocumentMapper docMapper, Term uid, ParsedDocument doc) {
+        public IndexingOperation(DocumentMapper docMapper, Term uid, ParsedDocument doc, long version, VersionType versionType, Origin origin, long startTime) {
             this.docMapper = docMapper;
             this.uid = uid;
             this.doc = doc;
+            this.version = version;
+            this.versionType = versionType;
+            this.origin = origin;
+            this.startTime = startTime;
+        }
+
+        public IndexingOperation(DocumentMapper docMapper, Term uid, ParsedDocument doc) {
+            this(docMapper, uid, doc, Versions.MATCH_ANY, VersionType.INTERNAL, Origin.PRIMARY, System.nanoTime());
+        }
+
+        public DocumentMapper docMapper() {
+            return this.docMapper;
         }
 
         @Override
-        public DocumentMapper docMapper() {
-            return this.docMapper;
+        public Origin origin() {
+            return this.origin;
+        }
+
+        public ParsedDocument parsedDoc() {
+            return this.doc;
+        }
+
+        public Term uid() {
+            return this.uid;
+        }
+
+        public String type() {
+            return this.doc.type();
+        }
+
+        public String id() {
+            return this.doc.id();
+        }
+
+        public String routing() {
+            return this.doc.routing();
+        }
+
+        public long timestamp() {
+            return this.doc.timestamp();
+        }
+
+        public long ttl() {
+            return this.doc.ttl();
+        }
+
+        public long version() {
+            return this.version;
+        }
+
+        public void updateVersion(long version) {
+            this.version = version;
+            this.doc.version().setLongValue(version);
+        }
+
+        public VersionType versionType() {
+            return this.versionType;
+        }
+
+        public String parent() {
+            return this.doc.parent();
+        }
+
+        public List<Document> docs() {
+            return this.doc.docs();
+        }
+
+        public Analyzer analyzer() {
+            return this.doc.analyzer();
+        }
+
+        public BytesReference source() {
+            return this.doc.source();
+        }
+
+        /**
+         * Returns operation start time in nanoseconds.
+         */
+        public long startTime() {
+            return this.startTime;
+        }
+
+        public void endTime(long endTime) {
+            this.endTime = endTime;
+        }
+
+        /**
+         * Returns operation end time in nanoseconds.
+         */
+        public long endTime() {
+            return this.endTime;
+        }
+    }
+
+    static final class Create extends IndexingOperation {
+
+        public Create(DocumentMapper docMapper, Term uid, ParsedDocument doc, long version, VersionType versionType, Origin origin, long startTime) {
+            super(docMapper, uid, doc, version, versionType, origin, startTime);
+        }
+
+        public Create(DocumentMapper docMapper, Term uid, ParsedDocument doc) {
+            super(docMapper, uid, doc);
         }
 
         @Override
         public Type opType() {
             return Type.CREATE;
         }
-
-        public Create origin(Origin origin) {
-            this.origin = origin;
-            return this;
-        }
-
-        @Override
-        public Origin origin() {
-            return this.origin;
-        }
-
-        @Override
-        public ParsedDocument parsedDoc() {
-            return this.doc;
-        }
-
-        public Term uid() {
-            return this.uid;
-        }
-
-        public String type() {
-            return this.doc.type();
-        }
-
-        public String id() {
-            return this.doc.id();
-        }
-
-        public String routing() {
-            return this.doc.routing();
-        }
-
-        public long timestamp() {
-            return this.doc.timestamp();
-        }
-
-        public long ttl() {
-            return this.doc.ttl();
-        }
-
-        public long version() {
-            return this.version;
-        }
-
-        public Create version(long version) {
-            this.version = version;
-            this.doc.version().setLongValue(version);
-            return this;
-        }
-
-        public VersionType versionType() {
-            return this.versionType;
-        }
-
-        public Create versionType(VersionType versionType) {
-            this.versionType = versionType;
-            return this;
-        }
-
-        public String parent() {
-            return this.doc.parent();
-        }
-
-        @Override
-        public List<Document> docs() {
-            return this.doc.docs();
-        }
-
-        public Analyzer analyzer() {
-            return this.doc.analyzer();
-        }
-
-        public BytesReference source() {
-            return this.doc.source();
-        }
-
-        public Create startTime(long startTime) {
-            this.startTime = startTime;
-            return this;
-        }
-
-        /**
-         * Returns operation start time in nanoseconds.
-         */
-        public long startTime() {
-            return this.startTime;
-        }
-
-        public Create endTime(long endTime) {
-            this.endTime = endTime;
-            return this;
-        }
-
-        /**
-         * Returns operation end time in nanoseconds.
-         */
-        public long endTime() {
-            return this.endTime;
-        }
     }
 
-    static class Index implements IndexingOperation {
-        private final DocumentMapper docMapper;
-        private final Term uid;
-        private final ParsedDocument doc;
-        private long version = Versions.MATCH_ANY;
-        private VersionType versionType = VersionType.INTERNAL;
-        private Origin origin = Origin.PRIMARY;
+    static final class Index extends IndexingOperation {
         private boolean created;
 
-        private long startTime;
-        private long endTime;
-
-        public Index(DocumentMapper docMapper, Term uid, ParsedDocument doc) {
-            this.docMapper = docMapper;
-            this.uid = uid;
-            this.doc = doc;
+        public Index(DocumentMapper docMapper, Term uid, ParsedDocument doc, long version, VersionType versionType, Origin origin, long startTime) {
+            super(docMapper, uid, doc, version, versionType, origin, startTime);
         }
 
-        @Override
-        public DocumentMapper docMapper() {
-            return this.docMapper;
+        public Index(DocumentMapper docMapper, Term uid, ParsedDocument doc) {
+            super(docMapper, uid, doc);
         }
 
         @Override
         public Type opType() {
             return Type.INDEX;
-        }
-
-        public Index origin(Origin origin) {
-            this.origin = origin;
-            return this;
-        }
-
-        @Override
-        public Origin origin() {
-            return this.origin;
-        }
-
-        public Term uid() {
-            return this.uid;
-        }
-
-        @Override
-        public ParsedDocument parsedDoc() {
-            return this.doc;
-        }
-
-        public Index version(long version) {
-            this.version = version;
-            doc.version().setLongValue(version);
-            return this;
-        }
-
-        /**
-         * before indexing holds the version requested, after indexing holds the new version of the document.
-         */
-        public long version() {
-            return this.version;
-        }
-
-        public Index versionType(VersionType versionType) {
-            this.versionType = versionType;
-            return this;
-        }
-
-        public VersionType versionType() {
-            return this.versionType;
-        }
-
-        @Override
-        public List<Document> docs() {
-            return this.doc.docs();
-        }
-
-        public Analyzer analyzer() {
-            return this.doc.analyzer();
-        }
-
-        public String id() {
-            return this.doc.id();
-        }
-
-        public String type() {
-            return this.doc.type();
-        }
-
-        public String routing() {
-            return this.doc.routing();
-        }
-
-        public String parent() {
-            return this.doc.parent();
-        }
-
-        public long timestamp() {
-            return this.doc.timestamp();
-        }
-
-        public long ttl() {
-            return this.doc.ttl();
-        }
-
-        public BytesReference source() {
-            return this.doc.source();
-        }
-
-        public Index startTime(long startTime) {
-            this.startTime = startTime;
-            return this;
-        }
-
-        /**
-         * Returns operation start time in nanoseconds.
-         */
-        public long startTime() {
-            return this.startTime;
-        }
-
-        public Index endTime(long endTime) {
-            this.endTime = endTime;
-            return this;
-        }
-
-        /**
-         * Returns operation end time in nanoseconds.
-         */
-        public long endTime() {
-            return this.endTime;
         }
 
         /**
@@ -658,28 +535,36 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         private final String type;
         private final String id;
         private final Term uid;
-        private long version = Versions.MATCH_ANY;
-        private VersionType versionType = VersionType.INTERNAL;
-        private Origin origin = Origin.PRIMARY;
+        private long version;
+        private final VersionType versionType;
+        private final Origin origin;
         private boolean found;
 
-        private long startTime;
+        private final long startTime;
         private long endTime;
 
-        public Delete(String type, String id, Term uid) {
+        public Delete(String type, String id, Term uid, long version, VersionType versionType, Origin origin, long startTime, boolean found) {
             this.type = type;
             this.id = id;
             this.uid = uid;
+            this.version = version;
+            this.versionType = versionType;
+            this.origin = origin;
+            this.startTime = startTime;
+            this.found = found;
+        }
+
+        public Delete(String type, String id, Term uid) {
+            this(type, id, uid, Versions.MATCH_ANY, VersionType.INTERNAL, Origin.PRIMARY, System.nanoTime(), false);
+        }
+
+        public Delete(Delete template, VersionType versionType) {
+            this(template.type(), template.id(), template.uid(), template.version(), versionType, template.origin(), template.startTime(), template.found());
         }
 
         @Override
         public Type opType() {
             return Type.DELETE;
-        }
-
-        public Delete origin(Origin origin) {
-            this.origin = origin;
-            return this;
         }
 
         @Override
@@ -699,9 +584,9 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
             return this.uid;
         }
 
-        public Delete version(long version) {
+        public void updateVersion(long version, boolean found) {
             this.version = version;
-            return this;
+            this.found = found;
         }
 
         /**
@@ -709,11 +594,6 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
          */
         public long version() {
             return this.version;
-        }
-
-        public Delete versionType(VersionType versionType) {
-            this.versionType = versionType;
-            return this;
         }
 
         public VersionType versionType() {
@@ -724,16 +604,6 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
             return this.found;
         }
 
-        public Delete found(boolean found) {
-            this.found = found;
-            return this;
-        }
-
-        public Delete startTime(long startTime) {
-            this.startTime = startTime;
-            return this;
-        }
-
         /**
          * Returns operation start time in nanoseconds.
          */
@@ -741,9 +611,8 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
             return this.startTime;
         }
 
-        public Delete endTime(long endTime) {
+        public void endTime(long endTime) {
             this.endTime = endTime;
-            return this;
         }
 
         /**
@@ -761,18 +630,20 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
         private final Filter aliasFilter;
         private final String[] types;
         private final Filter parentFilter;
-        private Operation.Origin origin = Operation.Origin.PRIMARY;
+        private final Operation.Origin origin;
 
-        private long startTime;
+        private final long startTime;
         private long endTime;
 
-        public DeleteByQuery(Query query, BytesReference source, @Nullable String[] filteringAliases, @Nullable Filter aliasFilter, Filter parentFilter, String... types) {
+        public DeleteByQuery(Query query, BytesReference source, @Nullable String[] filteringAliases, @Nullable Filter aliasFilter, Filter parentFilter, Operation.Origin origin, long startTime, String... types) {
             this.query = query;
             this.source = source;
             this.types = types;
             this.filteringAliases = filteringAliases;
             this.aliasFilter = aliasFilter;
             this.parentFilter = parentFilter;
+            this.startTime = startTime;
+            this.origin = origin;
         }
 
         public Query query() {
@@ -803,18 +674,8 @@ public interface Engine extends IndexShardComponent, CloseableComponent {
             return parentFilter;
         }
 
-        public DeleteByQuery origin(Operation.Origin origin) {
-            this.origin = origin;
-            return this;
-        }
-
         public Operation.Origin origin() {
             return this.origin;
-        }
-
-        public DeleteByQuery startTime(long startTime) {
-            this.startTime = startTime;
-            return this;
         }
 
         /**

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -435,7 +435,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 }
             }
 
-            create.version(updatedVersion);
+            create.updateVersion(updatedVersion);
 
             if (create.docs().size() > 1) {
                 writer.addDocuments(create.docs(), create.analyzer());
@@ -495,7 +495,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             updatedVersion = index.versionType().updateVersion(currentVersion, expectedVersion);
 
 
-            index.version(updatedVersion);
+            index.updateVersion(updatedVersion);
             if (currentVersion == Versions.NOT_FOUND) {
                 // document does not exists, we can optimize for create
                 index.created(true);
@@ -567,16 +567,16 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
             if (currentVersion == Versions.NOT_FOUND) {
                 // doc does not exists and no prior deletes
-                delete.version(updatedVersion).found(false);
+                delete.updateVersion(updatedVersion, false);
                 Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
                 versionMap.put(versionKey, new VersionValue(updatedVersion, true, threadPool.estimatedTimeInMillis(), translogLocation));
             } else if (versionValue != null && versionValue.delete()) {
                 // a "delete on delete", in this case, we still increment the version, log it, and return that version
-                delete.version(updatedVersion).found(false);
+                delete.updateVersion(updatedVersion, false);
                 Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
                 versionMap.put(versionKey, new VersionValue(updatedVersion, true, threadPool.estimatedTimeInMillis(), translogLocation));
             } else {
-                delete.version(updatedVersion).found(true);
+                delete.updateVersion(updatedVersion, true);
                 writer.deleteDocuments(delete.uid());
                 Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
                 versionMap.put(versionKey, new VersionValue(updatedVersion, true, threadPool.estimatedTimeInMillis(), translogLocation));

--- a/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/IndexShard.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.cache.filter.FilterCacheStats;
 import org.elasticsearch.index.cache.filter.ShardFilterCache;
 import org.elasticsearch.index.cache.id.IdCacheStats;
@@ -128,19 +129,19 @@ public interface IndexShard extends IndexShardComponent {
 
     IndexShardState state();
 
-    Engine.Create prepareCreate(SourceToParse source) throws ElasticsearchException;
+    Engine.Create prepareCreate(SourceToParse source, long version, VersionType versionType, Engine.Operation.Origin origin) throws ElasticsearchException;
 
     ParsedDocument create(Engine.Create create) throws ElasticsearchException;
 
-    Engine.Index prepareIndex(SourceToParse source) throws ElasticsearchException;
+    Engine.Index prepareIndex(SourceToParse source, long version, VersionType versionType, Engine.Operation.Origin origin) throws ElasticsearchException;
 
     ParsedDocument index(Engine.Index index) throws ElasticsearchException;
 
-    Engine.Delete prepareDelete(String type, String id, long version) throws ElasticsearchException;
+    Engine.Delete prepareDelete(String type, String id, long version, VersionType versionType, Engine.Operation.Origin origin) throws ElasticsearchException;
 
     void delete(Engine.Delete delete) throws ElasticsearchException;
 
-    Engine.DeleteByQuery prepareDeleteByQuery(BytesReference source, @Nullable String[] filteringAliases, String... types) throws ElasticsearchException;
+    Engine.DeleteByQuery prepareDeleteByQuery(BytesReference source, @Nullable String[] filteringAliases, Engine.Operation.Origin origin, String... types) throws ElasticsearchException;
 
     void deleteByQuery(Engine.DeleteByQuery deleteByQuery) throws ElasticsearchException;
 


### PR DESCRIPTION
Today we use a builder pattern / setters to set relevant information
to Engine#Delete|Create|Index. Yet almost all the values are required
but they are not passed via ctor arguments but via an error prone builder
pattern. If we add a required argument we should see compile errors on that
level to make sure we don't miss any place to set them.

Prerequisite for #5917
