### PR TITLE
Use URI vs URL accessing File from classpath.

### DIFF
--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
@@ -55,7 +55,7 @@ import java.io.IOException;
 
 /**
  * Test parsing and executing a template request.
- * */
+ */
 public class TemplateQueryParserTest extends ElasticsearchTestCase {
 
     private Injector injector;
@@ -63,8 +63,7 @@ public class TemplateQueryParserTest extends ElasticsearchTestCase {
 
     @Before
     public void setup() throws IOException {
-        String scriptPath = this.getClass().getResource("config").getPath();
-        Settings settings = ImmutableSettings.settingsBuilder().put("path.conf", scriptPath).build();
+        Settings settings = ImmutableSettings.settingsBuilder().put("path.conf", this.getResource("config").getPath()).build();
 
         Index index = new Index("test");
         injector = new ModulesBuilder().add(

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -24,8 +24,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +41,7 @@ import static org.hamcrest.Matchers.is;
 
 /**
  * Full integration test of the template query plugin.
- * */
+ */
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
 public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
@@ -59,8 +57,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
 
     @Override
     public Settings nodeSettings(int nodeOrdinal) {
-        String scriptPath = this.getClass().getResource("config").getPath();
-        return settingsBuilder().put("path.conf", scriptPath).build();
+        return settingsBuilder().put("path.conf", this.getResource("config").getPath()).build();
     }
 
     @Test
@@ -78,7 +75,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
     @Test
     public void testTemplateInBodyWithSize() throws IOException {
         String request = "{\n" +
-                "    \"size\":0,"+
+                "    \"size\":0," +
                 "    \"query\": {\n" +
                 "        \"template\": {\n" +
                 "            \"query\": {\"match_{{template}}\": {}},\n" +
@@ -101,7 +98,7 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
                 "            }\n" +
                 "        }\n" +
                 "    },\n" +
-                "    \"size\":0"+
+                "    \"size\":0" +
                 "}";
 
         sr = client().prepareSearch().setSource(request)

--- a/src/test/java/org/elasticsearch/test/rest/support/FileUtils.java
+++ b/src/test/java/org/elasticsearch/test/rest/support/FileUtils.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileNotFoundException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
@@ -92,7 +93,8 @@ public final class FileUtils {
                 return file;
             }
         }
-        return new File(resource.getFile());
+
+        return new File(URI.create(resource.toString()));
     }
 
     private static URL findResource(String path, String optionalFileSuffix) {


### PR DESCRIPTION
URL escapes special characters such as spaces which
causes the resource to not be found when used to create
a File object.  Use URI.

Closes #5915
