### PR TITLE
Fix _cat/allocation rest test

### DIFF
--- a/rest-api-spec/test/cat.allocation/10_basic.yaml
+++ b/rest-api-spec/test/cat.allocation/10_basic.yaml
@@ -27,9 +27,9 @@
             /^
               ( 0                      \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+)?                 \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b    \s+)?  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b    \s+)?  #no value from client nodes
+                (\d+                   \s+)?  #no value from client nodes
                 [-\w.]+                \s+
                 \d+(\.\d+){3}          \s+
                 \w.*
@@ -55,11 +55,12 @@
   - match:
       $body: |
             /^
-              ( \d+                    \s+
+              ( \s*                          #allow leading spaces to account for right-justified text
+                \d+                    \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+)?                 \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
+                (\d+                  \s+)?  #no value from client nodes
                 [-\w.]+                \s+
                 \d+(\.\d+){3}          \s+
                 \w.*
@@ -84,9 +85,9 @@
             /^
               ( 0                      \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+)?                 \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
+                (\d+                  \s+)?  #no value from client nodes
                 [-\w.]+                \s+
                 \d+(\.\d+){3}          \s+
                 \w.*
@@ -122,11 +123,12 @@
                node                    \s+
                \n
 
-              ( \s+0                   \s+
+              ( \s*                          #allow leading spaces to account for right-justified text
+                0                      \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+(\.\d+)?[kmgt]b)?  \s+  #no value from client nodes
-                (\d+)?                 \s+  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
+                (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
+                (\d+                  \s+)?  #no value from client nodes
                 [-\w.]+                \s+
                 \d+(\.\d+){3}          \s+
                 \w.*
@@ -182,9 +184,9 @@
             /^
               ( 0                   \s+
                 \d+                 \s+
-                \d*                 \s+  #no value from client nodes
-                \d*                 \s+  #no value from client nodes
-                \d*                 \s+  #no value from client nodes
+                (\d+                 \s+)?  #no value from client nodes
+                (\d+                 \s+)?  #no value from client nodes
+                (\d+                 \s+)?  #no value from client nodes
                 [-\w.]+             \s+
                 \d+(\.\d+){3}       \s+
                 \w.*


### PR DESCRIPTION
The rest test for _cat/allocation was failing due to a regular
expression not accounting for space-padded right-justified text.
