### PR TITLE
Add the ability to specify the analyzer used for each Field

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -122,7 +122,7 @@ boost factor.
 |`analyzer` |The analyzer that will be used to analyze the text.
 Defaults to the analyzer associated with the field.
 
-|`fields_analyzer` | coming[1.3.0] When using `ids` or `docs`, a key-value pair object
+|`field_analyzers` | coming[1.3.0] When using `ids` or `docs`, a key-value pair object
 specifying the analyzer for each field. Unspecified keys default to the
 analyzer associated with the field.
 |=======================================================================

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -124,6 +124,6 @@ Defaults to the analyzer associated with the field.
 
 |`field_analyzers` | coming[1.3.0] When using `ids` or `docs`, a key-value pair object
 specifying the analyzer for each field. Unspecified keys default to the
-analyzer associated with the field.
+analyzer associated with `analyzer`.
 |=======================================================================
 

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -121,5 +121,9 @@ boost factor.
 
 |`analyzer` |The analyzer that will be used to analyze the text.
 Defaults to the analyzer associated with the field.
+
+|`fields_analyzer` |When using `ids` or `docs`, a key-value pair object
+specifying the analyzer for each field. Unspecified keys default to the
+analyzer associated with the field.
 |=======================================================================
 

--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -122,7 +122,7 @@ boost factor.
 |`analyzer` |The analyzer that will be used to analyze the text.
 Defaults to the analyzer associated with the field.
 
-|`fields_analyzer` |When using `ids` or `docs`, a key-value pair object
+|`fields_analyzer` | coming[1.3.0] When using `ids` or `docs`, a key-value pair object
 specifying the analyzer for each field. Unspecified keys default to the
 analyzer associated with the field.
 |=======================================================================

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -111,7 +111,7 @@ public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements Boosta
     private float boostTerms = -1;
     private float boost = -1;
     private String analyzer;
-    private Map<String, String> fieldsAnalyzer;
+    private Map<String, String> fieldAnalyzers;
     private Boolean failOnUnsupportedField;
     private String queryName;
 
@@ -250,18 +250,18 @@ public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements Boosta
     }
 
     public MoreLikeThisQueryBuilder addFieldAnalyzer(String field, String analyzer) {
-        if (this.fieldsAnalyzer == null) {
-            this.fieldsAnalyzer = new HashMap<>();
+        if (this.fieldAnalyzers == null) {
+            this.fieldAnalyzers = new HashMap<>();
         }
-        this.fieldsAnalyzer.put(field, analyzer);
+        this.fieldAnalyzers.put(field, analyzer);
         return this;
     }
 
     /**
      * The analyzers that will be used for each field. Unspecified keys default to the analyzer associated with the field.
      */
-    public MoreLikeThisQueryBuilder fieldsAnalyzer(Map<String, String> fieldsAnalyzer) {
-        this.fieldsAnalyzer = fieldsAnalyzer;
+    public MoreLikeThisQueryBuilder fieldAnalyzers(Map<String, String> fieldAnalyzers) {
+        this.fieldAnalyzers = fieldAnalyzers;
         return this;
     }
 
@@ -338,10 +338,10 @@ public class MoreLikeThisQueryBuilder extends BaseQueryBuilder implements Boosta
         if (analyzer != null) {
             builder.field(MoreLikeThisQueryParser.Fields.ANALYZER.getPreferredName(), analyzer);
         }
-        if (fieldsAnalyzer != null) {
-            builder.startObject(MoreLikeThisQueryParser.Fields.FIELDS_ANALYZER.getPreferredName());
-            for (String field : fieldsAnalyzer.keySet()) {
-                builder.field(field, fieldsAnalyzer.get(field));
+        if (fieldAnalyzers != null) {
+            builder.startObject(MoreLikeThisQueryParser.Fields.FIELD_ANALYZERS.getPreferredName());
+            for (String field : fieldAnalyzers.keySet()) {
+                builder.field(field, fieldAnalyzers.get(field));
             }
             builder.endObject();
         }

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queries.TermsFilter;
@@ -53,6 +54,9 @@ public class MoreLikeThisQueryParser implements QueryParser {
 
     public static class Fields {
         public static final ParseField LIKE_TEXT = new ParseField("like_text");
+        public static final ParseField FIELDS = new ParseField("fields");
+        public static final ParseField ANALYZER = new ParseField("analyzer");
+        public static final ParseField FIELDS_ANALYZER = new ParseField("fields_analyzer");
         public static final ParseField MIN_TERM_FREQ = new ParseField("min_term_freq");
         public static final ParseField MAX_QUERY_TERMS = new ParseField("max_query_terms");
         public static final ParseField MIN_WORD_LENGTH = new ParseField("min_word_length", "min_word_len");
@@ -89,6 +93,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
         MoreLikeThisQuery mltQuery = new MoreLikeThisQuery();
         mltQuery.setSimilarity(parseContext.searchSimilarity());
         Analyzer analyzer = null;
+        Map<String, Analyzer> fieldsAnalyzer = null;
         List<String> moreLikeFields = null;
         boolean failOnUnsupportedField = true;
         String queryName = null;
@@ -123,7 +128,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                     }
                 } else if (Fields.PERCENT_TERMS_TO_MATCH.match(currentFieldName, parseContext.parseFlags())) {
                     mltQuery.setPercentTermsToMatch(parser.floatValue());
-                } else if ("analyzer".equals(currentFieldName)) {
+                } else if (Fields.ANALYZER.match(currentFieldName, parseContext.parseFlags())) {
                     analyzer = parseContext.analysisService().analyzer(parser.text());
                 } else if ("boost".equals(currentFieldName)) {
                     mltQuery.setBoost(parser.floatValue());
@@ -143,7 +148,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         stopWords.add(parser.text());
                     }
                     mltQuery.setStopWords(stopWords);
-                } else if ("fields".equals(currentFieldName)) {
+                } else if (Fields.FIELDS.match(currentFieldName, parseContext.parseFlags())) {
                     moreLikeFields = Lists.newLinkedList();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         moreLikeFields.add(parseContext.indexName(parser.text()));
@@ -155,6 +160,18 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
                 }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (Fields.FIELDS_ANALYZER.match(currentFieldName, parseContext.parseFlags())) {
+                    fieldsAnalyzer = Maps.newHashMap();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                        String field = parseContext.indexName(parser.text());
+                        parser.nextToken();
+                        Analyzer _analyzer = parseContext.analysisService().analyzer(parser.text());
+                        fieldsAnalyzer.put(field, _analyzer);
+                    }
+                } else {
+                    throw new QueryParsingException(parseContext.index(), "[mlt] query does not support [" + currentFieldName + "]");
+                }
             }
         }
 
