### PR TITLE
CharArraySet doesn't know how to lookup the original string in an ImmutableList.

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.analysis;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.NumericTokenStream;
@@ -107,10 +106,10 @@ public class Analysis {
                 return new CharArraySet(version, Strings.commaDelimitedListToSet(value), false);
             }
         }
-        String[] stopWords = settings.getAsArray("stem_exclusion", null);
-        if (stopWords != null) {
+        String[] stemExclusion = settings.getAsArray("stem_exclusion", null);
+        if (stemExclusion != null) {
             // LUCENE 4 UPGRADE: Should be settings.getAsBoolean("stem_exclusion_case", false)?
-            return new CharArraySet(version, ImmutableList.of(stopWords), false);
+            return new CharArraySet(version, Arrays.asList(stemExclusion), false);
         } else {
             return defaultStemExclusion;
         }

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.Matchers.is;
+
+public class AnalysisTests extends ElasticsearchTestCase {
+    @Test
+    public void testParseStemExclusion() {
+
+        /* Comma separated list */
+        Settings settings = settingsBuilder().put("stem_exclusion", "foo,bar").build();
+        CharArraySet set = Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET, Version.CURRENT.luceneVersion);
+        assertThat(set.contains("foo"), is(true));
+        assertThat(set.contains("bar"), is(true));
+        assertThat(set.contains("baz"), is(false));
+
+        /* Array */
+        settings = settingsBuilder().putArray("stem_exclusion", "foo","bar").build();
+        set = Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET, Version.CURRENT.luceneVersion);
+        assertThat(set.contains("foo"), is(true));
+        assertThat(set.contains("bar"), is(true));
+        assertThat(set.contains("baz"), is(false));
+    }
+
+}


### PR DESCRIPTION
This was causing the `stem_exclusion` list, when passed as an array, to be incorrect.

Closes #6237
