### PR TITLE
Fix github download link when using specific version

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -482,7 +482,7 @@ public class PluginManager {
                 // Sonatype repository
                 addUrl(urls, "https://oss.sonatype.org/service/local/repositories/releases/content/" + user.replace('.', '/') + "/" + repo + "/" + version + "/" + repo + "-" + version + ".zip");
                 // Github repository
-                addUrl(urls, "https://github.com/" + user + "/" + repo + "/archive/v" + version + ".zip");
+                addUrl(urls, "https://github.com/" + user + "/" + repo + "/archive/" + version + ".zip");
             }
             // Github repository for master branch (assume site)
             addUrl(urls, "https://github.com/" + user + "/" + repo + "/archive/master.zip");


### PR DESCRIPTION
Removes the extraneous 'v' character which could have been used previously for Github links.

Does not include an updated test case since the PluginManagerTests class skips tests with invalid downloads (try-catch block in singlePluginInstallAndRemove). In addition, the PluginManager logs to System.out, which is removed during tests.
