### PR TITLE
Log script change/add and removal at INFO level

### DIFF
--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -212,7 +212,7 @@ public class ScriptService extends AbstractComponent {
                         if (s.equals(scriptNameExt.v2())) {
                             found = true;
                             try {
-                                logger.trace("compiling script file " + file.getAbsolutePath());
+                                logger.info("compiling script file [{}]", file.getAbsolutePath());
                                 String script = Streams.copyToString(new InputStreamReader(new FileInputStream(file), Charsets.UTF_8));
                                 staticCache.put(scriptNameExt.v1(), new CompiledScript(engineService.types()[0], engineService.compile(script)));
                             } catch (Throwable e) {
@@ -239,7 +239,7 @@ public class ScriptService extends AbstractComponent {
         @Override
         public void onFileDeleted(File file) {
             Tuple<String, String> scriptNameExt = scriptNameExt(file);
-            logger.trace("removing script file " + file.getAbsolutePath());
+            logger.info("removing script file [{}]", file.getAbsolutePath());
             staticCache.remove(scriptNameExt.v1());
         }
 


### PR DESCRIPTION
Now that dynamic scripting is disabled, it's extremely helpful to know if/when a script is added or removed via the `ScriptChangesListener`, previously these were only TRACE level messages, they now look like:

```
[2014-05-09 12:01:25,393][INFO ][script                   ] [Plunderer] compiling script file [/Users/hinmanm/src/elasticsearch/config/scripts/calculate-score.mvel]
[2014-05-09 12:02:25,397][INFO ][script                   ] [Plunderer] compiling script file [/Users/hinmanm/src/elasticsearch/config/scripts/test.mvel]
[2014-05-09 12:03:25,399][INFO ][script                   ] [Plunderer] removing script file [/Users/hinmanm/src/elasticsearch/config/scripts/test.mvel]
```

To give an indication as to when the script changes have noticed and the scripts added/reloaded/removed.
