### PR TITLE
Not possible to disable bulk size in BulkProcessor

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -323,7 +323,7 @@ public class BulkProcessor implements Closeable {
         if (bulkActions != -1 && bulkRequest.numberOfActions() >= bulkActions) {
             return true;
         }
-        if (bulkSize != -1 && bulkRequest.estimatedSizeInBytes() >= bulkSize) {
+        if (bulkSize.getBytes() != -1 && bulkRequest.estimatedSizeInBytes() >= bulkSize) {
             return true;
         }
         return false;


### PR DESCRIPTION
bulkSize will never equal -1, so we need to check for bulkSize.getBytes() instead.
