### PR TITLE
Internal: Added plugins to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iml
 work/
 /data/
+/plugins/
 logs/
 .DS_Store
 build/


### PR DESCRIPTION
Since plugins should never be committed to the core codebase and it is useful to be able to add plugins to the development environment adding plugins folder to the .gitignore file will stop it from appearing in the unstaged changes
