### PR TITLE
Use default forceAnalyzeQueryString if no query builder is present

### DIFF
--- a/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -263,6 +263,6 @@ public class MultiMatchQuery extends MatchQuery {
     }
 
     protected boolean forceAnalyzeQueryString() {
-        return this.queryBuilder.forceAnalyzeQueryString();
+        return this.queryBuilder == null ? super.forceAnalyzeQueryString() : this.queryBuilder.forceAnalyzeQueryString();
     }
 }

--- a/src/test/java/org/elasticsearch/search/query/MultiMatchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/MultiMatchQueryTests.java
@@ -211,6 +211,15 @@ public class MultiMatchQueryTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testSingleField() {
+        SearchResponse searchResponse = client().prepareSearch("test")
+                .setQuery(randomizeType(multiMatchQuery("15", "skill"))).get();
+        assertNoFailures(searchResponse);
+        assertFirstHit(searchResponse, hasId("theone"));
+        // TODO we need equivalence tests with match query here
+    }
+
+    @Test
     public void testCutoffFreq() throws ExecutionException, InterruptedException {
         final long numDocs = client().prepareCount("test")
                 .setQuery(matchAllQuery()).get().getCount();


### PR DESCRIPTION
In the single field case no query builder is selected which causes NPE
when the query has only a numeric field.

Closes #6215
