### PR TITLE
Added the ability to include the queried document for More Like This API.

### DIFF
--- a/docs/reference/search/more-like-this.asciidoc
+++ b/docs/reference/search/more-like-this.asciidoc
@@ -25,5 +25,8 @@ Rest parameters relating to search are also allowed, including
 When no `mlt_fields` are specified, all the fields of the document will
 be used in the `more_like_this` query generated.
 
+By default, the queried document is excluded from the response (`include`
+set to false).
+
 Note: In order to use the `mlt` feature a `mlt_field` needs to be either
 be `stored`, store `term_vector` or `source` needs to be enabled.

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisRequestBuilder.java
@@ -141,6 +141,14 @@ public class MoreLikeThisRequestBuilder extends ActionRequestBuilder<MoreLikeThi
     }
 
     /**
+     * Whether to include the queried document. Defaults to <tt>false</tt>.
+     */
+    public MoreLikeThisRequestBuilder setInclude(boolean include) {
+        request.include(include);
+        return this;
+    }
+
+    /**
      * An optional search source request allowing to control the search request for the
      * more like this documents.
      */

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -178,9 +178,11 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
                     }
 
                     // exclude myself
-                    Term uidTerm = docMapper.uidMapper().term(request.type(), request.id());
-                    boolBuilder.mustNot(termQuery(uidTerm.field(), uidTerm.text()));
-                    boolBuilder.adjustPureNegative(false);
+                    if (!request.include()) {
+                        Term uidTerm = docMapper.uidMapper().term(request.type(), request.id());
+                        boolBuilder.mustNot(termQuery(uidTerm.field(), uidTerm.text()));
+                        boolBuilder.adjustPureNegative(false);
+                    }
                 } catch (Throwable e) {
                     listener.onFailure(e);
                     return;

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -70,6 +70,7 @@ public class RestMoreLikeThisAction extends BaseRestHandler {
         mltRequest.minWordLength(request.paramAsInt("min_word_len", request.paramAsInt("min_word_length", -1)));
         mltRequest.maxWordLength(request.paramAsInt("max_word_len", request.paramAsInt("max_word_length", -1)));
         mltRequest.boostTerms(request.paramAsFloat("boost_terms", -1));
+        mltRequest.include(request.paramAsBoolean("include", false));
 
         mltRequest.searchType(SearchType.fromString(request.param("search_type")));
         mltRequest.searchIndices(request.paramAsStringArray("search_indices", null));


### PR DESCRIPTION
By default More Like This API excludes the queried document from the response.
However, when debugging or when comparing scores across different queries, it
could be useful to have the best possible matched hit. So this option lets users
explicitly specify the desired behavior.
