### PR TITLE
Missing scroll id now returns 404

### DIFF
--- a/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/test/scroll/11_clear.yaml
@@ -29,7 +29,6 @@
         scroll_id: $scroll_id1
 
   - do:
+      catch: missing
       scroll:
         scroll_id: $scroll_id1
-
-  - length: {hits.hits: 0}

--- a/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -23,10 +23,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -42,7 +39,7 @@ import static org.elasticsearch.search.internal.InternalSearchResponse.readInter
 /**
  * A response of a search request.
  */
-public class SearchResponse extends ActionResponse implements ToXContent {
+public class SearchResponse extends ActionResponse implements StatusToXContent {
 
     private InternalSearchResponse internalResponse;
 

--- a/src/main/java/org/elasticsearch/common/xcontent/StatusToXContent.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/StatusToXContent.java
@@ -16,30 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.elasticsearch.common.xcontent;
 
-package org.elasticsearch.search;
-
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.rest.RestStatus;
 
 /**
  *
  */
-public class SearchContextMissingException extends ElasticsearchException {
+public interface StatusToXContent extends ToXContent {
 
-    private final long id;
-
-    public SearchContextMissingException(long id) {
-        super("No search context found for id [" + id + "]");
-        this.id = id;
-    }
-
-    public long id() {
-        return this.id;
-    }
-
-    @Override
-    public RestStatus status() {
-        return RestStatus.NOT_FOUND;
-    }
+    /**
+     * Returns the REST status to make sure it is returned correctly
+     */
+    RestStatus status();
 }

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -71,7 +72,7 @@ public class RestSearchAction extends BaseRestHandler {
         SearchRequest searchRequest;
         searchRequest = RestSearchAction.parseSearchRequest(request);
         searchRequest.listenerThreaded(false);
-        client.search(searchRequest, new RestToXContentListener<SearchResponse>(channel));
+        client.search(searchRequest, new RestStatusToXContentListener<SearchResponse>(channel));
     }
 
     public static SearchRequest parseSearchRequest(RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.search;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
@@ -29,7 +28,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestActions;
-import org.elasticsearch.rest.action.support.RestToXContentListener;
+import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 import org.elasticsearch.search.Scroll;
 
 import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
@@ -63,6 +62,7 @@ public class RestSearchScrollAction extends BaseRestHandler {
         if (scroll != null) {
             searchScrollRequest.scroll(new Scroll(parseTimeValue(scroll, null)));
         }
-        client.searchScroll(searchScrollRequest, new RestToXContentListener<SearchResponse>(channel));
+
+        client.searchScroll(searchScrollRequest, new RestStatusToXContentListener(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/support/RestStatusToXContentListener.java
+++ b/src/main/java/org/elasticsearch/rest/action/support/RestStatusToXContentListener.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.rest.action.support;
+
+import org.elasticsearch.common.xcontent.StatusToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestResponse;
+
+/**
+ *
+ */
+public class RestStatusToXContentListener<Response extends StatusToXContent> extends RestResponseListener<Response> {
+
+    public RestStatusToXContentListener(RestChannel channel) {
+        super(channel);
+    }
+
+    @Override
+    public final RestResponse buildResponse(Response response) throws Exception {
+        return buildResponse(response, channel.newBuilder());
+    }
+
+    public final RestResponse buildResponse(Response response, XContentBuilder builder) throws Exception {
+        builder.startObject();
+        response.toXContent(builder, channel.request());
+        builder.endObject();
+        return new BytesRestResponse(response.status(), builder);
+    }
+
+}


### PR DESCRIPTION
A bad/non-existing scroll ID used to return a 200, however a 404 might be more useful.
Also, this PR returns the right Exception (SearchContextMissingException) in the Java API.

TODO: I need some more feedback for this PR. I think this solution is not optimal and there might be a better option (checking the exception type twice is not what I want to do, I do this in order to return a real exception instead of a shard failure, but it is not a good solution codewise and I think there are better solutions which I do not see at the moment).

Closes #5729
