### PR TITLE
time_zone should set pre AND post _zone in aggs

### DIFF
--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -50,7 +50,7 @@ computations to take the relevant zone into account. The time returned for each 
 epoch of the provided time zone.
 
 The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
-`time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.
+`time_zone` parameter simply sets `pre_zone` and `post_zone` parameters. By default, those are set to `UTC`.
 
 The zone value accepts either a numeric value for the hours offset, for example: `"time_zone" : -2`. It also accepts a
 format of hours and minutes, like `"time_zone" : "-02:30"`. Another option is to provide a time zone accepted as one of

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -79,6 +79,12 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
         return this;
     }
 
+    public DateHistogramBuilder timeZone(String timeZone) {
+        this.preZone = timeZone;
+        this.postZone = timeZone;
+        return this;
+    }
+
     public DateHistogramBuilder preZoneAdjustLargeInterval(boolean preZoneAdjustLargeInterval) {
         this.preZoneAdjustLargeInterval = preZoneAdjustLargeInterval;
         return this;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -100,6 +100,7 @@ public class DateHistogramParser implements Aggregator.Parser {
             } else if (token == XContentParser.Token.VALUE_STRING) {
                 if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
                     preZone = parseZone(parser.text());
+                    postZone = preZone;
                 } else if ("pre_zone".equals(currentFieldName) || "preZone".equals(currentFieldName)) {
                     preZone = parseZone(parser.text());
                 } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {
@@ -126,6 +127,7 @@ public class DateHistogramParser implements Aggregator.Parser {
                     minDocCount = parser.longValue();
                 } else if ("time_zone".equals(currentFieldName) || "timeZone".equals(currentFieldName)) {
                     preZone = DateTimeZone.forOffsetHours(parser.intValue());
+                    postZone = preZone;
                 } else if ("pre_zone".equals(currentFieldName) || "preZone".equals(currentFieldName)) {
                     preZone = DateTimeZone.forOffsetHours(parser.intValue());
                 } else if ("post_zone".equals(currentFieldName) || "postZone".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/search/facet/datehistogram/DateHistogramFacetParser.java
+++ b/src/main/java/org/elasticsearch/search/facet/datehistogram/DateHistogramFacetParser.java
@@ -125,6 +125,7 @@ public class DateHistogramFacetParser extends AbstractComponent implements Facet
                     interval = parser.text();
                 } else if ("time_zone".equals(fieldName) || "timeZone".equals(fieldName)) {
                     preZone = parseZone(parser, token);
+                    postZone = preZone;
                 } else if ("pre_zone".equals(fieldName) || "preZone".equals(fieldName)) {
                     preZone = parseZone(parser, token);
                 } else if ("pre_zone_adjust_large_interval".equals(fieldName) || "preZoneAdjustLargeInterval".equals(fieldName)) {


### PR DESCRIPTION
Until now, with aggregations and facets, when users use `time_zone` we get back some inaccurate results.

The cause is that we set only `pre_zone` when `time_zone` is set. So after computing values, we don't apply `post_zone` to results, which gives "strange" results.

Here is a full recreation:
## Create the test

```
DELETE /test

PUT /test/doc/1
{
  "date" : "2014-04-25T21:05:00"
}

PUT /test/doc/2
{
  "date" : "2014-04-25T22:06:00"
}

PUT /test/doc/3
{
  "date" : "2014-04-25T23:07:00"
}

PUT /test/doc/4
{
  "date" : "2014-04-26T00:08:00"
}
```
## Group by date

```
GET /test/doc/_search
{
  "size": 0,
  "aggs": {
    "bydate": {
      "date_histogram": {
        "field": "date",
        "interval": "day",
        "time_zone": "Europe/Paris"
      }
    }
  }
}
```

This gives

```
   "aggregations": {
      "bydate": {
         "buckets": [
            {
               "key_as_string": "2014-04-25T00:00:00.000Z",
               "key": 1398384000000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-26T00:00:00.000Z",
               "key": 1398470400000,
               "doc_count": 3
            }
         ]
      }
   }
```

When `pre_zone` and `post_zone` are used:

```
GET /test/doc/_search
{
  "size": 0,
  "aggs": {
    "bydate": {
      "date_histogram": {
        "field": "date",
        "interval": "day",
        "pre_zone": "Europe/Paris",
        "post_zone": "Europe/Paris"
      }
    }
  }
}
```

We get:

```
   "aggregations": {
      "bydate": {
         "buckets": [
            {
               "key_as_string": "2014-04-25T02:00:00.000Z",
               "key": 1398391200000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-26T02:00:00.000Z",
               "key": 1398477600000,
               "doc_count": 3
            }
         ]
      }
   }
```
## Grouping by hours

It's even more obvious when grouping by hours:

```
GET /test/doc/_search
{
  "size": 0,
  "aggs": {
    "bydate": {
      "date_histogram": {
        "field": "date",
        "interval": "hour",
        "time_zone": "Europe/Paris"
      }
    }
  }
}
```

gives

```
   "aggregations": {
      "bydate": {
         "buckets": [
            {
               "key_as_string": "2014-04-25T21:00:00.000Z",
               "key": 1398459600000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-25T22:00:00.000Z",
               "key": 1398463200000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-25T23:00:00.000Z",
               "key": 1398466800000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-26T00:00:00.000Z",
               "key": 1398470400000,
               "doc_count": 1
            }
         ]
      }
   }
```

and

```
GET /test/doc/_search
{
  "size": 0,
  "aggs": {
    "bydate": {
      "date_histogram": {
        "field": "date",
        "interval": "hour",
        "pre_zone": "Europe/Paris",
        "post_zone": "Europe/Paris"
      }
    }
  }
}

```

gives

```
   "aggregations": {
      "bydate": {
         "buckets": [
            {
               "key_as_string": "2014-04-25T23:00:00.000Z",
               "key": 1398466800000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-26T00:00:00.000Z",
               "key": 1398470400000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-26T01:00:00.000Z",
               "key": 1398474000000,
               "doc_count": 1
            },
            {
               "key_as_string": "2014-04-26T02:00:00.000Z",
               "key": 1398477600000,
               "doc_count": 1
            }
         ]
      }
   }
```

This patch fix this.
