### PR TITLE
Fixed a typo. Changed "should" to "optional" to match the docs for minimum_should_match.

### DIFF
--- a/docs/reference/query-dsl/queries/match-query.asciidoc
+++ b/docs/reference/query-dsl/queries/match-query.asciidoc
@@ -26,7 +26,7 @@ The default `match` query is of type `boolean`. It means that the text
 provided is analyzed and the analysis process constructs a boolean query
 from the provided text. The `operator` flag can be set to `or` or `and`
 to control the boolean clauses (defaults to `or`). The minimum number of
-optional clauses to match can be set using the
+`or` clauses to match can be set using the
 <<query-dsl-minimum-should-match,`minimum_should_match`>>
 parameter.
 

--- a/docs/reference/query-dsl/queries/match-query.asciidoc
+++ b/docs/reference/query-dsl/queries/match-query.asciidoc
@@ -26,12 +26,12 @@ The default `match` query is of type `boolean`. It means that the text
 provided is analyzed and the analysis process constructs a boolean query
 from the provided text. The `operator` flag can be set to `or` or `and`
 to control the boolean clauses (defaults to `or`). The minimum number of
-should clauses to match can be set using the
+optional clauses to match can be set using the
 <<query-dsl-minimum-should-match,`minimum_should_match`>>
 parameter.
 
 The `analyzer` can be set to control which analyzer will perform the
-analysis process on the text. It default to the field explicit mapping
+analysis process on the text. It defaults to the field explicit mapping
 definition, or the default search analyzer.
 
 `fuzziness` allows _fuzzy matching_ based on the type of field being queried.


### PR DESCRIPTION
It also might be clearer to change it to 'or' to keep consistent with the language of the section.
