### PR TITLE
Indices Stats: Add FieldData and Filter eviction rates

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -113,10 +113,14 @@ node (c) |d
 cache memory |0b
 |`fielddata.evictions` |`fe`, `fielddataEvictions` |No |Fielddata cache
 evictions |0
+|`fielddata.evictions_per_sec` |`feps`, `fielddataEvictionsPerSecond` |No |Fielddata
+cache evictions per Second (1m 5m 15m intervals) |[53 13.3 4.6]
 |`filter_cache.memory_size` |`fcm`, `filterCacheMemory` |No |Used filter
 cache memory |0b
 |`filter_cache.evictions` |`fce`, `filterCacheEvictions` |No |Filter
 cache evictions |0
+|`filter_cache.evictions_per_sec` |`fceps`, `filterCacheEvictionsPerSecond` |No |Filter
+cache evictions per Second (1m 5m 15m intervals) |[53 13.3 4.6]
 |`flush.total` |`ft`, `flushTotal` |No |Number of flushes |1
 |`flush.total_time` |`ftt`, `flushTotalTime` |No |Time spent in flush |1
 |`get.current` |`gc`, `getCurrent` |No |Number of current get

--- a/src/main/java/org/elasticsearch/common/metrics/EvictionStats.java
+++ b/src/main/java/org/elasticsearch/common/metrics/EvictionStats.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.common.metrics;
 
 

--- a/src/main/java/org/elasticsearch/common/metrics/EvictionStats.java
+++ b/src/main/java/org/elasticsearch/common/metrics/EvictionStats.java
@@ -1,0 +1,101 @@
+package org.elasticsearch.common.metrics;
+
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+
+public class EvictionStats implements Streamable, ToXContent {
+
+    private long evictions;
+    private double evictionsOneMinuteRate;
+    private double evictionsFiveMinuteRate;
+    private double evictionsFifteenMinuteRate;
+
+    public EvictionStats() {
+        this.evictions = 0;
+        this.evictionsOneMinuteRate = 0;
+        this.evictionsFiveMinuteRate = 0;
+        this.evictionsFifteenMinuteRate = 0;
+    }
+
+    public EvictionStats(long evictions, double oneMin, double fiveMin, double fifteenMin) {
+        this.evictions = evictions;
+        this.evictionsOneMinuteRate = oneMin;
+        this.evictionsFiveMinuteRate = fiveMin;
+        this.evictionsFifteenMinuteRate = fifteenMin;
+    }
+
+    public EvictionStats(MeterMetric evictionMeter) {
+        this.evictions = evictionMeter.count();
+        this.evictionsOneMinuteRate = evictionMeter.oneMinuteRate();
+        this.evictionsFiveMinuteRate = evictionMeter.fiveMinuteRate();
+        this.evictionsFifteenMinuteRate = evictionMeter.fifteenMinuteRate();
+    }
+
+    public void add(EvictionStats other) {
+        this.evictions += other.getEvictions();
+        this.evictionsOneMinuteRate += other.getEvictionsOneMinuteRate();
+        this.evictionsFiveMinuteRate += other.getEvictionsFiveMinuteRate();
+        this.evictionsFifteenMinuteRate += other.getEvictionsFifteenMinuteRate();
+    }
+
+    public long getEvictions() {
+        return evictions;
+    }
+
+    public double getEvictionsOneMinuteRate() {
+        return evictionsOneMinuteRate;
+    }
+
+    public double getEvictionsFiveMinuteRate() {
+        return evictionsFiveMinuteRate;
+    }
+
+    public double getEvictionsFifteenMinuteRate() {
+        return evictionsFifteenMinuteRate;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        evictions = in.readVLong();
+        evictionsOneMinuteRate = in.readDouble();
+        evictionsFiveMinuteRate = in.readDouble();
+        evictionsFifteenMinuteRate = in.readDouble();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(evictions);
+        out.writeDouble(evictionsOneMinuteRate);
+        out.writeDouble(evictionsFiveMinuteRate);
+        out.writeDouble(evictionsFifteenMinuteRate);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.EVICTIONS, getEvictions());
+
+        builder.startObject(Fields.RATES);
+            builder.field(Fields.ONE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsOneMinuteRate(), "")));
+            builder.field(Fields.FIVE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFiveMinuteRate(),"")));
+            builder.field(Fields.FIFTEEN_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFifteenMinuteRate(),"")));
+        builder.endObject();
+
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
+        static final XContentBuilderString RATES = new XContentBuilderString("evictions_per_sec");
+        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1m");
+        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5m");
+        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15m");
+    }
+}

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.metrics.EvictionStats;
 import org.elasticsearch.common.metrics.MeterMetric;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -37,28 +38,20 @@ import java.io.IOException;
 public class FilterCacheStats implements Streamable, ToXContent {
 
     long memorySize;
-    private long evictions;
-    private double evictionsOneMinuteRate;
-    private double evictionsFiveMinuteRate;
-    private double evictionsFifteenMinuteRate;
+    private EvictionStats evictionStats;
 
     public FilterCacheStats() {
+        evictionStats = new EvictionStats();
     }
 
     public FilterCacheStats(long memorySize, MeterMetric evictionMeter) {
         this.memorySize = memorySize;
-        this.evictions = evictionMeter.count();
-        this.evictionsOneMinuteRate = evictionMeter.oneMinuteRate();
-        this.evictionsFiveMinuteRate = evictionMeter.fiveMinuteRate();
-        this.evictionsFifteenMinuteRate = evictionMeter.fifteenMinuteRate();
+        this.evictionStats = new EvictionStats(evictionMeter);
     }
 
     public void add(FilterCacheStats stats) {
         this.memorySize += stats.memorySize;
-        this.evictions += stats.evictions;
-        this.evictionsOneMinuteRate += stats.evictionsOneMinuteRate;
-        this.evictionsFiveMinuteRate += stats.evictionsFiveMinuteRate;
-        this.evictionsFifteenMinuteRate += stats.evictionsFifteenMinuteRate;
+        this.evictionStats.add(stats.getEvictionStats());
     }
 
     public long getMemorySizeInBytes() {
@@ -69,20 +62,8 @@ public class FilterCacheStats implements Streamable, ToXContent {
         return new ByteSizeValue(memorySize);
     }
 
-    public long getEvictions() {
-        return this.evictions;
-    }
-
-    public double getEvictionsOneMinuteRate() {
-        return this.evictionsOneMinuteRate;
-    }
-
-    public double getEvictionsFiveMinuteRate() {
-        return this.evictionsFiveMinuteRate;
-    }
-
-    public double getEvictionsFifteenMinuteRate() {
-        return this.evictionsFifteenMinuteRate;
+    public EvictionStats getEvictionStats() {
+        return this.evictionStats;
     }
 
     public static FilterCacheStats readFilterCacheStats(StreamInput in) throws IOException {
@@ -94,28 +75,21 @@ public class FilterCacheStats implements Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         memorySize = in.readVLong();
-        evictions = in.readVLong();
-
         if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-            evictionsOneMinuteRate = in.readDouble();
-            evictionsFiveMinuteRate = in.readDouble();
-            evictionsFifteenMinuteRate = in.readDouble();
+            evictionStats = new EvictionStats();
+            evictionStats.readFrom(in);
         } else {
-            evictionsOneMinuteRate = -1;
-            evictionsFiveMinuteRate = -1;
-            evictionsFifteenMinuteRate = -1;
+            evictionStats = new EvictionStats(in.readVLong(), -1, -1, -1);
         }
-
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(memorySize);
-        out.writeVLong(evictions);
         if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-            out.writeDouble(evictionsOneMinuteRate);
-            out.writeDouble(evictionsFiveMinuteRate);
-            out.writeDouble(evictionsFifteenMinuteRate);
+            evictionStats.writeTo(out);
+        } else {
+            out.writeVLong(evictionStats.getEvictions());
         }
 
     }
@@ -124,13 +98,7 @@ public class FilterCacheStats implements Streamable, ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject(Fields.FILTER_CACHE);
         builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, memorySize);
