### PR TITLE
Track per-request allocated bytes.

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -73,6 +73,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.BigArraysModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.monitor.MonitorService;
@@ -176,6 +177,7 @@ public class TransportClient extends AbstractClient {
         ModulesBuilder modules = new ModulesBuilder();
         modules.add(new Version.Module(version));
         modules.add(new CacheRecyclerModule(settings));
+        modules.add(new BigArraysModule(settings)); // required by NettyTransport
         modules.add(new PluginsModule(this.settings, pluginsService));
         modules.add(new EnvironmentModule(environment));
         modules.add(new SettingsModule(this.settings));

--- a/src/main/java/org/elasticsearch/common/util/BigArraysImpl.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArraysImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.settings.Settings;
+
+/** Utility class to work with arrays. */
+public class BigArraysImpl extends BigArrays {
+
+    final PageCacheRecycler recycler;
+
+    @Inject
+    public BigArraysImpl(Settings settings, PageCacheRecycler recycler) {
+        super(settings);
+        this.recycler = recycler;
+    }
+
+    @Override
+    public ByteArray newByteArray(long size, boolean clearOnResize) {
+        if (size > BYTE_PAGE_SIZE) {
+            return new BigByteArray(size, recycler, clearOnResize);
+        } else if (size >= BYTE_PAGE_SIZE / 2 && recycler != null) {
+            final Recycler.V<byte[]> page = recycler.bytePage(clearOnResize);
+            return new ByteArrayWrapper(page.v(), size, page, clearOnResize);
+        } else {
+            return new ByteArrayWrapper(new byte[(int) size], size, null, clearOnResize);
+        }
+    }
+
+    @Override
+    public IntArray newIntArray(long size, boolean clearOnResize) {
+        if (size > INT_PAGE_SIZE) {
+            return new BigIntArray(size, recycler, clearOnResize);
+        } else if (size >= INT_PAGE_SIZE / 2 && recycler != null) {
+            final Recycler.V<int[]> page = recycler.intPage(clearOnResize);
+            return new IntArrayWrapper(page.v(), size, page, clearOnResize);
+        } else {
+            return new IntArrayWrapper(new int[(int) size], size, null, clearOnResize);
+        }
+    }
+
+    @Override
+    public LongArray newLongArray(long size, boolean clearOnResize) {
+        if (size > LONG_PAGE_SIZE) {
+            return new BigLongArray(size, recycler, clearOnResize);
+        } else if (size >= LONG_PAGE_SIZE / 2 && recycler != null) {
+            final Recycler.V<long[]> page = recycler.longPage(clearOnResize);
+            return new LongArrayWrapper(page.v(), size, page, clearOnResize);
+        } else {
+            return new LongArrayWrapper(new long[(int) size], size, null, clearOnResize);
+        }
+    }
+
+    @Override
+    public DoubleArray newDoubleArray(long size, boolean clearOnResize) {
+        if (size > DOUBLE_PAGE_SIZE) {
+            return new BigDoubleArray(size, recycler, clearOnResize);
+        } else if (size >= DOUBLE_PAGE_SIZE / 2 && recycler != null) {
+            final Recycler.V<double[]> page = recycler.doublePage(clearOnResize);
+            return new DoubleArrayWrapper(page.v(), size, page, clearOnResize);
+        } else {
+            return new DoubleArrayWrapper(new double[(int) size], size, null, clearOnResize);
+        }
+    }
+
+    @Override
+    public FloatArray newFloatArray(long size, boolean clearOnResize) {
+        if (size > FLOAT_PAGE_SIZE) {
+            return new BigFloatArray(size, recycler, clearOnResize);
+        } else if (size >= FLOAT_PAGE_SIZE / 2 && recycler != null) {
+            final Recycler.V<float[]> page = recycler.floatPage(clearOnResize);
+            return new FloatArrayWrapper(page.v(), size, page, clearOnResize);
+        } else {
+            return new FloatArrayWrapper(new float[(int) size], size, null, clearOnResize);
+        }
+    }
+
+    @Override
+    public <T> ObjectArray<T> newObjectArray(long size) {
+        if (size > OBJECT_PAGE_SIZE) {
+            return new BigObjectArray<>(size, recycler);
+        } else if (size >= OBJECT_PAGE_SIZE / 2 && recycler != null) {
+            final Recycler.V<Object[]> page = recycler.objectPage();
+            return new ObjectArrayWrapper<>(page.v(), size, page);
+        } else {
+            return new ObjectArrayWrapper<>(new Object[(int) size], size, null);
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/common/util/ByteTrackingBigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/ByteTrackingBigArrays.java
@@ -48,7 +48,7 @@ public class ByteTrackingBigArrays extends BigArrays {
         allocatedBytes = new AtomicLong();
     }
 
-    private long ramBytesAllocated(int instances, long bytes) {
+    private static long ramBytesAllocated(int instances, long bytes) {
         return PER_INSTANCE_OVERHEAD * instances + bytes;
     }
 
@@ -151,7 +151,7 @@ public class ByteTrackingBigArrays extends BigArrays {
     }
 
     /**
-     * Return the total number of allocated array instances.
+     * Return the total number of allocated bytes. Please note that released bytes are not taken into account.
      */
     public long ramBytesAllocated() {
         return ramBytesAllocated(allocatedInstances.get(), allocatedBytes.get());

--- a/src/main/java/org/elasticsearch/common/util/ByteTrackingBigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/ByteTrackingBigArrays.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.settings.ImmutableSettings;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@link BigArrays} impl that tracks the total number of allocated bytes.
+ */
+public class ByteTrackingBigArrays extends BigArrays {
+
+    private static final long PER_INSTANCE_OVERHEAD = RamUsageEstimator.shallowSizeOfInstance(ByteArrayWrapper.class) + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+
+    private final BigArrays in;
+    private final long limit;
+    private AtomicInteger allocatedInstances;
+    private AtomicLong allocatedBytes;
+
+    public ByteTrackingBigArrays(BigArrays in, long limit) {
+        super(ImmutableSettings.EMPTY);
+        this.in = in;
+        this.limit = limit;
+        allocatedInstances = new AtomicInteger();
+        allocatedBytes = new AtomicLong();
+    }
+
+    private long ramBytesAllocated(int instances, long bytes) {
+        return PER_INSTANCE_OVERHEAD * instances + bytes;
+    }
+
+    private void checkRamBytesAllocated(Releasable releasable, int instances, long bytes) {
+        final long memoryUsage = ramBytesAllocated(instances, bytes);
+        if (memoryUsage >= limit) {
+            Releasables.closeWhileHandlingException(releasable);
+            throw new ElasticsearchIllegalStateException("Query tried to allocate more memory than it is allowed to: " + RamUsageEstimator.humanReadableUnits(limit));
+        }
+    }
+
+    private void onNewInstance(Releasable releasable, long bytes) {
+        checkRamBytesAllocated(releasable, allocatedInstances.incrementAndGet(), allocatedBytes.addAndGet(bytes));
+    }
+
+    private void onResize(Releasable releasable, long bytesDelta) {
+        checkRamBytesAllocated(releasable, allocatedInstances.get(), allocatedBytes.addAndGet(bytesDelta));
+    }
+
+    @Override
+    public ByteArray newByteArray(long size, boolean clearOnResize) {
+        final ByteArray array = in.newByteArray(size, clearOnResize);
+        onNewInstance(array, array.size() * RamUsageEstimator.NUM_BYTES_BYTE);
+        return array;
+    }
+
+    @Override
+    public IntArray newIntArray(long size, boolean clearOnResize) {
+        final IntArray array = in.newIntArray(size, clearOnResize);
+        onNewInstance(array, array.size() * RamUsageEstimator.NUM_BYTES_INT);
+        return array;
+    }
+
+    @Override
+    public LongArray newLongArray(long size, boolean clearOnResize) {
+        final LongArray array = in.newLongArray(size, clearOnResize);
+        onNewInstance(array, array.size() * RamUsageEstimator.NUM_BYTES_LONG);
+        return array;
+    }
+
+    @Override
+    public DoubleArray newDoubleArray(long size, boolean clearOnResize) {
+        final DoubleArray array = in.newDoubleArray(size, clearOnResize);
+        onNewInstance(array, array.size() * RamUsageEstimator.NUM_BYTES_DOUBLE);
+        return array;
+    }
+
+    @Override
+    public FloatArray newFloatArray(long size, boolean clearOnResize) {
+        final FloatArray array = in.newFloatArray(size, clearOnResize);
+        onNewInstance(array, array.size() * RamUsageEstimator.NUM_BYTES_FLOAT);
+        return array;
+    }
+
+    @Override
+    public <T> ObjectArray<T> newObjectArray(long size) {
+        final ObjectArray<T> array = in.newObjectArray(size);
+        onNewInstance(array, array.size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+        return array;
+    }
+
+    @Override
+    public ByteArray resize(ByteArray array, long size) {
+        final long oldSize = array.size();
+        final ByteArray resized = in.resize(array, size);
+        onResize(resized, (resized.size() - oldSize) * RamUsageEstimator.NUM_BYTES_BYTE);
+        return resized;
+    }
+
+    @Override
+    public IntArray resize(IntArray array, long size) {
+        final long oldSize = array.size();
+        final IntArray resized = in.resize(array, size);
+        onResize(resized, (resized.size() - oldSize) * RamUsageEstimator.NUM_BYTES_INT);
+        return resized;
+    }
+
+    @Override
+    public LongArray resize(LongArray array, long size) {
+        final long oldSize = array.size();
+        final LongArray resized = in.resize(array, size);
+        onResize(resized, (resized.size() - oldSize) * RamUsageEstimator.NUM_BYTES_LONG);
+        return resized;
+    }
+
+    @Override
+    public DoubleArray resize(DoubleArray array, long size) {
+        final long oldSize = array.size();
+        final DoubleArray resized = in.resize(array, size);
+        onResize(resized, (resized.size() - oldSize) * RamUsageEstimator.NUM_BYTES_DOUBLE);
+        return resized;
+    }
+
+    @Override
+    public FloatArray resize(FloatArray array, long size) {
+        final long oldSize = array.size();
+        final FloatArray resized = in.resize(array, size);
+        onResize(resized, (resized.size() - oldSize) * RamUsageEstimator.NUM_BYTES_FLOAT);
+        return resized;
+    }
+
+    /**
+     * Return the total number of allocated array instances.
+     */
+    public long ramBytesAllocated() {
+        return ramBytesAllocated(allocatedInstances.get(), allocatedBytes.get());
+    }
+}

--- a/src/main/java/org/elasticsearch/common/util/DefaultBigArraysModule.java
+++ b/src/main/java/org/elasticsearch/common/util/DefaultBigArraysModule.java
@@ -26,14 +26,11 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class DefaultBigArraysModule extends AbstractModule {
 
-    private final Settings settings;
-
     public DefaultBigArraysModule(Settings settings) {
-        this.settings = settings;
     }
 
     @Override
     protected void configure() {
-        bind(BigArrays.class).asEagerSingleton();
+        bind(BigArrays.class).to(BigArraysImpl.class).asEagerSingleton();
     }
 }

--- a/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
+++ b/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTest.java
@@ -24,9 +24,9 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BigArraysImpl;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.test.ElasticsearchTestCase;
-import org.elasticsearch.test.cache.recycler.MockBigArrays;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.junit.After;
 import org.junit.Before;
@@ -45,7 +45,7 @@ public class PagedBytesReferenceTest extends ElasticsearchTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        bigarrays = new BigArrays(ImmutableSettings.EMPTY, null);
+        bigarrays = new BigArraysImpl(ImmutableSettings.EMPTY, null);
     }
 
     @After

--- a/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
+++ b/src/test/java/org/elasticsearch/index/search/child/ChildrenConstantScoreQueryTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.lucene.search.XFilteredQuery;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BigArraysImpl;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.cache.filter.weighted.WeightedFilterCache;
 import org.elasticsearch.index.engine.Engine;
@@ -350,7 +351,7 @@ public class ChildrenConstantScoreQueryTests extends ElasticsearchLuceneTestCase
         final CacheRecycler cacheRecycler = new CacheRecycler(ImmutableSettings.EMPTY);
         ThreadPool threadPool = new ThreadPool();
         final PageCacheRecycler pageCacheRecycler = new PageCacheRecycler(ImmutableSettings.EMPTY, threadPool);
-        final BigArrays bigArrays = new BigArrays(ImmutableSettings.EMPTY, pageCacheRecycler);
+        final BigArrays bigArrays = new BigArraysImpl(ImmutableSettings.EMPTY, pageCacheRecycler);
         Settings settings = ImmutableSettings.EMPTY;
         MapperService mapperService = MapperTestUtils.newMapperService(index, settings);
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(index, new DummyCircuitBreakerService());

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class MockBigArrays extends BigArrays {
+public class MockBigArrays extends BigArraysImpl {
 
     /**
      * Tracking allocations is useful when debugging a leak but shouldn't be enabled by default as this would also be very costly


### PR DESCRIPTION
As more and more data-structures are implemented on top of BigArrays, we can
add byte tracking on top of BigArrays in order to get a picture of how many
bytes have been allocated by the current request.

A potential follow-up to this change would be the ability to fail requests that
allocate too much memory instead of letting them cause out-of-memory errors on
the cluster.
