### PR TITLE
Change the default type of the page recycler to CONCURRENT instead of SOFT_CONCURRENT.

### DIFF
--- a/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
+++ b/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
@@ -256,7 +256,7 @@ public class PageCacheRecycler extends AbstractComponent {
 
         public static Type parse(String type) {
             if (Strings.isNullOrEmpty(type)) {
-                return SOFT_CONCURRENT;
+                return CONCURRENT;
             }
             try {
                 return Type.valueOf(type.toUpperCase(Locale.ROOT));


### PR DESCRIPTION
This default type has been inherited from its ancestor, the (non-paged) recycler whose memory
usage was unbounded and required soft references to make sure it could release memory eventually.
On the contrary, the page cache recycler memory usage is bounded so we could remove soft
references in order to remove load on the garbage collector.

Note: the cache type is already randomized in integration tests.
