### PR TITLE
Use GeoUtils.earthDiameter in the bounding box optimization.

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -140,7 +140,8 @@ public enum GeoDistance {
 
     public static DistanceBoundingCheck distanceBoundingCheck(double sourceLatitude, double sourceLongitude, double distance, DistanceUnit unit) {
         // angular distance in radians on a great circle
-        double radDist = distance / unit.getEarthRadius();
+        // assume worst-case: use the minor axis
+        double radDist = unit.toMeters(distance) / GeoUtils.EARTH_SEMI_MINOR_AXIS;
 
         double radLat = Math.toRadians(sourceLatitude);
         double radLon = Math.toRadians(sourceLongitude);

--- a/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceFilter.java
@@ -52,7 +52,7 @@ public class GeoDistanceFilter extends Filter {
     private final IndexGeoPointFieldData indexFieldData;
 
     private final GeoDistance.FixedSourceDistance fixedSourceDistance;
-    private GeoDistance.DistanceBoundingCheck distanceBoundingCheck;
+    private final GeoDistance.DistanceBoundingCheck distanceBoundingCheck;
     private final Filter boundingBoxFilter;
 
     public GeoDistanceFilter(double lat, double lon, double distance, GeoDistance geoDistance, IndexGeoPointFieldData indexFieldData, GeoPointFieldMapper mapper,
@@ -64,6 +64,7 @@ public class GeoDistanceFilter extends Filter {
         this.indexFieldData = indexFieldData;
 
         this.fixedSourceDistance = geoDistance.fixedSourceDistance(lat, lon, DistanceUnit.DEFAULT);
+        GeoDistance.DistanceBoundingCheck distanceBoundingCheck = null;
         if (optimizeBbox != null && !"none".equals(optimizeBbox)) {
             distanceBoundingCheck = GeoDistance.distanceBoundingCheck(lat, lon, distance, DistanceUnit.DEFAULT);
             if ("memory".equals(optimizeBbox)) {
@@ -78,6 +79,7 @@ public class GeoDistanceFilter extends Filter {
             distanceBoundingCheck = GeoDistance.ALWAYS_INSTANCE;
             boundingBoxFilter = null;
         }
+        this.distanceBoundingCheck = distanceBoundingCheck;
     }
 
     public double lat() {


### PR DESCRIPTION
We switched to Lucene's SloppyMath way of computing an approximate value of
the eath diameter given a latitude in order to compute distances, yet the
bounding box optimization of the geo distance filter still assumed a constant
earth diameter, equal to the average.

Close #6008
