### PR TITLE
Include thread name when logging IndexWriter's infoStream messages

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/LoggerInfoStream.java
+++ b/src/main/java/org/elasticsearch/common/lucene/LoggerInfoStream.java
@@ -36,7 +36,7 @@ public final class LoggerInfoStream extends InfoStream {
     }
 
     public void message(String component, String message) {
-        logger.trace("{}: {}",  component, message);
+        logger.trace("{} {}: {}", Thread.currentThread().getName(), component, message);
     }
   
     public boolean isEnabled(String component) {


### PR DESCRIPTION
When I enabled TRACE logging to see IndexWriter's infoStream messages, I noticed the message doesn't show the thread name, which is useful when diagnosing indexing issues ... so I just added it to the message passed to logger.trace.  This seems to work but maybe there's a better way to just ask the logger to include it?
