### PR TITLE
Function score multi values

### DIFF
--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -150,6 +150,46 @@ that is initialized with a `seed`.
 }
 --------------------------------------------------
 
+===== Field Value factor
+The `field_value_factor` function allows you to use a field from a document to
+influence the score. It's similar to using the `script_score` function, however,
+it avoids the overhead of scripting. If used on a multi-valued field, only the
+first value of the field is used in calculations.
+
+As an example, imagine you have a document indexed with a numeric `popularity`
+field and wish in influence the score of a document with this field, an example
+doing so would look like:
+
+[source,js]
+--------------------------------------------------
+"field_value_factor": {
+  "field": "popularity",
+  "factor": 1.2,
+  "modifier": "sqrt"
+}
+--------------------------------------------------
+
+Which will translate into the following forumla for scoring:
+
+`sqrt(1.2 * doc['popularity'].value)`
+
+There are a number of options for the `field_value_factor` function:
+
+[cols="<,<",options="header",]
+|=======================================================================
+| Parameter |Description
+|`field` |Field to be extracted from the document.
+|`factor` |Optional factor to multiply the field value with, defaults to 1.
+|`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
+ `log1p`, `log2p`, `ln`, `ln1p`, `ln2p`, `square`, `sqrt`, or `reciprocal`.
+ Defaults to `none`.
+|=======================================================================
+
+Keep in mind that taking the log() of 0, or the square root of a negative number
+is an illegal operation, and an exception will be thrown. Be sure to limit the
+values of the field with a range filter to avoid this, or use `log1p` and
+`ln1p`.
+
 ===== Decay functions
 
 Decay functions score a document with a function that decays depending
@@ -246,45 +286,31 @@ In contrast to the normal and exponential decay, this function actually
 sets the score to 0 if the field value exceeds twice the user given
 scale value.
 
-===== Field Value factor
-The `field_value_factor` function allows you to use a field from a document to
-influence the score. It's similar to using the `script_score` function, however,
-it avoids the overhead of scripting. If used on a multi-valued field, only the
-first value of the field is used in calculations.
+===== Multiple values:
 
-As an example, imagine you have a document indexed with a numeric `popularity`
-field and wish in influence the score of a document with this field, an example
-doing so would look like:
+If a field used for computing the decay contains multiple values, per default the value closest to the origin is chosen for determining the distance.
+This can be changed by setting `multi_value_mode`.
+
+[horizontal]
+`min`:: Distance is the minimum distance
+`max`:: Distance is the maximum distance
+`avg`:: Distance is the average distance
+`sum`:: Distance is the sum of all distances
+
+Example:
 
 [source,js]
 --------------------------------------------------
-"field_value_factor": {
-  "field": "popularity",
-  "factor": 1.2,
-  "modifier": "sqrt"
-}
+    "DECAY_FUNCTION": {
+        "FIELD_NAME": {
+              "origin": ...,
+              "scale": ...
+        },
+        "multi_value_mode": "avg"
+    }
 --------------------------------------------------
 
-Which will translate into the following forumla for scoring:
 
-`sqrt(1.2 * doc['popularity'].value)`
-
-There are a number of options for the `field_value_factor` function:
-
-[cols="<,<",options="header",]
-|=======================================================================
-| Parameter |Description
-|`field` |Field to be extracted from the document.
-|`factor` |Optional factor to multiply the field value with, defaults to 1.
-|`modifier` |Modifier to apply to the field value, can be one of: `none`, `log`,
- `log1p`, `log2p`, `ln`, `ln1p`, `ln2p`, `square`, `sqrt`, or `reciprocal`.
- Defaults to `none`.
-|=======================================================================
-
-Keep in mind that taking the log() of 0, or the square root of a negative number
-is an illegal operation, and an exception will be thrown. Be sure to limit the
-values of the field with a range filter to avoid this, or use `log1p` and
-`ln1p`.
 
 ==== Detailed example
 

--- a/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexComponent;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -97,7 +97,7 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
     /**
      * Comparator used for sorting.
      */
-    XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode);
+    XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode);
 
     /**
      * Clears any resources associated with this field data.

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -41,10 +42,10 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
     }
 
     private final IndexFieldData<?> indexFieldData;
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
     private final Object missingValue;
 
-    public BytesRefFieldComparatorSource(IndexFieldData<?> indexFieldData, Object missingValue, SortMode sortMode) {
+    public BytesRefFieldComparatorSource(IndexFieldData<?> indexFieldData, Object missingValue, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.sortMode = sortMode;
         this.missingValue = missingValue;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefOrdValComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefOrdValComparator.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -54,7 +55,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
        @lucene.internal */
     final long[] ords;
 
-    final SortMode sortMode;
+    final MultiValueMode sortMode;
 
     /* Values for each slot.
        @lucene.internal */
@@ -88,7 +89,7 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
     BytesRef top;
     long topOrd;
 
-    public BytesRefOrdValComparator(IndexFieldData.WithOrdinals<?> indexFieldData, int numHits, SortMode sortMode, BytesRef missingValue) {
+    public BytesRefOrdValComparator(IndexFieldData.WithOrdinals<?> indexFieldData, int numHits, MultiValueMode sortMode, BytesRef missingValue) {
         this.indexFieldData = indexFieldData;
         this.sortMode = sortMode;
         this.missingValue = missingValue;
@@ -395,11 +396,11 @@ public final class BytesRefOrdValComparator extends NestedWrappableComparator<By
         return -(low + 1);
     }
 
-    static long getRelevantOrd(Ordinals.Docs readerOrds, int docId, SortMode sortMode) {
+    static long getRelevantOrd(Ordinals.Docs readerOrds, int docId, MultiValueMode sortMode) {
         int length = readerOrds.setDocument(docId);
         long relevantVal = sortMode.startLong();
         long result = 0;
-        assert sortMode == SortMode.MAX || sortMode == SortMode.MIN;
+        assert sortMode == MultiValueMode.MAX || sortMode == MultiValueMode.MIN;
         for (int i = 0; i < length; i++) {
             result = relevantVal = sortMode.apply(readerOrds.nextOrd(), relevantVal);
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefValComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefValComparator.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -36,7 +37,7 @@ import java.io.IOException;
 public final class BytesRefValComparator extends NestedWrappableComparator<BytesRef> {
 
     private final IndexFieldData<?> indexFieldData;
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
     private final BytesRef missingValue;
 
     private final BytesRef[] values;
@@ -44,7 +45,7 @@ public final class BytesRefValComparator extends NestedWrappableComparator<Bytes
     private BytesRef top;
     private BytesValues docTerms;
 
-    BytesRefValComparator(IndexFieldData<?> indexFieldData, int numHits, SortMode sortMode, BytesRef missingValue) {
+    BytesRefValComparator(IndexFieldData<?> indexFieldData, int numHits, MultiValueMode sortMode, BytesRef missingValue) {
         this.sortMode = sortMode;
         values = new BytesRef[numHits];
         this.indexFieldData = indexFieldData;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparator.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -29,7 +30,7 @@ public final class DoubleValuesComparator extends DoubleValuesComparatorBase<Dou
 
     private final double[] values;
 
-    public DoubleValuesComparator(IndexNumericFieldData<?> indexFieldData, double missingValue, int numHits, SortMode sortMode) {
+    public DoubleValuesComparator(IndexNumericFieldData<?> indexFieldData, double missingValue, int numHits, MultiValueMode sortMode) {
         super(indexFieldData, missingValue, sortMode);
         assert indexFieldData.getNumericType().requiredBits() <= 64;
         this.values = new double[numHits];

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorBase.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorBase.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.FieldComparator;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -31,9 +32,9 @@ abstract class DoubleValuesComparatorBase<T extends Number> extends NumberCompar
     protected final double missingValue;
     protected double bottom;
     protected DoubleValues readerValues;
-    protected final SortMode sortMode;
+    protected final MultiValueMode sortMode;
 
-    public DoubleValuesComparatorBase(IndexNumericFieldData<?> indexFieldData, double missingValue, SortMode sortMode) {
+    public DoubleValuesComparatorBase(IndexNumericFieldData<?> indexFieldData, double missingValue, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.missingValue = missingValue;
         this.sortMode = sortMode;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -33,9 +34,9 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
 
     private final IndexNumericFieldData<?> indexFieldData;
     private final Object missingValue;
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
 
-    public DoubleValuesComparatorSource(IndexNumericFieldData<?> indexFieldData, @Nullable Object missingValue, SortMode sortMode) {
+    public DoubleValuesComparatorSource(IndexNumericFieldData<?> indexFieldData, @Nullable Object missingValue, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.missingValue = missingValue;
         this.sortMode = sortMode;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparator.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -28,7 +29,7 @@ public final class FloatValuesComparator extends DoubleValuesComparatorBase<Floa
 
     private final float[] values;
 
-    public FloatValuesComparator(IndexNumericFieldData<?> indexFieldData, float missingValue, int numHits, SortMode sortMode) {
+    public FloatValuesComparator(IndexNumericFieldData<?> indexFieldData, float missingValue, int numHits, MultiValueMode sortMode) {
         super(indexFieldData, missingValue, sortMode);
         assert indexFieldData.getNumericType().requiredBits() <= 32;
         this.values = new float[numHits];

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -32,9 +33,9 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
 
     private final IndexNumericFieldData<?> indexFieldData;
     private final Object missingValue;
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
 
-    public FloatValuesComparatorSource(IndexNumericFieldData<?> indexFieldData, @Nullable Object missingValue, SortMode sortMode) {
+    public FloatValuesComparatorSource(IndexNumericFieldData<?> indexFieldData, @Nullable Object missingValue, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.missingValue = missingValue;
         this.sortMode = sortMode;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/GeoDistanceComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/GeoDistanceComparator.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -40,7 +41,7 @@ public class GeoDistanceComparator extends NumberComparatorBase<Double> {
     protected final DistanceUnit unit;
     protected final GeoDistance geoDistance;
     protected final GeoDistance.FixedSourceDistance fixedSourceDistance;
-    protected final SortMode sortMode;
+    protected final MultiValueMode sortMode;
     private static final Double MISSING_VALUE = Double.MAX_VALUE;
 
     private final double[] values;
@@ -48,7 +49,7 @@ public class GeoDistanceComparator extends NumberComparatorBase<Double> {
 
     private GeoDistanceValues geoDistanceValues;
 
-    public GeoDistanceComparator(int numHits, IndexGeoPointFieldData<?> indexFieldData, double lat, double lon, DistanceUnit unit, GeoDistance geoDistance, SortMode sortMode) {
+    public GeoDistanceComparator(int numHits, IndexGeoPointFieldData<?> indexFieldData, double lat, double lon, DistanceUnit unit, GeoDistance geoDistance, MultiValueMode sortMode) {
         this.values = new double[numHits];
         this.indexFieldData = indexFieldData;
         this.lat = lat;
@@ -166,9 +167,9 @@ public class GeoDistanceComparator extends NumberComparatorBase<Double> {
     // Deals with more than one geo point per document
     private static final class MV extends GeoDistanceValues {
 
-        private final SortMode sortMode;
+        private final MultiValueMode sortMode;
 
-        MV(GeoPointValues readerValues, GeoDistance.FixedSourceDistance fixedSourceDistance, SortMode sortMode) {
+        MV(GeoPointValues readerValues, GeoDistance.FixedSourceDistance fixedSourceDistance, MultiValueMode sortMode) {
             super(readerValues, fixedSourceDistance);
             this.sortMode = sortMode;
         }

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/GeoDistanceComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/GeoDistanceComparatorSource.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -37,9 +38,9 @@ public class GeoDistanceComparatorSource extends IndexFieldData.XFieldComparator
     private final double lon;
     private final DistanceUnit unit;
     private final GeoDistance geoDistance;
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
 
-    public GeoDistanceComparatorSource(IndexGeoPointFieldData<?> indexFieldData, double lat, double lon, DistanceUnit unit, GeoDistance geoDistance, SortMode sortMode) {
+    public GeoDistanceComparatorSource(IndexGeoPointFieldData<?> indexFieldData, double lat, double lon, DistanceUnit unit, GeoDistance geoDistance, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.lat = lat;
         this.lon = lon;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparator.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparator.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.fielddata.fieldcomparator;
 
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -28,7 +29,7 @@ public final class LongValuesComparator extends LongValuesComparatorBase<Long> {
 
     private final long[] values;
 
-    public LongValuesComparator(IndexNumericFieldData<?> indexFieldData, long missingValue, int numHits, SortMode sortMode) {
+    public LongValuesComparator(IndexNumericFieldData<?> indexFieldData, long missingValue, int numHits, MultiValueMode sortMode) {
         super(indexFieldData, missingValue, sortMode);
         this.values = new long[numHits];
         assert indexFieldData.getNumericType().requiredBits() <= 64;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorBase.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorBase.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.FieldComparator;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.LongValues;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -31,10 +32,10 @@ abstract class LongValuesComparatorBase<T extends Number> extends NumberComparat
     protected final long missingValue;
     protected long bottom;
     protected LongValues readerValues;
-    protected final SortMode sortMode;
+    protected final MultiValueMode sortMode;
 
 
-    public LongValuesComparatorBase(IndexNumericFieldData<?> indexFieldData, long missingValue, SortMode sortMode) {
+    public LongValuesComparatorBase(IndexNumericFieldData<?> indexFieldData, long missingValue, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.missingValue = missingValue;
         this.sortMode = sortMode;

--- a/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 
@@ -32,9 +33,9 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
 
     private final IndexNumericFieldData<?> indexFieldData;
     private final Object missingValue;
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
 
-    public LongValuesComparatorSource(IndexNumericFieldData<?> indexFieldData, @Nullable Object missingValue, SortMode sortMode) {
+    public LongValuesComparatorSource(IndexNumericFieldData<?> indexFieldData, @Nullable Object missingValue, MultiValueMode sortMode) {
         this.indexFieldData = indexFieldData;
         this.missingValue = missingValue;
         this.sortMode = sortMode;

--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.InternalGlobalOrdinalsBuilder.OrdinalMappingSource;
 import org.elasticsearch.index.fielddata.plain.AtomicFieldDataWithOrdinalsTermsEnum;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -90,7 +90,7 @@ public final class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent i
     }
 
     @Override
-    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         throw new UnsupportedOperationException("no global ordinals sorting yet");
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractBytesIndexFieldData.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
@@ -61,7 +61,7 @@ public abstract class AbstractBytesIndexFieldData<FD extends AtomicFieldData.Wit
     }
 
     @Override
-    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         return new BytesRefFieldComparatorSource(this, missingValue, sortMode);
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractGeoPointIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractGeoPointIndexFieldData.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 
 import java.io.IOException;
@@ -122,7 +122,7 @@ abstract class AbstractGeoPointIndexFieldData extends AbstractIndexFieldData<Ato
     }
 
     @Override
-    public final XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public final XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         throw new ElasticsearchIllegalArgumentException("can't sort on geo_point field without using specific sorting feature, like geo_distance");
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVIndexFieldData.java
@@ -24,7 +24,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 
 public class BinaryDVIndexFieldData extends DocValuesIndexFieldData implements IndexFieldData<BinaryDVAtomicFieldData> {
@@ -49,7 +49,7 @@ public class BinaryDVIndexFieldData extends DocValuesIndexFieldData implements I
     }
 
     @Override
-    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, SortMode sortMode) {
+    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, MultiValueMode sortMode) {
         return new BytesRefFieldComparatorSource(this, missingValue, sortMode);
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BinaryDVNumericIndexFieldData.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 
 import java.io.IOException;
@@ -48,7 +48,7 @@ public class BinaryDVNumericIndexFieldData extends DocValuesIndexFieldData imple
         return false;
     }
 
-    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(final Object missingValue, final SortMode sortMode) {
+    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(final Object missingValue, final MultiValueMode sortMode) {
         switch (numericType) {
         case FLOAT:
             return new FloatValuesComparatorSource(this, missingValue, sortMode);

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVIndexFieldData.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
@@ -49,7 +49,7 @@ public class BytesBinaryDVIndexFieldData extends DocValuesIndexFieldData impleme
     }
 
     @Override
-    public final XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public final XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         throw new ElasticsearchIllegalArgumentException("can't sort on binary field");
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DisabledIndexFieldData.java
@@ -24,7 +24,7 @@ import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
@@ -62,7 +62,7 @@ public final class DisabledIndexFieldData extends AbstractIndexFieldData<AtomicF
     }
 
     @Override
-    public IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, SortMode sortMode) {
+    public IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, MultiValueMode sortMode) {
         throw fail();
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/DoubleArrayIndexFieldData.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.util.BigDoubleArrayList;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
@@ -138,7 +138,7 @@ public class DoubleArrayIndexFieldData extends AbstractIndexFieldData<DoubleArra
     }
 
     @Override
-    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         return new DoubleValuesComparatorSource(this, missingValue, sortMode);
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/FloatArrayIndexFieldData.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.util.BigFloatArrayList;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
@@ -137,7 +137,7 @@ public class FloatArrayIndexFieldData extends AbstractIndexFieldData<FloatArrayA
     }
 
     @Override
-    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         return new FloatValuesComparatorSource(this, missingValue, sortMode);
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/GeoPointBinaryDVIndexFieldData.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
@@ -47,7 +47,7 @@ public class GeoPointBinaryDVIndexFieldData extends DocValuesIndexFieldData impl
     }
 
     @Override
-    public final XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public final XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         throw new ElasticsearchIllegalArgumentException("can't sort on geo_point field without using specific sorting feature, like geo_distance");
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/NumericDVIndexFieldData.java
@@ -24,7 +24,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 
 public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements IndexNumericFieldData<NumericDVAtomicFieldData> {
@@ -49,7 +49,7 @@ public class NumericDVIndexFieldData extends DocValuesIndexFieldData implements 
     }
 
     @Override
-    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, SortMode sortMode) {
+    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, MultiValueMode sortMode) {
         return new LongValuesComparatorSource(this, missingValue, sortMode);
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals.Docs;
@@ -322,7 +322,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
     }
 
     @Override
-    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         return new LongValuesComparatorSource(this, missingValue, sortMode);
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
@@ -80,7 +80,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<ParentChil
     }
 
     @Override
-    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, SortMode sortMode) {
+    public XFieldComparatorSource comparatorSource(@Nullable Object missingValue, MultiValueMode sortMode) {
         return new BytesRefFieldComparatorSource(this, missingValue, sortMode);
     }
 

--- a/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesIndexFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesIndexFieldData.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
@@ -53,7 +53,7 @@ public class SortedSetDVBytesIndexFieldData extends DocValuesIndexFieldData impl
         return true;
     }
 
-    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, SortMode sortMode) {
+    public org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource comparatorSource(Object missingValue, MultiValueMode sortMode) {
         return new BytesRefFieldComparatorSource((IndexFieldData<?>) this, missingValue, sortMode);
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -75,7 +75,7 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
         }
         builder.endObject();
         if (multiValueMode != null) {
-            builder.field(DecayFunctionParser.MULTI_VALUE_MODE, multiValueMode.name());
+            builder.field(DecayFunctionParser.MULTI_VALUE_MODE.getPreferredName(), multiValueMode.name());
         }
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -21,8 +21,10 @@ package org.elasticsearch.index.query.functionscore;
 
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
+import java.util.Locale;
 
 public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
 
@@ -36,7 +38,7 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
     private Object scale;
     private double decay = -1;
     private Object offset;
-    private String multiValueMode = null;
+    private MultiValueMode multiValueMode = null;
 
     public DecayFunctionBuilder(String fieldName, Object origin, Object scale) {
         this.fieldName = fieldName;
@@ -73,14 +75,19 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
         }
         builder.endObject();
         if (multiValueMode != null) {
-            builder.field(DecayFunctionParser.MULTI_VALUE_MODE, multiValueMode);
+            builder.field(DecayFunctionParser.MULTI_VALUE_MODE, multiValueMode.name());
         }
         builder.endObject();
         return builder;
     }
 
-    public ScoreFunctionBuilder setMultiValueMode(String multiValueMode) {
+    public ScoreFunctionBuilder setMultiValueMode(MultiValueMode multiValueMode) {
         this.multiValueMode = multiValueMode;
+        return this;
+    }
+
+    public ScoreFunctionBuilder setMultiValueMode(String multiValueMode) {
+        this.multiValueMode = MultiValueMode.fromString(multiValueMode.toUpperCase(Locale.ROOT));
         return this;
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -36,6 +36,7 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
     private Object scale;
     private double decay = -1;
     private Object offset;
+    private String multiValueMode = "MIN";
 
     public DecayFunctionBuilder(String fieldName, Object origin, Object scale) {
         this.fieldName = fieldName;
@@ -71,8 +72,13 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
             builder.field(OFFSET, offset);
         }
         builder.endObject();
+        builder.field(DecayFunctionParser.MULTI_VALUE_MODE, multiValueMode);
         builder.endObject();
         return builder;
     }
 
+    public ScoreFunctionBuilder setMultiValueMode(String multiValueMode) {
+        this.multiValueMode = multiValueMode;
+        return this;
+    }
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -36,7 +36,7 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
     private Object scale;
     private double decay = -1;
     private Object offset;
-    private String multiValueMode = "MIN";
+    private String multiValueMode = null;
 
     public DecayFunctionBuilder(String fieldName, Object origin, Object scale) {
         this.fieldName = fieldName;
@@ -72,7 +72,9 @@ public abstract class DecayFunctionBuilder implements ScoreFunctionBuilder {
             builder.field(OFFSET, offset);
         }
         builder.endObject();
-        builder.field(DecayFunctionParser.MULTI_VALUE_MODE, multiValueMode);
+        if (multiValueMode != null) {
+            builder.field(DecayFunctionParser.MULTI_VALUE_MODE, multiValueMode);
+        }
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -413,7 +413,6 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             ce.addDetail(func.explainFunction(getDistanceString(docId), distance(docId), scale));
             return ce;
         }
-
     }
 
 }

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -313,23 +313,23 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         @Override
         protected String getDistanceString(int docId) {
-            String modeName = mode.name();
-            String values = modeName + " of: [";
+            StringBuilder values = new StringBuilder(mode.name());
+            values.append(" of: [");
             final int num = geoPointValues.setDocument(docId);
             if (num > 0) {
                 for (int i = 0; i < num; i++) {
                     GeoPoint value = geoPointValues.nextValue();
-                    values += "Math.max(arcDistance(" + value + "(=doc value),"
-                            + origin + "(=origin)) - " + offset + "(=offset), 0)";
+                    values.append("Math.max(arcDistance(");
+                    values.append(value).append("(=doc value),").append(origin).append("(=origin)) - ").append(offset).append("(=offset), 0)");
                     if (i != num - 1) {
-                        values += ", ";
+                        values.append(", ");
                     }
                 }
             } else {
-                values += "0.0";
+                values.append("0.0");
             }
-            values += "]";
-            return values;
+            values.append("]");
+            return values.toString();
         }
 
         @Override
@@ -372,23 +372,25 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
         @Override
         protected String getDistanceString(int docId) {
-            String modeName = mode.name();
-            String values = modeName + " of: [";
+
+            StringBuilder values = new StringBuilder(mode.name());
+            values.append(" of: [");
             final int num = doubleValues.setDocument(docId);
             if (num > 0) {
                 for (int i = 0; i < num; i++) {
                     double value = doubleValues.nextValue();
-                    values += "Math.max(Math.abs(" + value + "(=doc value) - "
-                            + origin + "(=origin)) - " + offset + "(=offset), 0)";
+                    values.append("Math.max(Math.abs(");
+                    values.append(value).append("(=doc value) - ").append(origin).append("(=origin))) - ").append(offset).append("(=offset), 0)");
                     if (i != num - 1) {
-                        values += ", ";
+                        values.append(", ");
                     }
                 }
             } else {
-                values += "0.0";
+                values.append("0.0");
             }
-            values += "]";
-            return values;
+            values.append("]");
+            return values.toString();
+
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -121,7 +121,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         String currentFieldName;
         XContentParser.Token token;
         AbstractDistanceScoreFunction scoreFunction = null;
-        String multiValueMode = "MIN";
+        String multiValueMode = null;
         while ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
             currentFieldName = parser.currentName();
             token = parser.nextToken();
@@ -137,7 +137,9 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         if (scoreFunction == null) {
             throw new ElasticsearchParseException("Malformed score function score parameters.");
         }
-        scoreFunction.setMultiValueMode(MultiValueMode.fromString(multiValueMode.toUpperCase(Locale.ROOT)));
+        if (multiValueMode != null) {
+            scoreFunction.setMultiValueMode(MultiValueMode.fromString(multiValueMode.toUpperCase(Locale.ROOT)));
+        }
         return scoreFunction;
     }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.ComplexExplanation;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
@@ -94,7 +95,7 @@ import java.util.Locale;
 
 public abstract class DecayFunctionParser implements ScoreFunctionParser {
 
-    public static final String MULTI_VALUE_MODE = "multi_value_mode";
+    public static final ParseField MULTI_VALUE_MODE = new ParseField("multi_value_mode");
 
     /**
      * Override this function if you want to produce your own scorer.
@@ -128,7 +129,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             if (token == XContentParser.Token.START_OBJECT) {
                 // parse per field the origin and scale value
                 scoreFunction = parseVariable(currentFieldName, parser, parseContext);
-            } else if (currentFieldName.equals(MULTI_VALUE_MODE)) {
+            } else if (MULTI_VALUE_MODE.match(currentFieldName)) {
                 multiValueMode = parser.text();
             } else {
                 throw new ElasticsearchParseException("Malformed score function score parameters.");

--- a/src/main/java/org/elasticsearch/index/query/functionscore/exp/ExponentialDecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/exp/ExponentialDecayFunctionParser.java
@@ -51,7 +51,7 @@ public class ExponentialDecayFunctionParser extends DecayFunctionParser {
         public Explanation explainFunction(String valueExpl, double value, double scale) {
             ComplexExplanation ce = new ComplexExplanation();
             ce.setValue((float) evaluate(value, scale));
-            ce.setDescription("exp(- abs(" + valueExpl + ") * " + -1 * scale + ")");
+            ce.setDescription("exp(- " + valueExpl + " * " + -1 * scale + ")");
             return ce;
         }
 

--- a/src/main/java/org/elasticsearch/index/query/functionscore/lin/LinearDecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/lin/LinearDecayFunctionParser.java
@@ -51,7 +51,7 @@ public class LinearDecayFunctionParser extends DecayFunctionParser {
         public Explanation explainFunction(String valueExpl, double value, double scale) {
             ComplexExplanation ce = new ComplexExplanation();
             ce.setValue((float) evaluate(value, scale));
-            ce.setDescription("max(0.0, ((" + scale + " - abs(" + valueExpl + "))/" + scale + ")");
+            ce.setDescription("max(0.0, ((" + scale + " - " + valueExpl + ")/" + scale + ")");
             return ce;
         }
 

--- a/src/main/java/org/elasticsearch/index/search/nested/NestedFieldComparatorSource.java
+++ b/src/main/java/org/elasticsearch/index/search/nested/NestedFieldComparatorSource.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.lucene.docset.DocIdSets;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.NestedWrappableComparator;
 import org.elasticsearch.index.fielddata.fieldcomparator.NumberComparatorBase;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -38,12 +38,12 @@ import java.util.Locale;
  */
 public class NestedFieldComparatorSource extends IndexFieldData.XFieldComparatorSource {
 
-    private final SortMode sortMode;
+    private final MultiValueMode sortMode;
     private final IndexFieldData.XFieldComparatorSource wrappedSource;
     private final Filter rootDocumentsFilter;
     private final Filter innerDocumentsFilter;
 
-    public NestedFieldComparatorSource(SortMode sortMode, IndexFieldData.XFieldComparatorSource wrappedSource, Filter rootDocumentsFilter, Filter innerDocumentsFilter) {
+    public NestedFieldComparatorSource(MultiValueMode sortMode, IndexFieldData.XFieldComparatorSource wrappedSource, Filter rootDocumentsFilter, Filter innerDocumentsFilter) {
         this.sortMode = sortMode;
         this.wrappedSource = wrappedSource;
         this.rootDocumentsFilter = rootDocumentsFilter;

--- a/src/main/java/org/elasticsearch/search/MultiValueMode.java
+++ b/src/main/java/org/elasticsearch/search/MultiValueMode.java
@@ -18,7 +18,7 @@
  */
 
 
-package org.elasticsearch.index.fielddata.fieldcomparator;
+package org.elasticsearch.search;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
@@ -32,7 +32,7 @@ import java.util.Locale;
 /**
  * Defines what values to pick in the case a document contains multiple values for a particular field.
  */
-public enum SortMode {
+public enum MultiValueMode {
 
     /**
      * Sum of all the values.
@@ -256,7 +256,7 @@ public enum SortMode {
      * Applies the sort mode and returns the result. This method is meant to be
      * a binary function that is commonly used in a loop to find the relevant
      * value for the sort mode in a list of values. For instance if the sort mode
-     * is {@link SortMode#MAX} this method is equivalent to {@link Math#max(double, double)}.
+     * is {@link MultiValueMode#MAX} this method is equivalent to {@link Math#max(double, double)}.
      *
      * Note: all implementations are idempotent.
      *
@@ -270,7 +270,7 @@ public enum SortMode {
      * Applies the sort mode and returns the result. This method is meant to be
      * a binary function that is commonly used in a loop to find the relevant
      * value for the sort mode in a list of values. For instance if the sort mode
-     * is {@link SortMode#MAX} this method is equivalent to {@link Math#max(long, long)}.
+     * is {@link MultiValueMode#MAX} this method is equivalent to {@link Math#max(long, long)}.
      *
      * Note: all implementations are idempotent.
      *
@@ -318,7 +318,7 @@ public enum SortMode {
     }
 
     /**
-     * Returns the aggregated value based on the sort mode. For instance if {@link SortMode#AVG} is used
+     * Returns the aggregated value based on the sort mode. For instance if {@link MultiValueMode#AVG} is used
      * this method divides the given value by the number of values. The default implementation returns
      * the first argument.
      *
@@ -329,7 +329,7 @@ public enum SortMode {
     }
 
     /**
-     * Returns the aggregated value based on the sort mode. For instance if {@link SortMode#AVG} is used
+     * Returns the aggregated value based on the sort mode. For instance if {@link MultiValueMode#AVG} is used
      * this method divides the given value by the number of values. The default implementation returns
      * the first argument.
      *
@@ -344,7 +344,7 @@ public enum SortMode {
      *
      * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if the given string doesn't match a sort mode or is <code>null</code>.
      */
-    public static SortMode fromString(String sortMode) {
+    public static MultiValueMode fromString(String sortMode) {
         try {
             return valueOf(sortMode.toUpperCase(Locale.ROOT));
         } catch (Throwable t) {
@@ -353,7 +353,7 @@ public enum SortMode {
     }
 
     /**
-     * Returns the relevant value for the given document based on the {@link SortMode}. This
+     * Returns the relevant value for the given document based on the {@link MultiValueMode}. This
      * method will apply each value for the given document to {@link #apply(double, double)} and returns
      * the reduced value from {@link #reduce(double, int)} if the document has at least one value. Otherwise it will
      * return the given default value.
@@ -373,7 +373,7 @@ public enum SortMode {
     }
 
     /**
-     * Returns the relevant value for the given document based on the {@link SortMode}. This
+     * Returns the relevant value for the given document based on the {@link MultiValueMode}. This
      * method will apply each value for the given document to {@link #apply(long, long)} and returns
      * the reduced value from {@link #reduce(long, int)} if the document has at least one value. Otherwise it will
      * return the given default value.
@@ -394,7 +394,7 @@ public enum SortMode {
 
 
     /**
-     * Returns the relevant value for the given document based on the {@link SortMode}
+     * Returns the relevant value for the given document based on the {@link MultiValueMode}
      * if the document has at least one value. Otherwise it will return same object given as the default value.
      * Note: This method is optional and will throw {@link UnsupportedOperationException} if the sort mode doesn't
      * allow a relevant value.

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.GeoDistanceComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.ObjectMappers;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
@@ -56,7 +56,7 @@ public class GeoDistanceSortParser implements SortParser {
         DistanceUnit unit = DistanceUnit.DEFAULT;
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         boolean reverse = false;
-        SortMode sortMode = null;
+        MultiValueMode sortMode = null;
         String nestedPath = null;
         Filter nestedFilter = null;
 
@@ -93,7 +93,7 @@ public class GeoDistanceSortParser implements SortParser {
                     normalizeLat = parser.booleanValue();
                     normalizeLon = parser.booleanValue();
                 } else if ("sort_mode".equals(currentName) || "sortMode".equals(currentName) || "mode".equals(currentName)) {
-                    sortMode = SortMode.fromString(parser.text());
+                    sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
                     nestedPath = parser.text();
                 } else {
@@ -108,10 +108,10 @@ public class GeoDistanceSortParser implements SortParser {
         }
 
         if (sortMode == null) {
-            sortMode = reverse ? SortMode.MAX : SortMode.MIN;
+            sortMode = reverse ? MultiValueMode.MAX : MultiValueMode.MIN;
         }
 
-        if (sortMode == SortMode.SUM) {
+        if (sortMode == MultiValueMode.SUM) {
             throw new ElasticsearchIllegalArgumentException("sort_mode [sum] isn't supported for sorting by geo distance");
         }
 

--- a/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -25,7 +25,7 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleScriptDataComparator;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.fieldcomparator.StringScriptDataComparator;
 import org.elasticsearch.index.mapper.ObjectMappers;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
@@ -55,7 +55,7 @@ public class ScriptSortParser implements SortParser {
         String type = null;
         Map<String, Object> params = null;
         boolean reverse = false;
-        SortMode sortMode = null;
+        MultiValueMode sortMode = null;
         String nestedPath = null;
         Filter nestedFilter = null;
 
@@ -83,7 +83,7 @@ public class ScriptSortParser implements SortParser {
                 } else if ("lang".equals(currentName)) {
                     scriptLang = parser.text();
                 } else if ("mode".equals(currentName)) {
-                    sortMode = SortMode.fromString(parser.text());
+                    sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
                     nestedPath = parser.text();
                 }
@@ -106,12 +106,12 @@ public class ScriptSortParser implements SortParser {
             throw new SearchParseException(context, "custom script sort type [" + type + "] not supported");
         }
 
-        if ("string".equals(type) && (sortMode == SortMode.SUM || sortMode == SortMode.AVG)) {
+        if ("string".equals(type) && (sortMode == MultiValueMode.SUM || sortMode == MultiValueMode.AVG)) {
             throw new SearchParseException(context, "type [string] doesn't support mode [" + sortMode + "]");
         }
 
         if (sortMode == null) {
-            sortMode = reverse ? SortMode.MAX : SortMode.MIN;
+            sortMode = reverse ? MultiValueMode.MAX : MultiValueMode.MIN;
         }
 
         // If nested_path is specified, then wrap the `fieldComparatorSource` in a `NestedFieldComparatorSource`

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -28,7 +28,7 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.ObjectMappers;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
@@ -119,7 +119,7 @@ public class SortParseElement implements SearchParseElement {
                 String missing = null;
                 String innerJsonName = null;
                 boolean ignoreUnmapped = false;
-                SortMode sortMode = null;
+                MultiValueMode sortMode = null;
                 Filter nestedFilter = null;
                 String nestedPath = null;
                 token = parser.nextToken();
@@ -154,7 +154,7 @@ public class SortParseElement implements SearchParseElement {
                                 } else if ("ignore_unmapped".equals(innerJsonName) || "ignoreUnmapped".equals(innerJsonName)) {
                                     ignoreUnmapped = parser.booleanValue();
                                 } else if ("mode".equals(innerJsonName)) {
-                                    sortMode = SortMode.fromString(parser.text());
+                                    sortMode = MultiValueMode.fromString(parser.text());
                                 } else if ("nested_path".equals(innerJsonName) || "nestedPath".equals(innerJsonName)) {
                                     nestedPath = parser.text();
                                 } else {
@@ -176,7 +176,7 @@ public class SortParseElement implements SearchParseElement {
         }
     }
 
-    private void addSortField(SearchContext context, List<SortField> sortFields, String fieldName, boolean reverse, boolean ignoreUnmapped, @Nullable final String missing, SortMode sortMode, String nestedPath, Filter nestedFilter) {
+    private void addSortField(SearchContext context, List<SortField> sortFields, String fieldName, boolean reverse, boolean ignoreUnmapped, @Nullable final String missing, MultiValueMode sortMode, String nestedPath, Filter nestedFilter) {
         if (SCORE_FIELD_NAME.equals(fieldName)) {
             if (reverse) {
                 sortFields.add(SORT_SCORE_REVERSE);
@@ -212,7 +212,7 @@ public class SortParseElement implements SearchParseElement {
             }*/
 
             // We only support AVG and SUM on number based fields
-            if (!(fieldMapper instanceof NumberFieldMapper) && (sortMode == SortMode.SUM || sortMode == SortMode.AVG)) {
+            if (!(fieldMapper instanceof NumberFieldMapper) && (sortMode == MultiValueMode.SUM || sortMode == MultiValueMode.AVG)) {
                 sortMode = null;
             }
             if (sortMode == null) {
@@ -248,8 +248,8 @@ public class SortParseElement implements SearchParseElement {
         }
     }
 
-    private static SortMode resolveDefaultSortMode(boolean reverse) {
-        return reverse ? SortMode.MAX : SortMode.MIN;
+    private static MultiValueMode resolveDefaultSortMode(boolean reverse) {
+        return reverse ? MultiValueMode.MAX : MultiValueMode.MIN;
     }
 
 }

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
@@ -26,7 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.HashedBytesRef;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
@@ -108,7 +108,7 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         TopFieldDocs topDocs;
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         assertThat(toString(((FieldDoc) topDocs.scoreDocs[0]).fields[0]), equalTo(one()));
@@ -118,7 +118,7 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         assertThat(toString(((FieldDoc) topDocs.scoreDocs[2]).fields[0]), equalTo(three()));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
@@ -223,14 +223,14 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         assertHashedValues(hashedBytesValues, 0, two(), four());
         
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
-        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+        TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs.length, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
 
-        topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+        topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs.length, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
@@ -301,7 +301,7 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
 
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
         TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(7));
@@ -322,7 +322,7 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(BytesRefFieldComparatorSource.MAX_TERM));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(6));

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTests.java
@@ -25,7 +25,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.*;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.junit.Test;
 
 import java.util.Locale;
@@ -84,14 +84,14 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         TopFieldDocs topDocs;
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
@@ -132,42 +132,42 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         TopFieldDocs topDocs;
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN)))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MIN)))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX), true))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(0));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("1", SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("1", MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
         assertThat(topDocs.scoreDocs[2].doc, equalTo(2));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("1", SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("1", MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(3));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
         assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
@@ -295,7 +295,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
         TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MIN)))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MIN)))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(7));
@@ -316,7 +316,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 //        assertThat(((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(null));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.MAX), true))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX), true))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(6));
@@ -338,7 +338,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         searcher = new IndexSearcher(DirectoryReader.open(writer, true));
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.SUM)))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.SUM)))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(7));
@@ -360,7 +360,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         searcher = new IndexSearcher(DirectoryReader.open(writer, true));
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.SUM), true))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.SUM), true))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(6));
@@ -382,7 +382,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         searcher = new IndexSearcher(DirectoryReader.open(writer, true));
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.AVG)))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.AVG)))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(7));
@@ -404,7 +404,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 
         searcher = new IndexSearcher(DirectoryReader.open(writer, true));
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource(null, SortMode.AVG), true))); // defaults to _last
+                new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.AVG), true))); // defaults to _last
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(6));
@@ -425,7 +425,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
 //        assertThat(((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(null));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
@@ -438,7 +438,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(topDocs.scoreDocs[7].doc, equalTo(6));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("_first", MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(1));
@@ -451,7 +451,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(topDocs.scoreDocs[7].doc, equalTo(7));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("-9", SortMode.MIN))));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("-9", MultiValueMode.MIN))));
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(7));
@@ -464,7 +464,7 @@ public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImp
         assertThat(topDocs.scoreDocs[7].doc, equalTo(6));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
-                new Sort(new SortField("value", indexFieldData.comparatorSource("9", SortMode.MAX), true)));
+                new Sort(new SortField("value", indexFieldData.comparatorSource("9", MultiValueMode.MAX), true)));
         assertThat(topDocs.totalHits, equalTo(8));
         assertThat(topDocs.scoreDocs.length, equalTo(8));
         assertThat(topDocs.scoreDocs[0].doc, equalTo(6));

--- a/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTests.java
@@ -42,7 +42,7 @@ import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsIndexFieldData;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.index.search.nested.NestedFieldComparatorSource;
@@ -244,7 +244,7 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
         final IndexFieldData indexFieldData = getForField("value");
         final String missingValue = values[1];
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
-        XFieldComparatorSource comparator = indexFieldData.comparatorSource(missingValue, SortMode.MIN);
+        XFieldComparatorSource comparator = indexFieldData.comparatorSource(missingValue, MultiValueMode.MIN);
         TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), randomBoolean() ? numDocs : randomIntBetween(10, numDocs), new Sort(new SortField("value", comparator, reverse)));
         assertEquals(numDocs, topDocs.totalHits);
         BytesRef previousValue = reverse ? UnicodeUtil.BIG_TERM : new BytesRef();
@@ -300,7 +300,7 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
         }
         final IndexFieldData indexFieldData = getForField("value");
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
-        XFieldComparatorSource comparator = indexFieldData.comparatorSource(first ? "_first" : "_last", SortMode.MIN);
+        XFieldComparatorSource comparator = indexFieldData.comparatorSource(first ? "_first" : "_last", MultiValueMode.MIN);
         TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), randomBoolean() ? numDocs : randomIntBetween(10, numDocs), new Sort(new SortField("value", comparator, reverse)));
         assertEquals(numDocs, topDocs.totalHits);
         BytesRef previousValue = first ? null : reverse ? UnicodeUtil.BIG_TERM : new BytesRef();
@@ -325,14 +325,14 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
     }
 
     public void testNestedSortingMin() throws IOException {
-        testNestedSorting(SortMode.MIN);
+        testNestedSorting(MultiValueMode.MIN);
     }
 
     public void testNestedSortingMax() throws IOException {
-        testNestedSorting(SortMode.MAX);
+        testNestedSorting(MultiValueMode.MAX);
     }
 
-    public void testNestedSorting(SortMode sortMode) throws IOException {
+    public void testNestedSorting(MultiValueMode sortMode) throws IOException {
         final String[] values = new String[randomIntBetween(2, 20)];
         for (int i = 0; i < values.length; ++i) {
             values[i] = _TestUtil.randomSimpleString(getRandom());
@@ -404,9 +404,9 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
                     final BytesRef bytesValue = new BytesRef(value);
                     if (cmpValue == null) {
                         cmpValue = bytesValue;
-                    } else if (sortMode == SortMode.MIN && bytesValue.compareTo(cmpValue) < 0) {
+                    } else if (sortMode == MultiValueMode.MIN && bytesValue.compareTo(cmpValue) < 0) {
                         cmpValue = bytesValue;
-                    } else if (sortMode == SortMode.MAX && bytesValue.compareTo(cmpValue) > 0) {
+                    } else if (sortMode == MultiValueMode.MAX && bytesValue.compareTo(cmpValue) > 0) {
                         cmpValue = bytesValue;
                     }
                 }

--- a/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -23,7 +23,7 @@ import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.IndexReader;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.FieldMapper.Names;
 import org.junit.Test;
 
@@ -68,7 +68,7 @@ public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTes
             }
 
             @Override
-            public XFieldComparatorSource comparatorSource(Object missingValue, SortMode sortMode) {
+            public XFieldComparatorSource comparatorSource(Object missingValue, MultiValueMode sortMode) {
                 return new BytesRefFieldComparatorSource(this, missingValue, sortMode);
             }
 

--- a/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
+++ b/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.compress.CompressedString;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestUtils;
 import org.elasticsearch.index.mapper.Uid;
@@ -140,7 +140,7 @@ public class ParentChildFieldDataTests extends AbstractFieldDataTests {
     public void testSorting() throws Exception {
         IndexFieldData indexFieldData = getForField(childType);
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, true));
-        IndexFieldData.XFieldComparatorSource comparator = indexFieldData.comparatorSource("_last", SortMode.MIN);
+        IndexFieldData.XFieldComparatorSource comparator = indexFieldData.comparatorSource("_last", MultiValueMode.MIN);
 
         TopFieldDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField(ParentFieldMapper.NAME, comparator, false)));
         assertThat(topDocs.totalHits, equalTo(8));

--- a/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTests.java
+++ b/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.lucene.search.NotFilter;
 import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.index.fielddata.AbstractFieldDataTests;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -204,7 +204,7 @@ public abstract class AbstractNumberNestedSortingTests extends AbstractFieldData
         document.add(new StringField("fieldXXX", "x", Field.Store.NO));
         writer.addDocument(document);
 
-        SortMode sortMode = SortMode.SUM;
+        MultiValueMode sortMode = MultiValueMode.SUM;
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, false));
         IndexFieldData.XFieldComparatorSource innerFieldComparator = createInnerFieldComparator("field2", sortMode, null);
         Filter parentFilter = new TermFilter(new Term("__type", "parent"));
@@ -320,7 +320,7 @@ public abstract class AbstractNumberNestedSortingTests extends AbstractFieldData
     }
 
     protected void assertAvgScoreMode(Filter parentFilter, IndexSearcher searcher, IndexFieldData.XFieldComparatorSource innerFieldComparator) throws IOException {
-        SortMode sortMode = SortMode.AVG;
+        MultiValueMode sortMode = MultiValueMode.AVG;
         Filter childFilter = new NotFilter(parentFilter);
         NestedFieldComparatorSource nestedComparatorSource = new NestedFieldComparatorSource(sortMode, innerFieldComparator, parentFilter, childFilter);
         Query query = new ToParentBlockJoinQuery(new XFilteredQuery(new MatchAllDocsQuery(), childFilter), new FixedBitSetCachingWrapperFilter(parentFilter), ScoreMode.None);
@@ -342,6 +342,6 @@ public abstract class AbstractNumberNestedSortingTests extends AbstractFieldData
 
     protected abstract IndexableField createField(String name, int value, Field.Store store);
 
-    protected abstract IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, SortMode sortMode, Object missingValue);
+    protected abstract IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, MultiValueMode sortMode, Object missingValue);
 
 }

--- a/src/test/java/org/elasticsearch/index/search/nested/DoubleNestedSortingTests.java
+++ b/src/test/java/org/elasticsearch/index/search/nested/DoubleNestedSortingTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.plain.DoubleArrayIndexFieldData;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class DoubleNestedSortingTests extends AbstractNumberNestedSortingTests {
     }
 
     @Override
-    protected IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, SortMode sortMode, Object missingValue) {
+    protected IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, MultiValueMode sortMode, Object missingValue) {
         DoubleArrayIndexFieldData fieldData = getForField(fieldName);
         return new DoubleValuesComparatorSource(fieldData, missingValue, sortMode);
     }
@@ -58,7 +58,7 @@ public class DoubleNestedSortingTests extends AbstractNumberNestedSortingTests {
     }
 
     protected void assertAvgScoreMode(Filter parentFilter, IndexSearcher searcher, IndexFieldData.XFieldComparatorSource innerFieldComparator) throws IOException {
-        SortMode sortMode = SortMode.AVG;
+        MultiValueMode sortMode = MultiValueMode.AVG;
         Filter childFilter = new NotFilter(parentFilter);
         NestedFieldComparatorSource nestedComparatorSource = new NestedFieldComparatorSource(sortMode, innerFieldComparator, parentFilter, childFilter);
         Query query = new ToParentBlockJoinQuery(new XFilteredQuery(new MatchAllDocsQuery(), childFilter), new FixedBitSetCachingWrapperFilter(parentFilter), ScoreMode.None);

--- a/src/test/java/org/elasticsearch/index/search/nested/FloatNestedSortingTests.java
+++ b/src/test/java/org/elasticsearch/index/search/nested/FloatNestedSortingTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.FloatValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.plain.FloatArrayIndexFieldData;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class FloatNestedSortingTests extends AbstractNumberNestedSortingTests {
     }
 
     @Override
-    protected IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, SortMode sortMode, Object missingValue) {
+    protected IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, MultiValueMode sortMode, Object missingValue) {
         FloatArrayIndexFieldData fieldData = getForField(fieldName);
         return new FloatValuesComparatorSource(fieldData, missingValue, sortMode);
     }
@@ -58,7 +58,7 @@ public class FloatNestedSortingTests extends AbstractNumberNestedSortingTests {
     }
 
     protected void assertAvgScoreMode(Filter parentFilter, IndexSearcher searcher, IndexFieldData.XFieldComparatorSource innerFieldComparator) throws IOException {
-        SortMode sortMode = SortMode.AVG;
+        MultiValueMode sortMode = MultiValueMode.AVG;
         Filter childFilter = new NotFilter(parentFilter);
         NestedFieldComparatorSource nestedComparatorSource = new NestedFieldComparatorSource(sortMode, innerFieldComparator, parentFilter, childFilter);
         Query query = new ToParentBlockJoinQuery(new XFilteredQuery(new MatchAllDocsQuery(), childFilter), new FixedBitSetCachingWrapperFilter(parentFilter), ScoreMode.None);

--- a/src/test/java/org/elasticsearch/index/search/nested/LongNestedSortingTests.java
+++ b/src/test/java/org/elasticsearch/index/search/nested/LongNestedSortingTests.java
@@ -24,7 +24,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.plain.PackedArrayIndexFieldData;
 
 /**
@@ -37,7 +37,7 @@ public class LongNestedSortingTests extends AbstractNumberNestedSortingTests {
     }
 
     @Override
-    protected IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, SortMode sortMode, Object missingValue) {
+    protected IndexFieldData.XFieldComparatorSource createInnerFieldComparator(String fieldName, MultiValueMode sortMode, Object missingValue) {
         PackedArrayIndexFieldData fieldData = getForField(fieldName);
         return new LongValuesComparatorSource(fieldData, missingValue, sortMode);
     }

--- a/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
+++ b/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.fielddata.AbstractFieldDataTests;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
-import org.elasticsearch.index.fielddata.fieldcomparator.SortMode;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.junit.Test;
 
@@ -211,7 +211,7 @@ public class NestedSortingTests extends AbstractFieldDataTests {
         document.add(new StringField("fieldXXX", "x", Field.Store.NO));
         writer.addDocument(document);
 
-        SortMode sortMode = SortMode.MIN;
+        MultiValueMode sortMode = MultiValueMode.MIN;
         IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(writer, false));
         PagedBytesIndexFieldData indexFieldData = getForField("field2");
         BytesRefFieldComparatorSource innerSource = new BytesRefFieldComparatorSource(indexFieldData, null, sortMode);
@@ -235,7 +235,7 @@ public class NestedSortingTests extends AbstractFieldDataTests {
         assertThat(topDocs.scoreDocs[4].doc, equalTo(19));
         assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[4]).fields[0]).utf8ToString(), equalTo("i"));
 
-        sortMode = SortMode.MAX;
+        sortMode = MultiValueMode.MAX;
         nestedComparatorSource = new NestedFieldComparatorSource(sortMode, innerSource, parentFilter, childFilter);
         sort = new Sort(new SortField("field2", nestedComparatorSource, true));
         topDocs = searcher.search(query, 5, sort);

--- a/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
@@ -726,9 +726,8 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                 .setSource(
                         jsonBuilder().startObject().field("test", "value").startObject("loc").field("lat", 11).field("lon", 22).endObject()
                                 .endObject());
-        IndexRequestBuilder[] builders = {doc1, doc2};
 
-        indexRandom(true, builders);
+        indexRandom(true, doc1, doc2);
 
         ActionFuture<SearchResponse> response = client().search(
                 searchRequest().source(
@@ -775,9 +774,8 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                 .setSource(
                         jsonBuilder().startObject().field("test", "value").field("num", 1.0)
                                 .endObject());
-        IndexRequestBuilder[] builders2 = {doc1, doc2};
 
-        indexRandom(true, builders2);
+        indexRandom(true, doc1, doc2);
         response = client().search(
                 searchRequest().source(
                         searchSource().query(

--- a/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
@@ -733,6 +733,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                 searchRequest().source(
                         searchSource().query(constantScoreQuery(termQuery("test", "value")))));
         SearchResponse sr = response.actionGet();
+        assertSearchHits(sr, "1", "2");
         SearchHits sh = sr.getHits();
         assertThat(sh.getTotalHits(), equalTo((long) (2)));
 
@@ -744,6 +745,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                         searchSource().query(
                                 functionScoreQuery(constantScoreQuery(termQuery("test", "value")), gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode("min")))));
         sr = response.actionGet();
+        assertSearchHits(sr, "1", "2");
         sh = sr.getHits();
 
         assertThat(sh.getAt(0).getId(), equalTo("1"));
@@ -753,6 +755,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                         searchSource().query(
                                 functionScoreQuery(constantScoreQuery(termQuery("test", "value")), gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode("max")))));
         sr = response.actionGet();
+        assertSearchHits(sr, "1", "2");
         sh = sr.getHits();
 
         assertThat(sh.getAt(0).getId(), equalTo("2"));
@@ -781,6 +784,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                         searchSource().query(
                                 functionScoreQuery(constantScoreQuery(termQuery("test", "value")), linearDecayFunction("num", "0", "10").setMultiValueMode("sum")))));
         sr = response.actionGet();
+        assertSearchHits(sr, "1", "2");
         sh = sr.getHits();
 
         assertThat(sh.getAt(0).getId(), equalTo("2"));
@@ -791,6 +795,7 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
                         searchSource().query(
                                 functionScoreQuery(constantScoreQuery(termQuery("test", "value")), linearDecayFunction("num", "0", "10").setMultiValueMode("avg")))));
         sr = response.actionGet();
+        assertSearchHits(sr, "1", "2");
         sh = sr.getHits();
         assertThat((double) (sh.getAt(0).getScore()), closeTo((double) (sh.getAt(1).getScore()), 1.e-6d));
     }

--- a/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/DecayFunctionScoreTests.java
@@ -703,4 +703,97 @@ public class DecayFunctionScoreTests extends ElasticsearchIntegrationTest {
         response.actionGet();
     }
 
+    @Test
+    public void testMultiFieldOptions() throws Exception {
+        assertAcked(prepareCreate("test").addMapping(
+                "type1",
+                jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("test").field("type", "string")
+                        .endObject().startObject("loc").field("type", "geo_point").endObject().startObject("num").field("type", "float").endObject().endObject().endObject().endObject()));
+        ensureYellow();
+
+        // Index for testing MIN and MAX
+        IndexRequestBuilder doc1 = client().prepareIndex()
+                .setType("type1")
+                .setId("1")
+                .setIndex("test")
+                .setSource(
+                        jsonBuilder().startObject().field("test", "value").startArray("loc").startObject().field("lat", 10).field("lon", 20).endObject().startObject().field("lat", 12).field("lon", 23).endObject().endArray()
+                                .endObject());
+        IndexRequestBuilder doc2 = client().prepareIndex()
+                .setType("type1")
+                .setId("2")
+                .setIndex("test")
+                .setSource(
+                        jsonBuilder().startObject().field("test", "value").startObject("loc").field("lat", 11).field("lon", 22).endObject()
+                                .endObject());
+        IndexRequestBuilder[] builders = {doc1, doc2};
+
+        indexRandom(true, builders);
+
+        ActionFuture<SearchResponse> response = client().search(
+                searchRequest().source(
+                        searchSource().query(constantScoreQuery(termQuery("test", "value")))));
+        SearchResponse sr = response.actionGet();
+        SearchHits sh = sr.getHits();
+        assertThat(sh.getTotalHits(), equalTo((long) (2)));
+
+        List<Float> lonlat = new ArrayList<>();
+        lonlat.add(20f);
+        lonlat.add(10f);
+        response = client().search(
+                searchRequest().source(
+                        searchSource().query(
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode("min")))));
+        sr = response.actionGet();
+        sh = sr.getHits();
+
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(1).getId(), equalTo("2"));
+        response = client().search(
+                searchRequest().source(
+                        searchSource().query(
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode("max")))));
+        sr = response.actionGet();
+        sh = sr.getHits();
+
+        assertThat(sh.getAt(0).getId(), equalTo("2"));
+        assertThat(sh.getAt(1).getId(), equalTo("1"));
+
+        // Now test AVG and SUM
+
+        doc1 = client().prepareIndex()
+                .setType("type1")
+                .setId("1")
+                .setIndex("test")
+                .setSource(
+                        jsonBuilder().startObject().field("test", "value").startArray("num").value(0.0).value(1.0).value(2.0).endArray()
+                                .endObject());
+        doc2 = client().prepareIndex()
+                .setType("type1")
+                .setId("2")
+                .setIndex("test")
+                .setSource(
+                        jsonBuilder().startObject().field("test", "value").field("num", 1.0)
+                                .endObject());
+        IndexRequestBuilder[] builders2 = {doc1, doc2};
+
+        indexRandom(true, builders2);
+        response = client().search(
+                searchRequest().source(
+                        searchSource().query(
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), linearDecayFunction("num", "0", "10").setMultiValueMode("sum")))));
+        sr = response.actionGet();
+        sh = sr.getHits();
+
+        assertThat(sh.getAt(0).getId(), equalTo("2"));
+        assertThat(sh.getAt(1).getId(), equalTo("1"));
+        assertThat((double)(1.0 - sh.getAt(0).getScore()), closeTo((double)((1.0 - sh.getAt(1).getScore())/3.0), 1.e-6d));
+        response = client().search(
+                searchRequest().source(
+                        searchSource().query(
+                                functionScoreQuery(constantScoreQuery(termQuery("test", "value")), linearDecayFunction("num", "0", "10").setMultiValueMode("avg")))));
+        sr = response.actionGet();
+        sh = sr.getHits();
+        assertThat((double) (sh.getAt(0).getScore()), closeTo((double) (sh.getAt(1).getScore()), 1.e-6d));
+    }
 }


### PR DESCRIPTION
Decay functions currently only use the first value in a field that contains
multiple values to compute the distance to the origin. Instead, they should
consider all distances if more values are in the field and then use
one of min/max/sum/avg which is defined by the user.

closes #3960
