### PR TITLE
[TEST] randomly introduced a client node within test cluster

### DIFF
--- a/rest-api-spec/test/cat.allocation/10_basic.yaml
+++ b/rest-api-spec/test/cat.allocation/10_basic.yaml
@@ -25,13 +25,13 @@
   - match:
       $body: >
             /^
-              ( 0                   \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+                 \s+
-                [-\w.]+             \s+
-                \d+(\.\d+){3}       \s+
+              ( 0                      \s+
+                \d+(\.\d+)?[kmgt]?b    \s+
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+)?                 \s+  #no value from client nodes
+                [-\w.]+                \s+
+                \d+(\.\d+){3}          \s+
                 \w.*
                 \n
               )+
@@ -55,19 +55,19 @@
   - match:
       $body: >
             /^
-              ( \d+                 \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+                 \s+
-                [-\w.]+             \s+
-                \d+(\.\d+){3}       \s+
+              ( \d+                    \s+
+                \d+(\.\d+)?[kmgt]?b    \s+
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+)?                 \s+  #no value from client nodes
+                [-\w.]+                \s+
+                \d+(\.\d+){3}          \s+
                 \w.*
                 \n
               )+
               (
-                \d+                 \s+
-                UNASSIGNED          \s+
+                \d+                    \s+
+                UNASSIGNED             \s+
                 \n
               )?
             $/
@@ -82,13 +82,13 @@
   - match:
       $body: >
             /^
-              ( 0                   \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+                 \s+
-                [-\w.]+             \s+
-                \d+(\.\d+){3}       \s+
+              ( 0                      \s+
+                \d+(\.\d+)?[kmgt]?b    \s+
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+)?                 \s+  #no value from client nodes
+                [-\w.]+                \s+
+                \d+(\.\d+){3}          \s+
                 \w.*
                 \n
               )
@@ -112,23 +112,23 @@
   - match:
 
       $body: >
-           /^  shards               \s+
-               disk.used            \s+
-               disk.avail           \s+
-               disk.total           \s+
-               disk.percent         \s+
-               host                 \s+
-               ip                   \s+
-               node                 \s+
+           /^  shards                  \s+
+               disk.used               \s+
+               disk.avail              \s+
+               disk.total              \s+
+               disk.percent            \s+
+               host                    \s+
+               ip                      \s+
+               node                    \s+
                \n
 
