### PR TITLE
Ensure internal scope extrators are always operating on a Map

### DIFF
--- a/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.lang.ref.SoftReference;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -163,7 +164,7 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
         public MustacheExecutableScript(Mustache mustache,
                 Map<String, Object> vars) {
             this.mustache = mustache;
-            this.vars = vars;
+            this.vars = vars == null ? Collections.EMPTY_MAP : vars;
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
+++ b/src/test/java/org/elasticsearch/index/query/TemplateQueryTest.java
@@ -169,6 +169,28 @@ public class TemplateQueryTest extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    // Releates to #6318
+    public void testSearchRequestFail() throws Exception {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices("_all");
+        try {
+            String query = "{ \"template\" : { \"query\": {\"match_all\": {}}, \"size\" : \"{{my_size}}\"  } }";
+            BytesReference bytesRef = new BytesArray(query);
+            searchRequest.templateSource(bytesRef, false);
+            client().search(searchRequest).get();
+            fail("expected exception");
+        } catch (Throwable ex) {
+            // expected - no params
+        }
+        String query = "{ \"template\" : { \"query\": {\"match_all\": {}}, \"size\" : \"{{my_size}}\"  }, \"params\" : { \"my_size\": 1 } }";
+        BytesReference bytesRef = new BytesArray(query);
+        searchRequest.templateSource(bytesRef, false);
+
+        SearchResponse searchResponse = client().search(searchRequest).get();
+        assertThat(searchResponse.getHits().hits().length, equalTo(1));
+    }
+
+    @Test
     public void testThatParametersCanBeSet() throws Exception {
         index("test", "type", "1", jsonBuilder().startObject().field("theField", "foo").endObject());
         index("test", "type", "2", jsonBuilder().startObject().field("theField", "foo 2").endObject());


### PR DESCRIPTION
Mustache extracts the key/value pairs for parameter substitution from
objects and maps but it's decided on the first execution. We need to
make sure if the params are null we pass an empty map to ensure we
bind the map based extractor

Closes #6318
