### PR TITLE
Add execution control for active benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,7 @@
                                 <java.io.tmpdir>.</java.io.tmpdir> <!-- we use '.' since this is different per JVM-->
                                 <!-- RandomizedTesting library system properties -->
                                 <tests.jvm.argline>${tests.jvm.argline}</tests.jvm.argline>
+                                <tests.processors>${tests.processors}</tests.processors>
                                 <tests.appendseed>${tests.appendseed}</tests.appendseed>
                                 <tests.iters>${tests.iters}</tests.iters>
                                 <tests.maxfailures>${tests.maxfailures}</tests.maxfailures>

--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -285,6 +285,7 @@ public class ActionModule extends AbstractModule {
         registerAction(BenchmarkAction.INSTANCE, TransportBenchmarkAction.class);
         registerAction(AbortBenchmarkAction.INSTANCE, TransportAbortBenchmarkAction.class);
         registerAction(BenchmarkStatusAction.INSTANCE, TransportBenchmarkStatusAction.class);
+        registerAction(BenchmarkControlAction.INSTANCE, TransportBenchmarkControlAction.class);
 
         // register Name -> GenericAction Map that can be injected to instances.
         MapBinder<String, GenericAction> actionsBinder

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -96,7 +96,7 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeOperatio
 
                     @Override
                     public void onFailure(Throwable t) {
-                        logger.debug("failed to delete template [{}]", t, request.name());
+                        logger.debug("failed to put template [{}]", t, request.name());
                         listener.onFailure(t);
                     }
                 });

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkControlAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkControlAction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.Client;
+
+/**
+ * Benchmark pause action
+ */
+public class BenchmarkControlAction extends Action<BenchmarkControlRequest, BenchmarkStatusResponse, BenchmarkControlRequestBuilder> {
+
+    public static final BenchmarkControlAction INSTANCE = new BenchmarkControlAction();
+    public static final String NAME = "benchmark/control";
+
+    public BenchmarkControlAction() {
+        super(NAME);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder newRequestBuilder(Client client) {
+        return new BenchmarkControlRequestBuilder(client);
+    }
+
+    @Override
+    public BenchmarkStatusResponse newResponse() {
+        return new BenchmarkStatusResponse();
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Administrative commands for benchmarks: pause, resume
+ */
+public class BenchmarkControlRequest extends AcknowledgedRequest {
+
+    private String benchmarkName;
+    private Command command;
+
+    public enum Command {
+        PAUSE((byte) 0),        // Pause an active benchmark
+        RESUME((byte) 1);       // Resume an active benchmark
+
+        private final byte id;
+        private static final Command[] COMMANDS = new Command[Command.values().length];
+
+        static {
+            for (Command command : Command.values()) {
+                assert command.id() < COMMANDS.length && command.id() >= 0;
+                COMMANDS[command.id()] = command;
+            }
+        }
+
+        Command(byte id) {
+            this.id = id;
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public static Command fromId(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id > values().length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return COMMANDS[id];
+        }
+    }
+
+    public BenchmarkControlRequest() { }
+
+    public BenchmarkControlRequest(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public void benchmarkName(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public String benchmarkName() {
+        return benchmarkName;
+    }
+
+    public void command(Command command) {
+        this.command = command;
+    }
+
+    public Command command() {
+        return command;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (benchmarkName == null) {
+            validationException = ValidateActions.addValidationError("benchmarkName must not be null", validationException);
+        }
+        if (command == null) {
+            validationException = ValidateActions.addValidationError("command must not be null", validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readString();
+        command = Command.fromId(in.readByte());
+        readTimeout(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(benchmarkName);
+        out.writeByte(command.id());
+        writeTimeout(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequestBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.internal.InternalClient;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestBuilder;
+
+/**
+ * Request builder for benchmark pause
+ */
+public class BenchmarkControlRequestBuilder extends ActionRequestBuilder<BenchmarkControlRequest, BenchmarkStatusResponse, BenchmarkControlRequestBuilder> {
+
+    public BenchmarkControlRequestBuilder(Client client) {
+        super((InternalClient) client, new BenchmarkControlRequest());
+    }
+
+    public BenchmarkControlRequestBuilder setBenchmarkName(String benchmarkName) {
+        request.benchmarkName(benchmarkName);
+        return this;
+    }
+
+    public BenchmarkControlRequestBuilder setCommand(BenchmarkControlRequest.Command command) {
+        request.command(command);
+        return this;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<BenchmarkStatusResponse> listener) {
+        ((Client) client).controlBenchmark(request, listener);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkExecutionException.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkExecutionException.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Indicates a benchmark failure due to too many failures being encountered.
+ * Indicates a general benchmark failure
  */
 public class BenchmarkExecutionException extends ElasticsearchException {
 

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
@@ -59,15 +59,17 @@ public class BenchmarkResponse extends ActionResponse implements Streamable, ToX
     /**
      * Benchmarks can be in one of:
      *  RUNNING     - executing normally
+     *  PAUSED      - execution suspended
      *  COMPLETE    - completed normally
      *  ABORTED     - aborted
      *  FAILED      - execution failed
      */
     public static enum State {
         RUNNING((byte) 0),
-        COMPLETE((byte) 1),
-        ABORTED((byte) 2),
-        FAILED((byte) 3);
+        PAUSED((byte) 1),
+        COMPLETE((byte) 2),
+        ABORTED((byte) 3),
+        FAILED((byte) 4);
 
         private final byte id;
         private static final State[] STATES = new State[State.values().length];

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -73,6 +73,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
     @Inject
     public BenchmarkService(Settings settings, ClusterService clusterService, ThreadPool threadPool,
                             Client client, TransportService transportService) {
+
         super(settings);
         this.threadPool = threadPool;
         this.executor = new BenchmarkExecutor(client, clusterService);
@@ -320,6 +321,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
         @Override
         public String executor() {
+            // Perform management tasks on GENERIC so as not to block pending acquisition of a thread from BENCH.
             return ThreadPool.Names.GENERIC;
         }
     }

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -81,6 +81,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
         transportService.registerHandler(BenchExecutionHandler.ACTION, new BenchExecutionHandler());
         transportService.registerHandler(AbortExecutionHandler.ACTION, new AbortExecutionHandler());
         transportService.registerHandler(StatusExecutionHandler.ACTION, new StatusExecutionHandler());
+        transportService.registerHandler(ControlExecutionHandler.ACTION, new ControlExecutionHandler());
     }
 
     @Override
@@ -104,10 +105,34 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
         if (nodes.size() == 0) {
             listener.onFailure(new BenchmarkNodeMissingException("No available nodes for executing benchmarks"));
         } else {
-            BenchmarkStatusAsyncHandler async = new BenchmarkStatusAsyncHandler(nodes.size(), request, listener);
+            BenchmarkStatusAsyncHandler async = new BenchmarkStatusAsyncHandler(nodes.size(), listener);
             for (DiscoveryNode node : nodes) {
                 assert isBenchmarkNode(node);
                 transportService.sendRequest(node, StatusExecutionHandler.ACTION, new NodeStatusRequest(request), async);
+            }
+        }
+    }
+
+    public void pauseBenchmark(final BenchmarkControlRequest request, final ActionListener<BenchmarkStatusResponse> listener) {
+        assert request.command() == BenchmarkControlRequest.Command.PAUSE;
+        controlBenchmark(request, listener);
+    }
+
+    public void resumeBenchmark(final BenchmarkControlRequest request, final ActionListener<BenchmarkStatusResponse> listener) {
+        assert request.command() == BenchmarkControlRequest.Command.RESUME;
+        controlBenchmark(request, listener);
+    }
+
+    private void controlBenchmark(final BenchmarkControlRequest request, final ActionListener<BenchmarkStatusResponse> listener) {
+
+        final List<DiscoveryNode> nodes = availableBenchmarkNodes();
+        if (nodes.size() == 0) {
+            listener.onFailure(new BenchmarkNodeMissingException("No available nodes for executing benchmarks"));
+        } else {
+            BenchmarkStatusAsyncHandler async = new BenchmarkStatusAsyncHandler(nodes.size(), listener);
+            for (DiscoveryNode node : nodes) {
+                assert isBenchmarkNode(node);
+                transportService.sendRequest(node, ControlExecutionHandler.ACTION, new NodeControlRequest(request), async);
             }
         }
     }
@@ -268,6 +293,37 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
         }
     }
 
+    private class ControlExecutionHandler extends BaseTransportRequestHandler<NodeControlRequest> {
+
+        static final String ACTION = "benchmark/executor/control";
+
+        @Override
+        public NodeControlRequest newInstance() {
+            return new NodeControlRequest();
+        }
+
+        @Override
+        public void messageReceived(NodeControlRequest request, TransportChannel channel) throws Exception {
+
+            final BenchmarkStatusNodeResponse nodeResponse;
+            if (request.request.command() == BenchmarkControlRequest.Command.PAUSE) {
+                nodeResponse = executor.pauseBenchmark(request.request.benchmarkName());
+            } else if (request.request.command() == BenchmarkControlRequest.Command.RESUME) {
+                nodeResponse = executor.resumeBenchmark(request.request.benchmarkName());
+            } else {
+                throw new ElasticsearchIllegalStateException("Invalid control command [" + request.request.command() + "]");
+            }
+
+            nodeResponse.nodeName(clusterService.localNode().name());
+            channel.sendResponse(nodeResponse);
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.GENERIC;
+        }
+    }
+
     private class StatusExecutionHandler extends BaseTransportRequestHandler<NodeStatusRequest> {
 
         static final String ACTION = "benchmark/executor/status";
@@ -335,6 +391,31 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(benchmarkName);
+        }
+    }
+
+    public static class NodeControlRequest extends TransportRequest {
+
+        final BenchmarkControlRequest request;
+
+        public NodeControlRequest(BenchmarkControlRequest request) {
+            this.request = request;
+        }
+
+        public NodeControlRequest() {
+            this(new BenchmarkControlRequest());
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            request.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
         }
     }
 
@@ -451,12 +532,10 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
     private class BenchmarkStatusAsyncHandler extends CountDownAsyncHandler<BenchmarkStatusNodeResponse> {
 
-        private final BenchmarkStatusRequest request;
         private final ActionListener<BenchmarkStatusResponse> listener;
 
-        public BenchmarkStatusAsyncHandler(int nodeCount, final BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        public BenchmarkStatusAsyncHandler(int nodeCount, ActionListener<BenchmarkStatusResponse> listener) {
             super(nodeCount);
-            this.request = request;
             this.listener = listener;
         }
 

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkControlAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkControlAction.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+/**
+ *
+ */
+public class TransportBenchmarkControlAction extends TransportMasterNodeOperationAction<BenchmarkControlRequest, BenchmarkStatusResponse> {
+
+    private final BenchmarkService service;
+
+    @Inject
+    public TransportBenchmarkControlAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                           ThreadPool threadPool, BenchmarkService service) {
+        super(settings, transportService, clusterService, threadPool);
+        this.service = service;
+    }
+
+    @Override
+    protected String transportAction() {
+        return BenchmarkControlAction.NAME;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    protected BenchmarkControlRequest newRequest() {
+        return new BenchmarkControlRequest();
+    }
+
+    @Override
+    protected BenchmarkStatusResponse newResponse() {
+        return new BenchmarkStatusResponse();
+    }
+
+    @Override
+    protected void masterOperation(BenchmarkControlRequest request, ClusterState state, ActionListener<BenchmarkStatusResponse> listener)
+            throws ElasticsearchException {
+        if (request.command() == BenchmarkControlRequest.Command.PAUSE) {
+            service.pauseBenchmark(request, listener);
+        } else if (request.command() == BenchmarkControlRequest.Command.RESUME) {
+            service.resumeBenchmark(request, listener);
+        } else {
+            throw new ElasticsearchIllegalArgumentException("Unknown benchmark control command [" + request.command() + "]");
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -590,4 +590,14 @@ public interface Client {
      * Reports on status of actively running benchmarks
      */
     BenchmarkStatusRequestBuilder prepareBenchStatus();
+
+    /**
+     * Sends a control command to an active benchmark
+     */
+    void controlBenchmark(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener);
+
+    /**
+     * Sends a control command to an active benchmark
+     */
+    BenchmarkControlRequestBuilder prepareControlBenchmark(String benchmarkName);
 }

--- a/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -417,4 +417,14 @@ public abstract class AbstractClient implements InternalClient {
     public BenchmarkStatusRequestBuilder prepareBenchStatus() {
         return new BenchmarkStatusRequestBuilder(this);
     }
+
+    @Override
+    public void controlBenchmark(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        execute(BenchmarkControlAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder prepareControlBenchmark(String benchmarkName) {
+        return new BenchmarkControlRequestBuilder(this).setBenchmarkName(benchmarkName);
+    }
 }

--- a/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -239,6 +239,8 @@ public class ClusterState implements ToXContent {
 
     public String prettyPrint() {
         StringBuilder sb = new StringBuilder();
+        sb.append("version: ").append(version).append("\n");
+        sb.append("meta data version: ").append(metaData.version()).append("\n");
         sb.append(nodes().prettyPrint());
         sb.append(routingTable().prettyPrint());
         sb.append(readOnlyRoutingNodes().prettyPrint());

--- a/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -76,37 +76,51 @@ public class ShardStateAction extends AbstractComponent {
     }
 
     public void shardFailed(final ShardRouting shardRouting, final String indexUUID, final String reason) throws ElasticsearchException {
+        DiscoveryNode masterNode = clusterService.state().nodes().masterNode();
+        if (masterNode == null) {
+            logger.debug("can't send shard failed for {}. no master known.", shardRouting);
+        }
+        shardFailed(shardRouting, indexUUID, reason, masterNode);
+    }
+
+    public void shardFailed(final ShardRouting shardRouting, final String indexUUID, final String reason, final DiscoveryNode masterNode) throws ElasticsearchException {
         ShardRoutingEntry shardRoutingEntry = new ShardRoutingEntry(shardRouting, indexUUID, reason);
         logger.warn("{} sending failed shard for {}", shardRouting.shardId(), shardRoutingEntry);
-        DiscoveryNodes nodes = clusterService.state().nodes();
-        if (nodes.localNodeMaster()) {
+        if (clusterService.localNode().equals(masterNode)) {
             innerShardFailed(shardRoutingEntry);
         } else {
             transportService.sendRequest(clusterService.state().nodes().masterNode(),
                     ShardFailedTransportHandler.ACTION, shardRoutingEntry, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                 @Override
                 public void handleException(TransportException exp) {
-                    logger.warn("failed to send failed shard to [{}]", exp, clusterService.state().nodes().masterNode());
+                    logger.warn("failed to send failed shard to {}", exp, masterNode);
                 }
             });
         }
     }
 
     public void shardStarted(final ShardRouting shardRouting, String indexUUID, final String reason) throws ElasticsearchException {
+        DiscoveryNode masterNode = clusterService.state().nodes().masterNode();
+        if (masterNode == null) {
+            logger.debug("can't send shard started for {}. no master known.", shardRouting);
+        }
+        shardStarted(shardRouting, indexUUID, reason, masterNode);
+    }
+
+    public void shardStarted(final ShardRouting shardRouting, String indexUUID, final String reason, final DiscoveryNode masterNode) throws ElasticsearchException {
 
         ShardRoutingEntry shardRoutingEntry = new ShardRoutingEntry(shardRouting, indexUUID, reason);
 
         logger.debug("sending shard started for {}", shardRoutingEntry);
 
-        DiscoveryNodes nodes = clusterService.state().nodes();
-        if (nodes.localNodeMaster()) {
+        if (clusterService.localNode().equals(masterNode)) {
             innerShardStarted(shardRoutingEntry);
         } else {
-            transportService.sendRequest(clusterService.state().nodes().masterNode(),
+            transportService.sendRequest(masterNode,
                     ShardStartedTransportHandler.ACTION, new ShardRoutingEntry(shardRouting, indexUUID, reason), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                 @Override
                 public void handleException(TransportException exp) {
-                    logger.warn("failed to send shard started to [{}]", exp, clusterService.state().nodes().masterNode());
+                    logger.warn("failed to send shard started to [{}]", exp, masterNode);
                 }
             });
         }

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -447,7 +447,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable> {
     }
 
     public String prettyPrint() {
-        StringBuilder sb = new StringBuilder("routing_table:\n");
+        StringBuilder sb = new StringBuilder("routing_table (version ").append(version).append("):\n");
         for (Map.Entry<String, IndexRoutingTable> entry : indicesRouting.entrySet()) {
             sb.append(entry.getValue().prettyPrint()).append('\n');
         }

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -379,10 +379,8 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 newClusterState.status(ClusterState.ClusterStateStatus.BEING_APPLIED);
 
                 if (logger.isTraceEnabled()) {
-                    StringBuilder sb = new StringBuilder("cluster state updated:\nversion [").append(newClusterState.version()).append("], source [").append(source).append("]\n");
-                    sb.append(newClusterState.nodes().prettyPrint());
-                    sb.append(newClusterState.routingTable().prettyPrint());
-                    sb.append(newClusterState.readOnlyRoutingNodes().prettyPrint());
+                    StringBuilder sb = new StringBuilder("cluster state updated, source [").append(source).append("]\n");
+                    sb.append(newClusterState.prettyPrint());
                     logger.trace(sb.toString());
                 } else if (logger.isDebugEnabled()) {
                     logger.debug("cluster state updated, version [{}], source [{}]", newClusterState.version(), source);

--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -30,6 +30,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class EsExecutors {
 
     /**
+     * Settings key to manually set the number of available processors.
+     * This is used to adjust thread pools sizes etc. per node.
+     */
+    public static final String PROCESSORS = "processors";
+
+    /**
      * Returns the number of processors available but at most <tt>32</tt>.
      */
     public static int boundedNumberOfProcessors(Settings settings) {
@@ -37,7 +43,7 @@ public class EsExecutors {
          * ie. >= 48 create too many threads and run into OOM see #3478
          * We just use an 32 core upper-bound here to not stress the system
          * too much with too many created threads */
-        return settings.getAsInt("processors", Math.min(32, Runtime.getRuntime().availableProcessors()));
+        return settings.getAsInt(PROCESSORS, Math.min(32, Runtime.getRuntime().availableProcessors()));
     }
 
     public static PrioritizedEsThreadPoolExecutor newSinglePrioritizing(ThreadFactory threadFactory) {

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -97,6 +97,7 @@ public class RecoverySource extends AbstractComponent {
         // the index operations will not be routed to it properly
         RoutingNode node = clusterService.state().readOnlyRoutingNodes().node(request.targetNode().id());
         if (node == null) {
+            logger.debug("delaying recovery of {} as source node {} is unknown", request.shardId(), request.targetNode());
             throw new DelayRecoveryException("source node does not have the node [" + request.targetNode() + "] in its state yet..");
         }
         ShardRouting targetShardRouting = null;
@@ -107,9 +108,12 @@ public class RecoverySource extends AbstractComponent {
             }
         }
         if (targetShardRouting == null) {
+            logger.debug("delaying recovery of {} as it is not listed as assigned to target node {}", request.shardId(), request.targetNode());
             throw new DelayRecoveryException("source node does not have the shard listed in its state as allocated on the node");
         }
         if (!targetShardRouting.initializing()) {
+            logger.debug("delaying recovery of {} as it is not listed as initializing on the target node {}. known shards state is [{}]",
+                    request.shardId(), request.targetNode(), targetShardRouting.state());
             throw new DelayRecoveryException("source node has the state of the target shard to be [" + targetShardRouting.state() + "], expecting to be [initializing]");
         }
 

--- a/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
+++ b/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
@@ -32,6 +32,8 @@ import com.carrotsearch.randomizedtesting.rules.StaticFieldsInvariantRule;
 import com.carrotsearch.randomizedtesting.rules.SystemPropertiesInvariantRule;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
@@ -90,6 +92,8 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
 
     public static final String SYSPROP_INTEGRATION = "tests.integration";
 
+    public static final String SYSPROP_PROCESSORS = "tests.processors";
+
     // -----------------------------------------------------------------
     // Truly immutable fields and constants, initialized once and valid 
     // for all suites ever since.
@@ -128,12 +132,20 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
      */
     public static final File TEMP_DIR;
 
+    public static final int TESTS_PROCESSORS;
+
     static {
         String s = System.getProperty("tempDir", System.getProperty("java.io.tmpdir"));
         if (s == null)
             throw new RuntimeException("To run tests, you need to define system property 'tempDir' or 'java.io.tmpdir'.");
         TEMP_DIR = new File(s);
         TEMP_DIR.mkdirs();
+
+        String processors = System.getProperty(SYSPROP_PROCESSORS, ""); // mvn sets "" as default
+        if (processors == null || processors.isEmpty()) {
+            processors = Integer.toString(EsExecutors.boundedNumberOfProcessors(ImmutableSettings.EMPTY));
+        }
+        TESTS_PROCESSORS = Integer.parseInt(processors);
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -27,6 +27,7 @@ import com.google.common.collect.*;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import org.apache.lucene.util.AbstractRandomizedTest;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
@@ -302,6 +303,11 @@ public final class TestCluster extends ImmutableTestCluster {
         }
         builder.put("plugins.isolation", random.nextBoolean());
         builder.put(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_INDEX_SETTING_KEY, 1 + random.nextInt(InternalGlobalOrdinalsBuilder.ORDINAL_MAPPING_THRESHOLD_DEFAULT));
+        if (random.nextInt(10) == 0) {
+            builder.put(EsExecutors.PROCESSORS, 1 + random.nextInt(AbstractRandomizedTest.TESTS_PROCESSORS));
+        } else {
+            builder.put(EsExecutors.PROCESSORS, AbstractRandomizedTest.TESTS_PROCESSORS);
+        }
         return builder.build();
     }
 

--- a/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
+++ b/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
@@ -450,6 +450,16 @@ public class RandomizingClient implements InternalClient {
     }
 
     @Override
+    public void controlBenchmark(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        delegate.controlBenchmark(request, listener);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder prepareControlBenchmark(String benchmarkName) {
+        return delegate.prepareControlBenchmark(benchmarkName);
+    }
+
+    @Override
     public ThreadPool threadPool() {
         return delegate.threadPool();
     }

--- a/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -21,6 +21,7 @@ package org.elasticsearch.test.junit.listeners;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.ReproduceErrorMessageBuilder;
 import com.carrotsearch.randomizedtesting.TraceFormatting;
+import org.apache.lucene.util.AbstractRandomizedTest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -139,6 +140,7 @@ public class ReproduceInfoPrinter extends RunListener {
             if (System.getProperty("tests.jvm.argline") != null && !System.getProperty("tests.jvm.argline").isEmpty()) {
                 appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");
             }
+            appendOpt(AbstractRandomizedTest.SYSPROP_PROCESSORS, Integer.toString(AbstractRandomizedTest.TESTS_PROCESSORS));
             return this;
         }
 


### PR DESCRIPTION
This commit adds the ability to pause and resume active benchmarks. It
adds new API calls for sending control requests.

TODO:
1. Pausing internally is implemented using a busy wait. Should this be
changed to use proper blocking concurrency primitives?
2. The returned status code can be incorrectly reported in some cases.
This is due to BenchmarkResponse.mergeState() assuming a natural
ordering of enum values.
3. Needs refactoring of test cases to use pause/resume feature.

Closes #6173
