### PR TITLE
Remove backward compatibility layer introduced in #6149

### DIFF
--- a/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -25,7 +25,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 

--- a/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/src/main/java/org/elasticsearch/index/VersionType.java
@@ -40,8 +40,7 @@ public enum VersionType {
             if (currentVersion == Versions.NOT_SET) {
                 return false;
             }
-            // we need to allow pre 1.2.0 match any as requests can come in for java code where the may be hardcoded
-            if (expectedVersion == Versions.MATCH_ANY || expectedVersion == Versions.MATCH_ANY_PRE_1_2_0) {
+            if (expectedVersion == Versions.MATCH_ANY) {
                 return false;
             }
             if (currentVersion == Versions.NOT_FOUND) {
@@ -61,13 +60,13 @@ public enum VersionType {
         @Override
         public boolean validateVersionForWrites(long version) {
             // not allowing Versions.NOT_FOUND as it is not a valid input value.
-            return version > 0L || version == Versions.MATCH_ANY || version == Versions.MATCH_ANY_PRE_1_2_0;
+            return version > 0L || version == Versions.MATCH_ANY;
         }
 
         @Override
         public boolean validateVersionForReads(long version) {
             // not allowing Versions.NOT_FOUND as it is not a valid input value.
-            return version > 0L || version == Versions.MATCH_ANY || version == Versions.MATCH_ANY_PRE_1_2_0;
+            return version > 0L || version == Versions.MATCH_ANY;
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsTests.java
+++ b/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -1136,7 +1137,7 @@ public class GetTermVectorsTests extends AbstractTermVectorsTests {
         // From translog:
 
         // version 0 means ignore version, which is the default
-        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(0).get();
+        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getVersion(), equalTo(1l));
@@ -1157,7 +1158,7 @@ public class GetTermVectorsTests extends AbstractTermVectorsTests {
         refresh();
 
         // version 0 means ignore version, which is the default
-        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(0).setRealtime(false).get();
+        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).setRealtime(false).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
@@ -1182,7 +1183,7 @@ public class GetTermVectorsTests extends AbstractTermVectorsTests {
         // From translog:
 
         // version 0 means ignore version, which is the default
-        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(0).get();
+        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
@@ -1205,7 +1206,7 @@ public class GetTermVectorsTests extends AbstractTermVectorsTests {
         refresh();
 
         // version 0 means ignore version, which is the default
-        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(0).setRealtime(false).get();
+        response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).setRealtime(false).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));

--- a/src/test/java/org/elasticsearch/action/termvectors/MultiTermVectorsTests.java
+++ b/src/test/java/org/elasticsearch/action/termvectors/MultiTermVectorsTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.junit.Test;
 
@@ -96,7 +97,7 @@ public class MultiTermVectorsTests extends AbstractTermVectorsTests {
 
         // Version from translog
         response = client().prepareMultiTermVectors()
-                .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(0))
+                .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(Versions.MATCH_ANY))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(1))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(2))
                 .get();
@@ -119,7 +120,7 @@ public class MultiTermVectorsTests extends AbstractTermVectorsTests {
         //Version from Lucene index
         refresh();
         response = client().prepareMultiTermVectors()
-                .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(0).realtime(false))
+                .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(Versions.MATCH_ANY).realtime(false))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(1).realtime(false))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "1").selectedFields("field").version(2).realtime(false))
                 .get();
@@ -144,7 +145,7 @@ public class MultiTermVectorsTests extends AbstractTermVectorsTests {
 
         // Version from translog
         response = client().prepareMultiTermVectors()
-                .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(0))
+                .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(Versions.MATCH_ANY))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(1))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(2))
                 .get();
@@ -169,7 +170,7 @@ public class MultiTermVectorsTests extends AbstractTermVectorsTests {
         //Version from Lucene index
         refresh();
         response = client().prepareMultiTermVectors()
-                .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(0))
+                .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(Versions.MATCH_ANY))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(1))
                 .add(new TermVectorsRequest(indexOrAlias(), "type1", "2").selectedFields("field").version(2))
                 .get();

--- a/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
@@ -533,8 +534,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         // From translog:
 
-        // version 0 means ignore version, which is the default
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(0).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getVersion(), equalTo(1l));
@@ -554,8 +554,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         // From Lucene index:
         refresh();
 
-        // version 0 means ignore version, which is the default
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(0).setRealtime(false).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).setRealtime(false).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
@@ -579,8 +578,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         // From translog:
 
-        // version 0 means ignore version, which is the default
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(0).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
@@ -602,8 +600,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         // From Lucene index:
         refresh();
 
-        // version 0 means ignore version, which is the default
-        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(0).setRealtime(false).get();
+        response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).setRealtime(false).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
@@ -639,7 +636,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         // Version from translog
         response = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(0))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(Versions.MATCH_ANY))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(1))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(2))
                 .get();
@@ -662,7 +659,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         //Version from Lucene index
         refresh();
         response = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(0))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(Versions.MATCH_ANY))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(1))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").version(2))
                 .setRealtime(false)
@@ -688,7 +685,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
         // Version from translog
         response = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(0))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(Versions.MATCH_ANY))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(1))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(2))
                 .get();
@@ -713,7 +710,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         //Version from Lucene index
         refresh();
         response = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(0))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(Versions.MATCH_ANY))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(1))
                 .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").version(2))
                 .setRealtime(false)

--- a/src/test/java/org/elasticsearch/index/VersionTypeTests.java
+++ b/src/test/java/org/elasticsearch/index/VersionTypeTests.java
@@ -43,11 +43,6 @@ public class VersionTypeTests extends ElasticsearchTestCase {
         assertFalse(VersionType.INTERNAL.isVersionConflictForWrites(Versions.NOT_FOUND, Versions.MATCH_ANY));
         assertFalse(VersionType.INTERNAL.isVersionConflictForReads(Versions.NOT_FOUND, Versions.MATCH_ANY));
 
-        // test 0 is still matching any for backwards compatibility with versions <1.2.0
-        assertFalse(VersionType.INTERNAL.isVersionConflictForWrites(10, Versions.MATCH_ANY_PRE_1_2_0));
-        assertFalse(VersionType.INTERNAL.isVersionConflictForReads(10, Versions.MATCH_ANY_PRE_1_2_0));
-
-
         // and the stupid usual case
         assertFalse(VersionType.INTERNAL.isVersionConflictForWrites(10, 10));
         assertFalse(VersionType.INTERNAL.isVersionConflictForReads(10, 10));


### PR DESCRIPTION
PR #6149 changed the `Versions.MATCH_ANY` value  from 0 to -3. This was done to allow 0 to be a valid external version. This commit removes the backward compatibility code from v2.0 and up.
