### PR TITLE
Update shade-plugin to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Shade-plugin 2.2 does not work with JDK8 (see http://jira.codehaus.org/browse/MSHADE/fixforversion/19828)

Not sure if we need to apply that patch in 1.2 branch as well?
