### PR TITLE
Fix offsets in DateHistogramBuilder

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramBuilder.java
@@ -41,8 +41,8 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     private String postZone;
     private boolean preZoneAdjustLargeInterval;
     private String format;
-    long preOffset = 0;
-    long postOffset = 0;
+    private Object preOffset;
+    private Object postOffset;
     float factor = 1.0f;
 
     public DateHistogramBuilder(String name) {
@@ -90,6 +90,16 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
     }
 
     public DateHistogramBuilder postOffset(long postOffset) {
+        this.postOffset = postOffset;
+        return this;
+    }
+
+    public DateHistogramBuilder preOffset( DateHistogram.Interval preOffset ) {
+        this.preOffset = preOffset;
+        return this;
+    }
+
+    public DateHistogramBuilder postOffset( DateHistogram.Interval postOffset ) {
         this.postOffset = postOffset;
         return this;
     }
@@ -153,11 +163,17 @@ public class DateHistogramBuilder extends ValuesSourceAggregationBuilder<DateHis
             builder.field("pre_zone_adjust_large_interval", true);
         }
 
-        if (preOffset != 0) {
+        if (preOffset != null) {
+            if (preOffset instanceof Number) {
+                preOffset = TimeValue.timeValueMillis(((Number) preOffset).longValue()).toString();
+            }
             builder.field("pre_offset", preOffset);
         }
 
-        if (postOffset != 0) {
+        if (postOffset != null) {
+            if (postOffset instanceof Number) {
+                postOffset = TimeValue.timeValueMillis(((Number) postOffset).longValue()).toString();
+            }
             builder.field("post_offset", postOffset);
         }
 

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -168,6 +168,117 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void singleValuedField_WithLongOffsets() throws Exception {
+        SearchResponse response;
+        response = client().prepareSearch("idx")
+            .addAggregation(dateHistogram("histo").field("date")
+                .interval(DateHistogram.Interval.DAY)
+                .preOffset(1000*60*60*24*2)
+                .postOffset(-1000*60*60*24))
+            .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        DateHistogram histo = response.getAggregations().get("histo");
+        assertThat(histo, notNullValue());
+        assertThat(histo.getName(), equalTo("histo"));
+        assertThat(histo.getBuckets().size(), equalTo(6));
+
+        long key = new DateTime(2012, 1, 3, 0, 0, DateTimeZone.UTC).getMillis();
+        DateHistogram.Bucket bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 2, 3, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 2, 16, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 3, 3, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 3, 16, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 3, 24, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+    }
+    
+    @Test
+    public void singleValuedField_WithIntervalOffsets() throws Exception {
+        SearchResponse response;
+        response = client().prepareSearch("idx")
+            .addAggregation(dateHistogram("histo").field("date")
+                .interval(DateHistogram.Interval.DAY)
+                .preOffset(DateHistogram.Interval.days(2))
+                .postOffset(DateHistogram.Interval.days(-1)))
+            .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        DateHistogram histo = response.getAggregations().get("histo");
+        assertThat(histo, notNullValue());
+        assertThat(histo.getName(), equalTo("histo"));
+        assertThat(histo.getBuckets().size(), equalTo(6));
+
+        long key = new DateTime(2012, 1, 3, 0, 0, DateTimeZone.UTC).getMillis();
+        DateHistogram.Bucket bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 2, 3, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 2, 16, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 3, 3, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 3, 16, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+
+        key = new DateTime(2012, 3, 24, 0, 0, DateTimeZone.UTC).getMillis();
+        bucket = histo.getBucketByKey(key);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKeyAsNumber().longValue(), equalTo(key));
+        assertThat(bucket.getDocCount(), equalTo(1l));
+    }
+
+
+    @Test
     public void singleValuedField_WithPostTimeZone() throws Exception {
         SearchResponse response;
         if (randomBoolean()) {


### PR DESCRIPTION
This PR fixes #5586 by correcting the behavior of the current `preOffset` and `postOffset` methods in DateHistogramBuilder and adds new versions of these methods that take `DateHistogram.Interval`.  It is patterned after the interval property that already exists in this class.

This PR is an alternative to #5587.  That PR removes the current methods and replaces them with `String` based fields.  This seems inconsistent with the other methods in the class and causes a change to the contract currently established by DateHistogramBuilder.
