### PR TITLE
Improve cluster update settings api

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -116,6 +116,19 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
             }
 
             private void reroute(final boolean updateSettingsAcked) {
+                // We're about to send a second update task, so we need to check if we're still the elected master
+                // For example the minimum_master_node could have been breached and we're no longer elected master,
+                // so we should *not* execute the reroute.
+                if (!clusterService.state().nodes().localNodeMaster()) {
+                    logger.debug("Skipping reroute after cluster update settings, because node is no longer master");
+                    listener.onResponse(new ClusterUpdateSettingsResponse(updateSettingsAcked, transientUpdates.build(), persistentUpdates.build()));
+                    return;
+                }
+
+                // The reason the reroute needs to be send as separate update task, is that all the *cluster* settings are encapsulate
+                // in the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible
+                // to the components until the ClusterStateListener instances have been invoked, but are visible after
+                // the first update task has been completed.
                 clusterService.submitStateUpdateTask("reroute_after_cluster_update_settings", Priority.URGENT, new AckedClusterStateUpdateTask() {
 
                     @Override
@@ -150,6 +163,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                     public void onFailure(String source, Throwable t) {
                         //if the reroute fails we only log
                         logger.debug("failed to perform [{}]", t, source);
+                        listener.onFailure(t);
                     }
 
                     @Override


### PR DESCRIPTION
- If the minimum master nodes has been breached the reroute shouldn't be executed
- Cluster update settings call should also return in case of failures during the reroute.
