### PR TITLE
Restored MetaData#concreteIndices(String[] indices) method

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -625,6 +625,16 @@ public class MetaData implements Iterable<IndexMetaData> {
 
     /**
      * Translates the provided indices or aliases, eventually containing wildcard expressions, into actual indices.
+     * @deprecated use {@link #concreteIndices(org.elasticsearch.action.support.IndicesOptions, String...)} instead and
+     * be explicit about indices options to be used for indices resolution
+     */
+    @Deprecated
+    public String[] concreteIndices(String[] indices) throws IndexMissingException {
+        return concreteIndices(IndicesOptions.strictExpand(), indices);
+    }
+
+    /**
+     * Translates the provided indices or aliases, eventually containing wildcard expressions, into actual indices.
      * @param indicesOptions how the aliases or indices need to be resolved to concrete indices
      * @param aliasesOrIndices the aliases or indices to be resolved to concrete indices
      * @return the obtained concrete indices


### PR DESCRIPTION
Restored MetaData#concreteIndices(String[] indices) method, deprecated instead or removed for backwards compatibility in 1.x

Relates to #6059
