### PR TITLE
Fix for build failure #847

### DIFF
--- a/rest-api-spec/test/cat.recovery/10_basic.yaml
+++ b/rest-api-spec/test/cat.recovery/10_basic.yaml
@@ -22,13 +22,13 @@
       cat.recovery: {}
   - match:
       $body: |
-              /^(index1 \s+ \d+ \s+ \d+ \s+
-                 (gateway|replica|snapshot|relocating) \s+
-                 (init|index|start|translog|finalize|done) \s+
-                 ([\w/.-])+ \s+ 
-                 ([\w/.-])+ \s+ 
-                 ([\w/.-])+ \s+
-                 ([\w/.-])+ \s+
-                 \d+ \s+ \d+\.\d+\% \s+ \d+ \s+ \d+\.\d+\% \s+ \n?)
-               {1,}$/
+              /(?m)^(index1 \s+ \d+ \s+ \d+ \s+
+                     (gateway|replica|snapshot|relocating) \s+
+                     (init|index|start|translog|finalize|done) \s+
+                     ([-\w/.])+ \s+
+                     ([-\w/.])+ \s+
+                     ([-\w/.])+ \s+
+                     ([-\w/.])+ \s+
+                     \d+ \s+ \d+\.\d+\% \s+
+                     \d+ \s+ \d+\.\d+\% \s*)${1,}/
 


### PR DESCRIPTION
This fixes a stack overflow in the test for the _cat/recovery API.
The regular expression that tests the response body was modified to
handle large responses properly.
