### PR TITLE
Highlight fields in request order

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -547,3 +547,20 @@ keep in mind that scoring more phrases consumes more time and memory.
 
 If using `matched_fields` keep in mind that `phrase_limit` phrases per
 matched field are considered.
+
+[[explicit-field-order]]
+=== Field Highlight Order
+Elasticsearch highlights the fields in the order that they are sent.  Per the
+json spec objects are unordered but if you need to be explicit about the order
+that fields are highlighted then you can use an array for `fields` like this:
+[source,js]
+--------------------------------------------------
+    "highlight": {
+        "fields": [
+            {"title":{ /*params*/ }},
+            {"text":{ /*params*/ }}
+        ]
+    }
+--------------------------------------------------
+None of the highlighters built into Elasticsearch care about the order that the
+fields are highlighted but a plugin may.

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -807,6 +807,15 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Send the fields to be highlighted using a syntax that is specific about the order in which they should be highlighted.
+     * @return this for chaining
+     */
+    public SearchRequestBuilder setHighlighterExplicitFieldOrder(boolean explicitFieldOrder) {
+        highlightBuilder().useExplicitFieldOrder(explicitFieldOrder);
+        return this;
+    }
+
+    /**
      * Delegates to {@link org.elasticsearch.search.suggest.SuggestBuilder#setText(String)}.
      */
     public SearchRequestBuilder setSuggestText(String globalText) {

--- a/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
@@ -74,6 +74,8 @@ public class HighlightBuilder implements ToXContent {
 
     private Boolean forceSource;
 
+    private boolean useExplicitFieldOrder = false;
+
     /**
      * Adds a field to be highlighted with default fragment size of 100 characters, and
      * default number of fragments of 5 using the default encoder
@@ -289,6 +291,15 @@ public class HighlightBuilder implements ToXContent {
         return this;
     }
 
+    /**
+     * Send the fields to be highlighted using a syntax that is specific about the order in which they should be highlighted.
+     * @return this for chaining
+     */
+    public HighlightBuilder useExplicitFieldOrder(boolean useExplicitFieldOrder) {
+        this.useExplicitFieldOrder = useExplicitFieldOrder;
+        return this;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject("highlight");
@@ -347,8 +358,15 @@ public class HighlightBuilder implements ToXContent {
             builder.field("force_source", forceSource);
         }
         if (fields != null) {
-            builder.startObject("fields");
+            if (useExplicitFieldOrder) {
+                builder.startArray("fields");
+            } else {
+                builder.startObject("fields");
+            }
             for (Field field : fields) {
+                if (useExplicitFieldOrder) {
+                    builder.startObject();
+                }
                 builder.startObject(field.name());
                 if (field.preTags != null) {
                     builder.field("pre_tags", field.preTags);
@@ -406,10 +424,16 @@ public class HighlightBuilder implements ToXContent {
                 }
 
                 builder.endObject();
+                if (useExplicitFieldOrder) {
+                    builder.endObject();
+                }
             }
-            builder.endObject();
+            if (useExplicitFieldOrder) {
+                builder.endArray();
+            } else {
+                builder.endObject();
+            }
         }
-
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -35,7 +35,7 @@ public class SearchContextHighlight {
 
     public SearchContextHighlight(Collection<Field> fields) {
         assert fields != null;
-        this.fields = Maps.newHashMap();
+        this.fields = new LinkedHashMap<String, Field>(fields.size());
         for (Field field : fields) {
             this.fields.put(field.field, field);
         }

--- a/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchTests.java
@@ -20,11 +20,11 @@ package org.elasticsearch.search.highlight;
 
 import com.google.common.collect.Maps;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,8 +32,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHighlight;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -53,12 +51,12 @@ public class CustomHighlighterSearchTests extends ElasticsearchIntegrationTest {
 
     @Before
     protected void setup() throws Exception{
-        client().prepareIndex("test", "test", "1").setSource(XContentFactory.jsonBuilder()
-                .startObject()
-                .field("name", "arbitrary content")
-                .endObject())
-                .setRefresh(true).execute().actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+        indexRandom(true,
+                client().prepareIndex("test", "test", "1").setSource(
+                        "name", "arbitrary content", "other_name", "foo", "other_other_name", "bar"),
+                client().prepareIndex("test", "test", "2").setSource(
+                        "other_name", "foo", "other_other_name", "bar"));
+        ensureYellow();
     }
 
     @Test
@@ -67,7 +65,7 @@ public class CustomHighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .setQuery(QueryBuilders.matchAllQuery())
                 .addHighlightedField("name").setHighlighterType("test-custom")
                 .execute().actionGet();
-        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response"));
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response for name at position 1"));
     }
 
     @Test
@@ -83,7 +81,7 @@ public class CustomHighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .addHighlightedField(highlightConfig)
                 .execute().actionGet();
 
-        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response"));
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response for name at position 1"));
         assertHighlight(searchResponse, 0, "name", 1, equalTo("field:myFieldOption:someValue"));
     }
 
@@ -99,7 +97,27 @@ public class CustomHighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .addHighlightedField("name")
                 .execute().actionGet();
 
-        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response"));
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response for name at position 1"));
         assertHighlight(searchResponse, 0, "name", 1, equalTo("field:myGlobalOption:someValue"));
+    }
+
+    @Test
+    public void testThatCustomHighlighterReceivesFieldsInOrder() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("test").setTypes("test")
+                .setQuery(QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery()).should(QueryBuilders
+                        .termQuery("name", "arbitrary")))
+                .setHighlighterType("test-custom")
+                .addHighlightedField("name")
+                .addHighlightedField("other_name")
+                .addHighlightedField("other_other_name")
+                .setHighlighterExplicitFieldOrder(true)
+                .get();
+
+        assertHighlight(searchResponse, 0, "name", 0, equalTo("standard response for name at position 1"));
+        assertHighlight(searchResponse, 0, "other_name", 0, equalTo("standard response for other_name at position 2"));
+        assertHighlight(searchResponse, 0, "other_other_name", 0, equalTo("standard response for other_other_name at position 3"));
+        assertHighlight(searchResponse, 1, "name", 0, equalTo("standard response for name at position 1"));
+        assertHighlight(searchResponse, 1, "other_name", 0, equalTo("standard response for other_name at position 2"));
+        assertHighlight(searchResponse, 1, "other_other_name", 0, equalTo("standard response for other_other_name at position 3"));
     }
 }


### PR DESCRIPTION
Because json objects are unordered this also adds an explicit order syntax
that looks like

``` js
    "highlight": {
        "fields": [
            {"title":{ /*params*/ }},
            {"text":{ /*params*/ }}
        ]
    }
```

This is not useful for any of the builtin highlighters but will be useful
in plugins.

Closes #4649
