### PR TITLE
Plain highlighter to use analyzer defined on a document level 

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -385,7 +385,11 @@ public class DocumentMapper implements ToXContent {
     public SourceFieldMapper sourceMapper() {
         return rootMapper(SourceFieldMapper.class);
     }
-
+    
+    public AnalyzerMapper analyzerMapper() {
+        return rootMapper(AnalyzerMapper.class);
+    }
+    
     public AllFieldMapper allFieldMapper() {
         return rootMapper(AllFieldMapper.class);
     }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
@@ -130,18 +130,24 @@ public class AnalyzerMapper implements Mapper, InternalMapper, RootMapper {
         return false;
     }
     
-    public void postHighlight(HighlighterContext context){
+    public Analyzer setAnalyzer(HighlighterContext context){
+        if (context.analyzer() != null){
+            return context.analyzer();
+        }
+        
         Analyzer analyzer = null;
         
         if (path != null) {
-            String analyzerName = (String)context.context.lookup().source().extractValue(path);
+            String analyzerName = (String) context.context.lookup().source().extractValue(path);
             analyzer = context.context.mapperService().analysisService().analyzer(analyzerName);
         }
         
-        if(analyzer == null){
+        if (analyzer == null) {
             analyzer = context.context.mapperService().documentMapper(context.hitContext.hit().type()).mappers().indexAnalyzer();  
         }
         context.analyzer(analyzer);
+        
+        return analyzer;
     }
     
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.*;
+import org.elasticsearch.search.highlight.HighlighterContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -128,7 +129,21 @@ public class AnalyzerMapper implements Mapper, InternalMapper, RootMapper {
     public boolean includeInObject() {
         return false;
     }
-
+    
+    public void postHighlight(HighlighterContext context){
+        Analyzer analyzer = null;
+        
+        if (path != null) {
+            String analyzerName = (String)context.context.lookup().source().extractValue(path);
+            analyzer = context.context.mapperService().analysisService().analyzer(analyzerName);
+        }
+        
+        if(analyzer == null){
+            analyzer = context.context.mapperService().documentMapper(context.hitContext.hit().type()).mappers().indexAnalyzer();  
+        }
+        context.analyzer(analyzer);
+    }
+    
     @Override
     public void parse(ParseContext context) throws IOException {
     }

--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.highlight;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchSubPhase;
@@ -34,7 +35,8 @@ public class HighlighterContext {
     public final SearchContext context;
     public final FetchSubPhase.HitContext hitContext;
     public final HighlightQuery query;
-
+    private Analyzer analyzer;
+    
     public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper<?> mapper, SearchContext context,
             FetchSubPhase.HitContext hitContext, HighlightQuery query) {
         this.fieldName = fieldName;
@@ -67,5 +69,13 @@ public class HighlighterContext {
         public Query query() {
             return query;
         }
+    }
+    
+    public Analyzer analyzer() {
+        return this.analyzer;
+    }
+
+    public void analyzer(Analyzer analyzer) {
+        this.analyzer = analyzer;
     }
 }

--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -30,10 +30,10 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.internal.AnalyzerMapper;
 import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -100,16 +100,11 @@ public class PlainHighlighter implements Highlighter {
         ArrayList<TextFragment> fragsList = new ArrayList<>();
         List<Object> textsToHighlight;
         
-        SearchLookup lookup = context.lookup();
-        //TODO generalize. 
-        String documentLanguageAnalyzer = (String)lookup.source().extractValue("language_analyzer"); 
-        Analyzer analyzer = null;
-        if (documentLanguageAnalyzer != null){
-            analyzer = context.mapperService().analysisService().analyzer(documentLanguageAnalyzer);
-        }
-        if(analyzer == null){
-            analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();  
-        }
+        AnalyzerMapper analyzerMapper = context.mapperService().documentMapper(hitContext.hit().type()).analyzerMapper();
+        
+        analyzerMapper.postHighlight(highlighterContext);
+            
+        Analyzer analyzer = highlighterContext.analyzer();
         
         try {
             textsToHighlight = HighlightUtils.loadFieldValues(field, mapper, context, hitContext);

--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -98,13 +99,24 @@ public class PlainHighlighter implements Highlighter {
         int numberOfFragments = field.fieldOptions().numberOfFragments() == 0 ? 1 : field.fieldOptions().numberOfFragments();
         ArrayList<TextFragment> fragsList = new ArrayList<>();
         List<Object> textsToHighlight;
-
+        
+        SearchLookup lookup = context.lookup();
+        //TODO generalize. 
+        String documentLanguageAnalyzer = (String)lookup.source().extractValue("language_analyzer"); 
+        Analyzer analyzer = null;
+        if (documentLanguageAnalyzer != null){
+            analyzer = context.mapperService().analysisService().analyzer(documentLanguageAnalyzer);
+        }
+        if(analyzer == null){
+            analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();  
+        }
+        
         try {
             textsToHighlight = HighlightUtils.loadFieldValues(field, mapper, context, hitContext);
-
+               
             for (Object textToHighlight : textsToHighlight) {
                 String text = textToHighlight.toString();
-                Analyzer analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();
+                
                 TokenStream tokenStream = analyzer.tokenStream(mapper.names().indexName(), text);
                 if (!tokenStream.hasAttribute(CharTermAttribute.class) || !tokenStream.hasAttribute(OffsetAttribute.class)) {
                     // can't perform highlighting if the stream has no terms (binary token stream) or no offsets
@@ -151,7 +163,6 @@ public class PlainHighlighter implements Highlighter {
         if (noMatchSize > 0 && textsToHighlight.size() > 0) {
             // Pull an excerpt from the beginning of the string but make sure to split the string on a term boundary.
             String fieldContents = textsToHighlight.get(0).toString();
-            Analyzer analyzer = context.mapperService().documentMapper(hitContext.hit().type()).mappers().indexAnalyzer();
             int end;
             try {
                 end = findGoodEndForNoHighlightExcerpt(noMatchSize, analyzer.tokenStream(mapper.names().indexName(), fieldContents));

--- a/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -102,9 +102,7 @@ public class PlainHighlighter implements Highlighter {
         
         AnalyzerMapper analyzerMapper = context.mapperService().documentMapper(hitContext.hit().type()).analyzerMapper();
         
-        analyzerMapper.postHighlight(highlighterContext);
-            
-        Analyzer analyzer = highlighterContext.analyzer();
+        Analyzer analyzer = analyzerMapper.setAnalyzer(highlighterContext);
         
         try {
             textsToHighlight = HighlightUtils.loadFieldValues(field, mapper, context, hitContext);

--- a/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchTests.java
@@ -651,11 +651,43 @@ public class HighlighterSearchTests extends ElasticsearchIntegrationTest {
                 .query(boolQuery().should(constantScoreQuery(prefixQuery("_all", "qui"))))
                 .from(0).size(60).explain(true)
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>"));
-
+ 
         searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_THEN_FETCH)).actionGet();
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
     }
+    
+    @Test
+    public void testPlainHighlighterDocumentAnalyzer() throws Exception {
+        client().admin().indices().prepareCreate("test")
+        .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("_analyzer")
+                .field("path", "language_analyzer")
+            .endObject()
+            .startObject("properties")
+                .startObject("language_analyzer")
+                    .field("type", "string")
+                    .field("index", "not_analyzed")
+                .endObject()
+                .startObject("text")
+                    .field("type", "string")
+                .endObject()
+            .endObject()
+            .endObject().endObject()).execute().actionGet();
+        ensureYellow();
+        
+        index("test", "type1", "1",
+                "language_analyzer", "english",
+                "text", "Look at me, I'm eating cars.");
+        refresh();
 
+        SearchResponse response = client().prepareSearch("test")
+                .setQuery(QueryBuilders.matchQuery("text", "car"))
+                .addHighlightedField(
+                        new HighlightBuilder.Field("text").preTags("<1>").postTags("</1>").requireFieldMatch(true))
+                .get();
+        assertHighlight(response, 0, "text", 0, 1, equalTo("Look at me, I'm eating <1>cars</1>."));
+    }
+    
     @Test
     public void testFastVectorHighlighter() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));


### PR DESCRIPTION
At the moment plain highligher only uses an analyzer defined for on the type level. However, during the indexing stage it is possible to define analyzer on per document level, for example mapping '_analyzer' to another field, containing required name. This commit attempts to make sure that highlighting works correctly in this scenario.

Important: the field containing the document analyzer is hardcoded to 'language_analyzer' at the moment. This should use document mappings instead. I just could not figure out a way to do it without introducing too many changes on DocumentMapper.

Closes #5497