@@ -162,10 +179,14 @@ public class MoreLikeThisQueryParser implements QueryParser {
             throw new QueryParsingException(parseContext.index(), "more_like_this requires at least 'like_text' or 'ids/docs' to be specified");
         }
 
+        Analyzer defaultAnalyzer = parseContext.mapperService().searchAnalyzer();
         if (analyzer == null) {
-            analyzer = parseContext.mapperService().searchAnalyzer();
+            analyzer = defaultAnalyzer;
         }
         mltQuery.setAnalyzer(analyzer);
+        if (fieldsAnalyzer != null) {
+            fieldsAnalyzer.put("__default__", defaultAnalyzer);
+        }
 
         if (moreLikeFields == null) {
             moreLikeFields = Lists.newArrayList(parseContext.defaultField());
@@ -209,7 +230,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
             // right now we are just building a boolean query
             BooleanQuery boolQuery = new BooleanQuery();
             for (MoreLikeThisFetchService.LikeText likeText : likeTexts) {
-                addMoreLikeThis(boolQuery, mltQuery, likeText.field, likeText.text);
+                addMoreLikeThis(boolQuery, mltQuery, likeText.field, likeText.text, fieldsAnalyzer);
             }
             // exclude the items from the search
             if (!include) {
@@ -227,11 +248,19 @@ public class MoreLikeThisQueryParser implements QueryParser {
         return mltQuery;
     }
 
-    private void addMoreLikeThis(BooleanQuery boolQuery, MoreLikeThisQuery mltQuery, String fieldName, String likeText) {
+    private void addMoreLikeThis(BooleanQuery boolQuery, MoreLikeThisQuery mltQuery, String fieldName, String likeText, Map<String, Analyzer> fieldsAnalyzer) {
         MoreLikeThisQuery mlt = new MoreLikeThisQuery();
         mlt.setMoreLikeFields(new String[] {fieldName});
         mlt.setLikeText(likeText);
-        mlt.setAnalyzer(mltQuery.getAnalyzer());
+        if (fieldsAnalyzer != null) {
+            if (fieldsAnalyzer.containsKey(fieldName)) {
+                mlt.setAnalyzer(fieldsAnalyzer.get(fieldName));
+            } else {
+                mlt.setAnalyzer(fieldsAnalyzer.get("__default__"));
+            }
+        } else {
+            mlt.setAnalyzer(mltQuery.getAnalyzer());
+        }
         mlt.setPercentTermsToMatch(mltQuery.getPercentTermsToMatch());
         mlt.setBoostTerms(mltQuery.isBoostTerms());
         mlt.setBoostTermsFactor(mltQuery.getBoostTermsFactor());

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -166,7 +166,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         assert token == XContentParser.Token.FIELD_NAME;
                         String field = parseContext.indexName(parser.text());
-                        assert parser.nextToken().isValue();
+                        token = parser.nextToken();
+                        assert token.isValue();
                         Analyzer _analyzer = parseContext.analysisService().analyzer(parser.text());
                         fieldsAnalyzer.put(field, _analyzer);
                     }

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1723,7 +1723,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testMoreLikeThisFieldsAnalyzer() throws Exception {
+    public void testMoreLikeThisFieldAnalyzers() throws Exception {
         MoreLikeThisQueryParser parser = (MoreLikeThisQueryParser) queryParser.queryParser("more_like_this");
         parser.setFetchService(new MockMoreLikeThisFetchService());
 

--- a/src/test/java/org/elasticsearch/index/query/mlt-fields-analyzer.json
+++ b/src/test/java/org/elasticsearch/index/query/mlt-fields-analyzer.json
@@ -1,0 +1,11 @@
+{
+    "more_like_this" : {
+        "fields" : ["title", "tags", "description"],
+        "fields_analyzer" : {
+            "tags" : "keyword",
+            "description" : "whitespace"
+        },
+        "ids" : ["1", "2"],
+        "include" : true
+    }
+}

--- a/src/test/java/org/elasticsearch/index/query/mlt-fields-analyzer.json
+++ b/src/test/java/org/elasticsearch/index/query/mlt-fields-analyzer.json
@@ -1,7 +1,7 @@
 {
     "more_like_this" : {
         "fields" : ["title", "tags", "description"],
-        "fields_analyzer" : {
+        "field_analyzers" : {
             "tags" : "keyword",
             "description" : "whitespace"
         },

--- a/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
@@ -483,4 +483,40 @@ public class MoreLikeThisActionTests extends ElasticsearchIntegrationTest {
         assertHitCount(mltResponse, numOfTypes);
     }
 
+    @Test
+    public void testSimpleFieldsAnalyzer() throws Exception {
+        logger.info("Creating index test");
+        assertAcked(prepareCreate("test").addMapping("type1",
+                jsonBuilder().startObject().startObject("type1").startObject("properties")
+                        .startObject("text").field("type", "string").endObject()
+                        .endObject().endObject().endObject()));
+
+        logger.info("Running Cluster Health");
+        assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));
+
+        logger.info("Indexing...");
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        builders.add(client().prepareIndex("test", "type1")
+                .setSource("title", "aaaa bbbb", "text", "Software Foundation").setId("1"));
+        builders.add(client().prepareIndex("test", "type1")
+                .setSource("title", "aaaa cccc", "text", "Software License").setId("2"));
+        builders.add(client().prepareIndex("test", "type1")
+                .setSource("title", "aaaa dddd", "text", "Apache Lucene").setId("3"));
+        indexRandom(true, builders);
+
+        logger.info("Running MoreLikeThis");
+        MoreLikeThisQueryBuilder queryBuilder = QueryBuilders.moreLikeThisQuery("title", "text").ids("1").minTermFreq(1).minDocFreq(1);
+        SearchResponse mltResponse = client().prepareSearch().setTypes("type1").setQuery(queryBuilder).execute().actionGet();
+        assertHitCount(mltResponse, 2l);
+
+        queryBuilder = QueryBuilders.moreLikeThisQuery("title", "text").ids("1").minTermFreq(1).minDocFreq(1)
+                .addFieldAnalyzer("title", "keyword");
+        mltResponse = client().prepareSearch().setTypes("type1").setQuery(queryBuilder).execute().actionGet();
+        assertHitCount(mltResponse, 1l);
+
+        queryBuilder = QueryBuilders.moreLikeThisQuery("title", "text").ids("2").minTermFreq(1).minDocFreq(1)
+                .addFieldAnalyzer("title", "keyword").addFieldAnalyzer("text", "keyword");
+        mltResponse = client().prepareSearch().setTypes("type1").setQuery(queryBuilder).execute().actionGet();
+        assertHitCount(mltResponse, 0l);
+    }
 }

--- a/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
+++ b/src/test/java/org/elasticsearch/mlt/MoreLikeThisActionTests.java
@@ -484,7 +484,7 @@ public class MoreLikeThisActionTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    public void testSimpleFieldsAnalyzer() throws Exception {
+    public void testSimpleFieldAnalyzers() throws Exception {
         logger.info("Creating index test");
         assertAcked(prepareCreate("test").addMapping("type1",
                 jsonBuilder().startObject().startObject("type1").startObject("properties")


### PR DESCRIPTION
When using multiple items, the user may want to specify which analyzer to use
for each field. Previously, either the analyzer specified by 'analyzer' would
be used for all the fields, or if not set, the analyzer associated with the
field would be chosen. This commit provides the ability to fine grain which
analyzer should be used for each field by providing a new 'fields_analyzer'
parameter to the More Like This Query.
