### PR TITLE
Update guide on vm.swappiness values

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -58,7 +58,7 @@ in the elasticsearch process being swapped out and suffer from low
 performance then.
 
 The first option is to ensure that the sysctl value `vm.swappiness` is set
-to `0`. This reduces the kernel's tendency to swap and should not lead to
+to `1`. This reduces the kernel's tendency to swap and should not lead to
 swapping under normal circumstances, while still allowing the whole system
 to swap in emergency conditions.
 


### PR DESCRIPTION
Recent versions of the Linux kernel (3.5-rc1, RHEL/CentOS > 2.6.32-303) have [changed the behaviour vm.swappiness](http://www.mysqlperformanceblog.com/2014/04/28/oom-relation-vm-swappiness0-new-kernel/). A swappiness value of `0` in these kernel's will prevent swapping out 
anonymous memory, other than unpinned file backed pages, making it much more likely the the OOM killer will be activated rather than the desired behaviour of the kernel using swap space. A value of `1` will still allow the use of swap space in emergencies.