-        builder.field(Fields.EVICTIONS, getEvictions());
-
-        builder.startObject(Fields.RATES);
-        builder.field(Fields.ONE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsOneMinuteRate(), "")));
-        builder.field(Fields.FIVE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFiveMinuteRate(), "")));
-        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFifteenMinuteRate(), "")));
-        builder.endObject();
+        evictionStats.toXContent(builder, params);
 
         builder.endObject();
         return builder;
@@ -140,10 +108,5 @@ public class FilterCacheStats implements Streamable, ToXContent {
         static final XContentBuilderString FILTER_CACHE = new XContentBuilderString("filter_cache");
         static final XContentBuilderString MEMORY_SIZE = new XContentBuilderString("memory_size");
         static final XContentBuilderString MEMORY_SIZE_IN_BYTES = new XContentBuilderString("memory_size_in_bytes");
-        static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
-        static final XContentBuilderString RATES = new XContentBuilderString("evictions_per_sec");
-        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1m");
-        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5m");
-        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15m");
     }
 }

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.text.DecimalFormat;
 
 /**
  */
@@ -112,11 +113,14 @@ public class FilterCacheStats implements Streamable, ToXContent {
         builder.startObject(Fields.FILTER_CACHE);
         builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
-        builder.startArray(Fields.RATES);
-        builder.value(getEvictionsOneMinuteRate());
-        builder.value(getEvictionsFiveMinuteRate());
-        builder.value(getEvictionsFifteenMinuteRate());
-        builder.endArray();
+
+        DecimalFormat threeDecimal = new DecimalFormat("#.###");
+        builder.startObject(Fields.RATES);
+        builder.field(Fields.ONE_MIN, Double.valueOf(threeDecimal.format(getEvictionsOneMinuteRate())));
+        builder.field(Fields.FIVE_MIN, Double.valueOf(threeDecimal.format(getEvictionsFiveMinuteRate())));
+        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(threeDecimal.format(getEvictionsFifteenMinuteRate())));
+        builder.endObject();
+
         builder.endObject();
         return builder;
     }
@@ -127,5 +131,8 @@ public class FilterCacheStats implements Streamable, ToXContent {
         static final XContentBuilderString MEMORY_SIZE_IN_BYTES = new XContentBuilderString("memory_size_in_bytes");
         static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
         static final XContentBuilderString RATES = new XContentBuilderString("rates");
+        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1_min");
+        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5_min");
+        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15_min");
     }
 }

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -75,7 +75,7 @@ public class FilterCacheStats implements Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         memorySize = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+        if (in.getVersion().onOrAfter(Version.V_1_5_0)) {
             evictionStats = new EvictionStats();
             evictionStats.readFrom(in);
         } else {
@@ -86,7 +86,7 @@ public class FilterCacheStats implements Streamable, ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(memorySize);
-        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
             evictionStats.writeTo(out);
         } else {
             out.writeVLong(evictionStats.getEvictions());

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.cache.filter;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -30,7 +31,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
-import java.text.DecimalFormat;
 
 /**
  */
@@ -126,11 +126,10 @@ public class FilterCacheStats implements Streamable, ToXContent {
         builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
 
-        DecimalFormat threeDecimal = new DecimalFormat("#.###");
         builder.startObject(Fields.RATES);
-        builder.field(Fields.ONE_MIN, Double.valueOf(threeDecimal.format(getEvictionsOneMinuteRate())));
-        builder.field(Fields.FIVE_MIN, Double.valueOf(threeDecimal.format(getEvictionsFiveMinuteRate())));
-        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(threeDecimal.format(getEvictionsFifteenMinuteRate())));
+        builder.field(Fields.ONE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsOneMinuteRate(), "")));
+        builder.field(Fields.FIVE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFiveMinuteRate(), "")));
+        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFifteenMinuteRate(), "")));
         builder.endObject();
 
         builder.endObject();
@@ -142,9 +141,9 @@ public class FilterCacheStats implements Streamable, ToXContent {
         static final XContentBuilderString MEMORY_SIZE = new XContentBuilderString("memory_size");
         static final XContentBuilderString MEMORY_SIZE_IN_BYTES = new XContentBuilderString("memory_size_in_bytes");
         static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
-        static final XContentBuilderString RATES = new XContentBuilderString("rates");
-        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1_min");
-        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5_min");
-        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15_min");
+        static final XContentBuilderString RATES = new XContentBuilderString("evictions_per_sec");
+        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1m");
+        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5m");
+        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15m");
     }
 }

