### PR TITLE
Only use dateline fix when polygon crosses dateline.

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.spatial4j.core.shape.Shape;
 import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
 
 public class MultiPolygonBuilder extends ShapeBuilder {
 
@@ -70,7 +71,7 @@ public class MultiPolygonBuilder extends ShapeBuilder {
 
         List<Shape> shapes = new ArrayList<Shape>(this.polygons.size());
         
-        if(wrapdateline) {
+        if(wrapdateline && crossesDateline(FACTORY)) {
             for (BasePolygonBuilder<?> polygon : this.polygons) {
                 for(Coordinate[][] part : polygon.coordinates()) {
                     shapes.add(jtsGeometry(PolygonBuilder.polygon(FACTORY, part)));
@@ -86,6 +87,14 @@ public class MultiPolygonBuilder extends ShapeBuilder {
         else
             return new ShapeCollection<Shape>(shapes, SPATIAL_CONTEXT);
         //note: ShapeCollection is probably faster than a Multi* geom.
+    }
+
+    private boolean crossesDateline(GeometryFactory factory) {
+        boolean result = false;
+        for (BasePolygonBuilder<?> polygon : this.polygons) {
+            result = result || polygon.crossesDateline(factory);
+        }
+        return result;
     }
 
     public static class InternalPolygonBuilder extends BasePolygonBuilder<InternalPolygonBuilder> {


### PR DESCRIPTION
- es1.x attempts to split polygons on the dateline along
  with holes, and then re-assign the holes to the new
  polygons.  In certain circumstances this assignment
  fails (https://github.com/elasticsearch/elasticsearch/issues/5773)
  The geojson format makes it clear which hole belongs to which
  polygon, and these issues can be avoided for polygons which
  do not span the dateline.
- there are additional issues with splitting polygons on the
  dateline.  Some shapes are lost in certain circumstances (bug
  yet to be filed).
  Sample shape: https://gist.github.com/anonymous/7f1bb6d7e9cd72f5977c
