### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/groovy-api/index.asciidoc
+++ b/docs/groovy-api/index.asciidoc
@@ -5,6 +5,8 @@
 [preface]
 == Preface
 
+*This client does not currently work with the 1.x versions of elasticsearch*
+
 This section describes the http://groovy.codehaus.org/[Groovy] API
 elasticsearch provides. All elasticsearch APIs are executed using a
 <<client,GClient>>, and are completely


### PR DESCRIPTION
Because this client doesn't apparently work with the 1.x elasticsearch (see https://github.com/elasticsearch/elasticsearch-lang-groovy/issues/20 ) and you can't find the source code either, we should tell people so they don't waste a lot of time :-)
