### PR TITLE
Tie-break suggestions by term

### DIFF
--- a/src/main/java/org/elasticsearch/search/suggest/phrase/CandidateScorer.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/CandidateScorer.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.suggest.phrase;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
@@ -42,7 +43,7 @@ final class CandidateScorer {
         PriorityQueue<Correction> corrections = new PriorityQueue<Correction>(maxNumCorrections) {
             @Override
             protected boolean lessThan(Correction a, Correction b) {
-                return a.score < b.score;
+                return a.compareTo(b) < 0;
             }
         };
         int numMissspellings = 1;
@@ -98,7 +99,7 @@ final class CandidateScorer {
                 Candidate[] c = new Candidate[candidates.length];
                 System.arraycopy(path, 0, c, 0, path.length);
                 corrections.add(new Correction(score, c));
-            } else if (corrections.top().score < score) {
+            } else if (corrections.top().compareTo(score, path) < 0) {
                 Correction top = corrections.top();
                 System.arraycopy(path, 0, top.candidates, 0, path.length);
                 top.score = score;

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/Correction.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/Correction.java
@@ -23,8 +23,9 @@ import org.elasticsearch.search.suggest.SuggestUtils;
 import org.elasticsearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
 
 import java.util.Arrays;
+
 //TODO public for tests
-public final class Correction {
+public final class Correction implements Comparable<Correction> {
 
     public static final Correction[] EMPTY = new Correction[0];
     public double score;
@@ -72,5 +73,29 @@ public final class Correction {
         result.offset = 0;
         result.grow(len);
         return SuggestUtils.joinPreAllocated(separator, result, toJoin);
+    }
+
+    /** Lower scores sorts first; if scores are equal,
+     *  than later terms (zzz) sort first .*/
+    @Override
+    public int compareTo(Correction other) {
+        return compareTo(other.score, other.candidates);
+    }
+
+    int compareTo(double otherScore, Candidate[] otherCandidates) {
+        if (score == otherScore) {
+            int limit = Math.min(candidates.length, otherCandidates.length);
+            for (int i=0;i<limit;i++) {
+                int cmp = candidates[i].term.compareTo(otherCandidates[i].term);
+                if (cmp != 0) {
+                    // Later (zzz) terms sort before (are weaker than) earlier (aaa) terms:
+                    return -cmp;
+                }
+            }
+
+            return candidates.length - otherCandidates.length;
+        } else {
+            return Double.compare(score, otherScore);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellChecker.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellChecker.java
@@ -126,9 +126,9 @@ public final class NoisyChannelSpellChecker {
             double inputPhraseScore = scorer.score(candidates, candidateSets);
             cutoffScore = inputPhraseScore * confidence;
         }
-        Correction[] findBestCandiates = scorer.findBestCandiates(candidateSets, maxErrors, cutoffScore);
+        Correction[] bestCandidates = scorer.findBestCandiates(candidateSets, maxErrors, cutoffScore);
         
-        return new Result(findBestCandiates, cutoffScore);
+        return new Result(bestCandidates, cutoffScore);
     }
 
     public Result getCorrections(Analyzer analyzer, BytesRef query, CandidateGenerator generator,

--- a/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
@@ -672,7 +672,6 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
 
     @Test
     @Nightly
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/pull/5962")
     public void testPhraseBoundaryCases() throws ElasticsearchException, IOException {
         CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
                 .put(indexSettings()).put(SETTING_NUMBER_OF_SHARDS, 1) // to get reliable statistics we should put this all into one shard
@@ -751,10 +750,17 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
         phraseSuggestion.field("ngram").analyzer("myDefAnalyzer")
                 .addCandidateGenerator(candidateGenerator("body").minWordLength(1).suggestMode("always"));
         Suggest suggest = searchSuggest( "Xor the Got-Jewel", phraseSuggestion);
-        assertSuggestion(suggest, 0, "simple_phrase", "xorr the god jewel");
+
+        // "xorr the god jewel" and and "xorn the god jewel" have identical scores (we are only using unigrams to score), so we tie break by
+        // earlier term (xorn):
+        assertSuggestion(suggest, 0, "simple_phrase", "xorn the god jewel");
 
         phraseSuggestion.analyzer(null);
         suggest = searchSuggest( "Xor the Got-Jewel", phraseSuggestion);
+
+        // In this case xorr has a better score than xorn... why?  Simon sez: because the probability that the term is not in the dictionary
+        // but is NOT a misspelling is relatively high in this case compared to the others that have no n-gram with the other terms in the
+        // phrase :) you can set this realWorldErrorLikelyhood - hope time makes sense?
         assertSuggestion(suggest, 0, "simple_phrase", "xorr the god jewel");
     }
 

--- a/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
@@ -758,9 +758,9 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
         phraseSuggestion.analyzer(null);
         suggest = searchSuggest( "Xor the Got-Jewel", phraseSuggestion);
 
-        // In this case xorr has a better score than xorn... why?  Simon sez: because the probability that the term is not in the dictionary
-        // but is NOT a misspelling is relatively high in this case compared to the others that have no n-gram with the other terms in the
-        // phrase :) you can set this realWorldErrorLikelyhood - hope time makes sense?
+        // In this case xorr has a better score than xorn because we set the field back to the default (my_shingle2) analyzer, so the
+        // probability that the term is not in the dictionary but is NOT a misspelling is relatively high in this case compared to the
+        // others that have no n-gram with the other terms in the phrase :) you can set this realWorldErrorLikelyhood
         assertSuggestion(suggest, 0, "simple_phrase", "xorr the god jewel");
     }
 

--- a/src/test/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellCheckerTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/phrase/NoisyChannelSpellCheckerTests.java
@@ -268,7 +268,7 @@ public class NoisyChannelSpellCheckerTests extends ElasticsearchTestCase{
         assertThat(corrections.length, equalTo(4));
         assertThat(corrections[0].join(new BytesRef(" ")).utf8ToString(), equalTo("xorr the god jewel"));
         assertThat(corrections[1].join(new BytesRef(" ")).utf8ToString(), equalTo("zorr the god jewel"));
-        assertThat(corrections[2].join(new BytesRef(" ")).utf8ToString(), equalTo("gorr the god jewel"));
+        assertThat(corrections[2].join(new BytesRef(" ")).utf8ToString(), equalTo("four the god jewel"));
 
 
         corrections = suggester.getCorrections(wrapper, new BytesRef("Zorr the Got-Jewel"), generator, 0.5f, 1, ir, "body", wordScorer, 1.5f, 2).corrections;


### PR DESCRIPTION
OK, DirectCandidateGenerator.CandidateSet.candidates also required
tie-breaking because CandidateScorer.findBestCandidates would change
its results depending on the sort order of the candidates in each
CandidateSet.  And it was tricky because the tests would
intermittently fail since BytesRef.hashCode is different for
every JVM instance...

So I added an Arrays.sort in addCandidates, and fixed Correction and
Candidate to implement Comparable, and fixed CandidateScorer.updateTop
to use .compareTo when checking if the new correction competes with
the top of the PQ.

I folded in Simon's comment as-is into SuggestSearchTests, but I still
don't fully understand the test, e.g. why after
"phraseSuggestion.analyzer(null);" would this get bigram to
participate in scoring again?  (The previous test did
.forceUnigrams(true) which I think is why xorn/xorr were tied for score).
