### PR TITLE
Add support for Byte and BytesRef to the XContentBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -529,6 +529,16 @@ public final class XContentBuilder implements BytesStream {
         return this;
     }
 
+    public XContentBuilder utf8Field(XContentBuilderString name, BytesRef value) throws IOException {
+        field(name);
+        generator.writeUTF8String(value.bytes, value.offset, value.length);
+        return this;
+    }
+
+    /**
+     * replaced with {@link #utf8Field(XContentBuilderString, org.apache.lucene.util.BytesRef)}
+     */
+    @Deprecated
     public XContentBuilder field(XContentBuilderString name, BytesRef value) throws IOException {
         field(name);
         generator.writeUTF8String(value.bytes, value.offset, value.length);
@@ -1135,6 +1145,8 @@ public final class XContentBuilder implements BytesStream {
             generator.writeNumber(((Float) value).floatValue());
         } else if (type == Double.class) {
             generator.writeNumber(((Double) value).doubleValue());
+        } else if (type == Byte.class) {
+            generator.writeNumber(((Byte)value).byteValue());
         } else if (type == Short.class) {
             generator.writeNumber(((Short) value).shortValue());
         } else if (type == Boolean.class) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -144,7 +144,7 @@ public class SignificantStringTerms extends InternalSignificantTerms {
             // and I end up with buckets that contravene the user's min_doc_count criteria in my reducer
             if (bucket.subsetDf >= minDocCount) {
                 builder.startObject();
-                builder.field(CommonFields.KEY, ((Bucket) bucket).termBytes);
+                builder.utf8Field(CommonFields.KEY, ((Bucket) bucket).termBytes);
                 builder.field(CommonFields.DOC_COUNT, bucket.getDocCount());
                 builder.field("score", bucket.score);
                 builder.field("bg_count", bucket.supersetDf);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -132,7 +132,7 @@ public class StringTerms extends InternalTerms {
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();
-            builder.field(CommonFields.KEY, ((Bucket) bucket).termBytes);
+            builder.utf8Field(CommonFields.KEY, ((Bucket) bucket).termBytes);
             builder.field(CommonFields.DOC_COUNT, bucket.getDocCount());
             ((InternalAggregations) bucket.getAggregations()).toXContentInternal(builder, params);
             builder.endObject();

--- a/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -173,6 +173,13 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testByteConversion() throws Exception {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        builder.startObject().field("test_name", (Byte)(byte)120).endObject();
+        assertThat(builder.bytes().toUtf8(), equalTo("{\"test_name\":120}"));
+    }
+
+    @Test
     public void testDateTypesConversion() throws Exception {
         Date date = new Date();
         String expectedDate = XContentBuilder.defaultDatePrinter.print(date.getTime());


### PR DESCRIPTION
Hi all,

currently the XContentBuilder will call .ToString()  on the object as fallback if it isn't known.
This will cause Byte instances to become a String instead of staying a number and BytesRef have some kind of hex representation which is wrong.

We could work around this if course by converting the values beforehand, but for performance reasons it would be nice to have the XContentBuilder handling the cases correctly.
