### PR TITLE
Fix bug for BENCH thread pool size == 1

### DIFF
--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -286,7 +286,8 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
         @Override
         public String executor() {
-            return ThreadPool.Names.BENCH;
+            // Perform management tasks on GENERIC so as not to block pending acquisition of a thread from BENCH.
+            return ThreadPool.Names.GENERIC;
         }
     }
 
@@ -308,7 +309,8 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
         @Override
         public String executor() {
-            return ThreadPool.Names.BENCH;
+            // Perform management tasks on GENERIC so as not to block pending acquisition of a thread from BENCH.
+            return ThreadPool.Names.GENERIC;
         }
     }
 


### PR DESCRIPTION
On small hardware, the BENCH thread pool can be set to size 1. This is
problematic as it means that while a benchmark is active, there are no
threads available to service administrative tasks such as listing and
aborting. This change fixes that by executing list and abort operations
on the GENERIC thread pool.

Closes #6174
