### PR TITLE
Changed the respnose structure of the percentiles aggregation

### DIFF
--- a/docs/reference/search/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/metrics/percentile-aggregation.asciidoc
@@ -57,22 +57,27 @@ percentiles: `[ 1, 5, 25, 50, 75, 95, 99 ]`.  The response will look like this:
 
    "aggregations": {
       "load_time_outlier": {
-         "1.0": 15,
-         "5.0": 20,
-         "25.0": 23,
-         "50.0": 25,
-         "75.0": 29,
-         "95.0": 60,
-         "99.0": 150
+         "values" : {
+            "1.0": 15,
+            "5.0": 20,
+            "25.0": 23,
+            "50.0": 25,
+            "75.0": 29,
+            "95.0": 60,
+            "99.0": 150
+         }
       }
    }
 }
 --------------------------------------------------
 
+WARNING: added[1.2.0] The above response structure applies for `1.2.0` and above. Pre `1.2.0` release, the `values` object was
+         missing and all the percentiles where placed directly under the aggregation name object
+
 As you can see, the aggregation will return a calculated value for each percentile
 in the default range.  If we assume response times are in milliseconds, it is 
 immediately obvious that the webpage normally loads in 15-30ms, but occasionally
-spikes to 60-150ms.  
+spikes to 60-150ms.
 
 Often, administrators are only interested in outliers -- the extreme percentiles.
 We can specify just the percents we are interested in (requested percentiles 

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -157,6 +157,7 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
     public static final class CommonFields {
         public static final XContentBuilderString BUCKETS = new XContentBuilderString("buckets");
         public static final XContentBuilderString VALUE = new XContentBuilderString("value");
+        public static final XContentBuilderString VALUES = new XContentBuilderString("values");
         public static final XContentBuilderString VALUE_AS_STRING = new XContentBuilderString("value_as_string");
         public static final XContentBuilderString DOC_COUNT = new XContentBuilderString("doc_count");
         public static final XContentBuilderString KEY = new XContentBuilderString("key");

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -137,8 +137,9 @@ public class InternalPercentiles extends MetricsAggregation.MultiValue implement
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
         if (keyed) {
-            builder.startObject(name);
+            builder.startObject(CommonFields.VALUES);
             for(int i = 0; i < percents.length; ++i) {
                 String key = String.valueOf(percents[i]);
                 double value = percentile(percents[i]);
@@ -149,7 +150,7 @@ public class InternalPercentiles extends MetricsAggregation.MultiValue implement
             }
             builder.endObject();
         } else {
-            builder.startArray(name);
+            builder.startArray(CommonFields.VALUES);
             for (int i = 0; i < percents.length; i++) {
                 double value = percentile(percents[i]);
                 builder.startObject();
@@ -162,6 +163,7 @@ public class InternalPercentiles extends MetricsAggregation.MultiValue implement
             }
             builder.endArray();
         }
+        builder.endObject();
         return builder;
     }
 


### PR DESCRIPTION
now all the percentiles are placed under a `values` object (or `values` array in case the `keyed` flag is set to `false`)

Closes #5870