--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.cache.filter;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -94,18 +95,29 @@ public class FilterCacheStats implements Streamable, ToXContent {
     public void readFrom(StreamInput in) throws IOException {
         memorySize = in.readVLong();
         evictions = in.readVLong();
-        evictionsOneMinuteRate = in.readDouble();
-        evictionsFiveMinuteRate = in.readDouble();
-        evictionsFifteenMinuteRate = in.readDouble();
+
+        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            evictionsOneMinuteRate = in.readDouble();
+            evictionsFiveMinuteRate = in.readDouble();
+            evictionsFifteenMinuteRate = in.readDouble();
+        } else {
+            evictionsOneMinuteRate = -1;
+            evictionsFiveMinuteRate = -1;
+            evictionsFifteenMinuteRate = -1;
+        }
+
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(memorySize);
         out.writeVLong(evictions);
-        out.writeDouble(evictionsOneMinuteRate);
-        out.writeDouble(evictionsFiveMinuteRate);
-        out.writeDouble(evictionsFifteenMinuteRate);
+        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            out.writeDouble(evictionsOneMinuteRate);
+            out.writeDouble(evictionsFiveMinuteRate);
+            out.writeDouble(evictionsFifteenMinuteRate);
+        }
+
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCache.java
@@ -31,20 +31,21 @@ import org.elasticsearch.index.cache.filter.weighted.WeightedFilterCache;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
  */
 public class ShardFilterCache extends AbstractIndexShardComponent implements RemovalListener<WeightedFilterCache.FilterCacheKey, DocIdSet> {
 
-    final MeterMetric evictionMeter = new MeterMetric(Executors.newSingleThreadScheduledExecutor(), TimeUnit.MINUTES);
+    final MeterMetric evictionMeter;
     final CounterMetric totalMetric = new CounterMetric();
 
     @Inject
-    public ShardFilterCache(ShardId shardId, @IndexSettings Settings indexSettings) {
+    public ShardFilterCache(ShardId shardId, @IndexSettings Settings indexSettings, ThreadPool threadPool) {
         super(shardId, indexSettings);
+        evictionMeter = new MeterMetric(threadPool.scheduler(), TimeUnit.MINUTES);
     }
 
     public FilterCacheStats stats() {

--- a/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.fielddata;
 import com.carrotsearch.hppc.ObjectLongOpenHashMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -32,7 +33,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
-import java.text.DecimalFormat;
 
 /**
  */
@@ -168,11 +168,10 @@ public class FieldDataStats implements Streamable, ToXContent {
         builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
 
-        DecimalFormat threeDecimal = new DecimalFormat("#.###");
         builder.startObject(Fields.RATES);
-        builder.field(Fields.ONE_MIN, Double.valueOf(threeDecimal.format(getEvictionsOneMinuteRate())));
-        builder.field(Fields.FIVE_MIN, Double.valueOf(threeDecimal.format(getEvictionsFiveMinuteRate())));
-        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(threeDecimal.format(getEvictionsFifteenMinuteRate())));
+        builder.field(Fields.ONE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsOneMinuteRate(),"")));
+        builder.field(Fields.FIVE_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFiveMinuteRate(),"")));
+        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(Strings.format1Decimals(getEvictionsFifteenMinuteRate(),"")));
         builder.endObject();
 
         if (fields != null) {
@@ -199,9 +198,9 @@ public class FieldDataStats implements Streamable, ToXContent {
         static final XContentBuilderString MEMORY_SIZE_IN_BYTES = new XContentBuilderString("memory_size_in_bytes");
         static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
         static final XContentBuilderString FIELDS = new XContentBuilderString("fields");
-        static final XContentBuilderString RATES = new XContentBuilderString("rates");
-        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1_min");
-        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5_min");
-        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15_min");
+        static final XContentBuilderString RATES = new XContentBuilderString("evictions_per_sec");
+        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1m");
+        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5m");
+        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15m");
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.text.DecimalFormat;
 
 /**
  */
@@ -157,11 +158,14 @@ public class FieldDataStats implements Streamable, ToXContent {
         builder.startObject(Fields.FIELDDATA);
         builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
-        builder.startArray(Fields.RATES);
-        builder.value(getEvictionsOneMinuteRate());
-        builder.value(getEvictionsFiveMinuteRate());
-        builder.value(getEvictionsFifteenMinuteRate());
-        builder.endArray();
+
+        DecimalFormat threeDecimal = new DecimalFormat("#.###");
+        builder.startObject(Fields.RATES);
+        builder.field(Fields.ONE_MIN, Double.valueOf(threeDecimal.format(getEvictionsOneMinuteRate())));
+        builder.field(Fields.FIVE_MIN, Double.valueOf(threeDecimal.format(getEvictionsFiveMinuteRate())));
+        builder.field(Fields.FIFTEEN_MIN, Double.valueOf(threeDecimal.format(getEvictionsFifteenMinuteRate())));
+        builder.endObject();
+
         if (fields != null) {
             builder.startObject(Fields.FIELDS);
             final boolean[] states = fields.allocated;
@@ -187,5 +191,8 @@ public class FieldDataStats implements Streamable, ToXContent {
         static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
         static final XContentBuilderString FIELDS = new XContentBuilderString("fields");
         static final XContentBuilderString RATES = new XContentBuilderString("rates");
+        static final XContentBuilderString ONE_MIN = new XContentBuilderString("1_min");
+        static final XContentBuilderString FIVE_MIN = new XContentBuilderString("5_min");
+        static final XContentBuilderString FIFTEEN_MIN = new XContentBuilderString("15_min");
     }
 }

--- a/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -98,7 +98,7 @@ public class FieldDataStats implements Streamable, ToXContent {
     public void readFrom(StreamInput in) throws IOException {
         memorySize = in.readVLong();
 
-        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+        if (in.getVersion().onOrAfter(Version.V_1_5_0)) {
             evictionStats = new EvictionStats();
             evictionStats.readFrom(in);
         } else {
@@ -118,7 +118,7 @@ public class FieldDataStats implements Streamable, ToXContent {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(memorySize);
 
-        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+        if (out.getVersion().onOrAfter(Version.V_1_5_0)) {
             evictionStats.writeTo(out);
         } else {
             out.writeVLong(evictionStats.getEvictions());

--- a/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
@@ -32,24 +32,25 @@ import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
  */
 public class ShardFieldData extends AbstractIndexShardComponent implements IndexFieldDataCache.Listener {
 
-    final MeterMetric evictionMeter = new MeterMetric(Executors.newSingleThreadScheduledExecutor(), TimeUnit.MINUTES);
+    final MeterMetric evictionMeter;
     final CounterMetric totalMetric = new CounterMetric();
 
     final ConcurrentMap<String, CounterMetric> perFieldTotals = ConcurrentCollections.newConcurrentMap();
 
     @Inject
-    public ShardFieldData(ShardId shardId, @IndexSettings Settings indexSettings) {
+    public ShardFieldData(ShardId shardId, @IndexSettings Settings indexSettings, ThreadPool threadPool) {
         super(shardId, indexSettings);
+        evictionMeter = new MeterMetric(threadPool.scheduler(), TimeUnit.MINUTES);
     }
 
     public FieldDataStats stats(String... fields) {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -317,14 +317,14 @@ public class RestIndicesAction extends AbstractCatAction {
             table.addCell(indexStats == null ? null : indexStats.getTotal().getFieldData().getMemorySize());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getFieldData().getMemorySize());
 
-            table.addCell(indexStats == null ? null : indexStats.getTotal().getFieldData().getEvictions());
-            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getFieldData().getEvictions());
+            table.addCell(indexStats == null ? null : indexStats.getTotal().getFieldData().getEvictionStats().getEvictions());
+            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getFieldData().getEvictionStats().getEvictions());
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getFilterCache().getMemorySize());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getFilterCache().getMemorySize());
 
-            table.addCell(indexStats == null ? null : indexStats.getTotal().getFilterCache().getEvictions());
-            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getFilterCache().getEvictions());
+            table.addCell(indexStats == null ? null : indexStats.getTotal().getFilterCache().getEvictionStats().getEvictions());
+            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getFilterCache().getEvictionStats().getEvictions());
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getQueryCache().getMemorySize());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getQueryCache().getMemorySize());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -120,9 +120,11 @@ public class RestNodesAction extends AbstractCatAction {
 
         table.addCell("fielddata.memory_size", "alias:fm,fielddataMemory;default:false;text-align:right;desc:used fielddata cache");
         table.addCell("fielddata.evictions", "alias:fe,fielddataEvictions;default:false;text-align:right;desc:fielddata evictions");
+        table.addCell("fielddata.evictions_per_sec", "alias:feps,fielddataEvictionsPerSecond;default:false;text-align:right;desc:fielddata evictions per second (1m 5m 15m intervals)");
 
         table.addCell("filter_cache.memory_size", "alias:fcm,filterCacheMemory;default:false;text-align:right;desc:used filter cache");
         table.addCell("filter_cache.evictions", "alias:fce,filterCacheEvictions;default:false;text-align:right;desc:filter cache evictions");
+        table.addCell("filter_cache.evictions_per_sec", "alias:fceps,filterCacheEvictionsPerSecond;default:false;text-align:right;desc:filter cache evictions per second (1m 5m 15m intervals)");
 
         table.addCell("query_cache.memory_size", "alias:qcm,queryCacheMemory;default:false;text-align:right;desc:used query cache");
         table.addCell("query_cache.evictions", "alias:qce,queryCacheEvictions;default:false;text-align:right;desc:query cache evictions");
@@ -237,9 +239,19 @@ public class RestNodesAction extends AbstractCatAction {
 
             table.addCell(stats == null ? null : stats.getIndices().getFieldData().getMemorySize());
             table.addCell(stats == null ? null : stats.getIndices().getFieldData().getEvictions());
+            table.addCell(stats == null ? null : "["
+                    + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionsOneMinuteRate(),"")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionsFiveMinuteRate(),"")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionsFifteenMinuteRate(), "")
+                    + "]");
 
             table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getMemorySize());
             table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getEvictions());
