### PR TITLE
Randomize CMS settings in index template

### DIFF
--- a/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
+++ b/src/main/java/org/elasticsearch/index/merge/scheduler/ConcurrentMergeSchedulerProvider.java
@@ -47,6 +47,12 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
     private final IndexSettingsService indexSettingsService;
     private final ApplySettings applySettings = new ApplySettings();
 
+    private static final String MAX_THREAD_COUNT_KEY = "max_thread_count";
+    private static final String MAX_MERGE_COUNT_KEY = "max_merge_count";
+
+    public static final String MAX_THREAD_COUNT = "index.merge.scheduler." + MAX_THREAD_COUNT_KEY;
+    public static final String MAX_MERGE_COUNT = "index.merge.scheduler." + MAX_MERGE_COUNT_KEY;
+
     private volatile int maxThreadCount;
     private volatile int maxMergeCount;
 
@@ -57,8 +63,8 @@ public class ConcurrentMergeSchedulerProvider extends MergeSchedulerProvider {
         super(shardId, indexSettings, threadPool);
         this.indexSettingsService = indexSettingsService;
         // TODO LUCENE MONITOR this will change in Lucene 4.0
-        this.maxThreadCount = componentSettings.getAsInt("max_thread_count", Math.max(1, Math.min(3, Runtime.getRuntime().availableProcessors() / 2)));
-        this.maxMergeCount = componentSettings.getAsInt("max_merge_count", maxThreadCount + 2);
+        this.maxThreadCount = componentSettings.getAsInt(MAX_THREAD_COUNT_KEY, Math.max(1, Math.min(3, EsExecutors.boundedNumberOfProcessors(indexSettings) / 2)));
+        this.maxMergeCount = componentSettings.getAsInt(MAX_MERGE_COUNT_KEY, maxThreadCount + 2);
         logger.debug("using [concurrent] merge scheduler with max_thread_count[{}], max_merge_count[{}]", maxThreadCount, maxMergeCount);
 
         indexSettingsService.addListener(applySettings);

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -405,7 +405,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                 builder.put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC, new ByteSizeValue(RandomInts.randomIntBetween(random, 10, 200), ByteSizeUnit.MB));
             }
         }
-
         return builder;
     }
 
@@ -434,7 +433,11 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         }
         switch (random.nextInt(4)) {
             case 3:
-                builder.put(MergeSchedulerModule.MERGE_SCHEDULER_TYPE_KEY, ConcurrentMergeSchedulerProvider.class.getName());
+                builder.put(MergeSchedulerModule.MERGE_SCHEDULER_TYPE_KEY, ConcurrentMergeSchedulerProvider.class);
+                final int maxThreadCount = RandomInts.randomIntBetween(random, 1, 4);
+                final int maxMergeCount = RandomInts.randomIntBetween(random, maxThreadCount, maxThreadCount+4);
+                builder.put(ConcurrentMergeSchedulerProvider.MAX_MERGE_COUNT, maxMergeCount);
+                builder.put(ConcurrentMergeSchedulerProvider.MAX_THREAD_COUNT, maxThreadCount);
                 break;
         }
 


### PR DESCRIPTION
This commit adds randomization for:
- `index.merge.scheduler.max_thread_count`
- `index.merge.scheduler.max_merge_count`

This commit also moves to use
EsExecutors#boundedNumberOfProcessors(Settings) to default
configure the default `max_thread_count` for better reproducibility

Closes #6194
