### PR TITLE
Unified MetaData#concreteIndices methods into a single method that accepts indices (or aliases) and indices options

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -140,7 +140,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
             }
             if (request.indices().length > 0) {
                 try {
-                    clusterState.metaData().concreteIndices(request.indices(), IndicesOptions.strictExpand());
+                    clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), request.indices());
                     waitForCounter++;
                 } catch (IndexMissingException e) {
                     response.status = ClusterHealthStatus.RED; // no indices, make sure its RED
@@ -221,7 +221,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
         }
         String[] concreteIndices;
         try {
-            concreteIndices = clusterState.metaData().concreteIndices(request.indices(), IndicesOptions.lenientExpandOpen());
+            concreteIndices = clusterState.metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), request.indices());
         } catch (IndexMissingException e) {
             // one of the specified indices is not there - treat it as RED.
             ClusterHealthResponse response = new ClusterHealthResponse(clusterName.value(), Strings.EMPTY_ARRAY, clusterState);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -71,7 +71,7 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadO
     @Override
     protected void masterOperation(final ClusterSearchShardsRequest request, final ClusterState state, final ActionListener<ClusterSearchShardsResponse> listener) throws ElasticsearchException {
         ClusterState clusterState = clusterService.state();
-        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
         Map<String, Set<String>> routingMap = clusterState.metaData().resolveSearchRouting(request.routing(), request.indices());
         Set<String> nodeIds = newHashSet();
         GroupShardsIterator groupShardsIterator = clusterService.operationRouting().searchShards(clusterState, request.indices(), concreteIndices, routingMap, request.preference());

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -103,7 +103,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadOperatio
             }
 
             if (request.indices().length > 0) {
-                String[] indices = currentState.metaData().concreteIndices(request.indices(), IndicesOptions.lenientExpandOpen());
+                String[] indices = currentState.metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), request.indices());
                 for (String filteredIndex : indices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(filteredIndex);
                     if (indexMetaData != null) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -99,7 +99,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
         Set<String> aliases = new HashSet<>();
         for (AliasActions action : actions) {
             //expand indices
-            String[] concreteIndices = state.metaData().concreteIndices(action.indices(), request.indicesOptions());
+            String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), action.indices());
             //collect the aliases
             for (String alias : action.aliases()) {
                 aliases.add(alias);

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
@@ -61,7 +61,7 @@ public class TransportAliasesExistAction extends TransportMasterNodeReadOperatio
 
     @Override
     protected void masterOperation(GetAliasesRequest request, ClusterState state, ActionListener<AliasesExistResponse> listener) throws ElasticsearchException {
-        String[] concreteIndices = state.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), request.indices());
         request.indices(concreteIndices);
 
         boolean result = state.metaData().hasAliases(request.aliases(), request.indices());

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -64,7 +64,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadOperationA
 
     @Override
     protected void masterOperation(GetAliasesRequest request, ClusterState state, ActionListener<GetAliasesResponse> listener) throws ElasticsearchException {
-        String[] concreteIndices = state.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), request.indices());
         request.indices(concreteIndices);
 
         @SuppressWarnings("unchecked") // ImmutableList to List results incompatible type

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -93,7 +93,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, AnalyzeRequest request) {
         if (request.index() != null) {
-            request.index(state.metaData().concreteIndex(request.index()));
+            request.index(state.metaData().concreteSingleIndex(request.index()));
             return state.blocks().indexBlockedException(ClusterBlockLevel.READ, request.index());
         }
         return null;

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -86,7 +86,7 @@ public class TransportCloseIndexAction extends TransportMasterNodeOperationActio
 
     @Override
     protected void masterOperation(final CloseIndexRequest request, final ClusterState state, final ActionListener<CloseIndexResponse> listener) throws ElasticsearchException {
-        request.indices(state.metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
         CloseIndexClusterStateUpdateRequest updateRequest = new CloseIndexClusterStateUpdateRequest()
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(request.indices());

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -85,7 +85,7 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
 
     @Override
     protected void masterOperation(final DeleteIndexRequest request, final ClusterState state, final ActionListener<DeleteIndexResponse> listener) throws ElasticsearchException {
-        request.indices(state.metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
         if (request.indices().length == 0) {
             listener.onResponse(new DeleteIndexResponse(true));
             return;

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -81,7 +81,7 @@ public class TransportIndicesExistsAction extends TransportMasterNodeReadOperati
         boolean exists;
         try {
             // Similar as the previous behaviour, but now also aliases and wildcards are supported.
-            clusterService.state().metaData().concreteIndices(request.indices(), request.indicesOptions());
+            clusterService.state().metaData().concreteIndices(request.indicesOptions(), request.indices());
             exists = true;
         } catch (IndexMissingException e) {
             exists = false;

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -71,7 +71,7 @@ public class TransportTypesExistsAction extends TransportMasterNodeReadOperation
 
     @Override
     protected void masterOperation(final TypesExistsRequest request, final ClusterState state, final ActionListener<TypesExistsResponse> listener) throws ElasticsearchException {
-        String[] concreteIndices = state.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), request.indices());
         if (concreteIndices.length == 0) {
             listener.onResponse(new TypesExistsResponse(false));
             return;

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
@@ -116,7 +116,7 @@ public class TransportDeleteMappingAction extends TransportMasterNodeOperationAc
 
     @Override
     protected void masterOperation(final DeleteMappingRequest request, final ClusterState state, final ActionListener<DeleteMappingResponse> listener) throws ElasticsearchException {
-        request.indices(state.metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
         flushAction.execute(Requests.flushRequest(request.indices()), new ActionListener<FlushResponse>() {
             @Override
             public void onResponse(FlushResponse flushResponse) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -55,7 +55,7 @@ public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMap
     @Override
     protected void doExecute(GetFieldMappingsRequest request, final ActionListener<GetFieldMappingsResponse> listener) {
         ClusterState clusterState = clusterService.state();
-        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
         final AtomicInteger indexCounter = new AtomicInteger();
         final AtomicInteger completionCounter = new AtomicInteger(concreteIndices.length);
         final AtomicReferenceArray<Object> indexResponses = new AtomicReferenceArray<>(concreteIndices.length);

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -71,7 +71,7 @@ public class TransportPutMappingAction extends TransportMasterNodeOperationActio
 
     @Override
     protected void doExecute(PutMappingRequest request, ActionListener<PutMappingResponse> listener) {
-        request.indices(clusterService.state().metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(clusterService.state().metaData().concreteIndices(request.indicesOptions(), request.indices()));
         super.doExecute(request, listener);
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -86,7 +86,7 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
 
     @Override
     protected void masterOperation(final OpenIndexRequest request, final ClusterState state, final ActionListener<OpenIndexResponse> listener) throws ElasticsearchException {
-        request.indices(state.metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
         OpenIndexClusterStateUpdateRequest updateRequest = new OpenIndexClusterStateUpdateRequest()
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(request.indices());

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -73,7 +73,7 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadOperation
 
     @Override
     protected void masterOperation(GetSettingsRequest request, ClusterState state, ActionListener<GetSettingsResponse> listener) throws ElasticsearchException {
-        request.indices(state.metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
         ImmutableOpenMap.Builder<String, Settings> indexToSettingsBuilder = ImmutableOpenMap.builder();
         for (String concreteIndex : request.indices()) {
             IndexMetaData indexMetaData = state.getMetaData().index(concreteIndex);

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -69,7 +69,7 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeOperationA
 
     @Override
     protected void doExecute(UpdateSettingsRequest request, ActionListener<UpdateSettingsResponse> listener) {
-        request.indices(clusterService.state().metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(clusterService.state().metaData().concreteIndices(request.indicesOptions(), request.indices()));
         super.doExecute(request, listener);
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -79,7 +79,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeOperationAct
     @Override
     protected void doExecute(DeleteWarmerRequest request, ActionListener<DeleteWarmerResponse> listener) {
         // update to concrete indices
-        request.indices(clusterService.state().metaData().concreteIndices(request.indices(), request.indicesOptions()));
+        request.indices(clusterService.state().metaData().concreteIndices(request.indicesOptions(), request.indices()));
         super.doExecute(request, listener);
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -83,7 +83,7 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
 
     @Override
     protected ClusterBlockException checkBlock(PutWarmerRequest request, ClusterState state) {
-        String[] concreteIndices = clusterService.state().metaData().concreteIndices(request.searchRequest().indices(), request.searchRequest().indicesOptions());
+        String[] concreteIndices = clusterService.state().metaData().concreteIndices(request.searchRequest().indicesOptions(), request.searchRequest().indices());
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA, concreteIndices);
     }
 
@@ -134,7 +134,7 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         MetaData metaData = currentState.metaData();
-                        String[] concreteIndices = metaData.concreteIndices(request.searchRequest().indices(), request.searchRequest().indicesOptions());
+                        String[] concreteIndices = metaData.concreteIndices(request.searchRequest().indicesOptions(), request.searchRequest().indices());
 
                         BytesReference source = null;
                         if (request.searchRequest().source() != null && request.searchRequest().source().length() > 0) {

--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -202,7 +202,7 @@ public class TransportBulkAction extends TransportAction<BulkRequest, BulkRespon
             if (request instanceof IndexRequest) {
                 IndexRequest indexRequest = (IndexRequest) request;
                 String aliasOrIndex = indexRequest.index();
-                indexRequest.index(clusterState.metaData().concreteIndex(indexRequest.index()));
+                indexRequest.index(clusterState.metaData().concreteSingleIndex(indexRequest.index()));
 
                 MappingMetaData mappingMd = null;
                 if (metaData.hasIndex(indexRequest.index())) {
@@ -220,11 +220,11 @@ public class TransportBulkAction extends TransportAction<BulkRequest, BulkRespon
             } else if (request instanceof DeleteRequest) {
                 DeleteRequest deleteRequest = (DeleteRequest) request;
                 deleteRequest.routing(clusterState.metaData().resolveIndexRouting(deleteRequest.routing(), deleteRequest.index()));
-                deleteRequest.index(clusterState.metaData().concreteIndex(deleteRequest.index()));
+                deleteRequest.index(clusterState.metaData().concreteSingleIndex(deleteRequest.index()));
             } else if (request instanceof UpdateRequest) {
                 UpdateRequest updateRequest = (UpdateRequest) request;
                 updateRequest.routing(clusterState.metaData().resolveIndexRouting(updateRequest.routing(), updateRequest.index()));
-                updateRequest.index(clusterState.metaData().concreteIndex(updateRequest.index()));
+                updateRequest.index(clusterState.metaData().concreteSingleIndex(updateRequest.index()));
             }
         }
 

--- a/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -103,7 +103,7 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     @Override
     protected boolean resolveRequest(final ClusterState state, final DeleteRequest request, final ActionListener<DeleteResponse> listener) {
         request.routing(state.metaData().resolveIndexRouting(request.routing(), request.index()));
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
         if (state.metaData().hasIndex(request.index())) {
             // check if routing is required, if so, do a broadcast delete
             MappingMetaData mappingMd = state.metaData().index(request.index()).mappingOrDefault(request.type());

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -98,9 +98,9 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
 
     @Override
     protected void resolveRequest(ClusterState state, ExplainRequest request) {
-        String concreteIndex = state.metaData().concreteIndex(request.index());
+        String concreteIndex = state.metaData().concreteSingleIndex(request.index());
         request.filteringAlias(state.metaData().filteringAliases(concreteIndex, request.index()));
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
 
         // Fail fast on the node that received the request.
         if (request.routing() == null && state.getMetaData().routingRequired(request.index(), request.type())) {

--- a/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -89,7 +89,7 @@ public class TransportGetAction extends TransportShardSingleOperationAction<GetR
         }
         // update the routing (request#index here is possibly an alias)
         request.routing(state.metaData().resolveIndexRouting(request.routing(), request.index()));
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
 
         // Fail fast on the node that received the request.
         if (request.routing() == null && state.getMetaData().routingRequired(request.index(), request.type())) {

--- a/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -74,7 +74,7 @@ public class TransportMultiGetAction extends TransportAction<MultiGetRequest, Mu
             }
 
             item.routing(clusterState.metaData().resolveIndexRouting(item.routing(), item.index()));
-            item.index(clusterState.metaData().concreteIndex(item.index()));
+            item.index(clusterState.metaData().concreteSingleIndex(item.index()));
             ShardId shardId = clusterService.operationRouting()
                     .getShards(clusterState, item.index(), item.type(), item.id(), item.routing(), null).shardId();
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);

--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -112,7 +112,7 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
     protected boolean resolveRequest(ClusterState state, IndexRequest request, ActionListener<IndexResponse> indexResponseActionListener) {
         MetaData metaData = clusterService.state().metaData();
         String aliasOrIndex = request.index();
-        request.index(metaData.concreteIndex(request.index()));
+        request.index(metaData.concreteSingleIndex(request.index()));
         MappingMetaData mappingMd = null;
         if (metaData.hasIndex(request.index())) {
             mappingMd = metaData.index(request.index()).mappingOrDefault(request.type());

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -92,7 +92,7 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
         // update to actual index name
         ClusterState clusterState = clusterService.state();
         // update to the concrete index
-        final String concreteIndex = clusterState.metaData().concreteIndex(request.index());
+        final String concreteIndex = clusterState.metaData().concreteSingleIndex(request.index());
 
         Iterable<MutableShardRouting> routingNode = clusterState.getRoutingNodes().routingNodeIter(clusterService.localNode().getId());
         if (routingNode == null) {

--- a/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -166,7 +166,7 @@ public class TransportMultiPercolateAction extends TransportAction<MultiPercolat
                     PercolateRequest percolateRequest = (PercolateRequest) element;
                     String[] concreteIndices;
                     try {
-                         concreteIndices = clusterState.metaData().concreteIndices(percolateRequest.indices(), percolateRequest.indicesOptions());
+                         concreteIndices = clusterState.metaData().concreteIndices(percolateRequest.indicesOptions(), percolateRequest.indices());
                     } catch (IndexMissingException e) {
                         reducedResponses.set(slot, e);
                         responsesByItemAndShard.set(slot, new AtomicReferenceArray(0));

--- a/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -80,7 +80,7 @@ public class TransportSearchAction extends TransportAction<SearchRequest, Search
         if (optimizeSingleShard && searchRequest.searchType() != SCAN && searchRequest.searchType() != COUNT) {
             try {
                 ClusterState clusterState = clusterService.state();
-                String[] concreteIndices = clusterState.metaData().concreteIndices(searchRequest.indices(), searchRequest.indicesOptions());
+                String[] concreteIndices = clusterState.metaData().concreteIndices(searchRequest.indicesOptions(), searchRequest.indices());
                 Map<String, Set<String>> routingMap = clusterState.metaData().resolveSearchRouting(searchRequest.routing(), searchRequest.indices());
                 int shardCount = clusterService.operationRouting().searchShardsCount(clusterState, searchRequest.indices(), concreteIndices, routingMap, searchRequest.preference());
                 if (shardCount == 1) {

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -110,7 +110,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
 
             clusterState.blocks().globalBlockedRaiseException(ClusterBlockLevel.READ);
 
-            String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices(), request.indicesOptions());
+            String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
 
             for (String index : concreteIndices) {
                 clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index);

--- a/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -35,6 +35,12 @@ public class IndicesOptions {
 
     private static final IndicesOptions[] VALUES;
 
+    private static final byte IGNORE_UNAVAILABLE = 1;
+    private static final byte ALLOW_NO_INDICES = 2;
+    private static final byte EXPAND_WILDCARDS_OPEN = 4;
+    private static final byte EXPAND_WILDCARDS_CLOSED = 8;
+    private static final byte DONT_ALLOW_ALIASES_TO_MULTIPLE_INDICES = 16;
+
     static {
         byte max = 1 << 5;
         VALUES = new IndicesOptions[max];
@@ -53,7 +59,7 @@ public class IndicesOptions {
      * @return Whether specified concrete indices should be ignored when unavailable (missing or closed)
      */
     public boolean ignoreUnavailable() {
-        return (id & 1) != 0;
+        return (id & IGNORE_UNAVAILABLE) != 0;
     }
 
     /**
@@ -61,21 +67,21 @@ public class IndicesOptions {
      *         The `_all` string or empty list of indices count as wildcard expressions too.
      */
     public boolean allowNoIndices() {
-        return (id & 2) != 0;
+        return (id & ALLOW_NO_INDICES) != 0;
     }
 
     /**
      * @return Whether wildcard expressions should get expanded to open indices
      */
     public boolean expandWildcardsOpen() {
-        return (id & 4) != 0;
+        return (id & EXPAND_WILDCARDS_OPEN) != 0;
     }
 
     /**
      * @return Whether wildcard expressions should get expanded to closed indices
      */
     public boolean expandWildcardsClosed() {
-        return (id & 8) != 0;
+        return (id & EXPAND_WILDCARDS_CLOSED) != 0;
     }
 
     /**
@@ -84,7 +90,7 @@ public class IndicesOptions {
     public boolean allowAliasesToMultipleIndices() {
         //true is default here, for bw comp we keep the first 16 values
         //in the array same as before + the default value for the new flag
-        return (id & 16) == 0;
+        return (id & DONT_ALLOW_ALIASES_TO_MULTIPLE_INDICES) == 0;
     }
 
     public void writeIndicesOptions(StreamOutput out) throws IOException {
@@ -93,7 +99,7 @@ public class IndicesOptions {
         if (allowAliasesToMultipleIndices() || out.getVersion().onOrAfter(Version.V_1_2_0)) {
             out.write(id);
         } else {
-            out.write(id ^ 16);
+            out.write(id ^ DONT_ALLOW_ALIASES_TO_MULTIPLE_INDICES);
         }
     }
 
@@ -179,7 +185,7 @@ public class IndicesOptions {
      * throws error if any of the aliases resolves to multiple indices
      */
     public static IndicesOptions strictSingleIndexNoExpand() {
-        return VALUES[16];
+        return VALUES[DONT_ALLOW_ALIASES_TO_MULTIPLE_INDICES];
     }
 
     /**
@@ -203,21 +209,21 @@ public class IndicesOptions {
     private static byte toByte(boolean ignoreUnavailable, boolean allowNoIndices, boolean wildcardExpandToOpen, boolean wildcardExpandToClosed, boolean allowAliasesToMultipleIndices) {
         byte id = 0;
         if (ignoreUnavailable) {
-            id |= 1;
+            id |= IGNORE_UNAVAILABLE;
         }
         if (allowNoIndices) {
-            id |= 2;
+            id |= ALLOW_NO_INDICES;
         }
         if (wildcardExpandToOpen) {
-            id |= 4;
+            id |= EXPAND_WILDCARDS_OPEN;
         }
         if (wildcardExpandToClosed) {
-            id |= 8;
+            id |= EXPAND_WILDCARDS_CLOSED;
         }
         //true is default here, for bw comp we keep the first 16 values
         //in the array same as before + the default value for the new flag
         if (!allowAliasesToMultipleIndices) {
-            id |= 16;
+            id |= DONT_ALLOW_ALIASES_TO_MULTIPLE_INDICES;
         }
         return id;
     }

--- a/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
@@ -117,7 +117,7 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
                 throw blockException;
             }
             // update to concrete indices
-            String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices(), request.indicesOptions());
+            String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
             blockException = checkRequestBlock(clusterState, request, concreteIndices);
             if (blockException != null) {
                 throw blockException;

--- a/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -44,7 +44,7 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
 
     @Override
     protected final void masterOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) throws ElasticsearchException {
-        String[] concreteIndices = state.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), request.indices());
         request.indices(concreteIndices);
         doMasterOperation(request, state, listener);
     }

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndexReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndexReplicationOperationAction.java
@@ -70,7 +70,7 @@ public abstract class TransportIndexReplicationOperationAction<Request extends I
             throw blockException;
         }
         // update to concrete index
-        request.index(clusterState.metaData().concreteIndex(request.index()));
+        request.index(clusterState.metaData().concreteSingleIndex(request.index()));
         blockException = checkRequestBlock(clusterState, request);
         if (blockException != null) {
             throw blockException;

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
@@ -74,7 +74,7 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
             throw blockException;
         }
         // get actual indices
-        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indices(), request.indicesOptions());
+        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
         blockException = checkRequestBlock(clusterState, request, concreteIndices);
         if (blockException != null) {
             throw blockException;

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -138,7 +138,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
      * means a different execution, then return false here to indicate not to continue and execute this request.
      */
     protected boolean resolveRequest(ClusterState state, Request request, ActionListener<Response> listener) {
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
         return true;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -89,7 +89,7 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
      * means a different execution, then return false here to indicate not to continue and execute this request.
      */
     protected boolean resolveRequest(ClusterState state, Request request, ActionListener<Response> listener) {
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
         return true;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -89,7 +89,7 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
     protected abstract ClusterBlockException checkRequestBlock(ClusterState state, Request request);
 
     protected void resolveRequest(ClusterState state, Request request) {
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
     }
 
     protected abstract ShardIterator shards(ClusterState state, Request request) throws ElasticsearchException;

--- a/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
@@ -76,7 +76,7 @@ public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVe
                         termVectorRequest.type(), termVectorRequest.id(), "routing is required, but hasn't been specified")));
                 continue;
             }
-            termVectorRequest.index(clusterState.metaData().concreteIndex(termVectorRequest.index()));
+            termVectorRequest.index(clusterState.metaData().concreteSingleIndex(termVectorRequest.index()));
             ShardId shardId = clusterService
                     .operationRouting()
                     .getShards(clusterState, termVectorRequest.index(), termVectorRequest.type(), termVectorRequest.id(),

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
@@ -80,7 +80,7 @@ public class TransportSingleShardTermVectorAction extends TransportShardSingleOp
     protected void resolveRequest(ClusterState state, TermVectorRequest request) {
         // update the routing (request#index here is possibly an alias)
         request.routing(state.metaData().resolveIndexRouting(request.routing(), request.index()));
-        request.index(state.metaData().concreteIndex(request.index()));
+        request.index(state.metaData().concreteSingleIndex(request.index()));
 
         // Fail fast on the node that received the request.
         if (request.routing() == null && state.getMetaData().routingRequired(request.index(), request.type())) {

--- a/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -121,7 +121,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
         MetaData metaData = clusterService.state().metaData();
         String aliasOrIndex = request.index();
         request.routing((metaData.resolveIndexRouting(request.routing(), aliasOrIndex)));
-        request.index(metaData.concreteIndex(request.index()));
+        request.index(metaData.concreteSingleIndex(request.index()));
 
         // Fail fast on the node that received the request, rather than failing when translating on the index or delete request.
         if (request.routing() == null && state.getMetaData().routingRequired(request.index(), request.type())) {

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -624,15 +624,6 @@ public class MetaData implements Iterable<IndexMetaData> {
     }
 
     /**
-     * Translates the provided indices (possibly aliased) into actual indices.
-     * @deprecated use {@link #concreteIndices(org.elasticsearch.action.support.IndicesOptions, String...)} instead
-     */
-    @Deprecated
-    public String[] concreteIndices(String[] aliasesOrIndices, IndicesOptions indicesOptions) throws IndexMissingException {
-        return concreteIndices(indicesOptions, aliasesOrIndices);
-    }
-
-    /**
      * Translates the provided indices or aliases, eventually containing wildcard expressions, into actual indices.
      * @param indicesOptions how the aliases or indices need to be resolved to concrete indices
      * @param aliasesOrIndices the aliases or indices to be resolved to concrete indices

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -686,14 +686,7 @@ public class MetaData implements Iterable<IndexMetaData> {
         return actualIndices.toArray(new String[actualIndices.size()]);
     }
 
-    /**
-     * @return the concrete index that the index or alias provided as an argument points to.
-     * @throws IndexMissingException if the index or alias doesn't exist
-     * @throws ElasticsearchIllegalArgumentException if the provided alias points to multiple indices
-     * @deprecated in favor of {@link #concreteIndices(org.elasticsearch.action.support.IndicesOptions, String...)}
-     */
-    @Deprecated
-    public String concreteIndex(String indexOrAlias) throws IndexMissingException, ElasticsearchIllegalArgumentException {
+    public String concreteSingleIndex(String indexOrAlias) throws IndexMissingException, ElasticsearchIllegalArgumentException {
         String[] indices = concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), indexOrAlias);
         assert indices.length == 1;
         return indices[0];

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -625,40 +625,49 @@ public class MetaData implements Iterable<IndexMetaData> {
 
     /**
      * Translates the provided indices (possibly aliased) into actual indices.
+     * @deprecated use {@link #concreteIndices(org.elasticsearch.action.support.IndicesOptions, String...)} instead
      */
+    @Deprecated
     public String[] concreteIndices(String[] aliasesOrIndices, IndicesOptions indicesOptions) throws IndexMissingException {
-        if (isAllIndices(aliasesOrIndices)) {
-            String[] concreteIndices;
-            if (indicesOptions.expandWildcardsOpen() && indicesOptions.expandWildcardsClosed()) {
-                concreteIndices = concreteAllIndices();
-            } else if (indicesOptions.expandWildcardsOpen()) {
-                concreteIndices = concreteAllOpenIndices();
-            } else if (indicesOptions.expandWildcardsClosed()) {
-                concreteIndices = concreteAllClosedIndices();
-            } else {
-                assert false : "Shouldn't end up here";
-                concreteIndices = Strings.EMPTY_ARRAY;
+        return concreteIndices(indicesOptions, aliasesOrIndices);
+    }
+
+    /**
+     * Translates the provided indices or aliases, eventually containing wildcard expressions, into actual indices.
+     * @param indicesOptions how the aliases or indices need to be resolved to concrete indices
+     * @param aliasesOrIndices the aliases or indices to be resolved to concrete indices
+     * @return the obtained concrete indices
+     * @throws IndexMissingException if one of the aliases or indices is missing and the provided indices options
+     * don't allow such a case, or if the final result of the indices resolution is no indices and the indices options
+     * don't allow such a case.
+     * @throws ElasticsearchIllegalArgumentException if one of the aliases resolve to multiple indices and the provided
+     * indices options don't allow such a case.
+     */
+    public String[] concreteIndices(IndicesOptions indicesOptions, String... aliasesOrIndices) throws IndexMissingException, ElasticsearchIllegalArgumentException {
+
+        if (indicesOptions.expandWildcardsOpen() || indicesOptions.expandWildcardsClosed()) {
+            if (isAllIndices(aliasesOrIndices)) {
+                String[] concreteIndices;
+                if (indicesOptions.expandWildcardsOpen() && indicesOptions.expandWildcardsClosed()) {
+                    concreteIndices = concreteAllIndices();
+                } else if (indicesOptions.expandWildcardsOpen()) {
+                    concreteIndices = concreteAllOpenIndices();
+                } else {
+                    concreteIndices = concreteAllClosedIndices();
+                }
+
+                if (!indicesOptions.allowNoIndices() && concreteIndices.length == 0) {
+                    throw new IndexMissingException(new Index("_all"));
+                }
+                return concreteIndices;
             }
 
-            if (!indicesOptions.allowNoIndices() && concreteIndices.length == 0) {
-                throw new IndexMissingException(new Index("_all"));
-            }
-            return concreteIndices;
+            aliasesOrIndices = convertFromWildcards(aliasesOrIndices, indicesOptions);
         }
-        aliasesOrIndices = convertFromWildcards(aliasesOrIndices, indicesOptions);
+
         // optimize for single element index (common case)
         if (aliasesOrIndices.length == 1) {
-            String aliasOrIndex = aliasesOrIndices[0];
-            // if a direct index name, just return the array provided
-            if (this.indices.containsKey(aliasOrIndex)) {
-                return aliasesOrIndices;
-            }
-            String[] actualLst = aliasAndIndexToIndexMap.getOrDefault(aliasOrIndex, Strings.EMPTY_ARRAY);
-            if (actualLst.length == 0 && !indicesOptions.allowNoIndices()) {
-                throw new IndexMissingException(new Index(aliasOrIndex));
-            } else {
-                return actualLst;
-            }
+            return concreteIndices(aliasesOrIndices[0], indicesOptions.allowNoIndices(), indicesOptions.allowAliasesToMultipleIndices());
         }
 
         // check if its a possible aliased index, if not, just return the
@@ -675,17 +684,9 @@ public class MetaData implements Iterable<IndexMetaData> {
         }
 
         Set<String> actualIndices = new HashSet<>();
-        for (String index : aliasesOrIndices) {
-            String[] actualLst = aliasAndIndexToIndexMap.get(index);
-            if (actualLst == null) {
-                if (!indicesOptions.ignoreUnavailable()) {
-                    throw new IndexMissingException(new Index(index));
-                }
-            } else {
-                for (String x : actualLst) {
-                    actualIndices.add(x);
-                }
-            }
+        for (String aliasOrIndex : aliasesOrIndices) {
+            String[] indices = concreteIndices(aliasOrIndex, indicesOptions.ignoreUnavailable(), indicesOptions.allowAliasesToMultipleIndices());
+            Collections.addAll(actualIndices, indices);
         }
 
         if (!indicesOptions.allowNoIndices() && actualIndices.isEmpty()) {
@@ -694,20 +695,33 @@ public class MetaData implements Iterable<IndexMetaData> {
         return actualIndices.toArray(new String[actualIndices.size()]);
     }
 
-    public String concreteIndex(String index) throws IndexMissingException, ElasticsearchIllegalArgumentException {
+    /**
+     * @return the concrete index that the index or alias provided as an argument points to.
+     * @throws IndexMissingException if the index or alias doesn't exist
+     * @throws ElasticsearchIllegalArgumentException if the provided alias points to multiple indices
+     * @deprecated in favor of {@link #concreteIndices(org.elasticsearch.action.support.IndicesOptions, String...)}
+     */
+    @Deprecated
+    public String concreteIndex(String indexOrAlias) throws IndexMissingException, ElasticsearchIllegalArgumentException {
+        String[] indices = concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), indexOrAlias);
+        assert indices.length == 1;
+        return indices[0];
+    }
+
+    private String[] concreteIndices(String aliasOrIndex, boolean allowNoIndices, boolean allowMultipleIndices) throws IndexMissingException, ElasticsearchIllegalArgumentException {
         // a quick check, if this is an actual index, if so, return it
-        if (indices.containsKey(index)) {
-            return index;
+        if (indices.containsKey(aliasOrIndex)) {
+            return new String[]{aliasOrIndex};
         }
         // not an actual index, fetch from an alias
-        String[] lst = aliasAndIndexToIndexMap.get(index);
-        if (lst == null) {
-            throw new IndexMissingException(new Index(index));
+        String[] indices = aliasAndIndexToIndexMap.getOrDefault(aliasOrIndex, Strings.EMPTY_ARRAY);
+        if (indices.length == 0 && !allowNoIndices) {
+            throw new IndexMissingException(new Index(aliasOrIndex));
         }
-        if (lst.length > 1) {
-            throw new ElasticsearchIllegalArgumentException("Alias [" + index + "] has more than one indices associated with it [" + Arrays.toString(lst) + "], can't execute a single index op");
+        if (indices.length > 1 && !allowMultipleIndices) {
+            throw new ElasticsearchIllegalArgumentException("Alias [" + aliasOrIndex + "] has more than one indices associated with it [" + Arrays.toString(indices) + "], can't execute a single index op");
         }
-        return lst[0];
+        return indices;
     }
 
     /**
@@ -781,7 +795,7 @@ public class MetaData implements Iterable<IndexMetaData> {
             } else if (indicesOptions.expandWildcardsClosed()) {
                 indices = concreteAllClosedIndices();
             } else {
-                assert false : "Shouldn't end up here";
+                assert false : "convertFromWildcards shouldn't get called if wildcards expansion is disabled";
                 indices = Strings.EMPTY_ARRAY;
             }
             boolean found = false;

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -229,7 +229,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
             @Override
             public ClusterState execute(ClusterState currentState) {
-                String[] actualIndices = currentState.metaData().concreteIndices(request.indices(), IndicesOptions.strictExpand());
+                String[] actualIndices = currentState.metaData().concreteIndices(IndicesOptions.strictExpand(), request.indices());
                 RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
                 MetaData.Builder metaDataBuilder = MetaData.builder(currentState.metaData());
 

--- a/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesFilterParser.java
@@ -146,7 +146,7 @@ public class IndicesFilterParser implements FilterParser {
     }
 
     protected boolean matchesIndices(String currentIndex, String... indices) {
-        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(indices, IndicesOptions.lenientExpandOpen());
+        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, currentIndex)) {
                 return true;

--- a/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -147,7 +147,7 @@ public class IndicesQueryParser implements QueryParser {
     }
 
     protected boolean matchesIndices(String currentIndex, String... indices) {
-        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(indices, IndicesOptions.lenientExpandOpen());
+        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, currentIndex)) {
                 return true;

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -72,7 +72,7 @@ public class RestIndicesAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(indices, IndicesOptions.lenientExpandOpen());
+                final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
                 ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest(concreteIndices);
                 clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
                 client.admin().cluster().health(clusterHealthRequest, new RestActionListener<ClusterHealthResponse>(channel) {

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -164,7 +164,7 @@ public class SnapshotsService extends AbstractComponent implements ClusterStateL
                 SnapshotMetaData snapshots = metaData.custom(SnapshotMetaData.TYPE);
                 if (snapshots == null || snapshots.entries().isEmpty()) {
                     // Store newSnapshot here to be processed in clusterStateProcessed
-                    ImmutableList<String> indices = ImmutableList.copyOf(metaData.concreteIndices(request.indices(), request.indicesOptions()));
+                    ImmutableList<String> indices = ImmutableList.copyOf(metaData.concreteIndices(request.indicesOptions(), request.indices()));
                     logger.trace("[{}][{}] creating snapshot for indices [{}]", request.repository(), request.name(), indices);
                     newSnapshot = new SnapshotMetaData.Entry(snapshotId, request.includeGlobalState(), State.INIT, indices, null);
                     snapshots = new SnapshotMetaData(newSnapshot);

--- a/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class IndicesOptionsTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testSerialization() throws Exception {
+        int iterations = randomIntBetween(5, 20);
+        for (int i = 0; i < iterations; i++) {
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+
+            BytesStreamOutput output = new BytesStreamOutput();
+            Version outputVersion = randomVersion();
+            output.setVersion(outputVersion);
+            indicesOptions.writeIndicesOptions(output);
+
+            BytesStreamInput bytesStreamInput = new BytesStreamInput(output.bytes());
+            bytesStreamInput.setVersion(randomVersion());
+            IndicesOptions indicesOptions2 = IndicesOptions.readIndicesOptions(bytesStreamInput);
+
+            assertThat(indicesOptions2.ignoreUnavailable(), equalTo(indicesOptions.ignoreUnavailable()));
+            assertThat(indicesOptions2.allowNoIndices(), equalTo(indicesOptions.allowNoIndices()));
+            assertThat(indicesOptions2.expandWildcardsOpen(), equalTo(indicesOptions.expandWildcardsOpen()));
+            assertThat(indicesOptions2.expandWildcardsClosed(), equalTo(indicesOptions.expandWildcardsClosed()));
+
+            if (outputVersion.onOrAfter(Version.V_1_2_0)) {
+                assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
+            } else {
+                //default value (true) if the node version doesn't support the allowAliasesToMultipleIndices flag
+                assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(true));
+            }
+        }
+    }
+
+    @Test
+    public void testFromOptions() {
+        int iterations = randomIntBetween(5, 20);
+        for (int i = 0; i < iterations; i++) {
+            boolean ignoreUnavailable = randomBoolean();
+            boolean allowNoIndices = randomBoolean();
+            boolean expandToOpenIndices = randomBoolean();
+            boolean expandToClosedIndices = randomBoolean();
+            boolean allowAliasesToMultipleIndices = randomBoolean();
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices);
+
+            assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
+            assertThat(indicesOptions.allowNoIndices(), equalTo(allowNoIndices));
+            assertThat(indicesOptions.expandWildcardsOpen(), equalTo(expandToOpenIndices));
+            assertThat(indicesOptions.expandWildcardsClosed(), equalTo(expandToClosedIndices));
+            assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -189,7 +189,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
             routingTable.add(indexRoutingTable);
         }
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null, IndicesOptions.strictExpand()), clusterState);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[])null), clusterState);
         logger.info("cluster status: {}, expected {}", clusterHealth.getStatus(), counter.status());
 
         assertClusterHealth(clusterHealth, counter);
@@ -210,7 +210,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         metaData.put(indexMetaData, true);
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(null, IndicesOptions.strictExpand()), clusterState);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[])null), clusterState);
         // currently we have no cluster level validation failures as index validation issues are reported per index.
         assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));
     }

--- a/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import com.google.common.collect.Sets;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -28,9 +29,7 @@ import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
-import static org.hamcrest.Matchers.emptyArray;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 /**
  */
@@ -39,8 +38,8 @@ public class MetaDataTests extends ElasticsearchTestCase {
     @Test
     public void testIndexOptions_strict() {
         MetaData.Builder mdBuilder = MetaData.builder()
-                .put(indexBuilder("foo"))
-                .put(indexBuilder("foobar"))
+                .put(indexBuilder("foo").putAlias(AliasMetaData.builder("foofoobar")))
+                .put(indexBuilder("foobar").putAlias(AliasMetaData.builder("foofoobar")))
                 .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         MetaData md = mdBuilder.build();
@@ -48,61 +47,79 @@ public class MetaDataTests extends ElasticsearchTestCase {
         IndicesOptions[] indicesOptions = new IndicesOptions[]{ IndicesOptions.strictExpandOpen(), IndicesOptions.strictExpand()};
 
         for (IndicesOptions options : indicesOptions) {
-            String[] results = md.concreteIndices(new String[]{"foo"}, options);
+            String[] results = md.concreteIndices(options, "foo");
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
 
             try {
-                md.concreteIndices(new String[]{"bar"}, options);
+                md.concreteIndices(options, "bar");
                 fail();
-            } catch (IndexMissingException e) {}
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("bar"));
+            }
 
-            results = md.concreteIndices(new String[]{"foofoo", "foobar"}, options);
+            results = md.concreteIndices(options, "foofoo", "foobar");
+            assertEquals(2, results.length);
+            assertThat(results, arrayContainingInAnyOrder("foofoo", "foobar"));
+
+            results = md.concreteIndices(options, "foofoobar");
+            assertEquals(2, results.length);
+            assertEquals("foo", results[0]);
+            assertEquals("foobar", results[1]);
+
+            try {
+                md.concreteIndices(options, "bar");
+                fail();
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("bar"));
+            }
+
+            try {
+                md.concreteIndices(options, "foo", "bar");
+                fail();
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("bar"));
+            }
+
+            results = md.concreteIndices(options, "barbaz", "foobar");
             assertEquals(2, results.length);
             assertThat(results, arrayContainingInAnyOrder("foofoo", "foobar"));
 
             try {
-                md.concreteIndices(new String[]{"foo", "bar"}, options);
+                md.concreteIndices(options, "barbaz", "bar");
                 fail();
-            } catch (IndexMissingException e) {}
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("bar"));
+            }
 
-            results = md.concreteIndices(new String[]{"barbaz", "foobar"}, options);
-            assertEquals(2, results.length);
-            assertThat(results, arrayContainingInAnyOrder("foofoo", "foobar"));
-
-            try {
-                md.concreteIndices(new String[]{"barbaz", "bar"}, options);
-                fail();
-            } catch (IndexMissingException e) {}
-
-            results = md.concreteIndices(new String[]{"baz*"}, options);
+            results = md.concreteIndices(options, "baz*");
             assertThat(results, emptyArray());
 
-            results = md.concreteIndices(new String[]{"foo", "baz*"}, options);
+            results = md.concreteIndices(options, "foo", "baz*");
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
         }
 
-        String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, IndicesOptions.strictExpandOpen());
+        String[] results = md.concreteIndices(IndicesOptions.strictExpandOpen(), Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
 
-        results = md.concreteIndices(Strings.EMPTY_ARRAY, IndicesOptions.strictExpand());
+        results = md.concreteIndices(IndicesOptions.strictExpand(), Strings.EMPTY_ARRAY);
         assertEquals(4, results.length);
 
-        results = md.concreteIndices(new String[]{"foofoo*"}, IndicesOptions.strictExpandOpen());
-        assertEquals(1, results.length);
-        assertEquals("foofoo", results[0]);
+        results = md.concreteIndices(IndicesOptions.strictExpandOpen(), "foofoo*");
+        assertEquals(3, results.length);
+        assertThat(results, arrayContainingInAnyOrder("foo", "foobar", "foofoo"));
 
-        results = md.concreteIndices(new String[]{"foofoo*"}, IndicesOptions.strictExpand());
-        assertEquals(2, results.length);
-        assertThat(results, arrayContainingInAnyOrder("foofoo", "foofoo-closed"));
+        results = md.concreteIndices(IndicesOptions.strictExpand(), "foofoo*");
+        assertEquals(4, results.length);
+        assertThat(results, arrayContainingInAnyOrder("foo", "foobar", "foofoo", "foofoo-closed"));
     }
 
     @Test
     public void testIndexOptions_lenient() {
         MetaData.Builder mdBuilder = MetaData.builder()
-                .put(indexBuilder("foo"))
-                .put(indexBuilder("foobar"))
+                .put(indexBuilder("foo").putAlias(AliasMetaData.builder("foofoobar")))
+                .put(indexBuilder("foobar").putAlias(AliasMetaData.builder("foofoobar")))
                 .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         MetaData md = mdBuilder.build();
@@ -111,50 +128,55 @@ public class MetaDataTests extends ElasticsearchTestCase {
         IndicesOptions[] indicesOptions = new IndicesOptions[]{ IndicesOptions.lenientExpandOpen(), lenientExpand};
 
         for (IndicesOptions options : indicesOptions) {
-            String[] results = md.concreteIndices(new String[]{"foo"}, options);
+            String[] results = md.concreteIndices(options, "foo");
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
 
-            results = md.concreteIndices(new String[]{"bar"}, options);
+            results = md.concreteIndices(options, "bar");
             assertThat(results, emptyArray());
 
-            results = md.concreteIndices(new String[]{"foofoo", "foobar"}, options);
+            results = md.concreteIndices(options, "foofoo", "foobar");
             assertEquals(2, results.length);
             assertThat(results, arrayContainingInAnyOrder("foofoo", "foobar"));
 
-            results = md.concreteIndices(new String[]{"foo", "bar"}, options);
+            results = md.concreteIndices(options, "foofoobar");
+            assertEquals(2, results.length);
+            assertEquals("foo", results[0]);
+            assertEquals("foobar", results[1]);
+
+            results = md.concreteIndices(options, "foo", "bar");
             assertEquals(1, results.length);
             assertThat(results, arrayContainingInAnyOrder("foo"));
 
-            results = md.concreteIndices(new String[]{"barbaz", "foobar"}, options);
+            results = md.concreteIndices(options, "barbaz", "foobar");
             assertEquals(2, results.length);
             assertThat(results, arrayContainingInAnyOrder("foofoo", "foobar"));
 
-            results = md.concreteIndices(new String[]{"barbaz", "bar"}, options);
+            results = md.concreteIndices(options, "barbaz", "bar");
             assertEquals(1, results.length);
             assertThat(results, arrayContainingInAnyOrder("foofoo"));
 
-            results = md.concreteIndices(new String[]{"baz*"}, options);
+            results = md.concreteIndices(options, "baz*");
             assertThat(results, emptyArray());
 
-            results = md.concreteIndices(new String[]{"foo", "baz*"}, options);
+            results = md.concreteIndices(options, "foo", "baz*");
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
         }
 
-        String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, IndicesOptions.lenientExpandOpen());
+        String[] results = md.concreteIndices(IndicesOptions.lenientExpandOpen(), Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
 
-        results = md.concreteIndices(Strings.EMPTY_ARRAY, lenientExpand);
+        results = md.concreteIndices(lenientExpand, Strings.EMPTY_ARRAY);
         assertEquals(4, results.length);
 
-        results = md.concreteIndices(new String[]{"foofoo*"}, IndicesOptions.lenientExpandOpen());
-        assertEquals(1, results.length);
-        assertEquals("foofoo", results[0]);
+        results = md.concreteIndices(IndicesOptions.lenientExpandOpen(), "foofoo*");
+        assertEquals(3, results.length);
+        assertThat(results, arrayContainingInAnyOrder("foo", "foobar", "foofoo"));
 
-        results = md.concreteIndices(new String[]{"foofoo*"}, lenientExpand);
-        assertEquals(2, results.length);
-        assertThat(results, arrayContainingInAnyOrder("foofoo", "foofoo-closed"));
+        results = md.concreteIndices(lenientExpand, "foofoo*");
+        assertEquals(4, results.length);
+        assertThat(results, arrayContainingInAnyOrder("foo", "foobar", "foofoo", "foofoo-closed"));
     }
 
     @Test
@@ -171,36 +193,36 @@ public class MetaDataTests extends ElasticsearchTestCase {
         IndicesOptions[] indicesOptions = new IndicesOptions[]{expandOpen, expand};
 
         for (IndicesOptions options : indicesOptions) {
-            String[] results = md.concreteIndices(new String[]{"foo"}, options);
+            String[] results = md.concreteIndices(options, "foo");
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
 
             try {
-                md.concreteIndices(new String[]{"bar"}, options);
+                md.concreteIndices(options, "bar");
                 fail();
             } catch(IndexMissingException e) {
                 assertThat(e.index().name(), equalTo("bar"));
             }
 
             try {
-                md.concreteIndices(new String[]{"baz*"}, options);
+                md.concreteIndices(options, "baz*");
                 fail();
             } catch (IndexMissingException e) {
                 assertThat(e.index().name(), equalTo("baz*"));
             }
 
             try {
-                md.concreteIndices(new String[]{"foo", "baz*"}, options);
+                md.concreteIndices(options, "foo", "baz*");
                 fail();
             } catch (IndexMissingException e) {
                 assertThat(e.index().name(), equalTo("baz*"));
             }
         }
 
-        String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, expandOpen);
+        String[] results = md.concreteIndices(expandOpen, Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
 
-        results = md.concreteIndices(Strings.EMPTY_ARRAY, expand);
+        results = md.concreteIndices(expand, Strings.EMPTY_ARRAY);
         assertEquals(4, results.length);
     }
 
@@ -214,59 +236,193 @@ public class MetaDataTests extends ElasticsearchTestCase {
 
         // Only closed
         IndicesOptions options = IndicesOptions.fromOptions(false, true, false, true);
-        String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
+        String[] results = md.concreteIndices(options, Strings.EMPTY_ARRAY);
         assertEquals(1, results.length);
         assertEquals("foo", results[0]);
 
-        results = md.concreteIndices(new String[]{"foo*"}, options);
+        results = md.concreteIndices(options, "foo*");
         assertEquals(1, results.length);
         assertEquals("foo", results[0]);
 
         // no wildcards, so wildcard expansion don't apply
-        results = md.concreteIndices(new String[]{"bar"}, options);
+        results = md.concreteIndices(options, "bar");
         assertEquals(1, results.length);
         assertEquals("bar", results[0]);
 
         // Only open
         options = IndicesOptions.fromOptions(false, true, true, false);
-        results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
+        results = md.concreteIndices(options, Strings.EMPTY_ARRAY);
         assertEquals(2, results.length);
         assertThat(results, arrayContainingInAnyOrder("bar", "foobar"));
 
-        results = md.concreteIndices(new String[]{"foo*"}, options);
+        results = md.concreteIndices(options, "foo*");
         assertEquals(1, results.length);
         assertEquals("foobar", results[0]);
 
-        results = md.concreteIndices(new String[]{"bar"}, options);
+        results = md.concreteIndices(options, "bar");
         assertEquals(1, results.length);
         assertEquals("bar", results[0]);
 
         // Open and closed
         options = IndicesOptions.fromOptions(false, true, true, true);
-        results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
+        results = md.concreteIndices(options, Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
         assertThat(results, arrayContainingInAnyOrder("bar", "foobar", "foo"));
 
-        results = md.concreteIndices(new String[]{"foo*"}, options);
+        results = md.concreteIndices(options, "foo*");
         assertEquals(2, results.length);
         assertThat(results, arrayContainingInAnyOrder("foobar", "foo"));
 
-        results = md.concreteIndices(new String[]{"bar"}, options);
+        results = md.concreteIndices(options, "bar");
         assertEquals(1, results.length);
         assertEquals("bar", results[0]);
 
-        results = md.concreteIndices(new String[]{"-foo*"}, options);
+        results = md.concreteIndices(options, "-foo*");
         assertEquals(1, results.length);
         assertEquals("bar", results[0]);
 
-        results = md.concreteIndices(new String[]{"-*"}, options);
+        results = md.concreteIndices(options, "-*");
         assertEquals(0, results.length);
 
         options = IndicesOptions.fromOptions(false, false, true, true);
         try {
-            md.concreteIndices(new String[]{"-*"}, options);
+            md.concreteIndices(options, "-*");
             fail();
-        } catch (IndexMissingException e) {}
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("[-*]"));
+        }
+    }
+
+    @Test
+    public void testIndexOptions_noExpandWildcards() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("foo").putAlias(AliasMetaData.builder("foofoobar")))
+                .put(indexBuilder("foobar").putAlias(AliasMetaData.builder("foofoobar")))
+                .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
+                .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
+        MetaData md = mdBuilder.build();
+
+        //ignore unavailable and allow no indices
+        {
+            IndicesOptions noExpandLenient = IndicesOptions.fromOptions(true, true, false, false);
+
+            String[] results = md.concreteIndices(noExpandLenient, "baz*");
+            assertThat(results, emptyArray());
+
+            results = md.concreteIndices(noExpandLenient, "foo", "baz*");
+            assertEquals(1, results.length);
+            assertEquals("foo", results[0]);
+
+            results = md.concreteIndices(noExpandLenient, "foofoobar");
+            assertEquals(2, results.length);
+            assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+        }
+
+        //ignore unavailable but don't allow no indices
+        {
+            IndicesOptions noExpandDisallowEmpty = IndicesOptions.fromOptions(true, false, false, false);
+
+            try {
+                md.concreteIndices(noExpandDisallowEmpty, "baz*");
+                fail();
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("baz*"));
+            }
+
+            String[] results = md.concreteIndices(noExpandDisallowEmpty, "foo", "baz*");
+            assertEquals(1, results.length);
+            assertEquals("foo", results[0]);
+
+            results = md.concreteIndices(noExpandDisallowEmpty, "foofoobar");
+            assertEquals(2, results.length);
+            assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+        }
+
+        //error on unavailable but allow no indices
+        {
+            IndicesOptions noExpandErrorUnavailable = IndicesOptions.fromOptions(false, true, false, false);
+
+            String[] results = md.concreteIndices(noExpandErrorUnavailable, "baz*");
+            assertThat(results, emptyArray());
+
+            try {
+                md.concreteIndices(noExpandErrorUnavailable, "foo", "baz*");
+                fail();
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("baz*"));
+            }
+
+            results = md.concreteIndices(noExpandErrorUnavailable, "foofoobar");
+            assertEquals(2, results.length);
+            assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+        }
+
+        //error on both unavailable and no indices
+        {
+            IndicesOptions noExpandStrict = IndicesOptions.fromOptions(false, false, false, false);
+
+            try {
+                md.concreteIndices(noExpandStrict, "baz*");
+                fail();
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("baz*"));
+            }
+
+            try {
+                md.concreteIndices(noExpandStrict, "foo", "baz*");
+                fail();
+            } catch (IndexMissingException e) {
+                assertThat(e.index().name(), equalTo("baz*"));
+            }
+
+            String[] results = md.concreteIndices(noExpandStrict, "foofoobar");
+            assertEquals(2, results.length);
+            assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+        }
+    }
+
+    @Test
+    public void testIndexOptions_singleIndexNoExpandWildcards() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("foo").putAlias(AliasMetaData.builder("foofoobar")))
+                .put(indexBuilder("foobar").putAlias(AliasMetaData.builder("foofoobar")))
+                .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
+                .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
+        MetaData md = mdBuilder.build();
+
+        //error on both unavailable and no indices + every alias needs to expand to a single index
+
+        try {
+            md.concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), "baz*");
+            fail();
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("baz*"));
+        }
+
+        try {
+            md.concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), "foo", "baz*");
+            fail();
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("baz*"));
+        }
+
+        try {
+            md.concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), "foofoobar");
+            fail();
+        } catch(ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("Alias [foofoobar] has more than one indices associated with it"));
+        }
+
+        try {
+            md.concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), "foo", "foofoobar");
+            fail();
+        } catch(ElasticsearchIllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("Alias [foofoobar] has more than one indices associated with it"));
+        }
+
+        String[] results = md.concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), "foo", "barbaz");
+        assertEquals(2, results.length);
+        assertThat(results, arrayContainingInAnyOrder("foo", "foofoo"));
     }
 
     @Test
@@ -274,34 +430,40 @@ public class MetaDataTests extends ElasticsearchTestCase {
         MetaData md = MetaData.builder().build();
         IndicesOptions options = IndicesOptions.strictExpandOpen();
 
-        String[] results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
+        String[] results = md.concreteIndices(options, Strings.EMPTY_ARRAY);
         assertThat(results, emptyArray());
         try {
-            md.concreteIndices(new String[]{"foo"}, options);
+            md.concreteIndices(options, "foo");
             fail();
-        } catch (IndexMissingException e) {}
-        results = md.concreteIndices(new String[]{"foo*"}, options);
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("foo"));
+        }
+        results = md.concreteIndices(options, "foo*");
         assertThat(results, emptyArray());
         try {
-            md.concreteIndices(new String[]{"foo*", "bar"}, options);
+            md.concreteIndices(options, "foo*", "bar");
             fail();
-        } catch (IndexMissingException e) {}
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("bar"));
+        }
 
 
         options = IndicesOptions.lenientExpandOpen();
-        results = md.concreteIndices(Strings.EMPTY_ARRAY, options);
+        results = md.concreteIndices(options, Strings.EMPTY_ARRAY);
         assertThat(results, emptyArray());
-        results = md.concreteIndices(new String[]{"foo"}, options);
+        results = md.concreteIndices(options, "foo");
         assertThat(results, emptyArray());
-        results = md.concreteIndices(new String[]{"foo*"}, options);
+        results = md.concreteIndices(options, "foo*");
         assertThat(results, emptyArray());
-        results = md.concreteIndices(new String[]{"foo*", "bar"}, options);
+        results = md.concreteIndices(options, "foo*", "bar");
         assertThat(results, emptyArray());
 
         options = IndicesOptions.fromOptions(true, false, true, false);
         try {
-            md.concreteIndices(Strings.EMPTY_ARRAY, options);
-        } catch (IndexMissingException e) {}
+            md.concreteIndices(options, Strings.EMPTY_ARRAY);
+        } catch (IndexMissingException e) {
+            assertThat(e.index().name(), equalTo("_all"));
+        }
     }
 
     @Test
@@ -345,7 +507,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        md.concreteIndices(new String[]{"testZZZ"}, IndicesOptions.strictExpandOpen());
+        md.concreteIndices(IndicesOptions.strictExpandOpen(), "testZZZ");
     }
 
     @Test
@@ -354,7 +516,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.concreteIndices(new String[]{"testXXX", "testZZZ"}, IndicesOptions.lenientExpandOpen())), equalTo(newHashSet("testXXX")));
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.lenientExpandOpen(), "testXXX", "testZZZ")), equalTo(newHashSet("testXXX")));
     }
 
     @Test(expected = IndexMissingException.class)
@@ -363,7 +525,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.concreteIndices(new String[]{"testMo", "testMahdy"}, IndicesOptions.strictExpandOpen())), equalTo(newHashSet("testXXX")));
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.strictExpandOpen(), "testMo", "testMahdy")), equalTo(newHashSet("testXXX")));
     }
 
     @Test
