### PR TITLE
Benchmark abort accepts wildcard patterns

### DIFF
--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.bench;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -30,25 +31,27 @@ import java.io.IOException;
  * A request to abort a specified benchmark
  */
 public class AbortBenchmarkRequest extends AcknowledgedRequest {
-    private String benchmarkName;
+
+    private String[] benchmarkNames = Strings.EMPTY_ARRAY;
 
     public AbortBenchmarkRequest() { }
 
-    public AbortBenchmarkRequest(String benchmarkName) {
-        this.benchmarkName = benchmarkName;
+    public AbortBenchmarkRequest(String... benchmarkNames) {
+        this.benchmarkNames = benchmarkNames;
     }
 
-    public void benchmarkName(String benchmarkName) {
-        this.benchmarkName = benchmarkName;
+    public void benchmarkNames(String... benchmarkNames) {
+        this.benchmarkNames = benchmarkNames;
     }
 
-    public String benchmarkName() {
-        return benchmarkName;
+    public String[] benchmarkNames() {
+        return benchmarkNames;
     }
+
     @Override
     public ActionRequestValidationException validate() {
-        if (benchmarkName == null) {
-            return ValidateActions.addValidationError("benchmarkName must not be null", null);
+        if (benchmarkNames == null || benchmarkNames.length == 0) {
+            return ValidateActions.addValidationError("benchmarkNames must not be null", null);
         }
         return null;
     }
@@ -56,14 +59,14 @@ public class AbortBenchmarkRequest extends AcknowledgedRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        benchmarkName = in.readString();
+        benchmarkNames = in.readStringArray();
         readTimeout(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(benchmarkName);
+        out.writeStringArray(benchmarkNames);
         writeTimeout(out);
     }
 }

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequestBuilder.java
@@ -33,7 +33,7 @@ public class AbortBenchmarkRequestBuilder extends ActionRequestBuilder<AbortBenc
         super((InternalClient) client, new AbortBenchmarkRequest());
     }
 
-    public AbortBenchmarkRequestBuilder setBenchmarkName(String... benchmarkNames) {
+    public AbortBenchmarkRequestBuilder setBenchmarkNames(String... benchmarkNames) {
         request.benchmarkNames(benchmarkNames);
         return this;
     }

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequestBuilder.java
@@ -33,8 +33,8 @@ public class AbortBenchmarkRequestBuilder extends ActionRequestBuilder<AbortBenc
         super((InternalClient) client, new AbortBenchmarkRequest());
     }
 
-    public AbortBenchmarkRequestBuilder setBenchmarkName(String benchmarkName) {
-        request.benchmarkName(benchmarkName);
+    public AbortBenchmarkRequestBuilder setBenchmarkName(String... benchmarkNames) {
+        request.benchmarkNames(benchmarkNames);
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkResponse.java
@@ -35,21 +35,10 @@ import java.util.ArrayList;
  */
 public class AbortBenchmarkResponse extends ActionResponse implements Streamable, ToXContent {
 
-    private String benchmarkName;
-    private String errorMessage;
     private List<AbortBenchmarkNodeResponse> nodeResponses = new ArrayList<>();
 
     AbortBenchmarkResponse() {
         super();
-    }
-
-    AbortBenchmarkResponse(String benchmarkName) {
-        this.benchmarkName = benchmarkName;
-    }
-
-    AbortBenchmarkResponse(String benchmarkName, String errorMessage) {
-        this.benchmarkName = benchmarkName;
-        this.errorMessage = errorMessage;
     }
 
     public void addNodeResponse(AbortBenchmarkNodeResponse nodeResponse) {
@@ -60,15 +49,9 @@ public class AbortBenchmarkResponse extends ActionResponse implements Streamable
         return nodeResponses;
     }
 
-    public String getBenchmarkName() {
-        return benchmarkName;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        benchmarkName = in.readString();
-        errorMessage = in.readOptionalString();
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
             AbortBenchmarkNodeResponse nodeResponse = new AbortBenchmarkNodeResponse();
@@ -80,8 +63,6 @@ public class AbortBenchmarkResponse extends ActionResponse implements Streamable
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(benchmarkName);
-        out.writeOptionalString(errorMessage);
         out.writeVInt(nodeResponses.size());
         for (AbortBenchmarkNodeResponse nodeResponse : nodeResponses) {
             nodeResponse.writeTo(out);
@@ -90,9 +71,6 @@ public class AbortBenchmarkResponse extends ActionResponse implements Streamable
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (errorMessage != null && !errorMessage.isEmpty()) {
-            builder.field(Fields.ERROR, errorMessage);
-        }
         if (nodeResponses.size() > 0) {
             builder.startArray(Fields.ABORTED);
             for (AbortBenchmarkNodeResponse nodeResponse : nodeResponses) {
@@ -104,7 +82,6 @@ public class AbortBenchmarkResponse extends ActionResponse implements Streamable
     }
 
     static final class Fields {
-        static final XContentBuilderString ERROR = new XContentBuilderString("error");
         static final XContentBuilderString ABORTED = new XContentBuilderString("aborted_benchmarks");
     }
 }

--- a/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
@@ -64,6 +64,6 @@ public class TransportAbortBenchmarkAction extends TransportMasterNodeOperationA
 
     @Override
     protected void masterOperation(AbortBenchmarkRequest request, ClusterState state, final ActionListener<AbortBenchmarkResponse> listener) throws ElasticsearchException {
-        service.abortBenchmark(request.benchmarkName(), listener);
+        service.abortBenchmark(request.benchmarkNames(), listener);
     }
 }

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -579,7 +579,7 @@ public interface Client {
     /**
      * Aborts a benchmark run on the server
      */
-    AbortBenchmarkRequestBuilder prepareAbortBench(String benchmarkId);
+    AbortBenchmarkRequestBuilder prepareAbortBench(String... benchmarkNames);
 
     /**
      * Reports on status of actively running benchmarks

--- a/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -404,8 +404,8 @@ public abstract class AbstractClient implements InternalClient {
     }
 
     @Override
-    public AbortBenchmarkRequestBuilder prepareAbortBench(String benchmarkId) {
-        return new AbortBenchmarkRequestBuilder(this).setBenchmarkName(benchmarkId);
+    public AbortBenchmarkRequestBuilder prepareAbortBench(String... benchmarkNames) {
+        return new AbortBenchmarkRequestBuilder(this).setBenchmarkNames(benchmarkNames);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -115,8 +115,8 @@ public class RestBenchAction extends BaseRestHandler {
      */
     private void handleAbortRequest(final RestRequest request, final RestChannel channel) {
 
-        String benchmarkName = request.param("name");
-        AbortBenchmarkRequest abortBenchmarkRequest = new AbortBenchmarkRequest(benchmarkName);
+        final String[] benchmarkNames = Strings.splitStringByCommaToArray(request.param("name"));
+        AbortBenchmarkRequest abortBenchmarkRequest = new AbortBenchmarkRequest(benchmarkNames);
 
         client.abortBench(abortBenchmarkRequest, new RestBuilderListener<AbortBenchmarkResponse>(channel) {
 

--- a/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
+++ b/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
@@ -435,8 +435,8 @@ public class RandomizingClient implements InternalClient {
     }
 
     @Override
-    public AbortBenchmarkRequestBuilder prepareAbortBench(String benchmarkId) {
-        return delegate.prepareAbortBench(benchmarkId);
+    public AbortBenchmarkRequestBuilder prepareAbortBench(String... benchmarkNames) {
+        return delegate.prepareAbortBench(benchmarkNames);
     }
 
     @Override


### PR DESCRIPTION
This adds support for sending a list of benchmark names and/or wildcard
patterns when submitting an abort request. Standard wildcards such as:
"_", "_xxx", and "xxx*" are supported. Multiple benchmark names and
wildcard patterns can be submitted together as a comma-separated list
from the REST API or as a string array from the Java API.

Closes #6185
