### PR TITLE
Security: Make JSONP responses optional.

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -375,3 +375,11 @@
 #monitor.jvm.gc.old.warn: 10s
 #monitor.jvm.gc.old.info: 5s
 #monitor.jvm.gc.old.debug: 2s
+
+################################## Security ################################
+
+# Uncomment if you want to disable JSONP as a valid return transport on the 
+# http server. With this enabled, it may pose a security risk, so disabling 
+# it unless you need it is recommended.
+#
+#http.jsonp.enable: false

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -241,8 +241,17 @@ document indexed.
 [float]
 === JSONP
 
-All REST APIs accept a `callback` parameter resulting in a
-http://en.wikipedia.org/wiki/JSONP[JSONP] result.
+By default JSONP resposes are enabled. All REST APIs accept a `callback` parameter 
+resulting in a http://en.wikipedia.org/wiki/JSONP[JSONP] result. You can disable 
+this behavior by adding the following to `config.yaml`:
+
+    http.jsonp.enable: false
+
+Please note, due to the architecture of Elasticsearch, this may pose a security
+risk. Under some circumstances, an attacker may be able to exfiltrate data in your
+Elasticsearch server if they're able to force your browser to make a JSONP request
+on your behalf (e.g. by including a <script> tag on an untrusted site with a 
+legitimate query against a local Elasticsearch server).
 
 [float]
 === Request body in query string

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -139,11 +139,21 @@ public class NettyHttpChannel extends HttpChannel {
                         buffer,
                         ChannelBuffers.wrappedBuffer(END_JSONP)
                 );
+                // Add content-type header of "application/javascript"
+                resp.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/javascript");
             }
             resp.setContent(buffer);
-            resp.headers().add(HttpHeaders.Names.CONTENT_TYPE, response.contentType());
-            resp.headers().add(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(buffer.readableBytes()));
-
+            
+            // If our response doesn't specify a content-type header, set one 
+            if (!resp.headers().contains(HttpHeaders.Names.CONTENT_TYPE)) {
+                resp.headers().add(HttpHeaders.Names.CONTENT_TYPE, response.contentType());
+            }
+            
+            // If our response has no content-length, calculate and set one
+            if (!resp.headers().contains(HttpHeaders.Names.CONTENT_LENGTH)) {
+                resp.headers().add(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(buffer.readableBytes()));
+            }
+            
             if (transport.resetCookies) {
                 String cookieString = nettyRequest.headers().get(HttpHeaders.Names.COOKIE);
                 if (cookieString != null) {

--- a/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionDisabledTest.java
+++ b/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionDisabledTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.options.jsonp;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.rest.helper.HttpClient;
+import org.elasticsearch.rest.helper.HttpClientResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+// Test to make sure that our JSONp response is disabled
+@ClusterScope(scope = Scope.TEST, numDataNodes = 1)
+public class JsonpOptionDisabledTest extends ElasticsearchIntegrationTest {
+    
+    // Build our cluster settings
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("http.jsonp.enable", false)
+                .put(super.nodeSettings(nodeOrdinal))
+                .build();
+    }
+    
+    // Make sure our response has both the callback as well as our "JSONP is disabled" message. 
+    @Test
+    public void testThatJSONPisDisabled() throws Exception {        
+        // Make the HTTP request
+        HttpServerTransport httpServerTransport = cluster().getDataNodeInstance(HttpServerTransport.class);
+        HttpClient httpClient = new HttpClient(httpServerTransport.boundAddress().publishAddress());
+        HttpClientResponse response = httpClient.request("/?callback=DisabledJSONPCallback");
+        assertThat(response.getHeader("Content-Type"), is("application/javascript"));
+        assertThat(response.response(), containsString("DisabledJSONPCallback("));
+        assertThat(response.response(), containsString("JSONP is disabled"));        
+    }
+}

--- a/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionEnabledTest.java
+++ b/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionEnabledTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.options.jsonp;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.rest.helper.HttpClient;
+import org.elasticsearch.rest.helper.HttpClientResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+// Test to make sure that our JSONp response is enabled by default
+@ClusterScope(scope = Scope.TEST, numDataNodes = 1)
+public class JsonpOptionEnabledTest extends ElasticsearchIntegrationTest {
+
+    // Build our cluster settings
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("http.jsonp.enable", true)
+                .put(super.nodeSettings(nodeOrdinal))
+                .build();
+    }
+    
+    // Make sure our response has both the callback and opening paren, as well as the famous Elasticsearch tagline :)
+    @Test
+    public void testThatJSONPisEnabled() throws Exception {       
+        // Make the HTTP request
+        HttpServerTransport httpServerTransport = cluster().getDataNodeInstance(HttpServerTransport.class);
+        HttpClient httpClient = new HttpClient(httpServerTransport.boundAddress().publishAddress());
+        HttpClientResponse response = httpClient.request("/?callback=EnabledJSONPCallback");
+        assertThat(response.getHeader("Content-Type"), is("application/javascript"));
+        assertThat(response.response(), containsString("EnabledJSONPCallback("));
+        assertThat(response.response(), containsString("You Know, for Search"));
+    }
+}


### PR DESCRIPTION
This poses a significant security threat by being on by default. If an attacker can entice a user to load a legitimate ElasticSearch query as a script tag, they can effectively bypass SOP and exfiltrate the contents of a local ElasticSearch instance (or bypass firewall rules by using a victim's browser to talk to a remote instance). 

This would be trivial to implement from an attackers perspective, and I'll be submitting a pull request to the BeEF project (https://github.com/beefproject/beef) to automate this sort of attack, as it'll be useful during a pentesting engagement. 

If you have any questions or change requests please let me know, and I'll be more than happy to accommodate. 

Thanks!
Fitblip