@@ -372,7 +534,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         MetaData md = mdBuilder.build();
-        assertThat(newHashSet(md.concreteIndices(new String[]{}, IndicesOptions.lenientExpandOpen())), equalTo(Sets.<String>newHashSet("kuku", "testXXX")));
+        assertThat(newHashSet(md.concreteIndices(IndicesOptions.lenientExpandOpen(), new String[]{})), equalTo(Sets.newHashSet("kuku", "testXXX")));
     }
 
     @Test
@@ -451,18 +613,15 @@ public class MetaDataTests extends ElasticsearchTestCase {
     public void testIsPatternMatchingAllIndices_explicitList() throws Exception {
         //even though it does identify all indices, it's not a pattern but just an explicit list of them
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
-        String[] indicesOrAliases = concreteIndices;
-        String[] allConcreteIndices = concreteIndices;
-        MetaData metaData = metaDataBuilder(allConcreteIndices);
-        assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(false));
+        MetaData metaData = metaDataBuilder(concreteIndices);
+        assertThat(metaData.isPatternMatchingAllIndices(concreteIndices, concreteIndices), equalTo(false));
     }
 
     @Test
     public void testIsPatternMatchingAllIndices_onlyWildcard() throws Exception {
         String[] indicesOrAliases = new String[]{"*"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
-        String[] allConcreteIndices = concreteIndices;
-        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        MetaData metaData = metaDataBuilder(concreteIndices);
         assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -470,8 +629,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
     public void testIsPatternMatchingAllIndices_matchingTrailingWildcard() throws Exception {
         String[] indicesOrAliases = new String[]{"index*"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
-        String[] allConcreteIndices = concreteIndices;
-        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        MetaData metaData = metaDataBuilder(concreteIndices);
         assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -488,8 +646,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
     public void testIsPatternMatchingAllIndices_matchingSingleExclusion() throws Exception {
         String[] indicesOrAliases = new String[]{"-index1", "+index1"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
-        String[] allConcreteIndices = concreteIndices;
-        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        MetaData metaData = metaDataBuilder(concreteIndices);
         assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -506,8 +663,7 @@ public class MetaDataTests extends ElasticsearchTestCase {
     public void testIsPatternMatchingAllIndices_matchingTrailingWildcardAndExclusion() throws Exception {
         String[] indicesOrAliases = new String[]{"index*", "-index1", "+index1"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
-        String[] allConcreteIndices = concreteIndices;
-        MetaData metaData = metaDataBuilder(allConcreteIndices);
+        MetaData metaData = metaDataBuilder(concreteIndices);
         assertThat(metaData.isPatternMatchingAllIndices(indicesOrAliases, concreteIndices), equalTo(true));
     }
 

--- a/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationTests.java
@@ -67,7 +67,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.*;
 
-public class IndicesOptionsTests extends ElasticsearchIntegrationTest {
+public class IndicesOptionsIntegrationTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSpecifiedIndexUnavailable() throws Exception {


### PR DESCRIPTION
The goal of this PR is to have a single method in `MetaData` that allows to resolve aliases or indices (eventually containing wildcard expressions) to concrete indices. That way all the apis will just refer to this same new method passing the proper indices options as argument.

In order to achieve that a new internal flag has been added to IndicesOptions, which tells whether aliases can be resolved to multiple indices or not.

Also it's now possible to decide not to expand wildcards at all via indices options, while previously it was possible to decide whether to expand them to open indices, closed indices, or both.

Note that the PR is against 1.x to handle backwards compatibility properly when needed. Bw comp checks will be removed when porting to master.
