### PR TITLE
Clean up Java-API docs.

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -1,7 +1,7 @@
 [[client]]
 == Client
 
-You can use the *java client* in multiple ways:
+You can use the *Java client* in multiple ways:
 
 * Perform standard <<index_,index>>, <<get,get>>,
   <<delete,delete>> and <<search,search>> operations on an
@@ -13,9 +13,9 @@ You can use the *java client* in multiple ways:
 Obtaining an elasticsearch `Client` is simple. The most common way to
 get a client is by:
 
-1.  creating an embedded link:#nodeclient[`Node`] that acts as a node
-within a cluster
-2.  requesting a `Client` from your embedded `Node`.
+1.  Creating an embedded link:#nodeclient[`Node`] that acts as a node
+within a cluster.
+2.  Requesting a `Client` from your embedded `Node`.
 
 Another manner is by creating a link:#transport-client[`TransportClient`]
 that connects to a cluster.
@@ -24,7 +24,7 @@ that connects to a cluster.
 
 ______________________________________________________________________________________________________________________________________________________________
 Please note that you are encouraged to use the same version on client
-and cluster sides. You may hit some incompatibilities issues when mixing
+and cluster sides. You may hit some incompatibility issues when mixing
 major versions.
 ______________________________________________________________________________________________________________________________________________________________
 
@@ -50,10 +50,10 @@ node.close();
 --------------------------------------------------
 
 When you start a `Node`, it joins an elasticsearch cluster. You can have
-different clusters by simple setting the `cluster.name` setting, or
+different clusters by simply setting the `cluster.name` setting, or
 explicitly using the `clusterName` method on the builder.
 
-You can define `cluster.name` in `/src/main/resources/elasticsearch.yml`
+You can define `cluster.name` in the `/src/main/resources/elasticsearch.yml`
 dir in your project. As long as `elasticsearch.yml` is present in the
 classpath, it will be used when you start your node.
 
@@ -143,7 +143,7 @@ Client client = new TransportClient()
 client.close();
 --------------------------------------------------
 
-Note that you have to set the cluster name if you use one different to
+Note that you have to set the cluster name if you use one different than
 "elasticsearch":
 
 [source,java]
@@ -158,7 +158,7 @@ Or using `elasticsearch.yml` file as shown in the link:#nodeclient[Node
 Client section]
 
 The client allows to sniff the rest of the cluster, and add those into
-its list of machines to use. In this case, note that the ip addresses
+its list of machines to use. In this case, note that the IP addresses
 used will be the ones that the other nodes were started with (the
 "publish" address). In order to enable it, set the
 `client.transport.sniff` to `true`:

--- a/docs/java-api/count.asciidoc
+++ b/docs/java-api/count.asciidoc
@@ -1,7 +1,7 @@
 [[count]]
 == Count API
 
-The count API allows to easily execute a query and get the number of
+The count API allows one to easily execute a query and get the number of
 matches for that query. It can be executed across one or more indices
 and across one or more types. The query can be provided using the
 {ref}/query-dsl.html[Query DSL].
@@ -23,7 +23,7 @@ For more information on the count operation, check out the REST
 
 === Operation Threading
 
-The count API allows to set the threading model the operation will be
+The count API allows one to set the threading model the operation will be
 performed when the actual execution of the API is performed on the same
 node (the API is executed on a shard that is allocated on the same
 server).

--- a/docs/java-api/delete-by-query.asciidoc
+++ b/docs/java-api/delete-by-query.asciidoc
@@ -1,7 +1,7 @@
 [[delete-by-query]]
 == Delete By Query API
 
-The delete by query API allows to delete documents from one or more
+The delete by query API allows one to delete documents from one or more
 indices and one or more types based on a <<query-dsl-queries,query>>. Here
 is an example:
 

--- a/docs/java-api/delete.asciidoc
+++ b/docs/java-api/delete.asciidoc
@@ -1,7 +1,7 @@
 [[delete]]
 == Delete API
 
-The delete API allows to delete a typed JSON document from a specific
+The delete API allows one to delete a typed JSON document from a specific
 index based on its id. The following example deletes the JSON document
 from an index called twitter, under a type called tweet, with id valued
 1:

--- a/docs/java-api/facets.asciidoc
+++ b/docs/java-api/facets.asciidoc
@@ -296,7 +296,7 @@ learn how to build queries using Java.
 [[statistical]]
 ==== Statistical
 
-Here is how you can use
+Here is how you can use the
 {ref}/search-facets-statistical-facet.html[Statistical
 Facet] with Java API.
 
@@ -340,7 +340,7 @@ f.getVariance();        // Variance
 [[terms-stats]]
 ==== Terms Stats Facet
 
-Here is how you can use
+Here is how you can use the
 {ref}/search-facets-terms-stats-facet.html[Terms
 Stats Facet] with Java API.
 
