### PR TITLE
Some minor cleanups related to bench API

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -144,7 +144,7 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
                 }
             }
             if (request.recycler()) {
-                logger.info("Clear CacheRecycler on index [{}]", service.index());
+                logger.debug("Clear CacheRecycler on index [{}]", service.index());
                 clearedAtLeastOne = true;
                 // cacheRecycler.clear();
             }

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkExecutor.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkExecutor.java
@@ -187,6 +187,10 @@ public class BenchmarkExecutor {
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             benchmarkResponse.state(BenchmarkResponse.State.ABORTED);
+        } catch (Throwable ex) {
+            logger.debug("Unexpected exception during benchmark", ex);
+            benchmarkResponse.state(BenchmarkResponse.State.FAILED);
+            benchmarkResponse.errors(ex.getMessage());
         } finally {
             synchronized (lock) {
                 semaphore.stop();

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
@@ -183,7 +183,7 @@ public class BenchmarkResponse extends ActionResponse implements Streamable, ToX
      * Sets error messages
      * @param errors    Error messages
      */
-    public void errors(String[] errors) {
+    public void errors(String... errors) {
         this.errors = (errors == null) ? Strings.EMPTY_ARRAY : errors;
     }
 

--- a/src/test/java/org/elasticsearch/action/bench/BenchmarkTestUtil.java
+++ b/src/test/java/org/elasticsearch/action/bench/BenchmarkTestUtil.java
@@ -42,7 +42,7 @@ public class BenchmarkTestUtil {
     public static final int MAX_MULTIPLIER = 500;
     public static final int MIN_SMALL_INTERVAL = 1;
     public static final int MAX_SMALL_INTERVAL = 3;
-    public static final int MIN_LARGE_INTERVAL = 5;
+    public static final int MIN_LARGE_INTERVAL = 1;
     public static final int MAX_LARGE_INTERVAL = 7;
 
     public static final String BENCHMARK_NAME = "test_benchmark";

--- a/src/test/java/org/elasticsearch/test/ImmutableTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ImmutableTestCluster.java
@@ -24,6 +24,8 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.bench.BenchmarkNodeMissingException;
+import org.elasticsearch.action.bench.BenchmarkStatusResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.logging.ESLogger;
@@ -32,12 +34,13 @@ import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.repositories.RepositoryMissingException;
 
-
 import java.net.InetSocketAddress;
 import java.util.Random;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -78,6 +81,12 @@ public abstract class ImmutableTestCluster implements Iterable<Client> {
         assertAllSearchersClosed();
         assertAllFilesClosed();
         ensureEstimatedStats();
+        try {
+            final BenchmarkStatusResponse statusResponse = client().prepareBenchStatus().execute().actionGet();
+            assertThat(statusResponse.benchmarkResponses(), is(empty()));
+        } catch (BenchmarkNodeMissingException ex) {
+            // that's fine
+        }
     }
 
     /**


### PR DESCRIPTION
I found that some of the Bench tests leave benchmarks behind which can have an impact on other tests. We should shutdown all the benchmarks once tests are done. This PR adds some infra that detects this.
