### PR TITLE
Update allocation.asciidoc

### DIFF
--- a/docs/reference/index-modules/allocation.asciidoc
+++ b/docs/reference/index-modules/allocation.asciidoc
@@ -117,14 +117,14 @@ Once enabled, Elasticsearch uses two watermarks to decide whether
 shards should be allocated or can remain on the node.
 
 `cluster.routing.allocation.disk.watermark.low` controls the low
-watermark for disk usage. It defaults to 70%, meaning ES will not
+watermark for disk usage. It defaults to 70% (0.70), meaning ES will not
 allocate new shards to nodes once they have more than 70% disk
 used. It can also be set to an absolute byte value (like 500mb) to
 prevent ES from allocating shards if less than the configured amount
 of space is available.
 
 `cluster.routing.allocation.disk.watermark.high` controls the high
-watermark. It defaults to 85%, meaning ES will attempt to relocate
+watermark. It defaults to 85% (0.85), meaning ES will attempt to relocate
 shards to another node if the node disk usage rises above 85%. It can
 also be set to an absolute byte value (similar to the low watermark)
 to relocate shards once less than the configured amount of space is


### PR DESCRIPTION
It's minor, but I've added the percentage representations in brackets as it took me a couple of attempts to figure out I wasn't supposed to be using an actual percentage, eg 80%/90%, but a decimal representation of the value, eg 0.80/0.90.

That should make it a lot clearer for others.
