### PR TITLE
Fixed conversion of date field values when using multiple date formats

### DIFF
--- a/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.common.joda;
 
-import java.util.Locale;
-
 import org.elasticsearch.common.Strings;
 import org.joda.time.*;
 import org.joda.time.field.DividedDateTimeField;
 import org.joda.time.field.OffsetDateTimeField;
 import org.joda.time.field.ScaledDurationField;
 import org.joda.time.format.*;
+
+import java.util.Locale;
 
 /**
  *
@@ -142,11 +142,12 @@ public class Joda {
                 } else {
                     DateTimeFormatter dateTimeFormatter = null;
                     for (int i = 0; i < formats.length; i++) {
-                        DateTimeFormatter currentFormatter = forPattern(formats[i], locale).parser();
+                        FormatDateTimeFormatter currentFormatter = forPattern(formats[i], locale);
+                        DateTimeFormatter currentParser = currentFormatter.parser();
                         if (dateTimeFormatter == null) {
-                            dateTimeFormatter = currentFormatter;
+                            dateTimeFormatter = currentFormatter.printer();
                         }
-                        parsers[i] = currentFormatter.getParser();
+                        parsers[i] = currentParser.getParser();
                     }
 
                     DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder().append(dateTimeFormatter.withZone(DateTimeZone.UTC).getPrinter(), parsers);

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramTests.java
@@ -1200,4 +1200,33 @@ public class DateHistogramTests extends ElasticsearchIntegrationTest {
             key = key.plusDays(interval);
         }
     }
+
+    @Test
+    public void singleValue_WithMultipleDateFormatsFromMapping() throws Exception {
+        
+        String mappingJson = jsonBuilder().startObject().startObject("type").startObject("properties").startObject("date").field("type", "date").field("format", "dateOptionalTime||dd-MM-yyyy").endObject().endObject().endObject().endObject().string();
+        prepareCreate("idx2").addMapping("type", mappingJson).execute().actionGet();
+        IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
+        for (int i = 0; i < reqs.length; i++) {
+            reqs[i] = client().prepareIndex("idx2", "type", "" + i).setSource(jsonBuilder().startObject().field("date", "10-03-2014").endObject());
+        }
+        indexRandom(true, reqs);
+
+        SearchResponse response = client().prepareSearch("idx2")
+                .setQuery(matchAllQuery())
+                .addAggregation(dateHistogram("date_histo")
+                        .field("date")
+                        .interval(DateHistogram.Interval.DAY))
+                .execute().actionGet();
+
+        assertThat(response.getHits().getTotalHits(), equalTo(5l));
+
+        DateHistogram histo = response.getAggregations().get("date_histo");
+        Collection<? extends DateHistogram.Bucket> buckets = histo.getBuckets();
+        assertThat(buckets.size(), equalTo(1));
+
+        DateHistogram.Bucket bucket = histo.getBucketByKey("2014-03-10T00:00:00.000Z");
+        assertThat(bucket, Matchers.notNullValue());
+        assertThat(bucket.getDocCount(), equalTo(5l));
+    }
 }


### PR DESCRIPTION
When multiple date formats are specified using the || syntax in the field mappings the date_histogram aggregation breaks.  This is because we are getting a parser rather than a printer from the date formatter for the object we use to convert the DateTime values back into Strings.  Simple fix to get the printer form the date format and test to back it up

Closes #6239
