### PR TITLE
Reuse Lucene's TermsEnum for faster _uid/version lookup during indexing

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDAndVersionLookup.java
+++ b/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDAndVersionLookup.java
@@ -1,0 +1,161 @@
+package org.elasticsearch.common.lucene.uid;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.DocsAndPositionsEnum;
+import org.apache.lucene.index.DocsEnum;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.lucene.uid.Versions.DocIdAndVersion;
+import org.elasticsearch.index.mapper.internal.UidFieldMapper;
+import org.elasticsearch.index.mapper.internal.VersionFieldMapper;
+
+
+/** Utility class to do efficient primary-key (only 1 doc contains the
+ *  given term) lookups by segment, re-using the enums.  This class is
+ *  not thread safe, so it is the caller's job to create and use one
+ *  instance of this per thread.  Do not use this if a term may appear
+ *  in more than one document!  It will only return the first one it
+ *  finds. */
+
+final class PerThreadIDAndVersionLookup {
+
+    private final AtomicReaderContext[] readerContexts;
+    private final TermsEnum[] termsEnums;
+    private final DocsEnum[] docsEnums;
+    // Only used for back compat, to lookup a version from payload:
+    private final DocsAndPositionsEnum[] posEnums;
+    private final Bits[] liveDocs;
+    private final NumericDocValues[] versions;
+    private final int numSegs;
+    private final boolean hasDeletions;
+    private final boolean[] hasPayloads;
+
+    public PerThreadIDAndVersionLookup(IndexReader r) throws IOException {
+
+        List<AtomicReaderContext> leaves = new ArrayList<>(r.leaves());
+
+        // nocommit but ES goes backwards today... is that really best?  backwards is not necessarily reverse time order (TMP merges out of
+        // order)
+        // Larger segments are more likely to have the id, so we sort largest to smallest by numDocs:
+        CollectionUtil.timSort(leaves, new Comparator<AtomicReaderContext>() {
+                @Override
+                public int compare(AtomicReaderContext c1, AtomicReaderContext c2) {
+                    return c2.reader().numDocs() - c1.reader().numDocs();
+                }
+            });
+
+        readerContexts = leaves.toArray(new AtomicReaderContext[leaves.size()]);
+        termsEnums = new TermsEnum[leaves.size()];
+        docsEnums = new DocsEnum[leaves.size()];
+        posEnums = new DocsAndPositionsEnum[leaves.size()];
+        liveDocs = new Bits[leaves.size()];
+        versions = new NumericDocValues[leaves.size()];
+        hasPayloads = new boolean[leaves.size()];
+        int numSegs = 0;
+        boolean hasDeletions = false;
+        // iterate backwards to optimize for the frequently updated documents
+        // which are likely to be in the last segments
+        //for(int i=leaves.size()-1;i>=0;i--) {
+        for(int i=0;i<leaves.size();i++) {
+            AtomicReaderContext readerContext = leaves.get(i);
+            Fields fields = readerContext.reader().fields();
+            if (fields != null) {
+                Terms terms = fields.terms(UidFieldMapper.NAME);
+                if (terms != null) {
+                    readerContexts[numSegs] = readerContext;
+                    hasPayloads[numSegs] = terms.hasPayloads();
+                    termsEnums[numSegs] = terms.iterator(null);
+                    assert termsEnums[numSegs] != null;
+                    liveDocs[numSegs] = readerContext.reader().getLiveDocs();
+                    hasDeletions |= readerContext.reader().hasDeletions();
+                    versions[numSegs] = readerContext.reader().getNumericDocValues(VersionFieldMapper.NAME);
+                    numSegs++;
+                }
+            }
+        }
+        this.numSegs = numSegs;
+        this.hasDeletions = hasDeletions;
+    }
+
+    /** Return null if id is not found. */
+    public DocIdAndVersion lookup(BytesRef id) throws IOException {
+        for(int seg=0;seg<numSegs;seg++) {
+            if (termsEnums[seg].seekExact(id)) {
+
+                NumericDocValues segVersions = versions[seg];
+                if (segVersions != null || hasPayloads[seg] == false) {
+                    // Use NDV to retrieve the version, in which case we only need DocsEnum:
+
+                    // there may be more than one matching docID, in the case of nested docs, so we want the last one:
+                    DocsEnum docs = docsEnums[seg] = termsEnums[seg].docs(liveDocs[seg], docsEnums[seg], 0);
+                    int docID = DocsEnum.NO_MORE_DOCS;
+                    for (int d = docs.nextDoc(); d != DocsEnum.NO_MORE_DOCS; d = docs.nextDoc()) {
+                        docID = d;
+                    }
+
+                    if (docID != DocsEnum.NO_MORE_DOCS) {
+                        if (segVersions != null) {
+                            return new DocIdAndVersion(docID, segVersions.get(docID), readerContexts[seg]);
+                        } else {
+                            // _uid found, but no doc values and no payloads
+                            return new DocIdAndVersion(docID, Versions.NOT_SET, readerContexts[seg]);
+                        }
+                    } else {
+                        assert hasDeletions;
+                        continue;
+                    }
+                }
+
+                // ... but used to be stored as payloads; in this case we must use DocsAndPositionsEnum
+                DocsAndPositionsEnum dpe = posEnums[seg] = termsEnums[seg].docsAndPositions(liveDocs[seg], posEnums[seg], DocsAndPositionsEnum.FLAG_PAYLOADS);
+                assert dpe != null; // terms has payloads
+                int docID = DocsEnum.NO_MORE_DOCS;
+                for (int d = dpe.nextDoc(); d != DocsEnum.NO_MORE_DOCS; d = dpe.nextDoc()) {
+                    docID = d;
+                    dpe.nextPosition();
+                    final BytesRef payload = dpe.getPayload();
+                    if (payload != null && payload.length == 8) {
+                        // nocommit does this break the nested docs case?  we are not returning the last matching docID here?
+                        return new DocIdAndVersion(d, Numbers.bytesToLong(payload), readerContexts[seg]);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // TODO: add reopen method to carry over re-used enums...?
+}

--- a/src/main/java/org/elasticsearch/common/lucene/uid/Versions.java
+++ b/src/main/java/org/elasticsearch/common/lucene/uid/Versions.java
@@ -39,13 +39,13 @@ import org.elasticsearch.index.mapper.internal.VersionFieldMapper;
 public class Versions {
 
     public static final long MATCH_ANY = -3L; // Version was not specified by the user
-    // nocommit can we remove this now?  rolling upgrades only need to handle prev (not older than that) version...?
+    // TODO: can we remove this now?  rolling upgrades only need to handle prev (not older than that) version...?
     // the value for MATCH_ANY before ES 1.2.0 - will be removed
     public static final long MATCH_ANY_PRE_1_2_0 = 0L;
     public static final long NOT_FOUND = -1L;
     public static final long NOT_SET = -2L;
 
-    // nocommit is there somewhere else we can store these, not using ThreadLocal?
+    // TODO: is there somewhere else we can store these?
     private static final ConcurrentHashMap<IndexReader,CloseableThreadLocal<PerThreadIDAndVersionLookup>> lookupStates = new ConcurrentHashMap<>();
 
     // Evict this reader from lookupStates once it's closed:

--- a/src/main/java/org/elasticsearch/index/codec/postingsformat/PostingFormats.java
+++ b/src/main/java/org/elasticsearch/index/codec/postingsformat/PostingFormats.java
@@ -67,7 +67,6 @@ public class PostingFormats {
         for (String luceneName : PostingsFormat.availablePostingsFormats()) {
             buildInPostingFormatsX.put(luceneName, new PreBuiltPostingsFormatProvider.Factory(PostingsFormat.forName(luceneName)));
         }
-        // nocommit can we disable bloom by default
         final PostingsFormat defaultFormat = new Elasticsearch090PostingsFormat();
         //final PostingsFormat defaultFormat = PostingsFormat.forName("Lucene41");
         buildInPostingFormatsX.put("direct", new PreBuiltPostingsFormatProvider.Factory("direct", PostingsFormat.forName("Direct")));

--- a/src/main/java/org/elasticsearch/index/codec/postingsformat/PostingFormats.java
+++ b/src/main/java/org/elasticsearch/index/codec/postingsformat/PostingFormats.java
@@ -67,7 +67,9 @@ public class PostingFormats {
         for (String luceneName : PostingsFormat.availablePostingsFormats()) {
             buildInPostingFormatsX.put(luceneName, new PreBuiltPostingsFormatProvider.Factory(PostingsFormat.forName(luceneName)));
         }
-        final Elasticsearch090PostingsFormat defaultFormat = new Elasticsearch090PostingsFormat();
+        // nocommit can we disable bloom by default
+        final PostingsFormat defaultFormat = new Elasticsearch090PostingsFormat();
+        //final PostingsFormat defaultFormat = PostingsFormat.forName("Lucene41");
         buildInPostingFormatsX.put("direct", new PreBuiltPostingsFormatProvider.Factory("direct", PostingsFormat.forName("Direct")));
         buildInPostingFormatsX.put("memory", new PreBuiltPostingsFormatProvider.Factory("memory", PostingsFormat.forName("Memory")));
         // LUCENE UPGRADE: Need to change this to the relevant ones on a lucene upgrade

--- a/src/main/java/org/elasticsearch/index/codec/postingsformat/PostingFormats.java
+++ b/src/main/java/org/elasticsearch/index/codec/postingsformat/PostingFormats.java
@@ -68,7 +68,6 @@ public class PostingFormats {
             buildInPostingFormatsX.put(luceneName, new PreBuiltPostingsFormatProvider.Factory(PostingsFormat.forName(luceneName)));
         }
         final PostingsFormat defaultFormat = new Elasticsearch090PostingsFormat();
-        //final PostingsFormat defaultFormat = PostingsFormat.forName("Lucene41");
         buildInPostingFormatsX.put("direct", new PreBuiltPostingsFormatProvider.Factory("direct", PostingsFormat.forName("Direct")));
         buildInPostingFormatsX.put("memory", new PreBuiltPostingsFormatProvider.Factory("memory", PostingsFormat.forName("Memory")));
         // LUCENE UPGRADE: Need to change this to the relevant ones on a lucene upgrade


### PR DESCRIPTION
The TermsEnums used for lookup have highish cost to init, so if we
reuse them we may be able to stop using bloom filters.  I ran some bulk
update performance tests, showing that turning off blooms and reusing
the enums gets close to the same performance as master (using blooms
and not reusing the enums).

Closes #6212
