### PR TITLE
Benchmark: Fix abort benchmark test

### DIFF
--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkModule.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkModule.java
@@ -19,14 +19,30 @@
 package org.elasticsearch.action.bench;
 
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.settings.Settings;
 
 /**
  * Benchmark module
  */
 public class BenchmarkModule extends AbstractModule  {
 
+    private final Settings settings;
+
+    public static final String BENCHMARK_SERVICE_KEY = "benchmark.service.impl";
+
+    public BenchmarkModule(Settings settings) {
+        this.settings = settings;
+    }
+
     @Override
     protected void configure() {
-        bind(BenchmarkService.class).asEagerSingleton();
+
+        final Class<? extends BenchmarkService> service = settings.getAsClass(BENCHMARK_SERVICE_KEY, BenchmarkService.class);
+
+        if (!BenchmarkService.class.equals(service)) {
+            bind(BenchmarkService.class).to(service).asEagerSingleton();
+        } else {
+            bind(BenchmarkService.class).asEagerSingleton();
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -56,7 +56,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
     private final TransportService transportService;
-    private final BenchmarkExecutor executor;
+    protected final BenchmarkExecutor executor;
 
     /**
      * Constructs a service component for running benchmarks
@@ -463,6 +463,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
         @Override
         protected void sendResponse() {
+            int activeBenchmarks = 0;
             BenchmarkStatusResponse consolidatedResponse = new BenchmarkStatusResponse();
             Map<String, List<BenchmarkResponse>> nameNodeResponseMap = new HashMap<>();
 
@@ -476,6 +477,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
                     }
                     benchmarkResponses.add(benchmarkResponse);
                 }
+                activeBenchmarks += nodeResponse.activeBenchmarks();
             }
 
             for (Map.Entry<String, List<BenchmarkResponse>> entry : nameNodeResponseMap.entrySet()) {
@@ -483,6 +485,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
                 consolidatedResponse.addBenchResponse(consolidated);
             }
 
+            consolidatedResponse.totalActiveBenchmarks(activeBenchmarks);
             listener.onResponse(consolidatedResponse);
         }
     }

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusNodeResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusNodeResponse.java
@@ -40,7 +40,7 @@ public class BenchmarkStatusNodeResponse extends ActionResponse implements Strea
     private List<BenchmarkResponse> benchmarkResponses;
 
     public BenchmarkStatusNodeResponse() {
-        benchmarkResponses = new ArrayList<BenchmarkResponse>();
+        benchmarkResponses = new ArrayList<>();
     }
 
     public void nodeName(String nodeName) {
@@ -57,6 +57,10 @@ public class BenchmarkStatusNodeResponse extends ActionResponse implements Strea
 
     public List<BenchmarkResponse> benchResponses() {
         return benchmarkResponses;
+    }
+
+    public int activeBenchmarks() {
+        return benchResponses().size();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusResponse.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
  */
 public class BenchmarkStatusResponse extends ActionResponse implements Streamable, ToXContent {
 
+    private int totalActiveBenchmarks = 0;
     private final List<BenchmarkResponse> benchmarkResponses = new ArrayList<>();
 
     public BenchmarkStatusResponse() { }
@@ -45,6 +46,14 @@ public class BenchmarkStatusResponse extends ActionResponse implements Streamabl
 
     public List<BenchmarkResponse> benchmarkResponses() {
         return benchmarkResponses;
+    }
+
+    public void totalActiveBenchmarks(int totalActiveBenchmarks) {
+        this.totalActiveBenchmarks = totalActiveBenchmarks;
+    }
+
+    public int totalActiveBenchmarks() {
+        return totalActiveBenchmarks;
     }
 
     @Override
@@ -66,6 +75,7 @@ public class BenchmarkStatusResponse extends ActionResponse implements Streamabl
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
+        totalActiveBenchmarks = in.readVInt();
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
             BenchmarkResponse br = new BenchmarkResponse();
@@ -77,6 +87,7 @@ public class BenchmarkStatusResponse extends ActionResponse implements Streamabl
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        out.writeVInt(totalActiveBenchmarks);
         out.writeVInt(benchmarkResponses.size());
         for (BenchmarkResponse br : benchmarkResponses) {
             br.writeTo(out);

--- a/src/main/java/org/elasticsearch/node/internal/InternalNode.java
+++ b/src/main/java/org/elasticsearch/node/internal/InternalNode.java
@@ -184,7 +184,7 @@ public final class InternalNode implements Node {
         modules.add(new ResourceWatcherModule());
         modules.add(new RepositoriesModule());
         modules.add(new TribeModule());
-        modules.add(new BenchmarkModule());
+        modules.add(new BenchmarkModule(settings));
 
         injector = modules.createInjector();
 


### PR DESCRIPTION
In some cases a benchmark may complete before we have a chance to abort
it. Just log these cases and continue.
