### PR TITLE
Add time based UUIDs

### DIFF
--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -594,7 +594,7 @@ public class IndexRequest extends ShardReplicationOperationRequest<IndexRequest>
         // generate id if not already provided and id generation is allowed
         if (allowIdGeneration) {
             if (id == null) {
-                id(Strings.timestampBase64UUID());
+                id(Strings.base64UUID());
                 // since we generate the id, change it to CREATE
                 opType(IndexRequest.OpType.CREATE);
             }

--- a/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -594,7 +594,7 @@ public class IndexRequest extends ShardReplicationOperationRequest<IndexRequest>
         // generate id if not already provided and id generation is allowed
         if (allowIdGeneration) {
             if (id == null) {
-                id(Strings.randomBase64UUID());
+                id(Strings.timestampBase64UUID());
                 // since we generate the id, change it to CREATE
                 opType(IndexRequest.OpType.CREATE);
             }

--- a/src/main/java/org/elasticsearch/common/MacAddressProvider.java
+++ b/src/main/java/org/elasticsearch/common/MacAddressProvider.java
@@ -46,12 +46,30 @@ public class MacAddressProvider {
         return null; //Could not find a mac address
     }
 
+    private static boolean isValidAddress(byte[] address){
+        if (address == null || address.length != 6) {
+            return false;
+        }
+        boolean allEmpty = true;
+        for (byte b : address){
+            if (b != 0x00){
+                allEmpty = false;
+            }
+        }
+        return !allEmpty;
+    }
+
     public static byte[] getSecureMungedAddress() {
         byte[] address = null;
         try {
-             address = getMacAddress();
+            address = getMacAddress();
         } catch( SocketException se ) {
             logger.warn("Unable to get mac address, will use a dummy address",se);
+            address = constructDummyMulticastAddress();
+        }
+
+        if (!isValidAddress(address)){
+            logger.warn("Unable to get a valid mac address, will use a dummy address");
             address = constructDummyMulticastAddress();
         }
 

--- a/src/main/java/org/elasticsearch/common/MacAddressProvider.java
+++ b/src/main/java/org/elasticsearch/common/MacAddressProvider.java
@@ -50,13 +50,12 @@ public class MacAddressProvider {
         if (address == null || address.length != 6) {
             return false;
         }
-        boolean allEmpty = true;
         for (byte b : address){
             if (b != 0x00){
-                allEmpty = false;
+                return true; //If any of the bytes are non zero assume a good address
             }
         }
-        return !allEmpty;
+        return false;
     }
 
     public static byte[] getSecureMungedAddress() {

--- a/src/main/java/org/elasticsearch/common/MacAddressProvider.java
+++ b/src/main/java/org/elasticsearch/common/MacAddressProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+
+public class MacAddressProvider {
+
+    private static final ESLogger logger = Loggers.getLogger("MacAddressProvider");
+
+    public static byte[] getMacAddress() throws SocketException {
+        Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces();
+        while (en.hasMoreElements()) {
+            NetworkInterface nint = en.nextElement();
+            if (!nint.isLoopback()) {
+                //Pick the first non loopback address we find
+                byte[] address = nint.getHardwareAddress();
+                if (address != null && address.length == 6) {
+                    return address;
+                }
+            }
+        }
+        return null; //Could not find a mac address
+    }
+
+    public static byte[] getSecureMungedAddress() {
+        byte[] address = null;
+        try {
+             address = getMacAddress();
+        } catch( SocketException se ) {
+            logger.warn("Unable to get mac address, will use a dummy address",se);
+            address = constructDummyMulticastAddress();
+        }
+
+        byte[] mungedBytes = new byte[6];
+        RandomBasedUUID.SecureRandomHolder.INSTANCE.nextBytes(mungedBytes);
+        for (int i = 0; i < 6; ++i) {
+            mungedBytes[i] = (byte) (0xff & (mungedBytes[i] ^ address[i]));
+        }
+
+        return mungedBytes;
+    }
+
+    private static byte[] constructDummyMulticastAddress() {
+        byte[] dummy = new byte[6];
+        RandomBasedUUID.SecureRandomHolder.INSTANCE.nextBytes(dummy);
+        /*
+         * Set the broadcast bit to indicate this is not a _real_ mac address
+         */
+        dummy[0] |= (byte) 0x01;
+        return dummy;
+    }
+
+
+}

--- a/src/main/java/org/elasticsearch/common/PaddedAtomicLong.java
+++ b/src/main/java/org/elasticsearch/common/PaddedAtomicLong.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ *
+ */
+public class PaddedAtomicLong extends AtomicLong {
+    public volatile long p1, p2, p3, p4, p5, p6 = 7L;
+
+    public long sum(){
+        return p1 + p2 + p3 + p4 + p5 + p6;
+    }
+}

--- a/src/main/java/org/elasticsearch/common/PaddedAtomicLong.java
+++ b/src/main/java/org/elasticsearch/common/PaddedAtomicLong.java
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  */
 public class PaddedAtomicLong extends AtomicLong {
+    /*
+     * See http://mechanical-sympathy.blogspot.nl/2011/08/false-sharing-java-7.html
+     */
     public volatile long p1, p2, p3, p4, p5, p6 = 7L;
 
     public long sum(){

--- a/src/main/java/org/elasticsearch/common/RandomBasedUUID.java
+++ b/src/main/java/org/elasticsearch/common/RandomBasedUUID.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.ElasticsearchIllegalStateException;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Random;
+
+public class RandomBasedUUID implements UUIDGenerator{
+
+    protected static class SecureRandomHolder {
+        // class loading is atomic - this is a lazy & safe singleton
+        protected static final SecureRandom INSTANCE = new SecureRandom();
+    }
+
+    /**
+     * Returns a Base64 encoded version of a Version 4.0 compatible UUID
+     * as defined here: http://www.ietf.org/rfc/rfc4122.txt
+     */
+    public String getBase64UUID() {
+        return getBase64UUID(SecureRandomHolder.INSTANCE);
+    }
+
+    /**
+     * Returns a Base64 encoded version of a Version 4.0 compatible UUID
+     * randomly initialized by the given {@link java.util.Random} instance
+     * as defined here: http://www.ietf.org/rfc/rfc4122.txt
+     */
+    public String getBase64UUID(Random random) {
+        final byte[] randomBytes = new byte[16];
+        random.nextBytes(randomBytes);
+        /* Set the version to version 4 (see http://www.ietf.org/rfc/rfc4122.txt)
+         * The randomly or pseudo-randomly generated version.
+         * The version number is in the most significant 4 bits of the time
+         * stamp (bits 4 through 7 of the time_hi_and_version field).*/
+        randomBytes[6] &= 0x0f;  /* clear the 4 most significant bits for the version  */
+        randomBytes[6] |= 0x40;  /* set the version to 0100 / 0x40 */
+        
+        /* Set the variant: 
+         * The high field of th clock sequence multiplexed with the variant.
+         * We set only the MSB of the variant*/
+        randomBytes[8] &= 0x3f;  /* clear the 2 most significant bits */
+        randomBytes[8] |= 0x80;  /* set the variant (MSB is set)*/
+        try {
+            byte[] encoded = Base64.encodeBytesToBytes(randomBytes, 0, randomBytes.length, Base64.URL_SAFE);
+            // we know the bytes are 16, and not a multi of 3, so remove the 2 padding chars that are added
+            assert encoded[encoded.length - 1] == '=';
+            assert encoded[encoded.length - 2] == '=';
+            // we always have padding of two at the end, encode it differently
+            return new String(encoded, 0, encoded.length - 2, Base64.PREFERRED_ENCODING);
+        } catch (IOException e) {
+            throw new ElasticsearchIllegalStateException("should not be thrown");
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/common/TimeBasedUUID.java
+++ b/src/main/java/org/elasticsearch/common/TimeBasedUUID.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.ElasticsearchIllegalStateException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class TimeBasedUUID implements UUIDGenerator{
+
+    private PaddedAtomicLong sequenceNumber = new PaddedAtomicLong();
+    private PaddedAtomicLong lastTimestamp = new PaddedAtomicLong();
+
+    byte[] secureMungedAddress = MacAddressProvider.getSecureMungedAddress();
+
+    @Override
+    public String getBase64UUID()  {
+        long timestamp = System.currentTimeMillis();
+        long last;
+
+        final byte[] uuidBytes = new byte[22];
+        do {
+            last = lastTimestamp.get();
+            if (lastTimestamp.compareAndSet(last, timestamp)) {
+                break;
+            }
+        } while(last < timestamp);
+
+        ByteBuffer buffer = ByteBuffer.wrap(uuidBytes);
+        buffer.putLong(timestamp);
+        buffer.put(secureMungedAddress);
+        buffer.putLong(sequenceNumber.incrementAndGet());
+
+        try {
+            byte[] encoded = Base64.encodeBytesToBytes(uuidBytes, 0, uuidBytes.length, Base64.URL_SAFE);
+            // we know the bytes are 22, and not a multi of 3, so remove the 2 padding chars that are added
+            assert encoded[encoded.length - 1] == '=';
+            assert encoded[encoded.length - 2] == '=';
+            // we always have padding of two at the end, encode it differently
+            return new String(encoded, 0, encoded.length - 2, Base64.PREFERRED_ENCODING);
+        } catch (IOException e) {
+            throw new ElasticsearchIllegalStateException("should not be thrown");
+        }
+    }
+
+    public static long getTimestampFromUUID(String uuid) throws IOException {
+        byte[] uuidBytes = Base64.decode(uuid+"==",Base64.URL_SAFE);
+        ByteBuffer buffer = ByteBuffer.wrap(uuidBytes);
+        return buffer.getLong();
+    }
+
+    public static long getSequenceNumberFromUUID(String uuid) throws IOException {
+        byte[] uuidBytes = Base64.decode(uuid+"==",Base64.URL_SAFE);
+        ByteBuffer buffer = ByteBuffer.wrap(uuidBytes);
+        buffer.getLong();
+        byte[] mungedAddress = new byte[6];
+        buffer.get(mungedAddress);
+        return buffer.getLong();
+    }
+
+    public static byte[] getAddressBytesFromUUID(String uuid) throws IOException {
+        byte[] uuidBytes = Base64.decode(uuid+"==",Base64.URL_SAFE);
+        ByteBuffer buffer = ByteBuffer.wrap(uuidBytes);
+        buffer.getLong();
+        byte[] mungedAddress = new byte[6];
+        buffer.get(mungedAddress);
+        return mungedAddress;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/UUIDGenerator.java
+++ b/src/main/java/org/elasticsearch/common/UUIDGenerator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+/**
+ *
+ */
+public interface UUIDGenerator {
+    public String getBase64UUID();
+}

--- a/src/test/java/org/elasticsearch/common/UUIDTests.java
+++ b/src/test/java/org/elasticsearch/common/UUIDTests.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+/**
+ *
+ */
+public class UUIDTests extends ElasticsearchTestCase {
+
+    static UUIDGenerator timeUUIDGen = new TimeBasedUUID();
+    static UUIDGenerator randomUUIDGen = new RandomBasedUUID();
+
+    @Test
+    public void testRandomUUID(){
+        int iterations = 10000;
+        HashSet<String> uuidSet = generateUUIDSet(iterations, randomUUIDGen);
+        assertEquals(iterations,uuidSet.size());
+    }
+
+    @Test
+    public void testTimeUUID(){
+        int count = 100000;
+        HashSet uuidSet = generateUUIDSet(count, timeUUIDGen);
+        assertEquals(count,uuidSet.size());
+    }
+
+
+    @Test
+    public void testThreadedTimeUUID(){
+        testUUIDThreaded(timeUUIDGen);
+    }
+
+    @Test
+    public void testThreadedRandomUUID(){
+        testUUIDThreaded(randomUUIDGen);
+    }
+
+
+    HashSet generateUUIDSet(int count, UUIDGenerator uuidSource){
+        HashSet<String> uuidSet = new HashSet<>();
+        for (int i = 0; i < count; ++i){
+            String timeUUID = uuidSource.getBase64UUID();
+            if(uuidSet.contains(timeUUID)){
+                assertFalse(uuidSet.contains(timeUUID));
+            }
+            uuidSet.add(timeUUID);
+        }
+        return uuidSet;
+    }
+
+    class UUIDGenRunner implements Runnable{
+        int count;
+        public HashSet uuidSet = null;
+        UUIDGenerator uuidSource;
+
+
+        public UUIDGenRunner(int count, UUIDGenerator uuidSource){
+            this.count = count;
+            this.uuidSource = uuidSource;
+        }
+
+        @Override
+        public void run(){
+            uuidSet = generateUUIDSet(count, uuidSource );
+            assertEquals(count,uuidSet.size());
+        }
+    }
+
+    public void testUUIDThreaded(UUIDGenerator uuidSource){
+        HashSet<UUIDGenRunner> runners = new HashSet<>();
+        HashSet<Thread> threads = new HashSet<>();
+        int count = 100;
+        int uuids = 10000;
+        for (int i = 0; i < count; ++i){
+            UUIDGenRunner runner = new UUIDGenRunner(uuids, uuidSource);
+            Thread t = new Thread(runner);
+            threads.add(t);
+            runners.add(runner);
+        }
+        for (Thread t : threads){
+            t.start();
+        }
+        boolean retry = false;
+        do {
+            for (Thread t : threads) {
+                try {
+                    t.join();
+                } catch (InterruptedException ie) {
+                    retry = true;
+                }
+            }
+        } while (retry);
+
+        HashSet<String> globalSet = new HashSet<>();
+        for( UUIDGenRunner runner : runners ){
+            assertEquals(uuids,runner.uuidSet.size());
+            globalSet.addAll(runner.uuidSet);
+        }
+        assertEquals(count*uuids,globalSet.size());
+    }
+
+    @Test
+    public void testUUIDIntegrity(){
+        long lastSeq = 0;
+        long lastTime = 0;
+        byte[] mungedAddress = null;
+        try {
+            for (int i = 0; i < 10000; ++i) {
+                String uuid = timeUUIDGen.getBase64UUID();
+                long sequence = TimeBasedUUID.getSequenceNumberFromUUID(uuid);
+                long time = TimeBasedUUID.getTimestampFromUUID(uuid);
+                byte[] address = TimeBasedUUID.getAddressBytesFromUUID(uuid);
+                if (mungedAddress != null) {
+                    assertEquals(lastSeq+1,sequence);
+                    assertTrue(time-lastTime<10000);
+                    assertArrayEquals(mungedAddress,address);
+                }
+                lastSeq = sequence;
+                lastTime = time;
+                mungedAddress = address;
+            }
+        } catch (IOException ie){
+            assertFalse(ie!=null);
+        }
+    }
+
+
+}


### PR DESCRIPTION
See #5941.

Using SecureRandom as a UUID generator is slow and doesn't allow us
to take adavantage of some lucene optimizations around ids with common
prefixes. This commit will allow us to use a
timestamp64bit-macAddr-counter UUID. Since the macAddr may be shared
among several nodes running on the same hardware we use an xor of the
macaddr with a SecureRandom number generated on startup.
