### PR TITLE
Function Score: Add missing whitespace in error message when throwing exception

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -202,7 +202,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             }
         }
         if (!scaleFound || !refFound) {
-            throw new ElasticsearchParseException("Both " + DecayFunctionBuilder.SCALE + "and " + DecayFunctionBuilder.ORIGIN
+            throw new ElasticsearchParseException("Both " + DecayFunctionBuilder.SCALE + " and " + DecayFunctionBuilder.ORIGIN
                     + " must be set for numeric fields.");
         }
         IndexNumericFieldData<?> numericFieldData = parseContext.fieldData().getForField(mapper);


### PR DESCRIPTION
DecayFunctionParser throws a parse exception with a string containing "scaleand origin", this fixes the spacing issue.
