### PR TITLE
Shade mustache into org.elasticsearch.common package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,10 @@
                             <shadedPattern>org.elasticsearch.common.compress</shadedPattern>
                         </relocation>
                         <relocation>
+			    <pattern>com.github.mustachejava</pattern>
+                            <shadedPattern>org.elasticsearch.common.mustache</shadedPattern>
+                        </relocation>
+                        <relocation>
                             <pattern>com.tdunning.math.stats</pattern>
                             <shadedPattern>org.elasticsearch.common.stats</shadedPattern>
                         </relocation>


### PR DESCRIPTION
Previously we shared the jar but never rewrote the packages such
that the shading had no effect.

Closes #6192
