### PR TITLE
Benchmark: Do not throw an exception on unavailable nodes.

### DIFF
--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -102,7 +102,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
         final List<DiscoveryNode> nodes = availableBenchmarkNodes();
         if (nodes.size() == 0) {
-            listener.onFailure(new BenchmarkNodeMissingException("No available nodes for executing benchmarks"));
+            listener.onResponse(new BenchmarkStatusResponse());
         } else {
             BenchmarkStatusAsyncHandler async = new BenchmarkStatusAsyncHandler(nodes.size(), request, listener);
             for (DiscoveryNode node : nodes) {

--- a/src/test/java/org/elasticsearch/action/bench/BenchmarkNegativeTest.java
+++ b/src/test/java/org/elasticsearch/action/bench/BenchmarkNegativeTest.java
@@ -25,6 +25,8 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.*;
+
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 
 /**
@@ -45,9 +47,10 @@ public class BenchmarkNegativeTest extends ElasticsearchIntegrationTest {
                 client(), new String[] {INDEX_NAME}, cluster().size(), null)).actionGet();
     }
 
-    @Test(expected = BenchmarkNodeMissingException.class)
     public void testListBenchmarkNegative() {
-        client().prepareBenchStatus().execute().actionGet();
+        final BenchmarkStatusResponse response =
+                client().prepareBenchStatus().execute().actionGet();
+        assertThat(response.benchmarkResponses().size(), equalTo(0));
     }
 
     @Test(expected = BenchmarkNodeMissingException.class)


### PR DESCRIPTION
Changed behavior to not throw an exception on a status or abort request
when there are no available benchmark nodes.

Closes #6146