@@ -390,7 +390,7 @@ for (TermsStatsFacet.Entry entry : f) {
 ==== Geo Distance Facet
 
 Here is how you can use
-{ref}/search-facets-geo-distance-facet.html[Geo
+the {ref}/search-facets-geo-distance-facet.html[Geo
 Distance Facet] with Java API.
 
 

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -8,7 +8,7 @@ This section describes the Java API that elasticsearch provides. All
 elasticsearch operations are executed using a
 <<client,Client>> object. All
 operations are completely asynchronous in nature (either accepts a
-listener, or return a future).
+listener, or returns a future).
 
 Additionally, operations on a client may be accumulated and executed in
 <<bulk,Bulk>>.

--- a/docs/java-api/index_.asciidoc
+++ b/docs/java-api/index_.asciidoc
@@ -8,11 +8,11 @@ index and make it searchable.
 [[generate]]
 === Generate JSON document
 
-There are different way of generating JSON document:
+There are different way of generating a JSON document:
 
 * Manually (aka do it yourself) using native `byte[]` or as a `String`
 
-* Using `Map` that will be automatically converted to its JSON
+* Using a `Map` that will be automatically converted to its JSON
 equivalent
 
 * Using a third party library to serialize your beans such as
@@ -29,7 +29,7 @@ directly constructs a `byte[]`.
 ==== Do It Yourself
 
 Nothing really difficult here but note that you will have to encode
-dates regarding to the
+dates according to the
 {ref}/mapping-date-format.html[Date Format].
 
 [source,java]
@@ -60,7 +60,7 @@ json.put("message","trying out Elasticsearch");
 [[beans]]
 ==== Serialize your beans
 
-Elasticsearch already use Jackson but shade it under
+Elasticsearch already uses Jackson but shades it under
 `org.elasticsearch.common.jackson` package. +
  So, you can add your own Jackson version in your `pom.xml` file or in
 your classpath. See http://wiki.fasterxml.com/JacksonDownload[Jackson
@@ -109,8 +109,8 @@ XContentBuilder builder = jsonBuilder()
 --------------------------------------------------
 
 Note that you can also add arrays with `startArray(String)` and
-`endArray()` methods. By the way, `field` method +
- accept many object types. You can pass directly numbers, dates and even
+`endArray()` methods. By the way, the `field` method +
+ accepts many object types. You can directly pass numbers, dates and even
 other XContentBuilder objects.
 
 If you need to see the generated JSON content, you can use the
@@ -161,7 +161,7 @@ IndexResponse response = client.prepareIndex("twitter", "tweet")
         .actionGet();
 --------------------------------------------------
 
-`IndexResponse` object will give you report:
+`IndexResponse` object will give you a report:
 
 [source,java]
 --------------------------------------------------
@@ -176,7 +176,7 @@ long _version = response.version();
 --------------------------------------------------
 
 If you use percolation while indexing, `IndexResponse` object will give
-you percolator that have matched:
+you a percolator that have matched:
 
 [source,java]
 --------------------------------------------------
@@ -194,12 +194,12 @@ For more information on the index operation, check out the REST
 
 === Operation Threading
 
-The index API allows to set the threading model the operation will be
+The index API allows one to set the threading model the operation will be
 performed when the actual execution of the API is performed on the same
 node (the API is executed on a shard that is allocated on the same
 server).
 
 The options are to execute the operation on a different thread, or to
-execute it on the calling thread (note that the API is still async). By
+execute it on the calling thread (note that the API is still asynchronous). By
 default, `operationThreaded` is set to `true` which means the operation
 is executed on a different thread.

--- a/docs/java-api/percolate.asciidoc
+++ b/docs/java-api/percolate.asciidoc
@@ -1,8 +1,8 @@
 [[percolate]]
 == Percolate API
 
-The percolator allows to register queries against an index, and then
-send `percolate` requests which include a doc, and getting back the
+The percolator allows one to register queries against an index, and then
+send `percolate` requests which include a doc, getting back the
 queries that match on that doc out of the set of registered queries.
 
 Read the main {ref}/search-percolate.html[percolate]

--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -1,7 +1,7 @@
 [[search]]
 == Search API
 
-The search API allows to execute a search query and get back search hits
+The search API allows one to execute a search query and get back search hits
 that match the query. It can be executed across one or more indices and
 across one or more types. The query can either be provided using the
 <<query-dsl-queries,query Java API>> or
@@ -76,7 +76,7 @@ while (true) {
 
 === Operation Threading
 
-The search API allows to set the threading model the operation will be
+The search API allows one to set the threading model the operation will be
 performed when the actual execution of the API is performed on the same
 node (the API is executed on a shard that is allocated on the same
 server).


### PR DESCRIPTION
Fixed some awkward wording and subject/verb agreement while reading through the Java API documentation.
