### PR TITLE
Analyze API: Default analyzer accidentally removed stopwords

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -34,7 +34,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.*;
@@ -213,7 +212,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
             closeAnalyzer = true;
         } else if (analyzer == null) {
             if (indexService == null) {
-                analyzer = Lucene.STANDARD_ANALYZER;
+                analyzer = indicesAnalysisService.analyzer("standard");
             } else {
                 analyzer = indexService.analysisService().defaultIndexAnalyzer();
             }


### PR DESCRIPTION
The analyze API used the standard analyzer from lucene and therefore removed
stopwords instead of using the elasticsearch default analyzer.

Closes #5974
