### PR TITLE
Fix for benchmark test timeout

### DIFF
--- a/src/test/java/org/elasticsearch/action/bench/BenchmarkIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/action/bench/BenchmarkIntegrationTest.java
@@ -79,7 +79,6 @@ public class BenchmarkIntegrationTest extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    @AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/6094")
     public void testSubmitBenchmark() throws Exception {
 
         final BenchmarkRequest request =

--- a/src/test/java/org/elasticsearch/action/bench/BenchmarkTestUtil.java
+++ b/src/test/java/org/elasticsearch/action/bench/BenchmarkTestUtil.java
@@ -42,8 +42,8 @@ public class BenchmarkTestUtil {
     public static final int MAX_MULTIPLIER = 500;
     public static final int MIN_SMALL_INTERVAL = 1;
     public static final int MAX_SMALL_INTERVAL = 3;
-    public static final int MIN_LARGE_INTERVAL = 11;
-    public static final int MAX_LARGE_INTERVAL = 19;
+    public static final int MIN_LARGE_INTERVAL = 5;
+    public static final int MAX_LARGE_INTERVAL = 7;
 
     public static final String BENCHMARK_NAME = "test_benchmark";
     public static final String COMPETITOR_PREFIX = "competitor_";


### PR DESCRIPTION
Lower number of random requests generated for each test so as not to
timeout on heavy tests.

Addresses #6094
