### PR TITLE
Improve benchmark tests

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -284,7 +284,7 @@ public class ActionModule extends AbstractModule {
         registerAction(RecoveryAction.INSTANCE, TransportRecoveryAction.class);
         registerAction(BenchmarkAction.INSTANCE, TransportBenchmarkAction.class);
         registerAction(AbortBenchmarkAction.INSTANCE, TransportAbortBenchmarkAction.class);
-        registerAction(BenchmarkStatusAction.INSTANCE, TransportBenchmarkStatusAction.class);
+        registerAction(BenchmarkControlAction.INSTANCE, TransportBenchmarkControlAction.class);
 
         // register Name -> GenericAction Map that can be injected to instances.
         MapBinder<String, GenericAction> actionsBinder

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkControlAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkControlAction.java
@@ -23,24 +23,24 @@ import org.elasticsearch.action.Action;
 import org.elasticsearch.client.Client;
 
 /**
- * Benchmark status action
+ * Benchmark pause action
  */
-public class BenchmarkStatusAction extends Action<BenchmarkStatusRequest, BenchmarkStatusResponse, BenchmarkStatusRequestBuilder> {
+public class BenchmarkControlAction extends Action<BenchmarkControlRequest, BenchmarkStatusResponse, BenchmarkControlRequestBuilder> {
 
-    public static final BenchmarkStatusAction INSTANCE = new BenchmarkStatusAction();
-    public static final String NAME = "benchmark/status";
+    public static final BenchmarkControlAction INSTANCE = new BenchmarkControlAction();
+    public static final String NAME = "benchmark/control";
 
-    public BenchmarkStatusAction() {
+    public BenchmarkControlAction() {
         super(NAME);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder newRequestBuilder(Client client) {
+        return new BenchmarkControlRequestBuilder(client);
     }
 
     @Override
     public BenchmarkStatusResponse newResponse() {
         return new BenchmarkStatusResponse();
-    }
-
-    @Override
-    public BenchmarkStatusRequestBuilder newRequestBuilder(Client client) {
-        return new BenchmarkStatusRequestBuilder(client);
     }
 }

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Administrative commands for benchmarks: pause, resume
+ */
+public class BenchmarkControlRequest extends AcknowledgedRequest {
+
+    private String benchmarkName;
+    private Command command = Command.STATUS;
+
+    public enum Command {
+        PAUSE((byte) 0),                    // Pause an active benchmark
+        RESUME((byte) 1),                   // Resume an active benchmark
+        STATUS((byte) 2);                   // Report status of active benchmarks
+
+        private final byte id;
+        private static final Command[] COMMANDS = new Command[Command.values().length];
+
+        static {
+            for (Command command : Command.values()) {
+                assert command.id() < COMMANDS.length && command.id() >= 0;
+                COMMANDS[command.id()] = command;
+            }
+        }
+
+        Command(byte id) {
+            this.id = id;
+        }
+
+        public byte id() {
+            return id;
+        }
+
+        public static Command fromId(byte id) throws ElasticsearchIllegalArgumentException {
+            if (id < 0 || id > values().length) {
+                throw new ElasticsearchIllegalArgumentException("No mapping for id [" + id + "]");
+            }
+            return COMMANDS[id];
+        }
+    }
+
+    public BenchmarkControlRequest() { }
+
+    public BenchmarkControlRequest(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public void benchmarkName(String benchmarkName) {
+        this.benchmarkName = benchmarkName;
+    }
+
+    public String benchmarkName() {
+        return benchmarkName;
+    }
+
+    public void command(Command command) {
+        this.command = command;
+    }
+
+    public Command command() {
+        return command;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if ((command == Command.PAUSE || command == Command.RESUME) && benchmarkName == null) {
+            validationException = ValidateActions.addValidationError("benchmarkName must not be null", validationException);
+        }
+        if (command == null) {
+            validationException = ValidateActions.addValidationError("command must not be null", validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        benchmarkName = in.readOptionalString();
+        command = Command.fromId(in.readByte());
+        readTimeout(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(benchmarkName);
+        out.writeByte(command.id());
+        writeTimeout(out);
+    }
+}

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkControlRequestBuilder.java
@@ -25,16 +25,30 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestBuilder;
 
 /**
- * Request builder for benchmark status
+ * Request builder for benchmark pause
  */
-public class BenchmarkStatusRequestBuilder extends ActionRequestBuilder<BenchmarkStatusRequest, BenchmarkStatusResponse, BenchmarkStatusRequestBuilder> {
+public class BenchmarkControlRequestBuilder extends ActionRequestBuilder<BenchmarkControlRequest, BenchmarkStatusResponse, BenchmarkControlRequestBuilder> {
 
-    public BenchmarkStatusRequestBuilder(Client client) {
-        super((InternalClient) client, new BenchmarkStatusRequest());
+    public BenchmarkControlRequestBuilder(Client client) {
+        super((InternalClient) client, new BenchmarkControlRequest());
+    }
+
+    public BenchmarkControlRequestBuilder setBenchmarkName(String benchmarkName) {
+        request.benchmarkName(benchmarkName);
+        return this;
+    }
+
+    public BenchmarkControlRequestBuilder setBenchmarkName() {
+        return this;
+    }
+
+    public BenchmarkControlRequestBuilder setCommand(BenchmarkControlRequest.Command command) {
+        request.command(command);
+        return this;
     }
 
     @Override
     protected void doExecute(ActionListener<BenchmarkStatusResponse> listener) {
-        ((Client) client).benchStatus(request, listener);
+        ((Client) client).controlBenchmark(request, listener);
     }
 }

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkResponse.java
@@ -59,15 +59,17 @@ public class BenchmarkResponse extends ActionResponse implements Streamable, ToX
     /**
      * Benchmarks can be in one of:
      *  RUNNING     - executing normally
+     *  PAUSED      - execution suspended
      *  COMPLETE    - completed normally
      *  ABORTED     - aborted
      *  FAILED      - execution failed
      */
     public static enum State {
         RUNNING((byte) 0),
-        COMPLETE((byte) 1),
-        ABORTED((byte) 2),
-        FAILED((byte) 3);
+        PAUSED((byte) 1),
+        COMPLETE((byte) 2),
+        ABORTED((byte) 3),
+        FAILED((byte) 4);
 
         private final byte id;
         private static final State[] STATES = new State[State.values().length];

--- a/src/main/java/org/elasticsearch/client/Client.java
+++ b/src/main/java/org/elasticsearch/client/Client.java
@@ -584,10 +584,25 @@ public interface Client {
     /**
      * Reports on status of actively running benchmarks
      */
-    void benchStatus(BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener);
+    void benchStatus(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener);
 
     /**
      * Reports on status of actively running benchmarks
      */
-    BenchmarkStatusRequestBuilder prepareBenchStatus();
+    BenchmarkControlRequestBuilder prepareBenchStatus();
+
+    /**
+     * Sends a control command to an active benchmark
+     */
+    void controlBenchmark(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener);
+
+    /**
+     * Sends a control command to an active benchmark
+     */
+    BenchmarkControlRequestBuilder prepareControlBenchmark(String benchmarkName);
+
+    /**
+     * Sends a control command to an active benchmark
+     */
+    BenchmarkControlRequestBuilder prepareControlBenchmark();
 }

--- a/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -409,12 +409,27 @@ public abstract class AbstractClient implements InternalClient {
     }
 
     @Override
-    public void benchStatus(BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener) {
-        execute(BenchmarkStatusAction.INSTANCE, request, listener);
+    public BenchmarkControlRequestBuilder prepareBenchStatus() {
+        return new BenchmarkControlRequestBuilder(this);
     }
 
     @Override
-    public BenchmarkStatusRequestBuilder prepareBenchStatus() {
-        return new BenchmarkStatusRequestBuilder(this);
+    public void benchStatus(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        execute(BenchmarkControlAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public void controlBenchmark(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        execute(BenchmarkControlAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder prepareControlBenchmark(String benchmarkName) {
+        return new BenchmarkControlRequestBuilder(this).setBenchmarkName(benchmarkName);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder prepareControlBenchmark() {
+        return new BenchmarkControlRequestBuilder(this).setBenchmarkName();
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -69,21 +69,34 @@ public class RestBenchAction extends BaseRestHandler {
         controller.registerHandler(PUT, "/{index}/_bench", this);
         controller.registerHandler(PUT, "/{index}/{type}/_bench", this);
 
-        // Abort benchmark
-        controller.registerHandler(POST, "/_bench/abort/{name}", this);
+        // Abort/pause/resume benchmark
+        controller.registerHandler(POST, "/_bench/{command}/{name}", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel) {
         switch (request.method()) {
             case POST:
-                handleAbortRequest(request, channel);
+                switch (request.param("command", "")) {
+                    case "abort":
+                        handleAbortRequest(request, channel);
+                        break;
+                    case "pause":
+                        handleControlRequest(request, channel, BenchmarkControlRequest.Command.PAUSE);
+                        break;
+                    case "resume":
+                        handleControlRequest(request, channel, BenchmarkControlRequest.Command.RESUME);
+                        break;
+                    default:
+                        channel.sendResponse(new BytesRestResponse(BAD_REQUEST));
+                        break;
+                }
                 break;
             case PUT:
                 handleSubmitRequest(request, channel);
                 break;
             case GET:
-                handleStatusRequest(request, channel);
+                handleControlRequest(request, channel, BenchmarkControlRequest.Command.STATUS);
                 break;
             default:
                 // Politely ignore methods we don't support
@@ -92,14 +105,15 @@ public class RestBenchAction extends BaseRestHandler {
     }
 
     /**
-     * Reports on the status of all actively running benchmarks
+     * Sends a control request
      */
-    private void handleStatusRequest(final RestRequest request, final RestChannel channel) {
+    private void handleControlRequest(final RestRequest request, final RestChannel channel, BenchmarkControlRequest.Command command) {
 
-        BenchmarkStatusRequest benchmarkStatusRequest = new BenchmarkStatusRequest();
+        final String benchmarkName = request.param("name");
+        final BenchmarkControlRequest controlRequest = new BenchmarkControlRequest(benchmarkName);
+        controlRequest.command(command);
 
-        client.benchStatus(benchmarkStatusRequest, new RestBuilderListener<BenchmarkStatusResponse>(channel) {
-
+        client.controlBenchmark(controlRequest, new RestBuilderListener<BenchmarkStatusResponse>(channel) {
             @Override
             public RestResponse buildResponse(BenchmarkStatusResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/test/java/org/elasticsearch/action/bench/MockBenchmarkService.java
+++ b/src/test/java/org/elasticsearch/action/bench/MockBenchmarkService.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bench;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+
+public class MockBenchmarkService extends BenchmarkService {
+
+    @Inject
+    public MockBenchmarkService(Settings settings, ClusterService clusterService, ThreadPool threadPool,
+                                Client client, TransportService transportService) {
+        super(settings, clusterService, threadPool, client, transportService,
+                new MockBenchmarkExecutor(client, clusterService));
+    }
+
+    public void pauseSubmissions() throws InterruptedException {
+        executor.obtainSubmissionControl();
+    }
+
+    public void resumeSubmissions() {
+        executor.releaseSubmissionControl();
+    }
+
+    private static class MockBenchmarkExecutor extends BenchmarkExecutor {
+
+        public MockBenchmarkExecutor(Client client, ClusterService clusterService) {
+            super(client, clusterService);
+        }
+
+        @Override
+        protected void obtainSubmissionControl() throws InterruptedException {
+            submissionControl.acquire();
+        }
+
+        @Override
+        protected void releaseSubmissionControl() {
+            submissionControl.release();
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
+++ b/src/test/java/org/elasticsearch/test/client/RandomizingClient.java
@@ -440,13 +440,28 @@ public class RandomizingClient implements InternalClient {
     }
 
     @Override
-    public void benchStatus(BenchmarkStatusRequest request, ActionListener<BenchmarkStatusResponse> listener) {
-        delegate.benchStatus(request, listener);
+    public void benchStatus(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        delegate.controlBenchmark(request, listener);
     }
 
     @Override
-    public BenchmarkStatusRequestBuilder prepareBenchStatus() {
-        return delegate.prepareBenchStatus();
+    public BenchmarkControlRequestBuilder prepareBenchStatus() {
+        return delegate.prepareControlBenchmark();
+    }
+
+    @Override
+    public void controlBenchmark(BenchmarkControlRequest request, ActionListener<BenchmarkStatusResponse> listener) {
+        delegate.controlBenchmark(request, listener);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder prepareControlBenchmark(String benchmarkName) {
+        return delegate.prepareControlBenchmark(benchmarkName);
+    }
+
+    @Override
+    public BenchmarkControlRequestBuilder prepareControlBenchmark() {
+        return delegate.prepareControlBenchmark();
     }
 
     @Override


### PR DESCRIPTION
This commit improves the ability to test the benchmark API by adding
several features.

Pause/resume: New API commands are added to pause running benchmarks and
to resume them. The commands are exposed in the REST API at
/_bench/(pause|resume).

Control commands: Adding the pause/resume resulted in a lot of duplicate
code. Consequently, this commit consolidates the code for 3 different
API commands into one. The result is a new control API that handles the
logic for pause, resume, and status requests. REST API has not changed
for status requests. The Java API has been slightly modified to accept a
control command parameter to specify pause/resume/status.

Mocking: A mock service is implemented which provides the ability to
pause benchmarks after they have been submitted, but before they
actually start executing. This allows easy testing of various benchmark
states w/o having to do tricks to coerce runtime state.

Closes #6224
