### PR TITLE
Register uppercase as an exposed ES token filter.

### DIFF
--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
@@ -139,6 +139,7 @@ public class AnalysisFactoryTests extends ElasticsearchTestCase {
         put("trim",                      TrimTokenFilterFactory.class);
         put("truncate",                  TruncateTokenFilterFactory.class);
         put("turkishlowercase",          LowerCaseTokenFilterFactory.class);
+        put("uppercase",                 UpperCaseTokenFilterFactory.class);
         put("worddelimiter",             WordDelimiterTokenFilterFactory.class);
                 
         // TODO: these tokenfilters are not yet exposed: useful?
@@ -189,8 +190,6 @@ public class AnalysisFactoryTests extends ElasticsearchTestCase {
         put("type",                      Void.class);
         // puts the type into the payload
         put("typeaspayload",             Void.class);
-        // opposite of lowercase...
-        put("uppercase",                 Void.class);
     }};
     
     public void testTokenFilters() {


### PR DESCRIPTION
Just follow "lowercase" token filter example and register "uppercase" token filter as an exposed token filter. This will not, by itself, test whether ES is correctly handling "uppercase" TF; this is more of a "code as documentation" fix.

This PR is related to issue #6188.
