### PR TITLE
Change default filter cache to 10% and circuit breaker to 60%

### DIFF
--- a/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/filter/IndicesFilterCache.java
@@ -95,7 +95,7 @@ public class IndicesFilterCache extends AbstractComponent implements RemovalList
         super(settings);
         this.threadPool = threadPool;
         this.cacheRecycler = cacheRecycler;
-        this.size = componentSettings.get("size", "20%");
+        this.size = componentSettings.get("size", "10%");
         this.expire = componentSettings.getAsTime("expire", null);
         this.cleanInterval = componentSettings.getAsTime("clean_interval", TimeValue.timeValueSeconds(60));
         computeSizeInBytes();

--- a/src/main/java/org/elasticsearch/indices/fielddata/breaker/InternalCircuitBreakerService.java
+++ b/src/main/java/org/elasticsearch/indices/fielddata/breaker/InternalCircuitBreakerService.java
@@ -38,7 +38,7 @@ public class InternalCircuitBreakerService extends AbstractLifecycleComponent<In
     public static final String CIRCUIT_BREAKER_OVERHEAD_SETTING = "indices.fielddata.breaker.overhead";
 
     public static final double DEFAULT_OVERHEAD_CONSTANT = 1.03;
-    private static final String DEFAULT_BREAKER_LIMIT = "80%";
+    private static final String DEFAULT_BREAKER_LIMIT = "60%";
 
     private volatile MemoryCircuitBreaker breaker;
     private volatile long maxBytes;


### PR DESCRIPTION
The defaults we have today in our data intensive memory structures don't properly add up to properly protected from potential OOM.
The circuit breaker, today at 80%, aims at protecting from extensive field data loading. The default threshold today is too permissive and can still cause OOMs.
 The filter cache today is at 20%, and its too high when adding it to other limits we have, reduce it to 10%, which is still a big enough portion of the heap, yet provides improved safety measure.
