### PR TITLE
Allow to change concurrent merge scheduling setting dynamically

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/scheduler/MergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/MergeSchedulerProvider.java
@@ -127,4 +127,6 @@ public abstract class MergeSchedulerProvider extends AbstractIndexShardComponent
     public abstract MergeStats stats();
 
     public abstract Set<OnGoingMerge> onGoingMerges();
+
+    public abstract void close();
 }

--- a/src/main/java/org/elasticsearch/index/merge/scheduler/SerialMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/SerialMergeSchedulerProvider.java
@@ -74,6 +74,11 @@ public class SerialMergeSchedulerProvider extends MergeSchedulerProvider {
         return ImmutableSet.of();
     }
 
+    @Override
+    public void close() {
+
+    }
+
     public static class CustomSerialMergeScheduler extends TrackingSerialMergeScheduler {
 
         private final SerialMergeSchedulerProvider provider;

--- a/src/main/java/org/elasticsearch/index/service/InternalIndexService.java
+++ b/src/main/java/org/elasticsearch/index/service/InternalIndexService.java
@@ -49,6 +49,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.merge.policy.MergePolicyModule;
 import org.elasticsearch.index.merge.policy.MergePolicyProvider;
 import org.elasticsearch.index.merge.scheduler.MergeSchedulerModule;
+import org.elasticsearch.index.merge.scheduler.MergeSchedulerProvider;
 import org.elasticsearch.index.percolator.PercolatorQueriesRegistry;
 import org.elasticsearch.index.percolator.PercolatorShardModule;
 import org.elasticsearch.index.query.IndexQueryParserService;
@@ -401,6 +402,12 @@ public class InternalIndexService extends AbstractIndexComponent implements Inde
             shardInjector.getInstance(Engine.class).close();
         } catch (Throwable e) {
             logger.debug("failed to close engine", e);
+            // ignore
+        }
+        try {
+            shardInjector.getInstance(MergeSchedulerProvider.class).close();
+        } catch (Throwable e) {
+            logger.debug("failed to close merge policy scheduler", e);
             // ignore
         }
         try {

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -324,7 +324,7 @@ public class InternalEngineTests extends ElasticsearchTestCase {
 
     @Test
     public void testSegmentsWithMergeFlag() throws Exception {
-        ConcurrentMergeSchedulerProvider mergeSchedulerProvider = new ConcurrentMergeSchedulerProvider(shardId, EMPTY_SETTINGS, threadPool);
+        ConcurrentMergeSchedulerProvider mergeSchedulerProvider = new ConcurrentMergeSchedulerProvider(shardId, EMPTY_SETTINGS, threadPool, new IndexSettingsService(shardId.index(), EMPTY_SETTINGS));
         final AtomicReference<CountDownLatch> waitTillMerge = new AtomicReference<>();
         final AtomicReference<CountDownLatch> waitForMerge = new AtomicReference<>();
         mergeSchedulerProvider.addListener(new MergeSchedulerProvider.Listener() {


### PR DESCRIPTION
Allow to change the concurrent merge scheduler settings dynamically using the update settings API
