### PR TITLE
Making rpm update init.d script even if its been locally changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -896,7 +896,7 @@
                         <mapping>
                             <directory>/etc/rc.d/init.d/</directory>
                             <filemode>755</filemode>
-                            <configuration>true</configuration>
+                            <configuration>false</configuration>
                             <sources>
                                 <source>
                                     <location>src/rpm/init.d/elasticsearch</location>


### PR DESCRIPTION
since otherwise, you get a broken elasticsearch install, whenever the elasticsearch binary, that the init script runs (/usr/share/elasticsearch/bin/elasticsearch) changes something (like the startup needing -d - for it to be daemonized in 1.1.1 :) which makes the old init script not work.
