### PR TITLE
Unify IndicesOptions constants

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -140,7 +140,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
             }
             if (request.indices().length > 0) {
                 try {
-                    clusterState.metaData().concreteIndices(request.indices(), IndicesOptions.ERROR_UNAVAILABLE_EXPAND_OPEN_CLOSE);
+                    clusterState.metaData().concreteIndices(request.indices(), IndicesOptions.strictExpand());
                     waitForCounter++;
                 } catch (IndexMissingException e) {
                     response.status = ClusterHealthStatus.RED; // no indices, make sure its RED
@@ -221,7 +221,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
         }
         String[] concreteIndices;
         try {
-            concreteIndices = clusterState.metaData().concreteIndices(request.indices(), IndicesOptions.IGNORE_UNAVAILABLE_EXPAND_OPEN_ONLY);
+            concreteIndices = clusterState.metaData().concreteIndices(request.indices(), IndicesOptions.lenientExpandOpen());
         } catch (IndexMissingException e) {
             // one of the specified indices is not there - treat it as RED.
             ClusterHealthResponse response = new ClusterHealthResponse(clusterName.value(), Strings.EMPTY_ARRAY, clusterState);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -39,7 +39,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadOperationRequest<C
     @Nullable
     private String preference;
     private String[] types = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.lenient();
+    private IndicesOptions indicesOptions = IndicesOptions.lenientExpandOpen();
 
 
     public ClusterSearchShardsRequest() {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -69,7 +69,7 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
 
     private String[] indices = EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     private boolean partial = false;
 
@@ -364,10 +364,10 @@ public class CreateSnapshotRequest extends MasterNodeOperationRequest<CreateSnap
      * @return this request
      */
     public CreateSnapshotRequest source(Map source) {
-        boolean ignoreUnavailable = IndicesOptions.lenient().ignoreUnavailable();
-        boolean allowNoIndices = IndicesOptions.lenient().allowNoIndices();
-        boolean expandWildcardsOpen = IndicesOptions.lenient().expandWildcardsOpen();
-        boolean expandWildcardsClosed = IndicesOptions.lenient().expandWildcardsClosed();
+        boolean ignoreUnavailable = IndicesOptions.lenientExpandOpen().ignoreUnavailable();
+        boolean allowNoIndices = IndicesOptions.lenientExpandOpen().allowNoIndices();
+        boolean expandWildcardsOpen = IndicesOptions.lenientExpandOpen().expandWildcardsOpen();
+        boolean expandWildcardsClosed = IndicesOptions.lenientExpandOpen().expandWildcardsClosed();
         for (Map.Entry<String, Object> entry : ((Map<String, Object>) source).entrySet()) {
             String name = entry.getKey();
             if (name.equals("indices")) {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -57,7 +57,7 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
 
     private String[] indices = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     private String renamePattern;
 
@@ -382,10 +382,10 @@ public class RestoreSnapshotRequest extends MasterNodeOperationRequest<RestoreSn
      * @return this request
      */
     public RestoreSnapshotRequest source(Map source) {
-        boolean ignoreUnavailable = IndicesOptions.lenient().ignoreUnavailable();
-        boolean allowNoIndices = IndicesOptions.lenient().allowNoIndices();
-        boolean expandWildcardsOpen = IndicesOptions.lenient().expandWildcardsOpen();
-        boolean expandWildcardsClosed = IndicesOptions.lenient().expandWildcardsClosed();
+        boolean ignoreUnavailable = IndicesOptions.lenientExpandOpen().ignoreUnavailable();
+        boolean allowNoIndices = IndicesOptions.lenientExpandOpen().allowNoIndices();
+        boolean expandWildcardsOpen = IndicesOptions.lenientExpandOpen().expandWildcardsOpen();
+        boolean expandWildcardsClosed = IndicesOptions.lenientExpandOpen().expandWildcardsClosed();
 
         for (Map.Entry<String, Object> entry : ((Map<String, Object>) source).entrySet()) {
             String name = entry.getKey();

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -103,7 +103,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadOperatio
             }
 
             if (request.indices().length > 0) {
-                String[] indices = currentState.metaData().concreteIndices(request.indices(), IndicesOptions.IGNORE_UNAVAILABLE_EXPAND_OPEN_ONLY);
+                String[] indices = currentState.metaData().concreteIndices(request.indices(), IndicesOptions.lenientExpandOpen());
                 for (String filteredIndex : indices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(filteredIndex);
                     if (indexMetaData != null) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -35,7 +35,7 @@ public class GetAliasesRequest extends MasterNodeReadOperationRequest<GetAliases
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     public GetAliasesRequest(String[] aliases) {
         this.aliases = aliases;

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
@@ -36,7 +36,7 @@ public class TypesExistsRequest extends MasterNodeReadOperationRequest<TypesExis
     private String[] indices;
     private String[] types;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     TypesExistsRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
@@ -42,7 +42,7 @@ public class GetFieldMappingsRequest extends ActionRequest<GetFieldMappingsReque
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     public GetFieldMappingsRequest() {
 

--- a/src/main/java/org/elasticsearch/action/percolate/MultiPercolateRequest.java
+++ b/src/main/java/org/elasticsearch/action/percolate/MultiPercolateRequest.java
@@ -48,7 +48,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
 
     private String[] indices;
     private String documentType;
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
     private List<PercolateRequest> requests = Lists.newArrayList();
 
     public MultiPercolateRequest add(PercolateRequestBuilder requestBuilder) {
@@ -62,7 +62,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
         if (request.documentType() == null && documentType != null) {
             request.documentType(documentType);
         }
-        if (request.indicesOptions() == IndicesOptions.strict() && indicesOptions != IndicesOptions.strict()) {
+        if (request.indicesOptions() == IndicesOptions.strictExpandOpen() && indicesOptions != IndicesOptions.strictExpandOpen()) {
             request.indicesOptions(indicesOptions);
         }
         requests.add(request);
@@ -96,7 +96,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
             if (documentType != null) {
                 percolateRequest.documentType(documentType);
             }
-            if (indicesOptions != IndicesOptions.strict()) {
+            if (indicesOptions != IndicesOptions.strictExpandOpen()) {
                 percolateRequest.indicesOptions(indicesOptions);
             }
 
@@ -165,10 +165,10 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
             }
         }
 
-        boolean ignoreUnavailable = IndicesOptions.strict().ignoreUnavailable();
-        boolean allowNoIndices = IndicesOptions.strict().allowNoIndices();
-        boolean expandWildcardsOpen = IndicesOptions.strict().expandWildcardsOpen();
-        boolean expandWildcardsClosed = IndicesOptions.strict().expandWildcardsClosed();
+        boolean ignoreUnavailable = IndicesOptions.strictExpandOpen().ignoreUnavailable();
+        boolean allowNoIndices = IndicesOptions.strictExpandOpen().allowNoIndices();
+        boolean expandWildcardsOpen = IndicesOptions.strictExpandOpen().expandWildcardsOpen();
+        boolean expandWildcardsClosed = IndicesOptions.strictExpandOpen().expandWildcardsClosed();
 
         if (header.containsKey("id")) {
             GetRequest getRequest = new GetRequest(globalIndex);

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -48,7 +48,7 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
 
     private List<SearchRequest> requests = Lists.newArrayList();
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     /**
      * Add a search request to execute. Note, the order is important, the search response will be returned in the
@@ -70,7 +70,7 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
 
     public MultiSearchRequest add(byte[] data, int from, int length, boolean contentUnsafe,
                                   @Nullable String[] indices, @Nullable String[] types, @Nullable String searchType) throws Exception {
-        return add(new BytesArray(data, from, length), contentUnsafe, indices, types, searchType, null, IndicesOptions.strict(), true);
+        return add(new BytesArray(data, from, length), contentUnsafe, indices, types, searchType, null, IndicesOptions.strictExpandOpen(), true);
     }
 
     public MultiSearchRequest add(BytesReference data, boolean contentUnsafe, @Nullable String[] indices, @Nullable String[] types, @Nullable String searchType, IndicesOptions indicesOptions) throws Exception {
@@ -108,10 +108,10 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
             }
             searchRequest.searchType(searchType);
 
-            boolean ignoreUnavailable = IndicesOptions.strict().ignoreUnavailable();
-            boolean allowNoIndices = IndicesOptions.strict().allowNoIndices();
-            boolean expandWildcardsOpen = IndicesOptions.strict().expandWildcardsOpen();
-            boolean expandWildcardsClosed = IndicesOptions.strict().expandWildcardsClosed();
+            boolean ignoreUnavailable = IndicesOptions.strictExpandOpen().ignoreUnavailable();
+            boolean allowNoIndices = IndicesOptions.strictExpandOpen().allowNoIndices();
+            boolean expandWildcardsOpen = IndicesOptions.strictExpandOpen().expandWildcardsOpen();
+            boolean expandWildcardsClosed = IndicesOptions.strictExpandOpen().expandWildcardsClosed();
 
             // now parse the action
             if (nextMarker - from > 0) {

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
@@ -42,7 +42,7 @@ public class MultiSearchRequestBuilder extends ActionRequestBuilder<MultiSearchR
      * will not be used (if set).
      */
     public MultiSearchRequestBuilder add(SearchRequest request) {
-        if (request.indicesOptions() == IndicesOptions.strict() && request().indicesOptions() != IndicesOptions.strict()) {
+        if (request.indicesOptions() == IndicesOptions.strictExpandOpen() && request().indicesOptions() != IndicesOptions.strictExpandOpen()) {
             request.indicesOptions(request().indicesOptions());
         }
 
@@ -55,7 +55,7 @@ public class MultiSearchRequestBuilder extends ActionRequestBuilder<MultiSearchR
      * same order as the search requests.
      */
     public MultiSearchRequestBuilder add(SearchRequestBuilder request) {
-        if (request.request().indicesOptions() == IndicesOptions.strict() && request().indicesOptions() != IndicesOptions.strict()) {
+        if (request.request().indicesOptions() == IndicesOptions.strictExpandOpen() && request().indicesOptions() != IndicesOptions.strictExpandOpen()) {
             request.request().indicesOptions(request().indicesOptions());
         }
 

--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -83,7 +83,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> {
 
     private String[] types = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     public SearchRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -42,16 +42,6 @@ public class IndicesOptions {
         }
     }
 
-    /**
-     * Indices option that ignores unavailable indices, allows no indices and expand wildcards to open only indices
-     */
-    public static IndicesOptions IGNORE_UNAVAILABLE_EXPAND_OPEN_ONLY = fromOptions(true, true, true, false);
-    /**
-     * Indices option that doesn't ignore unavailable indices, allows no indices and expand wildcards to both open and closed indices
-     */
-    public static IndicesOptions ERROR_UNAVAILABLE_EXPAND_OPEN_CLOSE = fromOptions(false, true, true, true);
-
-
     private final byte id;
 
     private IndicesOptions(byte id) {
@@ -136,18 +126,27 @@ public class IndicesOptions {
     }
 
     /**
-     * @return indices options that requires any specified index to exists, expands wildcards only to open indices and
-     *         allow that no indices are resolved from wildcard expressions (not returning an error).
+     * @return indices options that requires every specified index to exist, expands wildcards only to open indices and
+     *         allows that no indices are resolved from wildcard expressions (not returning an error).
      */
-    public static IndicesOptions strict() {
+    public static IndicesOptions strictExpandOpen() {
         return VALUES[6];
     }
 
+
     /**
-     * @return indices options that ignore unavailable indices, expand wildcards only to open indices and
-     *         allow that no indices are resolved from wildcard expressions (not returning an error).
+     * @return indices option that requires every specified index to exist, expands wildcards to both open and closed
+     * indices and allows that no indices are resolved from wildcard expressions (not returning an error).
      */
-    public static IndicesOptions lenient() {
+    public static IndicesOptions strictExpand() {
+        return VALUES[14];
+    }
+
+    /**
+     * @return indices options that ignores unavailable indices, expands wildcards only to open indices and
+     *         allows that no indices are resolved from wildcard expressions (not returning an error).
+     */
+    public static IndicesOptions lenientExpandOpen() {
         return VALUES[7];
     }
 

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequest> extends ActionRequest<T> {
 
     protected String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     protected BroadcastOperationRequest() {
 

--- a/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -34,7 +34,7 @@ public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends M
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strict();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     @SuppressWarnings("unchecked")
     public T indices(String... indices) {

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -476,7 +476,7 @@ public class MetaData implements Iterable<IndexMetaData> {
     }
 
     public Map<String, Set<String>> resolveSearchRouting(@Nullable String routing, String aliasOrIndex) {
-        return resolveSearchRouting(routing, convertFromWildcards(new String[]{aliasOrIndex}, IndicesOptions.lenient()));
+        return resolveSearchRouting(routing, convertFromWildcards(new String[]{aliasOrIndex}, IndicesOptions.lenientExpandOpen()));
     }
 
     public Map<String, Set<String>> resolveSearchRouting(@Nullable String routing, String[] aliasesOrIndices) {
@@ -484,7 +484,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             return resolveSearchRoutingAllIndices(routing);
         }
 
-        aliasesOrIndices = convertFromWildcards(aliasesOrIndices, IndicesOptions.lenient());
+        aliasesOrIndices = convertFromWildcards(aliasesOrIndices, IndicesOptions.lenientExpandOpen());
 
         if (aliasesOrIndices.length == 1) {
             return resolveSearchRoutingSingleValue(routing, aliasesOrIndices[0]);
@@ -887,7 +887,7 @@ public class MetaData implements Iterable<IndexMetaData> {
      */
     public String[] filteringAliases(String index, String... indicesOrAliases) {
         // expand the aliases wildcard
-        indicesOrAliases = convertFromWildcards(indicesOrAliases, IndicesOptions.lenient());
+        indicesOrAliases = convertFromWildcards(indicesOrAliases, IndicesOptions.lenientExpandOpen());
 
         if (isAllIndices(indicesOrAliases)) {
             return null;

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -229,7 +229,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
             @Override
             public ClusterState execute(ClusterState currentState) {
-                String[] actualIndices = currentState.metaData().concreteIndices(request.indices(), IndicesOptions.ERROR_UNAVAILABLE_EXPAND_OPEN_CLOSE);
+                String[] actualIndices = currentState.metaData().concreteIndices(request.indices(), IndicesOptions.strictExpand());
                 RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
                 MetaData.Builder metaDataBuilder = MetaData.builder(currentState.metaData());
 

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
@@ -146,7 +146,7 @@ public class IndicesFilterParser implements FilterParser {
     }
 
     protected boolean matchesIndices(String currentIndex, String... indices) {
-        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(indices, IndicesOptions.IGNORE_UNAVAILABLE_EXPAND_OPEN_ONLY);
+        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(indices, IndicesOptions.lenientExpandOpen());
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, currentIndex)) {
                 return true;

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -147,7 +147,7 @@ public class IndicesQueryParser implements QueryParser {
     }
 
     protected boolean matchesIndices(String currentIndex, String... indices) {
-        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(indices, IndicesOptions.IGNORE_UNAVAILABLE_EXPAND_OPEN_ONLY);
+        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(indices, IndicesOptions.lenientExpandOpen());
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, currentIndex)) {
                 return true;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -52,7 +52,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
         final String[] names = request.paramAsStringArrayOrEmptyIfAll("name");
         GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
                 .indices(Strings.splitStringByCommaToArray(request.param("index")))
-                .indicesOptions(IndicesOptions.fromRequest(request, IndicesOptions.strict()))
+                .indicesOptions(IndicesOptions.fromRequest(request, IndicesOptions.strictExpandOpen()))
                 .names(names);
         getSettingsRequest.local(request.paramAsBoolean("local", getSettingsRequest.local()));
 

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -72,7 +72,7 @@ public class RestIndicesAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(indices, IndicesOptions.IGNORE_UNAVAILABLE_EXPAND_OPEN_ONLY);
+                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(indices, IndicesOptions.lenientExpandOpen());
                 ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest(concreteIndices);
                 clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
                 client.admin().cluster().health(clusterHealthRequest, new RestActionListener<ClusterHealthResponse>(channel) {

--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -70,7 +70,7 @@ import static org.elasticsearch.cluster.metadata.MetaDataIndexStateService.INDEX
  * {@link org.elasticsearch.index.gateway.IndexShardGatewayService#recover(boolean, org.elasticsearch.index.gateway.IndexShardGatewayService.RecoveryListener)}
  * method, which detects that shard should be restored from snapshot rather than recovered from gateway by looking
  * at the {@link org.elasticsearch.cluster.routing.ShardRouting#restoreSource()} property. If this property is not null
- * {@code recover} method uses {@link org.elasticsearch.index.snapshots.IndexShardSnapshotAndRestoreService#restore(org.elasticsearch.index.gateway.RecoveryStatus)}
+ * {@code recover} method uses {@link org.elasticsearch.index.snapshots.IndexShardSnapshotAndRestoreService#restore(org.elasticsearch.index.gateway.RecoveryState)}
  * method to start shard restore process.
  * <p/>
  * At the end of the successful restore process {@code IndexShardSnapshotAndRestoreService} calls {@link #indexShardRestoreCompleted(SnapshotId, ShardId)},
@@ -485,7 +485,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
 
         private String renameReplacement;
 
-        private IndicesOptions indicesOptions = IndicesOptions.strict();
+        private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
         private Settings settings;
 

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1153,7 +1153,7 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
 
         private String[] indices;
 
-        private IndicesOptions indicesOptions = IndicesOptions.strict();
+        private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
         private boolean partial;
 

--- a/src/test/java/org/elasticsearch/action/percolate/MultiPercolatorRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/percolate/MultiPercolatorRequestTests.java
@@ -44,7 +44,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strict()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -57,7 +57,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenient()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -96,7 +96,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strict()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(true));
         assertThat(percolateRequest.getRequest(), notNullValue());
         assertThat(percolateRequest.getRequest().id(), equalTo("2"));
@@ -110,7 +110,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("primary"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strict()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -122,7 +122,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
     public void testParseBulkRequests_defaults() throws Exception {
         byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/action/percolate/mpercolate2.json");
         MultiPercolateRequest request = new MultiPercolateRequest();
-        request.indices("my-index1").documentType("my-type1").indicesOptions(IndicesOptions.lenient());
+        request.indices("my-index1").documentType("my-type1").indicesOptions(IndicesOptions.lenientExpandOpen());
         request.add(data, 0, data.length, false);
 
         assertThat(request.requests().size(), equalTo(3));
@@ -131,7 +131,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenient()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -143,7 +143,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenient()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -153,7 +153,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         percolateRequest = request.requests().get(2);
         assertThat(percolateRequest.indices()[0], equalTo("my-index1"));
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenient()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());

--- a/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -189,7 +189,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
             routingTable.add(indexRoutingTable);
         }
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null, IndicesOptions.ERROR_UNAVAILABLE_EXPAND_OPEN_CLOSE), clusterState);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null, IndicesOptions.strictExpand()), clusterState);
         logger.info("cluster status: {}, expected {}", clusterHealth.getStatus(), counter.status());
 
         assertClusterHealth(clusterHealth, counter);
@@ -210,7 +210,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         metaData.put(indexMetaData, true);
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null, IndicesOptions.ERROR_UNAVAILABLE_EXPAND_OPEN_CLOSE), clusterState);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null, IndicesOptions.strictExpand()), clusterState);
         // currently we have no cluster level validation failures as index validation issues are reported per index.
         assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));
     }

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -44,7 +44,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         MetaData md = mdBuilder.build();
 
-        IndicesOptions options = IndicesOptions.strict();
+        IndicesOptions options = IndicesOptions.strictExpandOpen();
 
         String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
         assertEquals(3, results.length);
@@ -92,7 +92,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         MetaData md = mdBuilder.build();
 
-        IndicesOptions options = IndicesOptions.lenient();
+        IndicesOptions options = IndicesOptions.lenientExpandOpen();
 
         String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
         assertEquals(3, results.length);
@@ -227,7 +227,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
     @Test
     public void testIndexOptions_emptyCluster() {
         MetaData md = MetaData.builder().build();
-        IndicesOptions options = IndicesOptions.strict();
+        IndicesOptions options = IndicesOptions.strictExpandOpen();
 
         String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
         assertThat(results, emptyArray());
@@ -243,7 +243,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
         } catch (IndexMissingException e) {}
 
 
-        options = IndicesOptions.lenient();
+        options = IndicesOptions.lenientExpandOpen();
         results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
         assertThat(results, emptyArray());
         results = md.concreteIndices(new String[]{"foo"}, options);
@@ -267,12 +267,12 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testYYY"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testXXX"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testXXX", "testYYY"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testYYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testXXX", "ku*"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "kuku")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"test*"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*", "kuku"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY", "kuku")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testXXX"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testXXX", "testYYY"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testYYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testXXX", "ku*"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "kuku")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"test*"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testX*", "kuku"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY", "kuku")));
     }
 
     @Test
@@ -283,11 +283,11 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testYYY").putAlias(AliasMetaData.builder("alias3")))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testYY*", "alias*"}, IndicesOptions.lenient())), equalTo(newHashSet("alias1", "alias2", "alias3", "testYYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"-kuku"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"+test*", "-testYYY"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"+testX*", "+testYYY"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
-        assertThat(newHashSet(md.convertFromWildcards(new String[]{"+testYYY", "+testX*"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"testYY*", "alias*"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("alias1", "alias2", "alias3", "testYYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"-kuku"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"+test*", "-testYYY"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"+testX*", "+testYYY"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(md.convertFromWildcards(new String[]{"+testYYY", "+testX*"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
     }
 
     private IndexMetaData.Builder indexBuilder(String index) {
@@ -300,7 +300,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        md.concreteIndices(new String[]{"testZZZ"}, IndicesOptions.strict());
+        md.concreteIndices(new String[]{"testZZZ"}, IndicesOptions.strictExpandOpen());
     }
 
     @Test
@@ -309,7 +309,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.concreteIndices(new String[]{"testXXX", "testZZZ"}, IndicesOptions.lenient())), equalTo(newHashSet("testXXX")));
+        assertThat(newHashSet(md.concreteIndices(new String[]{"testXXX", "testZZZ"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX")));
     }
 
     @Test(expected = IndexMissingException.class)
@@ -318,7 +318,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.concreteIndices(new String[]{"testMo", "testMahdy"}, IndicesOptions.strict())), equalTo(newHashSet("testXXX")));
+        assertThat(newHashSet(md.concreteIndices(new String[]{"testMo", "testMahdy"}, IndicesOptions.strictExpandOpen())), equalTo(newHashSet("testXXX")));
     }
 
     @Test
@@ -327,7 +327,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.concreteIndices(new String[]{}, IndicesOptions.lenient())), equalTo(Sets.<String>newHashSet("kuku", "testXXX")));
+        assertThat(newHashSet(md.concreteIndices(new String[]{}, IndicesOptions.lenientExpandOpen())), equalTo(Sets.<String>newHashSet("kuku", "testXXX")));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/deleteByQuery/DeleteByQueryTests.java
+++ b/src/test/java/org/elasticsearch/deleteByQuery/DeleteByQueryTests.java
@@ -88,7 +88,7 @@ public class DeleteByQueryTests extends ElasticsearchIntegrationTest {
             //everything well
         }
 
-        deleteByQueryRequestBuilder.setIndicesOptions(IndicesOptions.lenient());
+        deleteByQueryRequestBuilder.setIndicesOptions(IndicesOptions.lenientExpandOpen());
         DeleteByQueryResponse actionGet = deleteByQueryRequestBuilder.execute().actionGet();
         assertThat(actionGet.status(), equalTo(RestStatus.OK));
         assertThat(actionGet.getIndex("twitter").getFailedShards(), equalTo(0));

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsTests.java
@@ -98,7 +98,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(getWarmer("test1", "test2"), true);
         verify(getSettings("test1", "test2"), true);
 
-        IndicesOptions options = IndicesOptions.strict();
+        IndicesOptions options = IndicesOptions.strictExpandOpen();
         verify(search("test1", "test2").setIndicesOptions(options), true);
         verify(msearch(options, "test1", "test2"), true);
         verify(count("test1", "test2").setIndicesOptions(options), true);
@@ -122,7 +122,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(getWarmer("test1", "test2").setIndicesOptions(options), true);
         verify(getSettings("test1", "test2").setIndicesOptions(options), true);
 
-        options = IndicesOptions.lenient();
+        options = IndicesOptions.lenientExpandOpen();
         verify(search("test1", "test2").setIndicesOptions(options), false);
         verify(msearch(options, "test1", "test2").setIndicesOptions(options), false);
         verify(count("test1", "test2").setIndicesOptions(options), false);
@@ -146,7 +146,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(getWarmer("test1", "test2").setIndicesOptions(options), false);
         verify(getSettings("test1", "test2").setIndicesOptions(options), false);
 
-        options = IndicesOptions.strict();
+        options = IndicesOptions.strictExpandOpen();
         assertAcked(prepareCreate("test2"));
         ensureYellow();
         verify(search("test1", "test2").setIndicesOptions(options), false);
@@ -186,15 +186,15 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(snapshot("snap2", "test1", "test2"), true);
         verify(restore("snap1", "test1", "test2"), true);
 
-        IndicesOptions options = IndicesOptions.strict();
+        IndicesOptions options = IndicesOptions.strictExpandOpen();
         verify(snapshot("snap2", "test1", "test2").setIndicesOptions(options), true);
         verify(restore("snap1", "test1", "test2").setIndicesOptions(options), true);
 
-        options = IndicesOptions.lenient();
+        options = IndicesOptions.lenientExpandOpen();
         verify(snapshot("snap2", "test1", "test2").setIndicesOptions(options), false);
         verify(restore("snap2", "test1", "test2").setIndicesOptions(options), false);
 
-        options = IndicesOptions.strict();
+        options = IndicesOptions.strictExpandOpen();
         assertAcked(prepareCreate("test2"));
         //TODO: temporary work-around for #5531
         ensureGreen();
@@ -348,7 +348,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         verify(snapshot("snap2", "foo*", "bar*").setIndicesOptions(options), true);
         verify(restore("snap1", "foo*", "bar*").setIndicesOptions(options), true);
 
-        options = IndicesOptions.strict();
+        options = IndicesOptions.strictExpandOpen();
         verify(snapshot("snap2", "foo*", "bar*").setIndicesOptions(options), false);
         verify(restore("snap2", "foo*", "bar*").setIndicesOptions(options), false);
 
@@ -370,19 +370,19 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
         createIndex("test1");
         client().prepareIndex("test1", "type", "1").setSource("k", "v").setRefresh(true).execute().actionGet();
         SearchResponse response = client().prepareSearch("test2")
-                .setIndicesOptions(IndicesOptions.lenient())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .setQuery(matchAllQuery())
                 .execute().actionGet();
         assertHitCount(response, 0l);
 
         response = client().prepareSearch("test2","test3").setQuery(matchAllQuery())
-                .setIndicesOptions(IndicesOptions.lenient())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .execute().actionGet();
         assertHitCount(response, 0l);
         
         //you should still be able to run empty searches without things blowing up
         response  = client().prepareSearch()
-                .setIndicesOptions(IndicesOptions.lenient())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .setQuery(matchAllQuery())
                 .execute().actionGet();
         assertHitCount(response, 1l);
@@ -660,7 +660,7 @@ public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
     // Indices exists never throws IndexMissingException, the indices options control its behaviour (return true or false)
     public void testIndicesExists() throws Exception {
         assertThat(client().admin().indices().prepareExists("foo").get().isExists(), equalTo(false));
-        assertThat(client().admin().indices().prepareExists("foo").setIndicesOptions(IndicesOptions.lenient()).get().isExists(), equalTo(true));
+        assertThat(client().admin().indices().prepareExists("foo").setIndicesOptions(IndicesOptions.lenientExpandOpen()).get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("foo*").get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("foo*").setIndicesOptions(IndicesOptions.fromOptions(false, true, true, false)).get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("_all").get().isExists(), equalTo(false));

--- a/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexTests.java
@@ -81,7 +81,7 @@ public class OpenCloseIndexTests extends ElasticsearchIntegrationTest {
         ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         CloseIndexResponse closeIndexResponse = client.admin().indices().prepareClose("test1", "test2")
-                .setIndicesOptions(IndicesOptions.lenient()).execute().actionGet();
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().actionGet();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1");
     }
@@ -102,7 +102,7 @@ public class OpenCloseIndexTests extends ElasticsearchIntegrationTest {
         ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1", "test2")
-                .setIndicesOptions(IndicesOptions.lenient()).execute().actionGet();
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().actionGet();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1");
     }

--- a/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
+++ b/src/test/java/org/elasticsearch/percolator/PercolatorTests.java
@@ -868,7 +868,7 @@ public class PercolatorTests extends ElasticsearchIntegrationTest {
         logger.info("--> Percolate doc to index test2 and test3, with ignore missing");
         response = client().preparePercolate()
                 .setIndices("test1", "test3").setDocumentType("type")
-                .setIndicesOptions(IndicesOptions.lenient())
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
         assertMatchCount(response, 5l);

--- a/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
@@ -78,7 +78,7 @@ public class RandomTests extends ElasticsearchIntegrationTest {
             source = source.endArray().endObject();
             client().prepareIndex("idx", "type").setSource(source).execute().actionGet();
         }
-        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenient()).execute().get());
+        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
 
         final int numRanges = randomIntBetween(1, 20);
         final double[][] ranges = new double[numRanges][];
@@ -206,7 +206,7 @@ public class RandomTests extends ElasticsearchIntegrationTest {
         }
         indexRandom(true, indexingRequests);
 
-        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenient()).execute().get());
+        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
 
         TermsAggregatorFactory.ExecutionMode[] globalOrdinalModes = new TermsAggregatorFactory.ExecutionMode[]{
                 TermsAggregatorFactory.ExecutionMode.GLOBAL_ORDINALS_HASH,
@@ -271,7 +271,7 @@ public class RandomTests extends ElasticsearchIntegrationTest {
             source = source.endArray().endObject();
             client().prepareIndex("idx", "type").setSource(source).execute().actionGet();
         }
-        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenient()).execute().get());
+        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
 
         SearchResponse resp = client().prepareSearch("idx")
                 .addAggregation(terms("terms").field("values").script("floor(_value / interval)").param("interval", interval).size(maxNumTerms))

--- a/src/test/java/org/elasticsearch/snapshots/SnapshotUtilsTests.java
+++ b/src/test/java/org/elasticsearch/snapshots/SnapshotUtilsTests.java
@@ -39,13 +39,13 @@ public class SnapshotUtilsTests {
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"-ba*"}, new String[]{"foo"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"+ba*"}, new String[]{"bar", "baz"});
         assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"+bar", "+foo"}, new String[]{"bar", "foo"});
-        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"zzz", "bar"}, IndicesOptions.lenient(), new String[]{"bar"});
-        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{""}, IndicesOptions.lenient(), new String[]{});
-        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"foo", "", "ba*"}, IndicesOptions.lenient(), new String[]{"foo", "bar", "baz"});
+        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"zzz", "bar"}, IndicesOptions.lenientExpandOpen(), new String[]{"bar"});
+        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{""}, IndicesOptions.lenientExpandOpen(), new String[]{});
+        assertIndexNameFiltering(new String[]{"foo", "bar", "baz"}, new String[]{"foo", "", "ba*"}, IndicesOptions.lenientExpandOpen(), new String[]{"foo", "bar", "baz"});
     }
 
     private void assertIndexNameFiltering(String[] indices, String[] filter, String[] expected) {
-        assertIndexNameFiltering(indices, filter, IndicesOptions.lenient(), expected);
+        assertIndexNameFiltering(indices, filter, IndicesOptions.lenientExpandOpen(), expected);
     }
 
     private void assertIndexNameFiltering(String[] indices, String[] filter, IndicesOptions indicesOptions, String[] expected) {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1028,7 +1028,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         }
         assertThat(actualErrors, emptyIterable());
         if (forceRefresh) {
-            assertNoFailures(client().admin().indices().prepareRefresh(indices).setIndicesOptions(IndicesOptions.lenient()).execute().get());
+            assertNoFailures(client().admin().indices().prepareRefresh(indices).setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
         }
     }
 
@@ -1044,13 +1044,13 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     private void postIndexAsyncActions(String[] indices, List<CountDownLatch> inFlightAsyncOperations) throws InterruptedException {
         if (rarely()) {
             if (rarely()) {
-                client().admin().indices().prepareRefresh(indices).setIndicesOptions(IndicesOptions.lenient()).execute(
+                client().admin().indices().prepareRefresh(indices).setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute(
                         new LatchedActionListener<RefreshResponse>(newLatch(inFlightAsyncOperations)));
             } else if (rarely()) {
-                client().admin().indices().prepareFlush(indices).setIndicesOptions(IndicesOptions.lenient()).execute(
+                client().admin().indices().prepareFlush(indices).setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute(
                         new LatchedActionListener<FlushResponse>(newLatch(inFlightAsyncOperations)));
             } else if (rarely()) {
-                client().admin().indices().prepareOptimize(indices).setIndicesOptions(IndicesOptions.lenient()).setMaxNumSegments(between(1, 10)).setFlush(randomBoolean()).execute(
+                client().admin().indices().prepareOptimize(indices).setIndicesOptions(IndicesOptions.lenientExpandOpen()).setMaxNumSegments(between(1, 10)).setFlush(randomBoolean()).execute(
                         new LatchedActionListener<OptimizeResponse>(newLatch(inFlightAsyncOperations)));
             }
         }


### PR DESCRIPTION
Renamed IndicesOptions#strict and IndicesOptions#lenient to make it clearer what they actually return, reused methods and introduced new one

Relates to #6059, where two new constants were introduced in IndicesOptions. There were already two constants there though, one of which we could have reused. This commit tries to unify them.