+            table.addCell(stats == null ? null : "["
+                    + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionsOneMinuteRate(), "")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionsFiveMinuteRate(), "")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionsFifteenMinuteRate(), "")
+                    + "]");
 
             table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getMemorySize());
             table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getEvictions());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -238,19 +238,19 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(stats == null ? null : stats.getIndices().getCompletion().getSize());
 
             table.addCell(stats == null ? null : stats.getIndices().getFieldData().getMemorySize());
-            table.addCell(stats == null ? null : stats.getIndices().getFieldData().getEvictions());
+            table.addCell(stats == null ? null : stats.getIndices().getFieldData().getEvictionStats().getEvictions());
             table.addCell(stats == null ? null : "["
-                    + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionsOneMinuteRate(),"")
-                    + " " + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionsFiveMinuteRate(),"")
-                    + " " + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionsFifteenMinuteRate(), "")
+                    + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionStats().getEvictionsOneMinuteRate(),"")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionStats().getEvictionsFiveMinuteRate(),"")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFieldData().getEvictionStats().getEvictionsFifteenMinuteRate(), "")
                     + "]");
 
             table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getMemorySize());
-            table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getEvictions());
+            table.addCell(stats == null ? null : stats.getIndices().getFilterCache().getEvictionStats().getEvictions());
             table.addCell(stats == null ? null : "["
-                    + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionsOneMinuteRate(), "")
-                    + " " + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionsFiveMinuteRate(), "")
-                    + " " + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionsFifteenMinuteRate(), "")
+                    + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionStats().getEvictionsOneMinuteRate(),"")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionStats().getEvictionsFiveMinuteRate(),"")
+                    + " " + Strings.format1Decimals(stats.getIndices().getFilterCache().getEvictionStats().getEvictionsFifteenMinuteRate(), "")
                     + "]");
 
             table.addCell(stats == null ? null : stats.getIndices().getQueryCache() == null ? null : stats.getIndices().getQueryCache().getMemorySize());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -191,10 +191,10 @@ public class RestShardsAction extends AbstractCatAction {
             table.addCell(shardStats == null ? null : shardStats.getCompletion().getSize());
 
             table.addCell(shardStats == null ? null : shardStats.getFieldData().getMemorySize());
-            table.addCell(shardStats == null ? null : shardStats.getFieldData().getEvictions());
+            table.addCell(shardStats == null ? null : shardStats.getFieldData().getEvictionStats().getEvictions());
 
             table.addCell(shardStats == null ? null : shardStats.getFilterCache().getMemorySize());
-            table.addCell(shardStats == null ? null : shardStats.getFilterCache().getEvictions());
+            table.addCell(shardStats == null ? null : shardStats.getFilterCache().getEvictionStats().getEvictions());
 
             table.addCell(shardStats == null ? null : shardStats.getFlush().getTotal());
             table.addCell(shardStats == null ? null : shardStats.getFlush().getTotalTime());

--- a/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
@@ -1,0 +1,285 @@
+package org.elasticsearch.indices.cache;
+
+import org.apache.lucene.util.English;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.metrics.EvictionStats;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ElasticsearchIntegrationTest.ClusterScope(scope= ElasticsearchIntegrationTest.Scope.SUITE, numClientNodes = 0)
+public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIntegrationTest {
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
+        return  ImmutableSettings.settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("indices.fielddata.cache.expire", "1ms")
+                .put("indices.fielddata.cache.size", "100b")
+                .put("indices.cache.filter.expire", "1ms")
+                .put("indices.cache.filter.size", "100b")
+                .build();
+    }
+
+    @Override
+    protected Settings externalNodeSettings(int nodeOrdinal) {
+        // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
+        return  ImmutableSettings.settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("indices.fielddata.cache.expire", "1ms")
+                .put("indices.fielddata.cache.size", "100b")
+                .put("indices.cache.filter.expire", "1ms")
+                .put("indices.cache.filter.size", "100b")
+                .build();
+    }
+
+
+    @Test
+    public void testFieldDataEvictions() throws Exception {
+        createIndex("test");
+
+        NodesInfoResponse nodesInfo = client().admin().cluster().prepareNodesInfo().execute().actionGet();
+        Map<String, NodeInfo> versions = nodesInfo.getNodesMap();
+
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("client.transport.ignore_cluster_name", true).build();
+
+        // We explicitly connect to each node with a custom TransportClient
+        for (NodeInfo n : nodesInfo.getNodes()) {
+            TransportClient tc = new TransportClient(settings).addTransportAddress(n.getNode().address());
+            NodesStatsResponse ns = tc.admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+            // This is the version of the node we are talking to via Transport Client
+            Version tcNodeVersion = versions.get(n.getNode().getId()).getVersion();
+
+            for (NodeStats stats : ns.getNodes()) {
+
+                // If the node we are talking to is 1.3.0+, it will have full responses
+                if (tcNodeVersion.onOrAfter(Version.V_1_3_0)) {
+
+                    EvictionStats ev = stats.getIndices().getFieldData().getEvictionStats();
+                    Version nodeVersion = versions.get(stats.getNode().getId()).getVersion();
+
+                    // If the node in the stats (not the node we are talking to) is 1.3.0+, it will have eviction rates
+                    if (nodeVersion.onOrAfter(Version.V_1_3_0)) {
+                        assertThat(ev.getEvictions(), equalTo(0l));
+                        assertThat(ev.getEvictionsOneMinuteRate(), equalTo(0D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(0D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(0D));
+                    } else {
+                        // Otherwise it will have negative one's for rates
+                        assertThat(ev.getEvictions(), equalTo(0l));
+                        assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                    }
+                } else {
+                    // If the node we are talking to is < 1.3.0, it will only have eviction counts and no rates.
+                    // But because this test code is executing in 1.3.0+, evictions will be present in response and negative
+                    EvictionStats ev = stats.getIndices().getFieldData().getEvictionStats();
+                    assertThat(ev.getEvictions(), equalTo(0l));
+                    assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                }
+            }
+        }
+
+        int numDocs = randomIntBetween(500, 5000);
+        IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource(
+                    "field1", English.intToEnglish(i),
+                    "field2", i
+            );
+        }
+
+        indexRandom(true, docs);
+        ensureGreen();
+
+        // sort to load it to field data...run multiple queries to thrash the evictions
+        for (int i = 0; i < 100; i++) {
+            client().prepareSearch().addSort("field1", SortOrder.ASC).execute().actionGet();
+            client().prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
+        }
+
+        // Just to give enough time for evictions to occur
+        Thread.sleep(2000);
+
+        // We explicitly connect to each node with a custom TransportClient
+        for (NodeInfo n : nodesInfo.getNodes()) {
+            TransportClient tc = new TransportClient(settings).addTransportAddress(n.getNode().address());
+            NodesStatsResponse ns = tc.admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+            // This is the version of the node we are talking to via Transport Client
+            Version tcNodeVersion = versions.get(n.getNode().getId()).getVersion();
+
+            for (NodeStats stats : ns.getNodes()) {
+                boolean hasDocs = stats.getIndices().getDocs().getCount() > 0;
+
+                // If the node we are talking to is 1.3.0+, it will have full responses
+                if (tcNodeVersion.onOrAfter(Version.V_1_3_0)) {
+
+                    EvictionStats ev = stats.getIndices().getFieldData().getEvictionStats();
+                    Version nodeVersion = versions.get(stats.getNode().getId()).getVersion();
+
+                    // If the node in the stats (not the node we are talking to) is 1.3.0+, it will have eviction rates
+                    if (nodeVersion.onOrAfter(Version.V_1_3_0)) {
+                        assertThat(ev.getEvictions(), hasDocs ? greaterThan(0l) : equalTo(0L));
+                        assertThat(ev.getEvictionsOneMinuteRate(), hasDocs ? greaterThan(0D) : equalTo(0D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), hasDocs ? greaterThan(0D) : equalTo(0D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), hasDocs ? greaterThan(0D) : equalTo(0D));
+                    } else {
+                        // Otherwise it will have negative one's for rates
+                        assertThat(ev.getEvictions(), hasDocs ? greaterThan(0l) : equalTo(0L));
+                        assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                    }
+                } else {
+                    // If the node we are talking to is < 1.3.0, it will only have eviction counts and no rates.
+                    // But because this test code is executing in 1.3.0+, evictions will be present in response and negative
+                    EvictionStats ev = stats.getIndices().getFieldData().getEvictionStats();
+                    assertThat(ev.getEvictions(), hasDocs ? greaterThan(0l) : equalTo(0L));
+                    assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testFilterEvictions() throws Exception {
+        createIndex("test");
+
+        NodesInfoResponse nodesInfo = client().admin().cluster().prepareNodesInfo().execute().actionGet();
+        Map<String, NodeInfo> versions = nodesInfo.getNodesMap();
+
+        Settings settings = ImmutableSettings.settingsBuilder()
+                .put("client.transport.ignore_cluster_name", true).build();
+
+        // We explicitly connect to each node with a custom TransportClient
+        for (NodeInfo n : nodesInfo.getNodes()) {
+            TransportClient tc = new TransportClient(settings).addTransportAddress(n.getNode().address());
+            NodesStatsResponse ns = tc.admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+            // This is the version of the node we are talking to via Transport Client
+            Version tcNodeVersion = versions.get(n.getNode().getId()).getVersion();
+
+            for (NodeStats stats : ns.getNodes()) {
+
+                // If the node we are talking to is 1.3.0+, it will have full responses
+                if (tcNodeVersion.onOrAfter(Version.V_1_3_0)) {
+
+                    EvictionStats ev = stats.getIndices().getFilterCache().getEvictionStats();
+                    Version nodeVersion = versions.get(stats.getNode().getId()).getVersion();
+
+                    // If the node in the stats (not the node we are talking to) is 1.3.0+, it will have eviction rates
+                    if (nodeVersion.onOrAfter(Version.V_1_3_0)) {
+                        assertThat(ev.getEvictions(), equalTo(0l));
+                        assertThat(ev.getEvictionsOneMinuteRate(), equalTo(0D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(0D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(0D));
+                    } else {
+                        // Otherwise it will have negative one's for rates
+                        assertThat(ev.getEvictions(), equalTo(0l));
+                        assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                    }
+                } else {
+                    // If the node we are talking to is < 1.3.0, it will only have eviction counts and no rates.
+                    // But because this test code is executing in 1.3.0+, evictions will be present in response and negative
+                    EvictionStats ev = stats.getIndices().getFilterCache().getEvictionStats();
+                    assertThat(ev.getEvictions(), equalTo(0l));
+                    assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                }
+            }
+        }
+
+
+        int numDocs = randomIntBetween(500, 1000);
+        IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource(
+                    "field1", English.intToEnglish(i),
+                    "field2", i
+            );
+        }
+
+        indexRandom(true, docs);
+        ensureGreen();
+
+        // Run some searches to cache and evict filters
+        for (int i = 0; i < 100; i++) {
+            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field1", English.intToEnglish(i)))).execute().actionGet();
+            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field2", i))).execute().actionGet();
+        }
+
+        // Just to give enough time for evictions to occur
+        Thread.sleep(2000);
+
+        // We explicitly connect to each node with a custom TransportClient
+        for (NodeInfo n : nodesInfo.getNodes()) {
+            TransportClient tc = new TransportClient(settings).addTransportAddress(n.getNode().address());
+            NodesStatsResponse ns = tc.admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+            // This is the version of the node we are talking to via Transport Client
+            Version tcNodeVersion = versions.get(n.getNode().getId()).getVersion();
+
+            for (NodeStats stats : ns.getNodes()) {
+                boolean hasDocs = stats.getIndices().getDocs().getCount() > 0;
+
+                // If the node we are talking to is 1.3.0+, it will have full responses
+                if (tcNodeVersion.onOrAfter(Version.V_1_3_0)) {
+
+                    EvictionStats ev = stats.getIndices().getFilterCache().getEvictionStats();
+                    Version nodeVersion = versions.get(stats.getNode().getId()).getVersion();
+
+                    // If the node in the stats (not the node we are talking to) is 1.3.0+, it will have eviction rates
+                    if (nodeVersion.onOrAfter(Version.V_1_3_0)) {
+                        assertThat(ev.getEvictions(), hasDocs ? greaterThan(0l) : equalTo(0L));
+                        assertThat(ev.getEvictionsOneMinuteRate(), hasDocs ? greaterThan(0D) : equalTo(0D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), hasDocs ? greaterThan(0D) : equalTo(0D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), hasDocs ? greaterThan(0D) : equalTo(0D));
+                    } else {
+                        // Otherwise it will have negative one's for rates
+                        assertThat(ev.getEvictions(), hasDocs ? greaterThan(0l) : equalTo(0L));
+                        assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                        assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                    }
+                } else {
+                    // If the node we are talking to is < 1.3.0, it will only have eviction counts and no rates.
+                    // But because this test code is executing in 1.3.0+, evictions will be present in response and negative
+                    EvictionStats ev = stats.getIndices().getFilterCache().getEvictionStats();
+                    assertThat(ev.getEvictions(), hasDocs ? greaterThan(0l) : equalTo(0L));
+                    assertThat(ev.getEvictionsOneMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(-1D));
+                    assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(-1D));
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
@@ -55,10 +55,10 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
         // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
         return  ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("indices.fielddata.cache.expire", "10ms")
-                .put("indices.fielddata.cache.size", "10b")
-                .put("indices.cache.filter.expire", "10ms")
-                .put("indices.cache.filter.size", "10b")
+                .put("indices.fielddata.cache.expire", "1ms")
+                .put("indices.fielddata.cache.size", "1b")
+                .put("indices.cache.filter.expire", "1ms")
+                .put("indices.cache.filter.size", "1b")
                 .build();
     }
 
@@ -67,26 +67,26 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
         // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
         return  ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("indices.fielddata.cache.expire", "10ms")
-                .put("indices.fielddata.cache.size", "10b")
-                .put("indices.cache.filter.expire", "10ms")
-                .put("indices.cache.filter.size", "10b")
+                .put("indices.fielddata.cache.expire", "1ms")
+                .put("indices.fielddata.cache.size", "1b")
+                .put("indices.cache.filter.expire", "1ms")
+                .put("indices.cache.filter.size", "1b")
                 .build();
     }
 
     @Override
     public Settings indexSettings() {
         ImmutableSettings.Builder builder = ImmutableSettings.builder();
-        if (randomizeNumberOfShardsAndReplicas()) {
-            int numberOfShards = between(5, 10);    // We need to override this so that all nodes have at least one shard
-            if (numberOfShards > 0) {
-                builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
-            }
-            int numberOfReplicas = numberOfReplicas();
-            if (numberOfReplicas >= 0) {
-                builder.put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
-            }
+
+        int numberOfShards = between(5, 10);    // We need to override this so that all nodes have at least one shard
+        if (numberOfShards > 0) {
+            builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
         }
+        int numberOfReplicas = numberOfReplicas();
+        if (numberOfReplicas >= 0) {
+            builder.put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
+        }
+
         return builder.build();
     }
 
@@ -94,6 +94,7 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
     @Test
     public void testFieldDataEvictions() throws Exception {
         createIndex("test");
+        ensureGreen();
 
         NodesInfoResponse nodesInfo = client().admin().cluster().prepareNodesInfo().execute().actionGet();
         Map<String, NodeInfo> versions = nodesInfo.getNodesMap();
@@ -211,6 +212,7 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
     @Test
     public void testFilterEvictions() throws Exception {
         createIndex("test");
+        ensureGreen();
 
         NodesInfoResponse nodesInfo = client().admin().cluster().prepareNodesInfo().execute().actionGet();
         Map<String, NodeInfo> versions = nodesInfo.getNodesMap();

--- a/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.indices.cache;
 
 import org.apache.lucene.util.English;

--- a/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/BackwardsCompatEvictionTests.java
@@ -78,7 +78,7 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
     public Settings indexSettings() {
         ImmutableSettings.Builder builder = ImmutableSettings.builder();
         if (randomizeNumberOfShardsAndReplicas()) {
-            int numberOfShards = between(3, 10);    // We need to override this so that all nodes have at least one shard
+            int numberOfShards = between(5, 10);    // We need to override this so that all nodes have at least one shard
             if (numberOfShards > 0) {
                 builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
             }
@@ -261,7 +261,7 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
         }
 
 
-        int numDocs = randomIntBetween(500, 1000);
+        int numDocs = randomIntBetween(1000, 3000);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
             docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource(
@@ -274,9 +274,9 @@ public class BackwardsCompatEvictionTests extends ElasticsearchBackwardsCompatIn
         ensureGreen();
 
         // Run some searches to cache and evict filters
-        for (int i = 0; i < 500; i++) {
-            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field1", English.intToEnglish(i)))).execute().actionGet();
-            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field2", i))).execute().actionGet();
+        for (int i = 0; i < 2000; i++) {
+            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field1", English.intToEnglish(i )))).execute().actionGet();
+            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field2", i % numDocs))).execute().actionGet();
         }
 
         // Just to give enough time for evictions to occur

--- a/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
@@ -51,26 +51,26 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
         // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
         return  ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("indices.fielddata.cache.expire", "10ms")
-                .put("indices.fielddata.cache.size", "10b")
-                .put("indices.cache.filter.expire", "10ms")
-                .put("indices.cache.filter.size", "10b")
+                .put("indices.fielddata.cache.expire", "1ms")
+                .put("indices.fielddata.cache.size", "1b")
+                .put("indices.cache.filter.expire", "1ms")
+                .put("indices.cache.filter.size", "1b")
                 .build();
     }
 
     @Override
     public Settings indexSettings() {
         ImmutableSettings.Builder builder = ImmutableSettings.builder();
-        if (randomizeNumberOfShardsAndReplicas()) {
-            int numberOfShards = between(4, 10);    // We need to override this so that all nodes have at least one shard
-            if (numberOfShards > 0) {
-                builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
-            }
-            int numberOfReplicas = numberOfReplicas();
-            if (numberOfReplicas >= 0) {
-                builder.put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
-            }
+
+        int numberOfShards = between(4, 10);    // We need to override this so that all nodes have at least one shard
+        if (numberOfShards > 0) {
+            builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
         }
+        int numberOfReplicas = numberOfReplicas();
+        if (numberOfReplicas >= 0) {
+            builder.put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
+        }
+
         return builder.build();
     }
 
@@ -78,6 +78,7 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
     @Test
     public void testFieldDataEvictions() throws Exception {
         createIndex("test");
+        ensureGreen();
 
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
 
@@ -125,6 +126,7 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
     @Test
     public void testFilterEvictions() throws Exception {
         createIndex("test");
+        ensureGreen();
 
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
 

--- a/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
@@ -1,0 +1,154 @@
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.cache;
+
+import org.apache.lucene.util.English;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.common.metrics.EvictionStats;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+
+/**
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope= Scope.SUITE, numClientNodes = 0)
+//@ClusterScope(scope= Scope.SUITE, numDataNodes =1, numClientNodes = 0, randomDynamicTemplates = false)
+public class EvictionTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
+        return  ImmutableSettings.settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("indices.fielddata.cache.expire", "1ms")
+                .put("indices.fielddata.cache.size", "100b")
+                .put("indices.cache.filter.expire", "1ms")
+                .put("indices.cache.filter.size", "100b")
+                .build();
+    }
+
+
+    @Test
+    public void testFieldDataEvictions() throws Exception {
+        createIndex("test");
+
+        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+        //Should be no evictions to start
+        for (NodeStats n : nodesStats.getNodes()) {
+            EvictionStats ev = n.getIndices().getFieldData().getEvictionStats();
+            assertThat(ev.getEvictions(), equalTo(0l));
+            assertThat(ev.getEvictionsOneMinuteRate(), equalTo(0D));
+            assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(0D));
+            assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(0D));
+        }
+
+        int numDocs = randomIntBetween(500, 5000);
+        IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource(
+                "field1", English.intToEnglish(i),
+                "field2", i
+            );
+        }
+
+        indexRandom(true, docs);
+        ensureGreen();
+
+        // sort to load it to field data...run multiple queries to thrash the evictions
+        for (int i = 0; i < 50; i++) {
+            client().prepareSearch().addSort("field1", SortOrder.ASC).execute().actionGet();
+            client().prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
+        }
+
+        // Just to give enough time for evictions to occur
+        Thread.sleep(2000);
+
+        nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+        //Should have some more evictions now
+        for (NodeStats n : nodesStats.getNodes()) {
+            EvictionStats ev = n.getIndices().getFieldData().getEvictionStats();
+            assertThat(ev.getEvictions(), greaterThan(0l));
+            assertThat(ev.getEvictionsOneMinuteRate(), greaterThan(0D));
+            assertThat(ev.getEvictionsFiveMinuteRate(), greaterThan(0D));
+            assertThat(ev.getEvictionsFifteenMinuteRate(), greaterThan(0D));
+        }
+    }
+
+    @Test
+    public void testFilterEvictions() throws Exception {
+        createIndex("test");
+
+        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+        //Should be no evictions to start
+        for (NodeStats n : nodesStats.getNodes()) {
+            EvictionStats ev = n.getIndices().getFieldData().getEvictionStats();
+            assertThat(ev.getEvictions(), equalTo(0l));
+            assertThat(ev.getEvictionsOneMinuteRate(), equalTo(0D));
+            assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(0D));
+            assertThat(ev.getEvictionsFifteenMinuteRate(), equalTo(0D));
+        }
+
+        int numDocs = randomIntBetween(500, 1000);
+        IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource(
+                    "field1", English.intToEnglish(i),
+                    "field2", i
+            );
+        }
+
+        indexRandom(true, docs);
+        ensureGreen();
+
+        // Run some searches to cache and evict filters
+        for (int i = 0; i < 100; i++) {
+            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field1", English.intToEnglish(i)))).execute().actionGet();
+            client().prepareSearch().setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.termFilter("field2", i))).execute().actionGet();
+        }
+
+        // Just to give enough time for evictions to occur
+        Thread.sleep(2000);
+
+        nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
+
+        //Should have some more evictions now
+        for (NodeStats n : nodesStats.getNodes()) {
+            EvictionStats ev = n.getIndices().getFilterCache().getEvictionStats();
+            assertThat(ev.getEvictions(), greaterThan(0l));
+            assertThat(ev.getEvictionsOneMinuteRate(), greaterThan(0D));
+            assertThat(ev.getEvictionsFiveMinuteRate(), greaterThan(0D));
+            assertThat(ev.getEvictionsFifteenMinuteRate(), greaterThan(0D));
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
@@ -111,7 +111,7 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
 
         //Should be no evictions to start
         for (NodeStats n : nodesStats.getNodes()) {
-            EvictionStats ev = n.getIndices().getFieldData().getEvictionStats();
+            EvictionStats ev = n.getIndices().getFilterCache().getEvictionStats();
             assertThat(ev.getEvictions(), equalTo(0l));
             assertThat(ev.getEvictionsOneMinuteRate(), equalTo(0D));
             assertThat(ev.getEvictionsFiveMinuteRate(), equalTo(0D));

--- a/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.*;
 /**
  */
 @ElasticsearchIntegrationTest.ClusterScope(scope= Scope.SUITE, numClientNodes = 0)
-//@ClusterScope(scope= Scope.SUITE, numDataNodes =1, numClientNodes = 0, randomDynamicTemplates = false)
 public class EvictionTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
+++ b/src/test/java/org/elasticsearch/indices/cache/EvictionTests.java
@@ -22,14 +22,18 @@ package org.elasticsearch.indices.cache;
 
 import com.google.common.base.Predicate;
 import org.apache.lucene.util.English;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.metrics.EvictionStats;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.cache.filter.FilterCacheModule;
+import org.elasticsearch.index.cache.filter.weighted.WeightedFilterCache;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.cache.filter.IndicesFilterCache;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
@@ -48,13 +52,14 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        // Set the fielddata and filter size to 1b and expire to 1ms, forces evictions immediately
+        // Set the fielddata and filter size to 2048b (due to 1024 min) and expire to 10ms, to encourage quick evictions
         return  ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("indices.fielddata.cache.expire", "1ms")
-                .put("indices.fielddata.cache.size", "1b")
-                .put("indices.cache.filter.expire", "1ms")
-                .put("indices.cache.filter.size", "1b")
+                .put("indices.fielddata.cache.expire", "10ms")
+                .put("indices.fielddata.cache.size", "2048b")
+                .put(IndicesFilterCache.INDICES_CACHE_FILTER_EXPIRE, "10ms")
+                .put(IndicesFilterCache.INDICES_CACHE_FILTER_SIZE, "2048b")
+                .put(FilterCacheModule.FilterCacheSettings.FILTER_CACHE_TYPE, WeightedFilterCache.class)
                 .build();
     }
 
@@ -63,9 +68,8 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
         ImmutableSettings.Builder builder = ImmutableSettings.builder();
 
         int numberOfShards = between(4, 10);    // We need to override this so that all nodes have at least one shard
-        if (numberOfShards > 0) {
-            builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
-        }
+        builder.put(SETTING_NUMBER_OF_SHARDS, numberOfShards).build();
+
         int numberOfReplicas = numberOfReplicas();
         if (numberOfReplicas >= 0) {
             builder.put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
@@ -101,6 +105,7 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
         }
 
         indexRandom(true, docs);
+        client().admin().indices().prepareRefresh("test").execute().actionGet();
         ensureGreen();
 
         // sort to load it to field data...run multiple queries to thrash the evictions
@@ -149,6 +154,7 @@ public class EvictionTests extends ElasticsearchIntegrationTest {
         }
 
         indexRandom(true, docs);
+        client().admin().indices().prepareRefresh("test").execute().actionGet();
         ensureGreen();
 
         // Run some searches to cache and evict filters


### PR DESCRIPTION
This adds one-, five- and fifteen-minute eviction rates for FieldData and Filter stats.  Cumulative eviction counts don't give much insight into the nature and frequency of evictions.  Particularly as server uptime increases, cumulative counts become relatively useless.

By measuring and the rates over short time intervals, the user can more easily understand how their system is behaving.  Rates are backed by an exponentially weighted moving average, so more recent evictions contribute to the counter moreso than older evictions.

Current example output (updated 06/27/2014):

``` json
{
    "filter_cache": {
       "memory_size_in_bytes": 62312,
       "evictions": 135,
       "evictions_per_sec": {
         "1m": 58.4 , 
         "5m": 13.8, 
         "15m": 4.7
       }
    },
    "fielddata": {
        "memory_size_in_bytes": 2101455,
        "evictions": 42,
        "evictions_per_sec": {
          "1m": 21.4 , 
          "5m": 18.8, 
          "15m": 6.7
        }
    }
}
```
