### PR TITLE
Documentation Query string date range 

### DIFF
--- a/docs/reference/query-dsl/queries/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/queries/query-string-syntax.asciidoc
@@ -133,7 +133,7 @@ curly brackets `{min TO max}`.
 
 * All days in 2012:
 
-    date:[2012/01/01 TO 2012/12/31]
+    date:[2012-01-01 TO 2012-12-31]
 
 * Numbers 1..5
 
@@ -149,7 +149,7 @@ curly brackets `{min TO max}`.
 
 * Dates before 2012
 
-    date:{* TO 2012/01/01}
+    date:{* TO 2012-01-01}
 
 Curly and square brackets can be combined:
 


### PR DESCRIPTION
I modified the date encoding in the example about date range in query string documentation. 
Yesterday i tried to send a query like "date:[2014/05/01 TO 2014/05/20] and my es server answered me : 

Parse Failure [Failed to parse source [{\"query\":{\"query_string\":{\"query\":\"(evt.date:[2014/05/01 TO 2014/05/20])\"}},\"size\":10,\"from\":0}]]]; nested: ElasticSearchParseException[failed to parse date field [2014/05/01], tried both date format [dateOptionalTime], and timestamp number]; nested: IllegalArgumentException[Invalid format: \"2014/05/01\" is malformed at \"/05/01\"]; }]

Then i tried with "date:[2014-05-01 TO 2014-05-20]" and it worked. 
I don't know if it's a bug about date encoding in es query string, That's why through this pull request i submit you the problem that i met and maybe an issue.
Anyway you did a great job with elasticsearch.
Have a good day
Sorry about my poor English, i m not fluent. 
