### PR TITLE
MetaData#concreteIndices to throw exception with a single index argument if allowNoIndices == false

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -27,8 +27,8 @@ import org.elasticsearch.rest.RestRequest;
 import java.io.IOException;
 
 /**
- * Controls how to deal when concrete indices are unavailable (closed & missing), to what wildcard expression expand
- * (all, closed or open indices) and how to deal when a wildcard expression resolves into no concrete indices.
+ * Controls how to deal with unavailable concrete indices (closed or missing), how wildcard expressions are expanded
+ * to actual indices (all, closed or open indices) and how to deal with wildcard expressions that resolve to no indices.
  */
 public class IndicesOptions {
 
@@ -56,22 +56,22 @@ public class IndicesOptions {
     }
 
     /**
-     * @return Whether to ignore if a wildcard indices expression resolves into no concrete indices.
-     *         The `_all` string or when no indices have been specified also count as wildcard expressions.
+     * @return Whether to ignore if a wildcard expression resolves to no concrete indices.
+     *         The `_all` string or empty list of indices count as wildcard expressions too.
      */
     public boolean allowNoIndices() {
         return (id & 2) != 0;
     }
 
     /**
-     * @return Whether wildcard indices expressions should expanded into open indices should be
+     * @return Whether wildcard expressions should get expanded to open indices
      */
     public boolean expandWildcardsOpen() {
         return (id & 4) != 0;
     }
 
     /**
-     * @return Whether wildcard indices expressions should expanded into closed indices should be
+     * @return Whether wildcard expressions should get expanded to closed indices
      */
     public boolean expandWildcardsClosed() {
         return (id & 8) != 0;

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -654,7 +654,7 @@ public class MetaData implements Iterable<IndexMetaData> {
                 return aliasesOrIndices;
             }
             String[] actualLst = aliasAndIndexToIndexMap.getOrDefault(aliasOrIndex, Strings.EMPTY_ARRAY);
-            if (!indicesOptions.allowNoIndices() && actualLst == null) {
+            if (actualLst.length == 0 && !indicesOptions.allowNoIndices()) {
                 throw new IndexMissingException(new Index(aliasOrIndex));
             } else {
                 return actualLst;

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -129,7 +129,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testIndexOptions_allowUnavailableExpandOpenDisAllowEmpty() {
+    public void testIndexOptions_allowUnavailableExpandOpenDisallowEmpty() {
         MetaData.Builder mdBuilder = MetaData.builder()
                 .put(indexBuilder("foo"))
                 .put(indexBuilder("foobar"))
@@ -145,18 +145,26 @@ public class MetaDataTests extends ElasticsearchTestCase {
         assertEquals(1, results.length);
         assertEquals("foo", results[0]);
 
-        results = md.concreteIndices(new String[]{"bar"}, options);
-        assertThat(results, emptyArray());
+        try {
+            md.concreteIndices(new String[]{"bar"}, options);
+            fail();
+        } catch(IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("bar"));
+        }
 
         try {
             md.concreteIndices(new String[]{"baz*"}, options);
             fail();
-        } catch (IndexMissingException e) {}
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("baz*"));
+        }
 
         try {
             md.concreteIndices(new String[]{"foo", "baz*"}, options);
             fail();
-        } catch (IndexMissingException e) {}
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("baz*"));
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixed MetaData#concreteIndices to throw exception with a single index argument in case allowNoIndices == false and ignoreUnavailable == true.

The current behaviour is inconsistent as 2 or more non existing indices would cause an exception to be thrown:

```
GET /a,b/_search?allow_no_indices=false&ignore_unavailable=true

{
   "error": "IndexMissingException[[[a, b]] missing]",
   "status": 404
}
```

On the other hand 

```
GET /a/_search?allow_no_indices=false&ignore_unavailable=true
```

returns 0 results and no exception regardless of the `allow_no_indices` value.

Took also the chance to improve the javadocs for `IndicesOptions` class.
