### PR TITLE
Add short_circuit option to limit filters, triggering a shard search failure on overly broad searches

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
+++ b/src/main/java/org/elasticsearch/index/query/FilterBuilders.java
@@ -43,6 +43,10 @@ public abstract class FilterBuilders {
         return new LimitFilterBuilder(limit);
     }
 
+    public static LimitFilterBuilder limitFilter(int limit, boolean short_circuit) {
+        return new LimitFilterBuilder(limit, short_circuit);
+    }
+
     public static NestedFilterBuilder nestedFilter(String path, QueryBuilder query) {
         return new NestedFilterBuilder(path, query);
     }
@@ -400,7 +404,7 @@ public abstract class FilterBuilders {
     public static GeohashCellFilter.Builder geoHashCellFilter(String name, String geohash, boolean neighbors) {
         return new GeohashCellFilter.Builder(name, geohash, neighbors);
     }
-    
+
     /**
      * A filter to filter based on a polygon defined by a set of locations  / points.
      *

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterBuilder.java
@@ -26,15 +26,25 @@ import java.io.IOException;
 public class LimitFilterBuilder extends BaseFilterBuilder {
 
     private final int limit;
+    private final boolean short_circuit;
 
     public LimitFilterBuilder(int limit) {
         this.limit = limit;
+        this.short_circuit = false;
+    }
+
+    public LimitFilterBuilder(int limit, boolean short_circuit) {
+        this.limit = limit;
+        this.short_circuit = short_circuit;
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(LimitFilterParser.NAME);
         builder.field("value", limit);
+        if (short_circuit) {
+          builder.field("short_circuit", short_circuit);
+        }
         builder.endObject();
     }
 }

--- a/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/LimitFilterParser.java
@@ -44,6 +44,7 @@ public class LimitFilterParser implements FilterParser {
         XContentParser parser = parseContext.parser();
 
         int limit = -1;
+        boolean short_circuit = false;
         String currentFieldName = null;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -52,7 +53,10 @@ public class LimitFilterParser implements FilterParser {
             } else if (token.isValue()) {
                 if ("value".equals(currentFieldName)) {
                     limit = parser.intValue();
-                } else {
+                } else if ("short_circuit".equals(currentFieldName)) {
+                    short_circuit = parser.booleanValue();
+                }
+                else {
                     throw new QueryParsingException(parseContext.index(), "[limit] filter does not support [" + currentFieldName + "]");
                 }
             }
@@ -62,6 +66,6 @@ public class LimitFilterParser implements FilterParser {
             throw new QueryParsingException(parseContext.index(), "No value specified for limit filter");
         }
 
-        return new LimitFilter(limit);
+        return new LimitFilter(limit, short_circuit);
     }
 }


### PR DESCRIPTION
Proposing this to get a discussion started on how to identify when a limit filter is dropping potentially valid matching documents.

The case I'm attempting to tackle occurs when a user makes a broad search with high computational complexity, say a script filter.  What I need is a mechanism to be able to terminate searches on shards after exceeding a certain number of filtered documents.  A better timeout mechanism would also help to alleviate this problem.

Limit filters are currently the best means to restrict expensive searches, but unfortunately there is no context returned to identify when they are tripped.  This makes it impossible to know when to inform a user that their query was too broad vs. trust that there are in fact no matches.

I see throwing an unchecked exception as a massive kludge, but I don't see a much better option to handle this sort of situation.  Any feedback/recommendations welcome.
