### PR TITLE
Fix behavior on default boost factor for More Like This.

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-field-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-field-query.asciidoc
@@ -58,7 +58,8 @@ ignored. Defaults to `0`. (Old name "min_word_len" is deprecated)
 ignored. Defaults to unbounded (`0`). (Old name "max_word_len" is deprecated)
 
 |`boost_terms` |Sets the boost factor to use when boosting terms.
-Defaults to `1`.
+Defaults to deactivated (`0`). Any other value activates boosting with given
+boost factor.
 
 |`boost` |Sets the boost value of the query. Defaults to `1.0`.
 

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -57,7 +57,8 @@ ignored. Defaults to `0`.(Old name "min_word_len" is deprecated)
 ignored. Defaults to unbounded (`0`). (Old name "max_word_len" is deprecated)
 
 |`boost_terms` |Sets the boost factor to use when boosting terms.
-Defaults to `1`.
+Defaults to deactivated (`0`). Any other value activates boosting with given
+boost factor.
 
 |`boost` |Sets the boost value of the query. Defaults to `1.0`.
 

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisFieldQueryParser.java
@@ -91,8 +91,11 @@ public class MoreLikeThisFieldQueryParser implements QueryParser {
                 } else if (MoreLikeThisQueryParser.Fields.MAX_WORD_LENGTH.match(currentFieldName,parseContext.parseFlags())) {
                     mltQuery.setMaxWordLen(parser.intValue());
                 } else if (MoreLikeThisQueryParser.Fields.BOOST_TERMS.match(currentFieldName,parseContext.parseFlags())) {
-                    mltQuery.setBoostTerms(true);
-                    mltQuery.setBoostTermsFactor(parser.floatValue());
+                    float boostFactor = parser.floatValue();
+                    if (boostFactor != 0) {
+                        mltQuery.setBoostTerms(true);
+                        mltQuery.setBoostTermsFactor(boostFactor);
+                    }
                 } else if (MoreLikeThisQueryParser.Fields.PERCENT_TERMS_TO_MATCH.match(currentFieldName,parseContext.parseFlags())) {
                     mltQuery.setPercentTermsToMatch(parser.floatValue());
                 } else if ("analyzer".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -99,8 +99,11 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 } else if (Fields.MAX_WORD_LENGTH.match(currentFieldName, parseContext.parseFlags())) {
                     mltQuery.setMaxWordLen(parser.intValue());
                 } else if (Fields.BOOST_TERMS.match(currentFieldName, parseContext.parseFlags())) {
-                    mltQuery.setBoostTerms(true);
-                    mltQuery.setBoostTermsFactor(parser.floatValue());
+                    float boostFactor = parser.floatValue();
+                    if (boostFactor != 0) {
+                        mltQuery.setBoostTerms(true);
+                        mltQuery.setBoostTermsFactor(boostFactor);
+                    }
                 } else if (Fields.PERCENT_TERMS_TO_MATCH.match(currentFieldName, parseContext.parseFlags())) {
                     mltQuery.setPercentTermsToMatch(parser.floatValue());
                 } else if ("analyzer".equals(currentFieldName)) {


### PR DESCRIPTION
A boost terms factor of 1.0 is not the same as no boosting of terms.
The desired behavior is to deactivate boosting by default. If the user
specifies any value other than 0, then boosting is activated.