-              ( \s+0                \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+(\.\d+)?[kmgt]b  \s+
-                \d+                 \s+
-                [-\w.]+             \s+
-                \d+(\.\d+){3}       \s+
+              ( \s+0                   \s+
+                \d+(\.\d+)?[kmgt]?b    \s+
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
+                (\d+)?                 \s+  #no value from client nodes
+                [-\w.]+                \s+
+                \d+(\.\d+){3}          \s+
                 \w.*
                 \n
               )+
@@ -144,7 +144,7 @@
   - match:
       $body: >
             /^
-              ( \d+                 \s+
+              ( \d*                 \s+
                 \w.*
                 \n
               )+
@@ -162,7 +162,7 @@
               node                  \s+
               \n
               (
-                \s+\d+              \s+
+                \s+\d*           \s+
                 \w.*
                 \n
               )+
@@ -182,9 +182,9 @@
             /^
               ( 0                   \s+
                 \d+                 \s+
-                \d+                 \s+
-                \d+                 \s+
-                \d+                 \s+
+                \d*                 \s+  #no value from client nodes
+                \d*                 \s+  #no value from client nodes
+                \d*                 \s+  #no value from client nodes
                 [-\w.]+             \s+
                 \d+(\.\d+){3}       \s+
                 \w.*

--- a/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsTests.java
@@ -31,9 +31,10 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.is;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1, numClientNodes = 0)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1, numClientNodes = 0)
 public class ClusterStatsTests extends ElasticsearchIntegrationTest {
 
     private void assertCounts(ClusterStatsNodes.Counts counts, int total, int masterOnly, int dataOnly, int masterData, int client) {

--- a/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsTests.java
+++ b/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsTests.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1)
+@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1, numClientNodes = 0)
 public class ClusterStatsTests extends ElasticsearchIntegrationTest {
 
     private void assertCounts(ClusterStatsNodes.Counts counts, int total, int masterOnly, int dataOnly, int masterData, int client) {
@@ -126,8 +126,8 @@ public class ClusterStatsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testValuesSmokeScreen() {
-        cluster().ensureAtMostNumNodes(5);
-        cluster().ensureAtLeastNumNodes(1);
+        cluster().ensureAtMostNumDataNodes(5);
+        cluster().ensureAtLeastNumDataNodes(1);
         SigarService sigarService = cluster().getInstance(SigarService.class);
         index("test1", "type", "1", "f", "f");
         /*

--- a/src/test/java/org/elasticsearch/action/bulk/BulkIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/action/bulk/BulkIntegrationTests.java
@@ -25,12 +25,13 @@ import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import static org.hamcrest.Matchers.*;
-import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
-
 import org.junit.Test;
 
-@ElasticsearchIntegrationTest.ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=1)
+import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.hamcrest.Matchers.equalTo;
+
+@ClusterScope(scope= Scope.SUITE, numDataNodes =1)
 public class BulkIntegrationTests  extends ElasticsearchIntegrationTest{
 
     @Test

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -25,7 +25,9 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0, transportClientRatio = 1.0)
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0, transportClientRatio = 1.0)
 public class TransportClientTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -44,12 +44,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.*;
 
 /**
  *
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class ClusterServiceTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -36,9 +36,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope = Scope.TEST, numDataNodes =0)
 public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -276,7 +276,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         }
 
         logger.info("--> stopping a node");
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         logger.info("--> verifying min master node has effect");
         assertNoMasterBlockOnAllNodes();
 

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -35,12 +35,13 @@ import org.junit.Test;
 import java.util.HashMap;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -61,7 +61,7 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
         cluster().startNode(settings);
         createIndex("test");
         client().admin().cluster().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         assertThat(awaitBusy(new Predicate<Object>() {
             public boolean apply(Object o) {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();

--- a/src/test/java/org/elasticsearch/cluster/SimpleDataNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/SimpleDataNodesTests.java
@@ -30,12 +30,13 @@ import org.junit.Test;
 import static org.elasticsearch.client.Requests.createIndexRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class SimpleDataNodesTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/SpecificMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/SpecificMasterNodesTests.java
@@ -27,13 +27,14 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
 /**
  *
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class SpecificMasterNodesTests extends ElasticsearchIntegrationTest {
 
     protected final ImmutableSettings.Builder settingsBuilder() {

--- a/src/test/java/org/elasticsearch/cluster/UpdateSettingsValidationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/UpdateSettingsValidationTests.java
@@ -29,11 +29,12 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class UpdateSettingsValidationTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckClusterUpdateSettingsTests.java
@@ -57,7 +57,7 @@ public class AckClusterUpdateSettingsTests extends ElasticsearchIntegrationTest 
 
     @Override
     protected int minimumNumberOfShards() {
-        return immutableCluster().size();
+        return immutableCluster().numDataNodes();
     }
 
     @Override
@@ -106,7 +106,7 @@ public class AckClusterUpdateSettingsTests extends ElasticsearchIntegrationTest 
     public void testClusterUpdateSettingsNoAcknowledgement() {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put("number_of_shards", between(immutableCluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
+                        .put("number_of_shards", between(immutableCluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put("number_of_replicas", 0)).get();
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -179,7 +179,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteAcknowledgement() throws InterruptedException {
         assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder()
                 .put(indexSettings())
-                .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
+                .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
                 .put(SETTING_NUMBER_OF_REPLICAS, 0)
         ));
         ensureGreen();
@@ -214,7 +214,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteNoAcknowledgement() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
@@ -228,7 +228,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteAcknowledgementDryRun() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 
@@ -261,7 +261,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
     public void testClusterRerouteNoAcknowledgementDryRun() throws InterruptedException {
         client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder()
-                        .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().dataNodes(), DEFAULT_MAX_NUM_SHARDS))
+                        .put(SETTING_NUMBER_OF_SHARDS, between(immutableCluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
                         .put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/cluster/allocation/AwarenessAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/AwarenessAllocationTests.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numDataNodes =0)
 public class AwarenessAllocationTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(AwarenessAllocationTests.class);

--- a/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
@@ -47,11 +47,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(ClusterRerouteTests.class);

--- a/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationTests.java
@@ -34,9 +34,10 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class FilteringAllocationTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(FilteringAllocationTests.class);

--- a/src/test/java/org/elasticsearch/cluster/allocation/ShardsAllocatorModuleTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ShardsAllocatorModuleTests.java
@@ -29,11 +29,11 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.instanceOf;
 
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class ShardsAllocatorModuleTests extends ElasticsearchIntegrationTest {
-
 
     public void testLoadDefaultShardsAllocator() {
         assertAllocatorInstance(ImmutableSettings.Builder.EMPTY_SETTINGS, BalancedShardsAllocator.class);

--- a/src/test/java/org/elasticsearch/cluster/allocation/ShardsAllocatorModuleTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ShardsAllocatorModuleTests.java
@@ -58,7 +58,7 @@ public class ShardsAllocatorModuleTests extends ElasticsearchIntegrationTest {
 
     private void assertAllocatorInstance(Settings settings, Class<? extends ShardsAllocator> clazz) {
         while (immutableCluster().size() != 0) {
-            cluster().stopRandomNode();     
+            cluster().stopRandomDataNode();
         }
         cluster().startNode(settings);
         ShardsAllocator instance = cluster().getInstance(ShardsAllocator.class);

--- a/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsTests.java
+++ b/src/test/java/org/elasticsearch/cluster/shards/ClusterSearchShardsTests.java
@@ -28,11 +28,12 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=2)
+@ClusterScope(scope= Scope.SUITE, numDataNodes =2)
 public class ClusterSearchShardsTests extends ElasticsearchIntegrationTest {
     
     @Override

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -44,7 +44,7 @@ import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ClusterScope(scope= Scope.SUITE, numNodes=0)
+@ClusterScope(scope= Scope.SUITE, numDataNodes =0)
 public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope=Scope.TEST, numNodes=2)
 public class ZenUnicastDiscoveryTests extends ElasticsearchIntegrationTest {
@@ -47,14 +47,14 @@ public class ZenUnicastDiscoveryTests extends ElasticsearchIntegrationTest {
     public void testUnicastDiscovery() {
         for (Client client : clients()) {
             ClusterState state = client.admin().cluster().prepareState().execute().actionGet().getState();
-            int clientNodes = 0;
+            //client nodes might be added randomly
+            int dataNodes = 0;
             for (DiscoveryNode discoveryNode : state.nodes()) {
-                if (discoveryNode.isClientNode()) {
-                    clientNodes++;
+                if (discoveryNode.isDataNode()) {
+                    dataNodes++;
                 }
             }
-            //client nodes might be added randomly
-            assertThat(state.nodes().size(), greaterThanOrEqualTo(2 + clientNodes));
+            assertThat(dataNodes, equalTo(2));
         }
     }
 }

--- a/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTests.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@ClusterScope(scope=Scope.TEST, numNodes=2)
+@ClusterScope(scope=Scope.TEST, numDataNodes =2)
 public class ZenUnicastDiscoveryTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTestsMinimumMasterNodes.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTestsMinimumMasterNodes.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@ClusterScope(scope=Scope.TEST, numNodes=0)
+@ClusterScope(scope=Scope.TEST, numDataNodes =0)
 public class ZenUnicastDiscoveryTestsMinimumMasterNodes extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTestsSpecificNodes.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTestsSpecificNodes.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.discovery;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -31,13 +30,16 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.apache.lucene.util.LuceneTestCase.Slow;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@LuceneTestCase.Slow
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@Slow
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class ZenUnicastDiscoveryTestsSpecificNodes extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -354,7 +354,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
 
         int replica = randomInt(2);
 
-        cluster().ensureAtLeastNumNodes(1 + replica);
+        cluster().ensureAtLeastNumDataNodes(1 + replica);
 
         assertAcked(prepareCreate("test").setSettings(
                 ImmutableSettings.builder()

--- a/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
@@ -43,13 +43,14 @@ import org.junit.Test;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 @Slow
 public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
 

--- a/src/test/java/org/elasticsearch/gateway/local/QuorumLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/QuorumLocalGatewayTests.java
@@ -37,6 +37,7 @@ import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.*;
@@ -44,7 +45,7 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-@ClusterScope(numNodes=0, scope= ElasticsearchIntegrationTest.Scope.TEST)
+@ClusterScope(numDataNodes =0, scope= Scope.TEST)
 public class QuorumLocalGatewayTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/SimpleRecoveryLocalGatewayTests.java
@@ -43,6 +43,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.*;
@@ -50,7 +51,7 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-@ClusterScope(numNodes = 0, scope = ElasticsearchIntegrationTest.Scope.TEST)
+@ClusterScope(numDataNodes = 0, scope = Scope.TEST)
 @Slow
 public class SimpleRecoveryLocalGatewayTests extends ElasticsearchIntegrationTest {
 

--- a/src/test/java/org/elasticsearch/gateway/none/RecoverAfterNodesTests.java
+++ b/src/test/java/org/elasticsearch/gateway/none/RecoverAfterNodesTests.java
@@ -31,13 +31,14 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
 /**
  *
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class RecoverAfterNodesTests extends ElasticsearchIntegrationTest {
 
     private final static TimeValue BLOCK_WAIT_TIMEOUT = TimeValue.timeValueSeconds(1);

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineMergeTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineMergeTests.java
@@ -18,15 +18,11 @@
  */
 package org.elasticsearch.index.engine.internal;
 
-import com.carrotsearch.randomizedtesting.annotations.Nightly;
-import com.carrotsearch.randomizedtesting.annotations.Seed;
 import com.google.common.base.Predicate;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -36,21 +32,22 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.lucene.util.LuceneTestCase.Slow;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
 /**
  */
-@ElasticsearchIntegrationTest.ClusterScope(numNodes = 1, scope = ElasticsearchIntegrationTest.Scope.SUITE)
+@ClusterScope(numDataNodes = 1, scope = Scope.SUITE)
 public class InternalEngineMergeTests extends ElasticsearchIntegrationTest {
 
     @Test
-    @LuceneTestCase.Slow
+    @Slow
     public void testMergesHappening() throws InterruptedException, IOException, ExecutionException {
         final int numOfShards = randomIntBetween(1,5);
         // some settings to keep num segments low

--- a/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsTests.java
+++ b/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsTests.java
@@ -56,7 +56,7 @@ public class SuggestStatsTests extends ElasticsearchIntegrationTest {
     public void testSimpleStats() throws Exception {
         // clear all stats first
         client().admin().indices().prepareStats().clear().execute().actionGet();
-        final int numNodes = immutableCluster().dataNodes();
+        final int numNodes = immutableCluster().numDataNodes();
         assertThat(numNodes, greaterThanOrEqualTo(2));
         final int shardsIdx1 = randomIntBetween(1, 10); // we make sure each node gets at least a single shard...
         final int shardsIdx2 = Math.max(numNodes - shardsIdx1, randomIntBetween(1, 10));
@@ -149,7 +149,7 @@ public class SuggestStatsTests extends ElasticsearchIntegrationTest {
     private Set<String> nodeIdsWithIndex(String... indices) {
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
         GroupShardsIterator allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
-        Set<String> nodes = new HashSet<String>();
+        Set<String> nodes = new HashSet<>();
         for (ShardIterator shardIterator : allAssignedShardsGrouped) {
             for (ShardRouting routing : shardIterator.asUnordered()) {
                 if (routing.active()) {

--- a/src/test/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionTests.java
+++ b/src/test/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionTests.java
@@ -46,13 +46,14 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.*;
 
 
 /**
  *
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class IndexLifecycleActionTests extends ElasticsearchIntegrationTest {
 
     @Slow

--- a/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerTests.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
-@ClusterScope(scope = Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class IndicesLifecycleListenerTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
+++ b/src/test/java/org/elasticsearch/indices/analyze/HunspellServiceTests.java
@@ -28,13 +28,14 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class HunspellServiceTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/cache/CacheTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/CacheTests.java
@@ -33,11 +33,12 @@ import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=1, numClientNodes = 0)
+@ClusterScope(scope= Scope.SUITE, numDataNodes =1, numClientNodes = 0)
 public class CacheTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/indices/cache/CacheTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/CacheTests.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=1)
+@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=1, numClientNodes = 0)
 public class CacheTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/indices/leaks/IndicesLeaksTests.java
+++ b/src/test/java/org/elasticsearch/indices/leaks/IndicesLeaksTests.java
@@ -34,11 +34,12 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=1)
+@ClusterScope(scope= Scope.TEST, numDataNodes =1)
 public class IndicesLeaksTests extends ElasticsearchIntegrationTest {
 
 

--- a/src/test/java/org/elasticsearch/indices/mapping/DedicatedMasterGetFieldMappingTests.java
+++ b/src/test/java/org/elasticsearch/indices/mapping/DedicatedMasterGetFieldMappingTests.java
@@ -19,19 +19,19 @@
 
 package org.elasticsearch.indices.mapping;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
 
+import static org.apache.lucene.util.LuceneTestCase.Slow;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 
 /**
  */
-@LuceneTestCase.Slow
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@Slow
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class DedicatedMasterGetFieldMappingTests extends SimpleGetFieldMappingsTests {
 
     @Before

--- a/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryTests.java
+++ b/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -45,7 +46,7 @@ import static org.hamcrest.Matchers.greaterThan;
 /**
  *
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class IndexRecoveryTests extends ElasticsearchIntegrationTest {
 
     private static final String INDEX_NAME = "test-idx-1";

--- a/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasTests.java
+++ b/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasTests.java
@@ -119,7 +119,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testAutoExpandNumberOfReplicas0ToData() {
-        cluster().ensureAtMostNumNodes(2);
+        cluster().ensureAtMostNumDataNodes(2);
         logger.info("--> creating index test with auto expand replicas");
         assertAcked(prepareCreate("test", 2, settingsBuilder().put("auto_expand_replicas", "0-all")));
 
@@ -147,7 +147,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
         logger.info("--> closing one node");
-        cluster().ensureAtMostNumNodes(2);
+        cluster().ensureAtMostNumDataNodes(2);
         allowNodes("test", 2);
 
         logger.info("--> running cluster health");
@@ -160,7 +160,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
         logger.info("--> closing another node");
-        cluster().ensureAtMostNumNodes(1);
+        cluster().ensureAtMostNumDataNodes(1);
         allowNodes("test", 1);
 
         logger.info("--> running cluster health");
@@ -176,7 +176,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
     @Test
     public void testAutoExpandNumberReplicas1ToData() {
         logger.info("--> creating index test with auto expand replicas");
-        cluster().ensureAtMostNumNodes(2);
+        cluster().ensureAtMostNumDataNodes(2);
         assertAcked(prepareCreate("test", 2, settingsBuilder().put("auto_expand_replicas", "1-all")));
 
         NumShards numShards = getNumShards("test");
@@ -203,7 +203,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
         logger.info("--> closing one node");
-        cluster().ensureAtMostNumNodes(2);
+        cluster().ensureAtMostNumDataNodes(2);
         allowNodes("test", 2);
 
         logger.info("--> running cluster health");
@@ -216,7 +216,7 @@ public class UpdateNumberOfReplicasTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
         logger.info("--> closing another node");
-        cluster().ensureAtMostNumNodes(1);
+        cluster().ensureAtMostNumDataNodes(1);
         allowNodes("test", 1);
 
         logger.info("--> running cluster health");

--- a/src/test/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllTests.java
@@ -30,11 +30,12 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=2)
+@ClusterScope(scope= Scope.TEST, numDataNodes =2)
 public class CloseIndexDisableCloseAllTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
@@ -39,10 +39,11 @@ import java.util.Random;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 2)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 2)
 public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
     @Test

--- a/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -34,12 +34,13 @@ import java.io.File;
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.client.Requests.createIndexRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class IndicesStoreTests extends ElasticsearchIntegrationTest {
     private static final Settings SETTINGS = settingsBuilder().put("gateway.type", "local").build();
 

--- a/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
+++ b/src/test/java/org/elasticsearch/indices/template/IndexTemplateFileLoadingTests.java
@@ -33,10 +33,11 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=1)
+@ClusterScope(scope= Scope.TEST, numDataNodes =1)
 public class IndexTemplateFileLoadingTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
+++ b/src/test/java/org/elasticsearch/indices/warmer/LocalGatewayIndicesWarmerTests.java
@@ -33,12 +33,13 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(numNodes=0, scope= ElasticsearchIntegrationTest.Scope.TEST)
+@ClusterScope(numDataNodes =0, scope= Scope.TEST)
 public class LocalGatewayIndicesWarmerTests extends ElasticsearchIntegrationTest {
 
     private final ESLogger logger = Loggers.getLogger(LocalGatewayIndicesWarmerTests.class);

--- a/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
+++ b/src/test/java/org/elasticsearch/nodesinfo/SimpleNodesInfoTests.java
@@ -48,12 +48,13 @@ import static com.google.common.base.Predicates.isNull;
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.client.Requests.nodesInfoRequest;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.*;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class SimpleNodesInfoTests extends ElasticsearchIntegrationTest {
 
     static final class Fields {

--- a/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
@@ -55,7 +55,7 @@ import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
-@ClusterScope(scope = Scope.TEST, numNodes = 1)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 1)
 public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorTests.java
@@ -185,8 +185,8 @@ public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
     @Slow
     @TestLogging("index.percolator:TRACE,percolator:TRACE")
     public void testLoadingPercolateQueriesDuringCloseAndOpen() throws Exception {
-        cluster().ensureAtLeastNumNodes(2);
-        cluster().ensureAtMostNumNodes(2);
+        cluster().ensureAtLeastNumDataNodes(2);
+        cluster().ensureAtMostNumDataNodes(2);
 
         assertAcked(client().admin().indices().prepareCreate("test")
                 .setSettings(settingsBuilder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2)
@@ -249,8 +249,8 @@ public class RecoveryPercolatorTests extends ElasticsearchIntegrationTest {
     // We only start and stop nodes 2 and 3, so all requests should succeed and never be partial.
     private void percolatorRecovery(final boolean multiPercolate) throws Exception {
         logger.info("--> ensuring exactly 2 nodes");
-        cluster().ensureAtLeastNumNodes(2);
-        cluster().ensureAtMostNumNodes(2);
+        cluster().ensureAtLeastNumDataNodes(2);
+        cluster().ensureAtMostNumDataNodes(2);
         logger.info("--> Adding 3th node");
         cluster().startNode(settingsBuilder().put("node.stay", true));
         ensureGreen();

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -46,11 +46,12 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0, transportClientRatio = 0.0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0, transportClientRatio = 0.0)
 public class PluginManagerTests extends ElasticsearchIntegrationTest {
     private static final Settings SETTINGS = ImmutableSettings.settingsBuilder()
             .put("discovery.zen.ping.multicast.enabled", false)

--- a/src/test/java/org/elasticsearch/plugin/ResponseHeaderPluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/ResponseHeaderPluginTests.java
@@ -32,12 +32,13 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Test a rest action that sets special response headers
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
 public class ResponseHeaderPluginTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/plugin/ResponseHeaderPluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/ResponseHeaderPluginTests.java
@@ -64,7 +64,7 @@ public class ResponseHeaderPluginTests extends ElasticsearchIntegrationTest {
     }
 
     private HttpClient httpClient() {
-        HttpServerTransport httpServerTransport = cluster().getInstance(HttpServerTransport.class);
+        HttpServerTransport httpServerTransport = cluster().getDataNodeInstance(HttpServerTransport.class);
         return new HttpClient(httpServerTransport.boundAddress().publishAddress());
     }
 }

--- a/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
@@ -55,20 +55,20 @@ public class SitePluginTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    public HttpClient httpClient(String id) {
-        HttpServerTransport httpServerTransport = cluster().getInstance(HttpServerTransport.class);
+    public HttpClient httpClient() {
+        HttpServerTransport httpServerTransport = cluster().getDataNodeInstance(HttpServerTransport.class);
         return new HttpClient(httpServerTransport.boundAddress().publishAddress());
     }
 
     @Test
     public void testRedirectSitePlugin() throws Exception {
         // We use an HTTP Client to test redirection
-        HttpClientResponse response = httpClient("test").request("/_plugin/dummy");
+        HttpClientResponse response = httpClient().request("/_plugin/dummy");
         assertThat(response.errorCode(), equalTo(RestStatus.MOVED_PERMANENTLY.getStatus()));
         assertThat(response.response(), containsString("/_plugin/dummy/"));
 
         // We test the real URL
-        response = httpClient("test").request("/_plugin/dummy/");
+        response = httpClient().request("/_plugin/dummy/");
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin</title>"));
     }
@@ -78,7 +78,7 @@ public class SitePluginTests extends ElasticsearchIntegrationTest {
      */
     @Test
     public void testAnyPage() throws Exception {
-        HttpClientResponse response = httpClient("test").request("/_plugin/dummy/index.html");
+        HttpClientResponse response = httpClient().request("/_plugin/dummy/index.html");
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin</title>"));
     }
@@ -89,14 +89,14 @@ public class SitePluginTests extends ElasticsearchIntegrationTest {
      */
     @Test
     public void testWelcomePageInSubDirs() throws Exception {
-        HttpClientResponse response = httpClient("test").request("/_plugin/subdir/dir/");
+        HttpClientResponse response = httpClient().request("/_plugin/subdir/dir/");
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin (subdir)</title>"));
 
-        response = httpClient("test").request("/_plugin/subdir/dir_without_index/");
+        response = httpClient().request("/_plugin/subdir/dir_without_index/");
         assertThat(response.errorCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
 
-        response = httpClient("test").request("/_plugin/subdir/dir_without_index/page.html");
+        response = httpClient().request("/_plugin/subdir/dir_without_index/page.html");
         assertThat(response.errorCode(), equalTo(RestStatus.OK.getStatus()));
         assertThat(response.response(), containsString("<title>Dummy Site Plugin (page)</title>"));
     }

--- a/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
+++ b/src/test/java/org/elasticsearch/plugin/SitePluginTests.java
@@ -31,13 +31,14 @@ import java.io.File;
 import java.net.URISyntaxException;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  * We want to test site plugins
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
 public class SitePluginTests extends ElasticsearchIntegrationTest {
 
 

--- a/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
+++ b/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
@@ -89,14 +89,14 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
         }
 
         // now start shutting nodes down
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForGreenStatus().setWaitForRelocatingShards(0).setWaitForNodes("4"));
 
         // going down to 3 nodes. note that the min_master_node may not be in effect when we shutdown the 4th
         // node, but that's OK as it is set to 3 before.
         setMinimumMasterNodes(2);
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForGreenStatus().setWaitForRelocatingShards(0).setWaitForNodes("3"));
 
@@ -106,13 +106,13 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
         }
 
         // closing the 3rd node
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForGreenStatus().setWaitForRelocatingShards(0).setWaitForNodes("2"));
 
         // closing the 2nd node
         setMinimumMasterNodes(1);
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
 
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForYellowStatus().setWaitForRelocatingShards(0).setWaitForNodes("1"));

--- a/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
+++ b/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
@@ -30,12 +30,13 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 /**
  *
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0, transportClientRatio = 0.0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0, transportClientRatio = 0.0)
 public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
 
     protected void assertTimeout(ClusterHealthRequestBuilder requestBuilder) {

--- a/src/test/java/org/elasticsearch/recovery/RelocationTests.java
+++ b/src/test/java/org/elasticsearch/recovery/RelocationTests.java
@@ -40,11 +40,12 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class RelocationTests extends ElasticsearchIntegrationTest {
     private final TimeValue ACCEPTABLE_RELOCATION_TIME = new TimeValue(5, TimeUnit.MINUTES);
 

--- a/src/test/java/org/elasticsearch/script/ScriptFieldTests.java
+++ b/src/test/java/org/elasticsearch/script/ScriptFieldTests.java
@@ -32,9 +32,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.equalTo;
 
-@ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 3)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 3)
 public class ScriptFieldTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexTests.java
+++ b/src/test/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexTests.java
@@ -68,7 +68,7 @@ public class SearchWhileCreatingIndexTests extends ElasticsearchIntegrationTest 
         // TODO: add a smarter choice based on actual consistency (when that is randomized)
         int shardsNo = numberOfReplicas + 1;
         int neededNodes = shardsNo <= 2 ? 1 : shardsNo / 2 + 1;
-        cluster().ensureAtLeastNumNodes(randomIntBetween(neededNodes, shardsNo));
+        cluster().ensureAtLeastNumDataNodes(randomIntBetween(neededNodes, shardsNo));
         for (int i = 0; i < 20; i++) {
             logger.info("running iteration {}", i);
             if (createIndex) {
@@ -99,7 +99,7 @@ public class SearchWhileCreatingIndexTests extends ElasticsearchIntegrationTest 
                 }
                 assertHitCount(searchResponse, 1);
                 status = client().admin().cluster().prepareHealth("test").get().getStatus();
-                cluster().ensureAtLeastNumNodes(numberOfReplicas + 1);
+                cluster().ensureAtLeastNumDataNodes(numberOfReplicas + 1);
             }
             immutableCluster().wipeIndices("test");
         }

--- a/src/test/java/org/elasticsearch/search/functionscore/FunctionScorePluginTests.java
+++ b/src/test/java/org/elasticsearch/search/functionscore/FunctionScorePluginTests.java
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-@ClusterScope(scope = Scope.SUITE, numNodes = 1)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
 public class FunctionScorePluginTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchTests.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-@ClusterScope(scope = Scope.SUITE, numNodes = 1)
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
 public class CustomHighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/search/stats/SearchStatsTests.java
+++ b/src/test/java/org/elasticsearch/search/stats/SearchStatsTests.java
@@ -57,7 +57,7 @@ public class SearchStatsTests extends ElasticsearchIntegrationTest {
     public void testSimpleStats() throws Exception {
         // clear all stats first
         client().admin().indices().prepareStats().clear().execute().actionGet();
-        final int numNodes = immutableCluster().dataNodes();
+        final int numNodes = immutableCluster().numDataNodes();
         assertThat(numNodes, greaterThanOrEqualTo(2));
         final int shardsIdx1 = randomIntBetween(1, 10); // we make sure each node gets at least a single shard...
         final int shardsIdx2 = Math.max(numNodes - shardsIdx1, randomIntBetween(1, 10));

--- a/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchTests.java
@@ -32,13 +32,14 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=1)
+@ClusterScope(scope= Scope.SUITE, numDataNodes =1)
 public class CustomSuggesterSearchTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotTests.java
@@ -41,7 +41,7 @@ public abstract class AbstractSnapshotTests extends ElasticsearchIntegrationTest
 
     public static long getFailureCount(String repository) {
         long failureCount = 0;
-        for (RepositoriesService repositoriesService : cluster().getInstances(RepositoriesService.class)) {
+        for (RepositoriesService repositoriesService : cluster().getDataNodeInstances(RepositoriesService.class)) {
             MockRepository mockRepository = (MockRepository) repositoriesService.repository(repository);
             failureCount += mockRepository.getFailureCount();
         }

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockDirectoryHelper;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -38,13 +37,15 @@ import java.util.ArrayList;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
 import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numNodes = 0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
     @Test

--- a/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.snapshots.mockstore.MockRepositoryModule;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockDirectoryHelper;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -153,7 +152,7 @@ public class DedicatedClusterSnapshotRestoreTests extends AbstractSnapshotTests 
         assertThat(client().prepareCount("test-idx-1").get().getCount(), equalTo(100L));
 
         logger.info("--> shutdown one of the nodes");
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         assertThat(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForNodes("<2").execute().actionGet().isTimedOut(), equalTo(false));
 
         assertAcked(prepareCreate("test-idx-2", 1, settingsBuilder().put("number_of_shards", 6)

--- a/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -982,7 +982,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
 
         long snapshotPause = 0L;
         long restorePause = 0L;
-        for (RepositoriesService repositoriesService : cluster().getInstances(RepositoriesService.class)) {
+        for (RepositoriesService repositoriesService : cluster().getDataNodeInstances(RepositoriesService.class)) {
             snapshotPause += repositoriesService.repository("test-repo").snapshotThrottleTimeInNanos();
             restorePause += repositoriesService.repository("test-repo").restoreThrottleTimeInNanos();
         }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -134,7 +134,7 @@ import static org.hamcrest.Matchers.equalTo;
  * the tests start.
  * <p/>
  *  <pre>
- * @ClusterScope(scope=Scope.SUITE, numNodes=3)
+ * @ClusterScope(scope=Scope.SUITE, numDataNodes=3)
  * public class SomeIntegrationTest extends ElasticsearchIntegrationTest {
  * @Test public void testMethod() {}
  * }
@@ -1032,19 +1032,19 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
          * a random number of nodes is used, where the minimum and maximum number of nodes
          * are either the specified ones or the default ones if not specified.
          */
-        int numNodes() default -1;
+        int numDataNodes() default -1;
 
         /**
-         * Returns the minimum number of nodes in the cluster. Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_MIN_NUM_NODES}.
-         * Ignored when {@link ClusterScope#numNodes()} is set.
+         * Returns the minimum number of nodes in the cluster. Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_MIN_NUM_DATA_NODES}.
+         * Ignored when {@link ClusterScope#numDataNodes()} is set.
          */
-        int minNumNodes() default TestCluster.DEFAULT_MIN_NUM_NODES;
+        int minNumDataNodes() default TestCluster.DEFAULT_MIN_NUM_DATA_NODES;
 
         /**
-         * Returns the maximum number of nodes in the cluster.  Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_MAX_NUM_NODES}.
-         * Ignored when {@link ClusterScope#numNodes()} is set.
+         * Returns the maximum number of nodes in the cluster.  Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_MAX_NUM_DATA_NODES}.
+         * Ignored when {@link ClusterScope#numDataNodes()} is set.
          */
-        int maxNumNodes() default TestCluster.DEFAULT_MAX_NUM_NODES;
+        int maxNumDataNodes() default TestCluster.DEFAULT_MAX_NUM_DATA_NODES;
 
         /**
          * Returns the number of client nodes in the cluster. Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_NUM_CLIENT_NODES}.
@@ -1129,17 +1129,17 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
     private int getNumNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
-        return annotation == null ? -1 : annotation.numNodes();
+        return annotation == null ? -1 : annotation.numDataNodes();
     }
 
     private int getMinNumNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
-        return annotation == null ? TestCluster.DEFAULT_MIN_NUM_NODES : annotation.minNumNodes();
+        return annotation == null ? TestCluster.DEFAULT_MIN_NUM_DATA_NODES : annotation.minNumDataNodes();
     }
 
     private int getMaxNumNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
-        return annotation == null ? TestCluster.DEFAULT_MAX_NUM_NODES : annotation.maxNumNodes();
+        return annotation == null ? TestCluster.DEFAULT_MAX_NUM_DATA_NODES : annotation.maxNumDataNodes();
     }
 
     private int getNumClientNodes() {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1127,17 +1127,17 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         return annotation == null ? Scope.GLOBAL : annotation.scope();
     }
 
-    private int getNumNodes() {
+    private int getNumDataNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
         return annotation == null ? -1 : annotation.numDataNodes();
     }
 
-    private int getMinNumNodes() {
+    private int getMinNumDataNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
         return annotation == null ? TestCluster.DEFAULT_MIN_NUM_DATA_NODES : annotation.minNumDataNodes();
     }
 
-    private int getMaxNumNodes() {
+    private int getMaxNumDataNodes() {
         ClusterScope annotation = getAnnotation(this.getClass());
         return annotation == null ? TestCluster.DEFAULT_MAX_NUM_DATA_NODES : annotation.maxNumDataNodes();
     }
@@ -1160,7 +1160,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
     private TestCluster buildTestCluster(Scope scope) {
         long currentClusterSeed = randomLong();
-        int numNodes = getNumNodes();
+        int numNodes = getNumDataNodes();
         NodeSettingsSource nodeSettingsSource;
         if (numNodes > 0) {
             NodeSettingsSource.Immutable.Builder nodesSettings = NodeSettingsSource.Immutable.builder();
@@ -1181,8 +1181,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         if (numNodes >= 0) {
             minNumNodes = maxNumNodes = numNodes;
         } else {
-            minNumNodes = getMinNumNodes();
-            maxNumNodes = getMaxNumNodes();
+            minNumNodes = getMinNumDataNodes();
+            maxNumNodes = getMaxNumDataNodes();
         }
 
         int numClientNodes = getNumClientNodes();

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1047,7 +1047,8 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         int maxNumDataNodes() default TestCluster.DEFAULT_MAX_NUM_DATA_NODES;
 
         /**
-         * Returns the number of client nodes in the cluster. Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_NUM_CLIENT_NODES}.
+         * Returns the number of client nodes in the cluster. Default is {@link org.elasticsearch.test.TestCluster#DEFAULT_NUM_CLIENT_NODES}, a
+         * negative value means that the number of client nodes will be randomized.
          */
         int numClientNodes() default TestCluster.DEFAULT_NUM_CLIENT_NODES;
 

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -46,7 +46,7 @@ public final class ExternalTestCluster extends ImmutableTestCluster {
 
     private final InetSocketAddress[] httpAddresses;
 
-    private final int dataNodes;
+    private final int numDataNodes;
 
     public ExternalTestCluster(TransportAddress... transportAddresses) {
         this.client = new TransportClient(ImmutableSettings.settingsBuilder().put("client.transport.ignore_cluster_name", true))
@@ -62,7 +62,7 @@ public final class ExternalTestCluster extends ImmutableTestCluster {
                 dataNodes++;
             }
         }
-        this.dataNodes = dataNodes;
+        this.numDataNodes = dataNodes;
         logger.info("Setup ExternalTestCluster [{}] made of [{}] nodes", nodeInfos.getClusterName().value(), size());
     }
 
@@ -82,8 +82,8 @@ public final class ExternalTestCluster extends ImmutableTestCluster {
     }
 
     @Override
-    public int dataNodes() {
-        return dataNodes;
+    public int numDataNodes() {
+        return numDataNodes;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/test/ImmutableTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ImmutableTestCluster.java
@@ -98,7 +98,7 @@ public abstract class ImmutableTestCluster implements Iterable<Client> {
     /**
      * Returns the number of data nodes in the cluster.
      */
-    public abstract int dataNodes();
+    public abstract int numDataNodes();
 
     /**
      * Returns the http addresses of the nodes within the cluster.

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -22,10 +22,7 @@ import com.carrotsearch.randomizedtesting.SeedUtils;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -124,6 +121,8 @@ public final class TestCluster extends ImmutableTestCluster {
     static final int DEFAULT_MIN_NUM_NODES = 2;
     static final int DEFAULT_MAX_NUM_NODES = 6;
 
+    static final int DEFAULT_NUM_CLIENT_NODES = 1;
+
     /* sorted map to make traverse order reproducible, concurrent since we do checks on it not within a sync block */
     private final NavigableMap<String, NodeAndClient> nodes = new TreeMap<>();
 
@@ -142,39 +141,50 @@ public final class TestCluster extends ImmutableTestCluster {
      * fully shared cluster to be more reproducible */
     private final long[] sharedNodesSeeds;
 
+    private final int numSharedDataNodes;
+
+    private final int numSharedClientNodes;
+
     private final NodeSettingsSource nodeSettingsSource;
 
     private final ExecutorService executor;
 
     public TestCluster(long clusterSeed, String clusterName) {
-        this(clusterSeed, DEFAULT_MIN_NUM_NODES, DEFAULT_MAX_NUM_NODES, clusterName, NodeSettingsSource.EMPTY);
+        this(clusterSeed, DEFAULT_MIN_NUM_NODES, DEFAULT_MAX_NUM_NODES, clusterName, NodeSettingsSource.EMPTY, DEFAULT_NUM_CLIENT_NODES);
     }
 
-    public TestCluster(long clusterSeed, int minNumNodes, int maxNumNodes, String clusterName) {
-        this(clusterSeed, minNumNodes, maxNumNodes, clusterName, NodeSettingsSource.EMPTY);
+    public TestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes) {
+        this(clusterSeed, minNumDataNodes, maxNumDataNodes, clusterName, NodeSettingsSource.EMPTY, numClientNodes);
     }
 
-    public TestCluster(long clusterSeed, int minNumNodes, int maxNumNodes, String clusterName, NodeSettingsSource nodeSettingsSource) {
+    public TestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, NodeSettingsSource nodeSettingsSource, int numClientNodes) {
         this.clusterName = clusterName;
 
-        if (minNumNodes < 0 || maxNumNodes < 0) {
-            throw new IllegalArgumentException("minimum and maximum number of nodes must be >= 0");
+        if (minNumDataNodes < 0 || maxNumDataNodes < 0) {
+            throw new IllegalArgumentException("minimum and maximum number of data nodes must be >= 0");
         }
 
-        if (maxNumNodes < minNumNodes) {
-            throw new IllegalArgumentException("maximum number of nodes must be >= minimum number of nodes");
+        if (maxNumDataNodes < minNumDataNodes) {
+            throw new IllegalArgumentException("maximum number of data nodes must be >= minimum number of  data nodes");
         }
 
         Random random = new Random(clusterSeed);
 
-        int numSharedNodes;
-        if (minNumNodes == maxNumNodes) {
-            numSharedNodes = minNumNodes;
+        if (minNumDataNodes == maxNumDataNodes) {
+            this.numSharedDataNodes = minNumDataNodes;
         } else {
-            numSharedNodes = minNumNodes + random.nextInt(maxNumNodes - minNumNodes);
+            this.numSharedDataNodes = minNumDataNodes + random.nextInt(maxNumDataNodes - minNumDataNodes);
         }
+        assert this.numSharedDataNodes >= 0;
 
-        assert numSharedNodes >= 0;
+        //for now all shared data nodes are also master eligible
+        if (numSharedDataNodes == 0) {
+            this.numSharedClientNodes = 0;
+        } else {
+            this.numSharedClientNodes = numClientNodes;
+        }
+        assert this.numSharedClientNodes >=0;
+
         /*
          *  TODO
          *  - we might want start some master only nodes?
@@ -182,11 +192,12 @@ public final class TestCluster extends ImmutableTestCluster {
          *  - we could add a flag that never returns a client to the master
          *  - along those lines use a dedicated node that is master eligible and let all other nodes be only data nodes
          */
-        sharedNodesSeeds = new long[numSharedNodes];
+        sharedNodesSeeds = new long[numSharedDataNodes + numSharedClientNodes];
         for (int i = 0; i < sharedNodesSeeds.length; i++) {
             sharedNodesSeeds[i] = random.nextLong();
         }
-        logger.info("Setup TestCluster [{}] with seed [{}] using [{}] nodes", clusterName, SeedUtils.formatSeed(clusterSeed), numSharedNodes);
+
+        logger.info("Setup TestCluster [{}] with seed [{}] using [{}] data nodes and [{}] client nodes", clusterName, SeedUtils.formatSeed(clusterSeed), numSharedDataNodes, numSharedClientNodes);
         this.nodeSettingsSource = nodeSettingsSource;
         Builder builder = ImmutableSettings.settingsBuilder();
         if (random.nextInt(5) == 0) { // sometimes set this
@@ -333,14 +344,14 @@ public final class TestCluster extends ImmutableTestCluster {
     }
 
     /**
-     * Ensures that at least <code>n</code> nodes are present in the cluster.
+     * Ensures that at least <code>n</code> data nodes are present in the cluster.
      * if more nodes than <code>n</code> are present this method will not
      * stop any of the running nodes.
      */
-    public void ensureAtLeastNumNodes(int n) {
+    public void ensureAtLeastNumDataNodes(int n) {
         List<ListenableFuture<String>> futures = Lists.newArrayList();
         synchronized (this) {
-            int size = nodes.size();
+            int size = numDataNodes();
             for (int i = size; i < n; i++) {
                 logger.info("increasing cluster size from {} to {}", size, n);
                 futures.add(startNodeAsync());
@@ -358,14 +369,17 @@ public final class TestCluster extends ImmutableTestCluster {
      * If less nodes that <code>n</code> are running this method
      * will not start any additional nodes.
      */
-    public synchronized void ensureAtMostNumNodes(int n) {
-        if (nodes.size() <= n) {
+    public synchronized void ensureAtMostNumDataNodes(int n) {
+        int size = numDataNodes();
+        if (size <= n) {
             return;
         }
-        // prevent killing the master if possible
-        final Iterator<NodeAndClient> values = n == 0 ? nodes.values().iterator() : Iterators.filter(nodes.values().iterator(), Predicates.not(new MasterNodePredicate(getMasterName())));
-        final Iterator<NodeAndClient> limit = Iterators.limit(values, nodes.size() - n);
-        logger.info("changing cluster size from {} to {}", nodes.size() - n, n);
+        // prevent killing the master if possible and client nodes
+        final Iterator<NodeAndClient> values = n == 0 ? nodes.values().iterator() : Iterators.filter(nodes.values().iterator(),
+                Predicates.and(new DataNodePredicate(), Predicates.not(new MasterNodePredicate(getMasterName()))));
+
+        final Iterator<NodeAndClient> limit = Iterators.limit(values, size - n);
+        logger.info("changing cluster size from {} to {}, {} data nodes", size(), n + numSharedClientNodes, n);
         Set<NodeAndClient> nodesToRemove = new HashSet<>();
         while (limit.hasNext()) {
             NodeAndClient next = limit.next();
@@ -412,6 +426,16 @@ public final class TestCluster extends ImmutableTestCluster {
         ensureOpen();
         /* Randomly return a client to one of the nodes in the cluster */
         return getOrBuildRandomNode().client(random);
+    }
+
+    /**
+     * Returns a node client to a data node in the cluster.
+     * Note: use this with care tests should not rely on a certain nodes client.
+     */
+    public synchronized Client dataNodeClient() {
+        ensureOpen();
+        /* Randomly return a client to one of the nodes in the cluster */
+        return getRandomNodeAndClient(new DataNodePredicate()).client(random);
     }
 
     /**
@@ -707,13 +731,26 @@ public final class TestCluster extends ImmutableTestCluster {
 
 
         Set<NodeAndClient> sharedNodes = new HashSet<>();
+        assert sharedNodesSeeds.length == numSharedDataNodes + numSharedClientNodes;
         boolean changed = false;
-        for (int i = 0; i < sharedNodesSeeds.length; i++) {
+        for (int i = 0; i < numSharedDataNodes; i++) {
             String buildNodeName = buildNodeName(i);
             NodeAndClient nodeAndClient = nodes.get(buildNodeName);
             if (nodeAndClient == null) {
                 changed = true;
                 nodeAndClient = buildNode(i, sharedNodesSeeds[i], null, Version.CURRENT);
+                nodeAndClient.node.start();
+                logger.info("Start Shared Node [{}] not shared", nodeAndClient.name);
+            }
+            sharedNodes.add(nodeAndClient);
+        }
+        for (int i = numSharedDataNodes; i < numSharedDataNodes + numSharedClientNodes; i++) {
+            String buildNodeName = buildNodeName(i);
+            NodeAndClient nodeAndClient = nodes.get(buildNodeName);
+            if (nodeAndClient == null) {
+                changed = true;
+                Settings clientSettings = ImmutableSettings.builder().put("node.data", "false").put("node.master", "false").build();
+                nodeAndClient = buildNode(i, sharedNodesSeeds[i], clientSettings, Version.CURRENT);
                 nodeAndClient.node.start();
                 logger.info("Start Shared Node [{}] not shared", nodeAndClient.name);
             }
@@ -792,6 +829,22 @@ public final class TestCluster extends ImmutableTestCluster {
     }
 
     /**
+     * Returns an Iterable to all instances for the given class &gt;T&lt; across all data nodes in the cluster.
+     */
+    public synchronized <T> Iterable<T> getDataNodeInstances(Class<T> clazz) {
+        return getInstances(clazz, new DataNodePredicate());
+    }
+
+    private synchronized <T> Iterable<T> getInstances(Class<T> clazz, Predicate<NodeAndClient> predicate) {
+        Iterable<NodeAndClient> filteredNodes = Iterables.filter(nodes.values(), predicate);
+        List<T> instances = new ArrayList<>();
+        for (NodeAndClient nodeAndClient : filteredNodes) {
+            instances.add(getInstanceFromNode(clazz, nodeAndClient.node));
+        }
+        return instances;
+    }
+
+    /**
      * Returns a reference to the given nodes instances of the given class &gt;T&lt;
      */
     public synchronized <T> T getInstance(Class<T> clazz, final String node) {
@@ -805,6 +858,14 @@ public final class TestCluster extends ImmutableTestCluster {
         } else {
             predicate = Predicates.alwaysTrue();
         }
+        return getInstance(clazz, predicate);
+    }
+
+    public synchronized <T> T getDataNodeInstance(Class<T> clazz) {
+        return getInstance(clazz, new DataNodePredicate());
+    }
+
+    private synchronized <T> T getInstance(Class<T> clazz, Predicate<NodeAndClient> predicate) {
         NodeAndClient randomNodeAndClient = getRandomNodeAndClient(predicate);
         assert randomNodeAndClient != null;
         return getInstanceFromNode(clazz, randomNodeAndClient.node);
@@ -814,7 +875,7 @@ public final class TestCluster extends ImmutableTestCluster {
      * Returns a reference to a random nodes instances of the given class &gt;T&lt;
      */
     public synchronized <T> T getInstance(Class<T> clazz) {
-        return getInstance(clazz, null);
+        return getInstance(clazz, Predicates.<NodeAndClient>alwaysTrue());
     }
 
     private synchronized <T> T getInstanceFromNode(Class<T> clazz, InternalNode node) {
@@ -836,11 +897,11 @@ public final class TestCluster extends ImmutableTestCluster {
     }
 
     /**
-     * Stops a random node in the cluster.
+     * Stops a random data node in the cluster.
      */
-    public synchronized void stopRandomNode() {
+    public synchronized void stopRandomDataNode() {
         ensureOpen();
-        NodeAndClient nodeAndClient = getRandomNodeAndClient();
+        NodeAndClient nodeAndClient = getRandomNodeAndClient(new DataNodePredicate());
         if (nodeAndClient != null) {
             logger.info("Closing random node [{}] ", nodeAndClient.name);
             nodes.remove(nodeAndClient.name);
@@ -899,13 +960,33 @@ public final class TestCluster extends ImmutableTestCluster {
         restartRandomNode(EMPTY_CALLBACK);
     }
 
-
     /**
      * Restarts a random node in the cluster and calls the callback during restart.
      */
     public void restartRandomNode(RestartCallback callback) throws Exception {
+        restartRandomNode(Predicates.<NodeAndClient>alwaysTrue(), callback);
+    }
+
+    /**
+     * Restarts a random data node in the cluster
+     */
+    public void restartRandomDataNode() throws Exception {
+        restartRandomNode(EMPTY_CALLBACK);
+    }
+
+    /**
+     * Restarts a random data node in the cluster and calls the callback during restart.
+     */
+    public void restartRandomDataNode(RestartCallback callback) throws Exception {
+        restartRandomNode(new DataNodePredicate(), callback);
+    }
+
+    /**
+     * Restarts a random node in the cluster and calls the callback during restart.
+     */
+    private void restartRandomNode(Predicate<NodeAndClient> predicate, RestartCallback callback) throws Exception {
         ensureOpen();
-        NodeAndClient nodeAndClient = getRandomNodeAndClient();
+        NodeAndClient nodeAndClient = getRandomNodeAndClient(predicate);
         if (nodeAndClient != null) {
             logger.info("Restarting random node [{}] ", nodeAndClient.name);
             nodeAndClient.restart(callback);
@@ -996,13 +1077,14 @@ public final class TestCluster extends ImmutableTestCluster {
         }
     }
 
-    synchronized Set<String> allButN(int numNodes) {
-        return nRandomNodes(size() - numNodes);
+    synchronized Set<String> allDataNodesButN(int numNodes) {
+        return nRandomDataNodes(numDataNodes() - numNodes);
     }
 
-    private synchronized Set<String> nRandomNodes(int numNodes) {
+    private synchronized Set<String> nRandomDataNodes(int numNodes) {
         assert size() >= numNodes;
-        return Sets.newHashSet(Iterators.limit(this.nodes.keySet().iterator(), numNodes));
+        NavigableMap<String, NodeAndClient> dataNodes = Maps.filterEntries(nodes, new EntryNodePredicate(new DataNodePredicate()));
+        return Sets.newHashSet(Iterators.limit(dataNodes.keySet().iterator(), numNodes));
     }
 
     public synchronized void startNodeClient(Settings settings) {
@@ -1154,11 +1236,11 @@ public final class TestCluster extends ImmutableTestCluster {
     }
 
     @Override
-    public int dataNodes() {
+    public int numDataNodes() {
         return dataNodeAndClients().size();
     }
 
-    private Collection<NodeAndClient> dataNodeAndClients() {
+    private synchronized Collection<NodeAndClient> dataNodeAndClients() {
         return Collections2.filter(nodes.values(), new DataNodePredicate());
     }
 
@@ -1183,10 +1265,22 @@ public final class TestCluster extends ImmutableTestCluster {
     }
 
     private static final class ClientNodePredicate implements Predicate<NodeAndClient> {
-
         @Override
         public boolean apply(NodeAndClient nodeAndClient) {
             return nodeAndClient.node.settings().getAsBoolean("node.client", false);
+        }
+    }
+
+    private static final class EntryNodePredicate implements Predicate<Map.Entry<String, NodeAndClient>> {
+        private final Predicate<NodeAndClient> delegateNodePredicate;
+
+        EntryNodePredicate(Predicate<NodeAndClient> delegateNodePredicate) {
+            this.delegateNodePredicate = delegateNodePredicate;
+        }
+
+        @Override
+        public boolean apply(Map.Entry<String, NodeAndClient> entry) {
+            return delegateNodePredicate.apply(entry.getValue());
         }
     }
 

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.SeedUtils;
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -118,8 +119,8 @@ public final class TestCluster extends ImmutableTestCluster {
 
     private static final boolean ENABLE_MOCK_MODULES = systemPropertyAsBoolean(TESTS_ENABLE_MOCK_MODULES, true);
 
-    static final int DEFAULT_MIN_NUM_NODES = 2;
-    static final int DEFAULT_MAX_NUM_NODES = 6;
+    static final int DEFAULT_MIN_NUM_DATA_NODES = 2;
+    static final int DEFAULT_MAX_NUM_DATA_NODES = 6;
 
     static final int DEFAULT_NUM_CLIENT_NODES = 1;
 
@@ -150,7 +151,7 @@ public final class TestCluster extends ImmutableTestCluster {
     private final ExecutorService executor;
 
     public TestCluster(long clusterSeed, String clusterName) {
-        this(clusterSeed, DEFAULT_MIN_NUM_NODES, DEFAULT_MAX_NUM_NODES, clusterName, NodeSettingsSource.EMPTY, DEFAULT_NUM_CLIENT_NODES);
+        this(clusterSeed, DEFAULT_MIN_NUM_DATA_NODES, DEFAULT_MAX_NUM_DATA_NODES, clusterName, NodeSettingsSource.EMPTY, DEFAULT_NUM_CLIENT_NODES);
     }
 
     public TestCluster(long clusterSeed, int minNumDataNodes, int maxNumDataNodes, String clusterName, int numClientNodes) {
@@ -173,7 +174,7 @@ public final class TestCluster extends ImmutableTestCluster {
         if (minNumDataNodes == maxNumDataNodes) {
             this.numSharedDataNodes = minNumDataNodes;
         } else {
-            this.numSharedDataNodes = minNumDataNodes + random.nextInt(maxNumDataNodes - minNumDataNodes);
+            this.numSharedDataNodes = RandomInts.randomIntBetween(random, minNumDataNodes, maxNumDataNodes);
         }
         assert this.numSharedDataNodes >= 0;
 

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -122,7 +122,9 @@ public final class TestCluster extends ImmutableTestCluster {
     static final int DEFAULT_MIN_NUM_DATA_NODES = 2;
     static final int DEFAULT_MAX_NUM_DATA_NODES = 6;
 
-    static final int DEFAULT_NUM_CLIENT_NODES = 1;
+    static final int DEFAULT_NUM_CLIENT_NODES = -1;
+    static final int DEFAULT_MIN_NUM_CLIENT_NODES = 0;
+    static final int DEFAULT_MAX_NUM_CLIENT_NODES = 1;
 
     /* sorted map to make traverse order reproducible, concurrent since we do checks on it not within a sync block */
     private final NavigableMap<String, NodeAndClient> nodes = new TreeMap<>();
@@ -171,18 +173,18 @@ public final class TestCluster extends ImmutableTestCluster {
 
         Random random = new Random(clusterSeed);
 
-        if (minNumDataNodes == maxNumDataNodes) {
-            this.numSharedDataNodes = minNumDataNodes;
-        } else {
-            this.numSharedDataNodes = RandomInts.randomIntBetween(random, minNumDataNodes, maxNumDataNodes);
-        }
+        this.numSharedDataNodes = RandomInts.randomIntBetween(random, minNumDataNodes, maxNumDataNodes);
         assert this.numSharedDataNodes >= 0;
 
         //for now all shared data nodes are also master eligible
         if (numSharedDataNodes == 0) {
             this.numSharedClientNodes = 0;
         } else {
-            this.numSharedClientNodes = numClientNodes;
+            if (numClientNodes < 0) {
+                this.numSharedClientNodes = RandomInts.randomIntBetween(random, DEFAULT_MIN_NUM_CLIENT_NODES, DEFAULT_MAX_NUM_CLIENT_NODES);
+            } else {
+                this.numSharedClientNodes = numClientNodes;
+            }
         }
         assert this.numSharedClientNodes >=0;
 

--- a/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
@@ -38,11 +38,12 @@ import java.util.Map;
 import java.util.concurrent.*;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.TEST, numNodes=2)
+@ClusterScope(scope= Scope.TEST, numDataNodes =2)
 public class SimpleThreadPoolTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
+++ b/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolTests.java
@@ -52,7 +52,7 @@ public class SimpleThreadPoolTests extends ElasticsearchIntegrationTest {
 
     @Test(timeout = 20000)
     public void testUpdatingThreadPoolSettings() throws Exception {
-        ThreadPool threadPool = cluster().getInstance(ThreadPool.class);
+        ThreadPool threadPool = cluster().getDataNodeInstance(ThreadPool.class);
         // Check that settings are changed
         assertThat(((ThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(5L));
         client().admin().cluster().prepareUpdateSettings().setTransientSettings(settingsBuilder().put("threadpool.search.keep_alive", "10m").build()).execute().actionGet();

--- a/src/test/java/org/elasticsearch/tribe/TribeTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeTests.java
@@ -58,9 +58,9 @@ public class TribeTests extends ElasticsearchIntegrationTest {
     public static void setupSecondCluster() throws Exception {
         ElasticsearchIntegrationTest.beforeClass();
         // create another cluster
-        cluster2 = new TestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()));
+        cluster2 = new TestCluster(randomLong(), 2, 2, Strings.randomBase64UUID(getRandom()), 0);
         cluster2.beforeTest(getRandom(), 0.1);
-        cluster2.ensureAtLeastNumNodes(2);
+        cluster2.ensureAtLeastNumDataNodes(2);
     }
 
     @AfterClass
@@ -301,7 +301,7 @@ public class TribeTests extends ElasticsearchIntegrationTest {
         });
 
         logger.info("stop a node, make sure its reflected");
-        cluster2.stopRandomNode();
+        cluster2.stopRandomDataNode();
         awaitSameNodeCounts();
     }
 

--- a/src/test/java/org/elasticsearch/ttl/SimpleTTLTests.java
+++ b/src/test/java/org/elasticsearch/ttl/SimpleTTLTests.java
@@ -32,10 +32,11 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.*;
 
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1)
+@ClusterScope(scope= Scope.SUITE, numDataNodes = 1)
 public class SimpleTTLTests extends ElasticsearchIntegrationTest {
 
     static private final long PURGE_INTERVAL = 200;

--- a/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
+++ b/src/test/java/org/elasticsearch/update/UpdateByNativeScriptTests.java
@@ -31,13 +31,14 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 /**
  *
  */
-@ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numNodes=1)
+@ClusterScope(scope= Scope.SUITE, numDataNodes =1)
 public class UpdateByNativeScriptTests extends ElasticsearchIntegrationTest {
 
     @Override


### PR DESCRIPTION
The default number of clients nodes is 1, applied to all cluster scopes (global, suite and test). Can be changed though through the newly added `@ClusterScope#numClientNodes`.

In our tests we currently refer to nodes in a generic way. All the tests that either stop or start nodes rely on the fact that those nodes hold data though. Made that clearer as that becomes more important when introducing other types of nodes within the test cluster. Reflected this by adapting and renaming the following methods in `TestCluster`:
- `ensureAtLeastNumNodes` to `ensureAtLeastNumDataNodes`
- `ensureAtMostNumNodes` to `ensureAtMostNumDataNodes`
- `stopRandomNode` to `stopRandomDataNode`

and the following ones in `ElasticsearchIntegrationTest`:
- `dataNodes` to `numDataNodes`.
- `@ClusterScope#numNodes` to `numDataNodes`
- `@ClusterScope#minNumNodes` to `minNumDataNodes`
- `@ClusterScope#maxNumNodes` to `maxNumDataNodes`

Added facilities to be able to deal with data nodes specifically, like for instance retrieve a client to a data node, or retrieve an instance of a class through guice only from data nodes.

Adapted existing tests to successfully run although there's a node client around.

Fixed _cat/allocation REST tests to make disk.total, disk.avail and disk.percent optional as client nodes won't return that info.
