### PR TITLE
s/boost_factor/boost in custom_filters_score doc

### DIFF
--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -511,7 +511,7 @@ and the `custom_filters_score`
 "custom_filters_score": {
     "filters": [
         {
-            "boost_factor": "3",
+            "boost": "3",
             "filter": {...}
         },
         {


### PR DESCRIPTION
I may be wrong but I think `custom_filters_score` used `boost` rather than `boost_factor`?
