### PR TITLE
Aggregations: Added GeoBounds Aggregation

### DIFF
--- a/docs/reference/search/aggregations.asciidoc
+++ b/docs/reference/search/aggregations.asciidoc
@@ -109,11 +109,13 @@ minimum value among all other values associated with the same document).
 
 The aggregations in this family compute metrics based on values extracted in one way or another from the documents that
 are being aggregated. The values are typically extracted from the fields of the document (using the field data), but
-can also be generated using scripts. Some aggregations output a single metric (e.g. `avg`) and are called `single-value
-metrics aggregation`, others generate multiple metrics (e.g. `stats`) and are called `multi-value metrics aggregation`.
-The distinction between single-value and multi-value metrics aggregations plays a role when these aggregations serve as
-direct sub-aggregations of some bucket aggregations (some bucket aggregation enable you to sort the returned buckets based
-on the metrics in each bucket).
+can also be generated using scripts. 
+
+Numeric metrics aggregations are a special type of metrics aggregation which output numeric values. Some aggregations output
+a single numeric metric (e.g. `avg`) and are called `single-value numeric metrics aggregation`, others generate multiple 
+metrics (e.g. `stats`) and are called `multi-value numeric metrics aggregation`. The distinction between single-value and 
+multi-value numeric metrics aggregations plays a role when these aggregations serve as direct sub-aggregations of some 
+bucket aggregations (some bucket aggregation enable you to sort the returned buckets based on the numeric metrics in each bucket).
 
 
 [float]

--- a/docs/reference/search/aggregations/metrics.asciidoc
+++ b/docs/reference/search/aggregations/metrics.asciidoc
@@ -17,3 +17,5 @@ include::metrics/valuecount-aggregation.asciidoc[]
 include::metrics/percentile-aggregation.asciidoc[]
 
 include::metrics/cardinality-aggregation.asciidoc[]
+
+include::metrics/geobounds-aggregation.asciidoc[]

--- a/docs/reference/search/aggregations/metrics/geobounds-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/metrics/geobounds-aggregation.asciidoc
@@ -1,0 +1,61 @@
+[[search-aggregations-metrics-geobounds-aggregation]]
+=== Geo Bounds Aggregation
+
+coming[1.3.0]
+
+A metric aggregation that computes the bounding box containing all geo_point values for a field.
+
+.Experimental!
+[IMPORTANT]
+=====
+This feature is marked as experimental, and may be subject to change in the
+future.  If you use this feature, please let us know your experience with it!
+=====
+
+Example:
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {
+        "match" : { "business_type" : "shop" }
+    },
+    "aggs" : {
+        "viewport" : {
+            "geo_bounds" : {
+                "field" : "location" <1>
+                "wrap_longitude" : "true" <2>
+            }
+        }
+    }
+}
+--------------------------------------------------
+
+<1> The `geo_bounds` aggregation specifies the field to use to obtain the bounds
+<2> `wrap_longitude` is an optional parameter which specifies whether the bounding box should be allowed to overlap the international date line. The default value is `true`
+
+The above aggregation demonstrates how one would compute the bounding box of the location field for all documents with a business type of shop
+
+The response for the above aggregation:
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+
+    "aggregations": {
+        "viewport": {
+            "bounds": {
+                "top_left": {
+                    "lat": 80.45,
+                    "lon": -160.22
+                },
+                "bottom_right": {
+                    "lat": 40.65,
+                    "lon": 42.57
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------

--- a/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -50,7 +50,7 @@ import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionParser;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilders.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilders.java
@@ -25,16 +25,17 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramBuild
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramBuilder;
 import org.elasticsearch.search.aggregations.bucket.missing.MissingBuilder;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedBuilder;
+import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4RangeBuilder;
-import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedBuilder;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.search.aggregations.bucket.tophits.TopHitsBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.AvgBuilder;
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityBuilder;
+import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsBuilder;
 import org.elasticsearch.search.aggregations.metrics.max.MaxBuilder;
 import org.elasticsearch.search.aggregations.metrics.min.MinBuilder;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesBuilder;
@@ -145,5 +146,9 @@ public class AggregationBuilders {
 
     public static TopHitsBuilder topHits(String name) {
         return new TopHitsBuilder(name);
+    }
+    
+    public static GeoBoundsBuilder geoBounds(String name) {
+        return new GeoBoundsBuilder(name);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
@@ -28,16 +28,17 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramParse
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramParser;
 import org.elasticsearch.search.aggregations.bucket.missing.MissingParser;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedParser;
+import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedParser;
 import org.elasticsearch.search.aggregations.bucket.range.RangeParser;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeParser;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceParser;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IpRangeParser;
-import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedParser;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsParser;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsParser;
 import org.elasticsearch.search.aggregations.bucket.tophits.TopHitsParser;
 import org.elasticsearch.search.aggregations.metrics.avg.AvgParser;
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityParser;
+import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsParser;
 import org.elasticsearch.search.aggregations.metrics.max.MaxParser;
 import org.elasticsearch.search.aggregations.metrics.min.MinParser;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesParser;
@@ -81,6 +82,7 @@ public class AggregationModule extends AbstractModule {
         parsers.add(NestedParser.class);
         parsers.add(ReverseNestedParser.class);
         parsers.add(TopHitsParser.class);
+        parsers.add(GeoBoundsParser.class);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
@@ -26,11 +26,11 @@ import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistog
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.elasticsearch.search.aggregations.bucket.missing.InternalMissing;
 import org.elasticsearch.search.aggregations.bucket.nested.InternalNested;
+import org.elasticsearch.search.aggregations.bucket.nested.InternalReverseNested;
 import org.elasticsearch.search.aggregations.bucket.range.InternalRange;
 import org.elasticsearch.search.aggregations.bucket.range.date.InternalDateRange;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.InternalGeoDistance;
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.InternalIPv4Range;
-import org.elasticsearch.search.aggregations.bucket.nested.InternalReverseNested;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantLongTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantStringTerms;
 import org.elasticsearch.search.aggregations.bucket.significant.UnmappedSignificantTerms;
@@ -41,6 +41,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
 import org.elasticsearch.search.aggregations.bucket.tophits.InternalTopHits;
 import org.elasticsearch.search.aggregations.metrics.avg.InternalAvg;
 import org.elasticsearch.search.aggregations.metrics.cardinality.InternalCardinality;
+import org.elasticsearch.search.aggregations.metrics.geobounds.InternalGeoBounds;
 import org.elasticsearch.search.aggregations.metrics.max.InternalMax;
 import org.elasticsearch.search.aggregations.metrics.min.InternalMin;
 import org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercentiles;
@@ -89,5 +90,6 @@ public class TransportAggregationModule extends AbstractModule {
         InternalNested.registerStream();
         InternalReverseNested.registerStream();
         InternalTopHits.registerStreams();
+        InternalGeoBounds.registerStream();
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalOrder.java
@@ -28,7 +28,7 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.OrderPath;
 
 import java.io.IOException;
@@ -171,13 +171,13 @@ class InternalOrder extends Terms.Order {
             // with only support single-bucket aggregators
             assert !(aggregator instanceof BucketsAggregator) : "this should be picked up before the aggregation is executed - on validate";
 
-            if (aggregator instanceof MetricsAggregator.MultiValue) {
+            if (aggregator instanceof NumericMetricsAggregator.MultiValue) {
                 assert key != null : "this should be picked up before the aggregation is executed - on validate";
                 return new Comparator<Terms.Bucket>() {
                     @Override
                     public int compare(Terms.Bucket o1, Terms.Bucket o2) {
-                        double v1 = ((MetricsAggregator.MultiValue) aggregator).metric(key, ((InternalTerms.Bucket) o1).bucketOrd);
-                        double v2 = ((MetricsAggregator.MultiValue) aggregator).metric(key, ((InternalTerms.Bucket) o2).bucketOrd);
+                        double v1 = ((NumericMetricsAggregator.MultiValue) aggregator).metric(key, ((InternalTerms.Bucket) o1).bucketOrd);
+                        double v2 = ((NumericMetricsAggregator.MultiValue) aggregator).metric(key, ((InternalTerms.Bucket) o2).bucketOrd);
                         // some metrics may return NaN (eg. avg, variance, etc...) in which case we'd like to push all of those to
                         // the bottom
                         return Comparators.compareDiscardNaN(v1, v2, asc);
@@ -189,8 +189,8 @@ class InternalOrder extends Terms.Order {
             return new Comparator<Terms.Bucket>() {
                 @Override
                 public int compare(Terms.Bucket o1, Terms.Bucket o2) {
-                    double v1 = ((MetricsAggregator.SingleValue) aggregator).metric(((InternalTerms.Bucket) o1).bucketOrd);
-                    double v2 = ((MetricsAggregator.SingleValue) aggregator).metric(((InternalTerms.Bucket) o2).bucketOrd);
+                    double v1 = ((NumericMetricsAggregator.SingleValue) aggregator).metric(((InternalTerms.Bucket) o1).bucketOrd);
+                    double v2 = ((NumericMetricsAggregator.SingleValue) aggregator).metric(((InternalTerms.Bucket) o2).bucketOrd);
                     // some metrics may return NaN (eg. avg, variance, etc...) in which case we'd like to push all of those to
                     // the bottom
                     return Comparators.compareDiscardNaN(v1, v2, asc);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMetricsAggregation.java
@@ -16,45 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
-/**
- *
- */
-public abstract class MetricsAggregation extends InternalAggregation {
+public abstract class InternalMetricsAggregation extends InternalAggregation {
 
-    protected ValueFormatter valueFormatter;
+    protected InternalMetricsAggregation() {} // for serialization
 
-    public static abstract class SingleValue extends MetricsAggregation {
-
-        protected SingleValue() {}
-
-        protected SingleValue(String name) {
-            super(name);
-        }
-
-        public abstract double value();
-    }
-
-    public static abstract class MultiValue extends MetricsAggregation {
-
-        protected MultiValue() {}
-
-        protected MultiValue(String name) {
-            super(name);
-        }
-
-        public abstract double value(String name);
-
-    }
-
-    protected MetricsAggregation() {} // for serialization
-
-    protected MetricsAggregation(String name) {
+    protected InternalMetricsAggregation(String name) {
         super(name);
     }
-
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
+
+/**
+ *
+ */
+public abstract class InternalNumericMetricsAggregation extends InternalMetricsAggregation {
+
+    protected ValueFormatter valueFormatter;
+
+    public static abstract class SingleValue extends InternalNumericMetricsAggregation {
+
+        protected SingleValue() {}
+
+        protected SingleValue(String name) {
+            super(name);
+        }
+
+        public abstract double value();
+    }
+
+    public static abstract class MultiValue extends InternalNumericMetricsAggregation {
+
+        protected MultiValue() {}
+
+        protected MultiValue(String name) {
+            super(name);
+        }
+
+        public abstract double value(String name);
+
+    }
+
+    protected InternalNumericMetricsAggregation() {} // for serialization
+
+    protected InternalNumericMetricsAggregation(String name) {
+        super(name);
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+/**
+ *
+ */
+public abstract class NumericMetricsAggregator extends MetricsAggregator {
+
+    private NumericMetricsAggregator(String name, long estimatedBucketsCount, AggregationContext context, Aggregator parent) {
+        super(name, estimatedBucketsCount, context, parent);
+    }
+
+    public static abstract class SingleValue extends NumericMetricsAggregator {
+
+        protected SingleValue(String name, long estimatedBucketsCount, AggregationContext context, Aggregator parent) {
+            super(name, estimatedBucketsCount, context, parent);
+        }
+
+        public abstract double metric(long owningBucketOrd);
+    }
+
+    public static abstract class MultiValue extends NumericMetricsAggregator {
+
+        protected MultiValue(String name, long estimatedBucketsCount, AggregationContext context, Aggregator parent) {
+            super(name, estimatedBucketsCount, context, parent);
+        }
+
+        public abstract boolean hasMetric(String name);
+
+        public abstract double metric(String name, long owningBucketOrd);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -36,7 +36,7 @@ import java.io.IOException;
 /**
  *
  */
-public class AvgAggregator extends MetricsAggregator.SingleValue {
+public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final ValuesSource.Numeric valuesSource;
     private DoubleValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -32,7 +32,7 @@ import java.util.List;
 /**
 *
 */
-public class InternalAvg extends MetricsAggregation.SingleValue implements Avg {
+public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue implements Avg {
 
     public final static Type TYPE = new Type("avg");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -37,7 +37,7 @@ import org.elasticsearch.index.fielddata.MurmurHash3Values;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 
@@ -46,7 +46,7 @@ import java.io.IOException;
 /**
  * An aggregator that computes approximate counts of unique values.
  */
-public class CardinalityAggregator extends MetricsAggregator.SingleValue {
+public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final int precision;
     private final boolean rehash;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -25,13 +25,13 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
 import java.util.List;
 
-public final class InternalCardinality extends MetricsAggregation.SingleValue implements Cardinality {
+public final class InternalCardinality extends InternalNumericMetricsAggregation.SingleValue implements Cardinality {
 
     public final static Type TYPE = new Type("cardinality");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBounds.java
@@ -17,15 +17,14 @@
  * under the License.
  */
 
-package org.elasticsearch.search.aggregations.metrics;
+package org.elasticsearch.search.aggregations.metrics.geobounds;
 
-import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.search.aggregations.Aggregation;
 
-public abstract class MetricsAggregator extends Aggregator {
-
-    protected MetricsAggregator(String name, long estimatedBucketsCount, AggregationContext context, Aggregator parent) {
-        super(name, BucketAggregationMode.MULTI_BUCKETS, AggregatorFactories.EMPTY, estimatedBucketsCount, context, parent);
-    }
+public interface GeoBounds extends Aggregation {
+    
+    GeoPoint topLeft();
+    
+    GeoPoint bottomRight();
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics.geobounds;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.index.fielddata.GeoPointValues;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+
+import java.io.IOException;
+
+public final class GeoBoundsAggregator extends MetricsAggregator {
+
+    private final ValuesSource.GeoPoint valuesSource;
+    private final boolean wrapLongitude;
+    private DoubleArray tops;
+    private DoubleArray bottoms;
+    private DoubleArray posLefts;
+    private DoubleArray posRights;
+    private DoubleArray negLefts;
+    private DoubleArray negRights;
+    private GeoPointValues values;
+
+    protected GeoBoundsAggregator(String name, long estimatedBucketsCount,
+            AggregationContext aggregationContext, Aggregator parent, ValuesSource.GeoPoint valuesSource, boolean wrapLongitude) {
+        super(name, estimatedBucketsCount, aggregationContext, parent);
+        this.valuesSource = valuesSource;
+        this.wrapLongitude = wrapLongitude;
+        if (valuesSource != null) {
+            final long initialSize = estimatedBucketsCount < 2 ? 1 : estimatedBucketsCount;
+            tops = bigArrays.newDoubleArray(initialSize, false);
+            tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
+            bottoms = bigArrays.newDoubleArray(initialSize, false);
+            bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
+            posLefts = bigArrays.newDoubleArray(initialSize, false);
+            posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
+            posRights = bigArrays.newDoubleArray(initialSize, false);
+            posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
+            negLefts = bigArrays.newDoubleArray(initialSize, false);
+            negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
+            negRights = bigArrays.newDoubleArray(initialSize, false);
+            negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
+        }
+    }
+
+    @Override
+    public boolean shouldCollect() {
+        return valuesSource != null;
+    }
+
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        this.values = this.valuesSource.geoPointValues();
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        if (valuesSource == null) {
+            return buildEmptyAggregation();
+        }
+        double top = tops.get(owningBucketOrdinal);
+        double bottom = bottoms.get(owningBucketOrdinal);
+        double posLeft = posLefts.get(owningBucketOrdinal);
+        double posRight = posRights.get(owningBucketOrdinal);
+        double negLeft = negLefts.get(owningBucketOrdinal);
+        double negRight = negRights.get(owningBucketOrdinal);
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude);
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalGeoBounds(name, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude);
+    }
+
+    @Override
+    public void collect(int docId, long owningBucketOrdinal) throws IOException {
+        if (owningBucketOrdinal >= tops.size()) {
+            long from = tops.size();
+            tops = bigArrays.grow(tops, owningBucketOrdinal + 1);
+            tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
+            bottoms = bigArrays.resize(bottoms, tops.size());
+            bottoms.fill(from, bottoms.size(), Double.NEGATIVE_INFINITY);
+            posLefts = bigArrays.resize(posLefts, tops.size());
+            posLefts.fill(from, posLefts.size(), Double.NEGATIVE_INFINITY);
+            posLefts = bigArrays.resize(posLefts, tops.size());
+            posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
+            negLefts = bigArrays.resize(negLefts, tops.size());
+            negLefts.fill(from, negLefts.size(), Double.NEGATIVE_INFINITY);
+            negRights = bigArrays.resize(negRights, tops.size());
+            negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
+        }
+
+        final int valuesCount = values.setDocument(docId);
+
+        for (int i = 0; i < valuesCount; ++i) {
+            GeoPoint value = values.nextValue();
+            double top = tops.get(owningBucketOrdinal);
+            if (value.lat() > top) {
+                top = value.lat();
+            }
+            double bottom = bottoms.get(owningBucketOrdinal);
+            if (value.lat() < bottom) {
+                bottom = value.lat();
+            }
+            double posLeft = posLefts.get(owningBucketOrdinal);
+            if (value.lon() > 0 && value.lon() < posLeft) {
+                posLeft = value.lon();
+            }
+            double posRight = posRights.get(owningBucketOrdinal);
+            if (value.lon() > 0 && value.lon() > posRight) {
+                posRight = value.lon();
+            }
+            double negLeft = negLefts.get(owningBucketOrdinal);
+            if (value.lon() < 0 && value.lon() < negLeft) {
+                negLeft = value.lon();
+            }
+            double negRight = negRights.get(owningBucketOrdinal);
+            if (value.lon() < 0 && value.lon() > negRight) {
+                negRight = value.lon();
+            }
+            tops.set(owningBucketOrdinal, top);
+            bottoms.set(owningBucketOrdinal, bottom);
+            posLefts.set(owningBucketOrdinal, posLeft);
+            posRights.set(owningBucketOrdinal, posRight);
+            negLefts.set(owningBucketOrdinal, negLeft);
+            negRights.set(owningBucketOrdinal, negRight);
+        }
+    }
+    
+    @Override
+    public void doClose() {
+        Releasables.close(tops, bottoms, posLefts, posRights, negLefts, negRights);
+    }
+
+    public static class Factory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
+
+        private final boolean wrapLongitude;
+
+        protected Factory(String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, boolean wrapLongitude) {
+            super(name, InternalGeoBounds.TYPE.name(), config);
+            this.wrapLongitude = wrapLongitude;
+        }
+
+        @Override
+        protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent) {
+            return new GeoBoundsAggregator(name, 0, aggregationContext, parent, null, wrapLongitude);
+        }
+
+        @Override
+        protected Aggregator create(ValuesSource.GeoPoint valuesSource, long expectedBucketsCount, AggregationContext aggregationContext,
+                Aggregator parent) {
+            return new GeoBoundsAggregator(name, expectedBucketsCount, aggregationContext, parent, valuesSource, wrapLongitude);
+        }
+
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics.geobounds;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.ValuesSourceAggregationBuilder;
+
+import java.io.IOException;
+
+public class GeoBoundsBuilder extends ValuesSourceAggregationBuilder<GeoBoundsBuilder> {
+
+    private Boolean wrapLongitude;
+    
+    public GeoBoundsBuilder(String name) {
+        super(name, InternalGeoBounds.TYPE.name());
+    }
+    
+    public GeoBoundsBuilder wrapLongitude(boolean wrapLongitude) {
+        this.wrapLongitude = wrapLongitude;
+        return this;
+    }
+
+    @Override
+    protected XContentBuilder doInternalXContent(XContentBuilder builder, Params params) throws IOException {
+        if (wrapLongitude != null) {
+            builder.field("wrap_longitude", wrapLongitude);
+        }
+        return builder;
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics.geobounds;
+
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;
+
+import java.io.IOException;
+import java.util.List;
+
+public class InternalGeoBounds extends InternalMetricsAggregation implements GeoBounds {
+
+    public final static Type TYPE = new Type("geo_bounds");
+    public final static AggregationStreams.Stream STREAM = new AggregationStreams.Stream() {
+        @Override
+        public InternalGeoBounds readResult(StreamInput in) throws IOException {
+            InternalGeoBounds result = new InternalGeoBounds();
+            result.readFrom(in);
+            return result;
+        }
+    };
+    
+    private double top;
+    private double bottom;
+    private double posLeft;
+    private double posRight;
+    private double negLeft;
+    private double negRight;
+    private boolean wrapLongitude;
+
+    InternalGeoBounds() {
+    }
+    
+    InternalGeoBounds(String name, double top, double bottom, double posLeft, double posRight,
+            double negLeft, double negRight, boolean wrapLongitude) {
+        super(name);
+        this.top = top;
+        this.bottom = bottom;
+        this.posLeft = posLeft;
+        this.posRight = posRight;
+        this.negLeft = negLeft;
+        this.negRight = negRight;
+        this.wrapLongitude = wrapLongitude;
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+    
+    @Override
+    public InternalAggregation reduce(ReduceContext reduceContext) {
+        InternalGeoBounds reduced = null;
+        List<InternalAggregation> aggregations = reduceContext.aggregations();
+        for (InternalAggregation aggregation : aggregations) {
+            InternalGeoBounds bounds = (InternalGeoBounds) aggregation;
+            
+            if (reduced == null) {
+                reduced = bounds;
+                continue;
+            }
+
+            if (bounds.top > reduced.top) {
+                reduced.top = bounds.top;
+            }
+            if (bounds.bottom < reduced.bottom) {
+                reduced.bottom = bounds.bottom;
+            }
+            if (bounds.posLeft < reduced.posLeft) {
+                reduced.posLeft = bounds.posLeft;
+            }
+            if (bounds.posRight > reduced.posRight) {
+                reduced.posRight = bounds.posRight;
+            }
+            if (bounds.negLeft < reduced.negLeft) {
+                reduced.negLeft = bounds.negLeft;
+            }
+            if (bounds.negRight > reduced.negRight) {
+                reduced.negRight = bounds.negRight;
+            }
+        }
+        return reduced;
+    }
+    
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        GeoPoint topLeft = topLeft();
+        GeoPoint bottomRight = bottomRight();
+        if (topLeft != null) {
+            builder.startObject("bounds");
+            builder.startObject("top_left");
+            builder.field("lat", topLeft.lat());
+            builder.field("lon", topLeft.lon());
+            builder.endObject();
+            builder.startObject("bottom_right");
+            builder.field("lat", bottomRight.lat());
+            builder.field("lon", bottomRight.lon());
+            builder.endObject();
+        }
+        return builder.endObject();
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        name = in.readString();
+        top = in.readDouble();
+        bottom = in.readDouble();
+        posLeft = in.readDouble();
+        posRight = in.readDouble();
+        negLeft = in.readDouble();
+        negRight = in.readDouble();
+        wrapLongitude = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeDouble(top);
+        out.writeDouble(bottom);
+        out.writeDouble(posLeft);
+        out.writeDouble(posRight);
+        out.writeDouble(negLeft);
+        out.writeDouble(negRight);
+        out.writeBoolean(wrapLongitude);
+    }
+
+    public static void registerStream() {
+        AggregationStreams.registerStream(STREAM, TYPE.stream());
+    }
+    
+    private static class BoundingBox {
+        private final GeoPoint topLeft;
+        private final GeoPoint bottomRight;
+        
+        public BoundingBox(GeoPoint topLeft, GeoPoint bottomRight) {
+            this.topLeft = topLeft;
+            this.bottomRight = bottomRight;
+        }
+        
+        public GeoPoint topLeft() {
+            return topLeft;
+        }
+        
+        public GeoPoint bottomRight() {
+            return bottomRight;
+        }
+    }
+    
+    private BoundingBox resolveBoundingBox() {
+        if (Double.isInfinite(top)) {
+            return null;
+        } else if (Double.isInfinite(posLeft)) {
+            return new BoundingBox(new GeoPoint(top, negLeft), new GeoPoint(bottom, posRight));
+        } else if (Double.isInfinite(negLeft)) {
+            return new BoundingBox(new GeoPoint(top, posLeft), new GeoPoint(bottom, negRight));
+        } else if (wrapLongitude) {
+            double unwrappedWidth = posRight - negLeft;
+            double wrappedWidth = (180 - posLeft) - (-180 - negRight);
+            if (unwrappedWidth <= wrappedWidth) {
+                return new BoundingBox(new GeoPoint(top, negLeft), new GeoPoint(bottom, posRight));
+            } else {
+                return new BoundingBox(new GeoPoint(top, posLeft), new GeoPoint(bottom, negRight));
+            }
+        } else {
+            return new BoundingBox(new GeoPoint(top, negLeft), new GeoPoint(bottom, posRight));
+        }
+    }
+
+    @Override
+    public GeoPoint topLeft() {
+        BoundingBox boundingBox = resolveBoundingBox();
+        if (boundingBox == null) {
+            return null;
+        } else {
+            return boundingBox.topLeft();
+        }
+    }
+
+    @Override
+    public GeoPoint bottomRight() {
+        BoundingBox boundingBox = resolveBoundingBox();
+        if (boundingBox == null) {
+            return null;
+        } else {
+            return boundingBox.bottomRight();
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -32,7 +32,7 @@ import java.util.List;
 /**
 *
 */
-public class InternalMax extends MetricsAggregation.SingleValue implements Max {
+public class InternalMax extends InternalNumericMetricsAggregation.SingleValue implements Max {
 
     public final static Type TYPE = new Type("max");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MaxAggregator extends MetricsAggregator.SingleValue {
+public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final ValuesSource.Numeric valuesSource;
     private DoubleValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -32,7 +32,7 @@ import java.util.List;
 /**
 *
 */
-public class InternalMin extends MetricsAggregation.SingleValue implements Min {
+public class InternalMin extends InternalNumericMetricsAggregation.SingleValue implements Min {
 
     public final static Type TYPE = new Type("min");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class MinAggregator extends MetricsAggregator.SingleValue {
+public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final ValuesSource.Numeric valuesSource;
     private DoubleValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
@@ -37,7 +37,7 @@ import java.util.List;
 /**
 *
 */
-public class InternalPercentiles extends MetricsAggregation.MultiValue implements Percentiles {
+public class InternalPercentiles extends InternalNumericMetricsAggregation.MultiValue implements Percentiles {
 
     public final static Type TYPE = new Type("percentiles");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -37,7 +37,7 @@ import java.io.IOException;
 /**
  *
  */
-public class PercentilesAggregator extends MetricsAggregator.MultiValue {
+public class PercentilesAggregator extends NumericMetricsAggregator.MultiValue {
 
     private static int indexOfPercent(double[] percents, double percent) {
         return ArrayUtils.binarySearch(percents, percent, 0.001);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -33,7 +33,7 @@ import java.util.List;
 /**
 *
 */
-public class InternalStats extends MetricsAggregation.MultiValue implements Stats {
+public class InternalStats extends InternalNumericMetricsAggregation.MultiValue implements Stats {
 
     public final static Type TYPE = new Type("stats");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -38,7 +38,7 @@ import java.io.IOException;
 /**
  *
  */
-public class StatsAggegator extends MetricsAggregator.MultiValue {
+public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
 
     private final ValuesSource.Numeric valuesSource;
     private DoubleValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -38,7 +38,7 @@ import java.io.IOException;
 /**
  *
  */
-public class ExtendedStatsAggregator extends MetricsAggregator.MultiValue {
+public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     private final ValuesSource.Numeric valuesSource;
     private DoubleValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
@@ -32,7 +32,7 @@ import java.util.List;
 /**
 *
 */
-public class InternalSum extends MetricsAggregation.SingleValue implements Sum {
+public class InternalSum extends InternalNumericMetricsAggregation.SingleValue implements Sum {
 
     public final static Type TYPE = new Type("sum");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.index.fielddata.DoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  *
  */
-public class SumAggregator extends MetricsAggregator.SingleValue {
+public class SumAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final ValuesSource.Numeric valuesSource;
     private DoubleValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * An internal implementation of {@link ValueCount}.
  */
-public class InternalValueCount extends MetricsAggregation implements ValueCount {
+public class InternalValueCount extends InternalNumericMetricsAggregation implements ValueCount {
 
     public static final Type TYPE = new Type("value_count", "vcount");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.BytesValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -38,7 +38,7 @@ import java.io.IOException;
  * This aggregator works in a multi-bucket mode, that is, when serves as a sub-aggregator, a single aggregator instance aggregates the
  * counts for all buckets owned by the parent aggregator)
  */
-public class ValueCountAggregator extends MetricsAggregator.SingleValue {
+public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final ValuesSource valuesSource;
     private BytesValues values;

--- a/src/main/java/org/elasticsearch/search/aggregations/support/OrderPath.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/OrderPath.java
@@ -27,8 +27,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.HasAggregations;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 
 /**
  * A path that can be used to sort/order buckets (in some multi-bucket aggregations, eg terms & histogram) based on
@@ -193,14 +193,14 @@ public class OrderPath {
                         "]. Metrics aggregations cannot have sub-aggregations (at [" + token + ">" + tokens[i+1] + "]");
             }
 
-            if (agg instanceof MetricsAggregation.SingleValue) {
+            if (agg instanceof InternalNumericMetricsAggregation.SingleValue) {
                 if (token.key != null && !token.key.equals("value")) {
                     throw new ElasticsearchIllegalArgumentException("Invalid order path [" + this +
                             "]. Unknown value key [" + token.key + "] for single-value metric aggregation [" + token.name +
                             "]. Either use [value] as key or drop the key all together");
                 }
                 parent = null;
-                value = ((MetricsAggregation.SingleValue) agg).value();
+                value = ((InternalNumericMetricsAggregation.SingleValue) agg).value();
                 continue;
             }
 
@@ -210,7 +210,7 @@ public class OrderPath {
                         "]. Missing value key in [" + token + "] which refers to a multi-value metric aggregation");
             }
             parent = null;
-            value = ((MetricsAggregation.MultiValue) agg).value(token.key);
+            value = ((InternalNumericMetricsAggregation.MultiValue) agg).value(token.key);
         }
 
         return value;
@@ -232,7 +232,7 @@ public class OrderPath {
             OrderPath.Token token = tokens[i];
             aggregator = aggregator.subAggregator(token.name);
             assert (aggregator instanceof SingleBucketAggregator && i <= tokens.length - 1) ||
-                    (aggregator instanceof MetricsAggregator && i == tokens.length - 1) :
+                    (aggregator instanceof NumericMetricsAggregator && i == tokens.length - 1) :
                     "this should be picked up before aggregation execution - on validate";
         }
         return aggregator;
@@ -272,7 +272,7 @@ public class OrderPath {
             }
         }
         boolean singleBucket = aggregator instanceof SingleBucketAggregator;
-        if (!singleBucket && !(aggregator instanceof MetricsAggregator)) {
+        if (!singleBucket && !(aggregator instanceof NumericMetricsAggregator)) {
             throw new AggregationExecutionException("Invalid terms aggregation order path [" + this +
                     "]. Terms buckets can only be sorted on a sub-aggregator path " +
                     "that is built out of zero or more single-bucket aggregations within the path and a final " +
@@ -290,7 +290,7 @@ public class OrderPath {
             return;   // perfectly valid to sort on single-bucket aggregation (will be sored on its doc_count)
         }
 
-        if (aggregator instanceof MetricsAggregator.SingleValue) {
+        if (aggregator instanceof NumericMetricsAggregator.SingleValue) {
             if (lastToken.key != null && !"value".equals(lastToken.key)) {
                 throw new AggregationExecutionException("Invalid terms aggregation order path [" + this +
                         "]. Ordering on a single-value metrics aggregation can only be done on its value. " +
@@ -305,7 +305,7 @@ public class OrderPath {
                     "]. When ordering on a multi-value metrics aggregation a metric name must be specified");
         }
 
-        if (!((MetricsAggregator.MultiValue) aggregator).hasMetric(lastToken.key)) {
+        if (!((NumericMetricsAggregator.MultiValue) aggregator).hasMetric(lastToken.key)) {
             throw new AggregationExecutionException("Invalid terms aggregation order path [" + this +
                     "]. Unknown metric name [" + lastToken.key + "] on multi-value metrics aggregation [" + lastToken.name + "]");
         }

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBounds;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.geoBounds;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+/**
+ *
+ */
+@ElasticsearchIntegrationTest.SuiteScopeTest
+public class GeoBoundsTests extends ElasticsearchIntegrationTest {
+
+    private static final String SINGLE_VALUED_FIELD_NAME = "geo_value";
+    private static final String MULTI_VALUED_FIELD_NAME = "geo_values";
+    private static final String NUMBER_FIELD_NAME = "l_values";
+
+    static int numDocs;
+    static int numUniqueGeoPoints;
+    static GeoPoint[] singleValues, multiValues;
+    static GeoPoint singleTopLeft, singleBottomRight, multiTopLeft, multiBottomRight, unmappedTopLeft, unmappedBottomRight;
+
+    @Override
+    public void setupSuiteScopeCluster() throws Exception {
+        assertAcked(prepareCreate("idx")
+                .addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=geo_point", MULTI_VALUED_FIELD_NAME, "type=geo_point", NUMBER_FIELD_NAME, "type=long", "tag", "type=string,index=not_analyzed"));
+        createIndex("idx_unmapped");
+        
+        unmappedTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        unmappedBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        singleTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        singleBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        multiTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        multiBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        
+        numDocs = randomIntBetween(6, 20);
+        numUniqueGeoPoints = randomIntBetween(1, numDocs);
+
+        singleValues = new GeoPoint[numUniqueGeoPoints];
+        for (int i = 0 ; i < singleValues.length; i++)
+        {
+            singleValues[i] = randomGeoPoint();
+            updateBoundsTopLeft(singleValues[i], singleTopLeft);
+            updateBoundsBottomRight(singleValues[i], singleBottomRight);
+        }
+        
+        multiValues = new GeoPoint[numUniqueGeoPoints];
+        for (int i = 0 ; i < multiValues.length; i++)
+        {
+            multiValues[i] = randomGeoPoint();
+            updateBoundsTopLeft(multiValues[i], multiTopLeft);
+            updateBoundsBottomRight(multiValues[i], multiBottomRight);
+        }
+        
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+
+
+        for (int i = 0; i < numDocs; i++) {
+            builders.add(client().prepareIndex("idx", "type").setSource(jsonBuilder()
+                    .startObject()
+                    .array(SINGLE_VALUED_FIELD_NAME, singleValues[i % numUniqueGeoPoints].lon(), singleValues[i % numUniqueGeoPoints].lat())
+                    .startArray(MULTI_VALUED_FIELD_NAME)
+                        .startArray().value(multiValues[i % numUniqueGeoPoints].lon()).value(multiValues[i % numUniqueGeoPoints].lat()).endArray()   
+                        .startArray().value(multiValues[(i+1) % numUniqueGeoPoints].lon()).value(multiValues[(i+1) % numUniqueGeoPoints].lat()).endArray()
+                     .endArray()
+                    .field(NUMBER_FIELD_NAME, i)
+                    .field("tag", "tag" + i)
+                    .endObject()));
+        }
+
+        assertAcked(prepareCreate("empty_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=geo_point"));
+        
+        assertAcked(prepareCreate("idx_dateline")
+                .addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=geo_point", MULTI_VALUED_FIELD_NAME, "type=geo_point", NUMBER_FIELD_NAME, "type=long", "tag", "type=string,index=not_analyzed"));
+
+        GeoPoint[] geoValues = new GeoPoint[5];
+        geoValues[0] = new GeoPoint(38, 178);
+        geoValues[1] = new GeoPoint(12, -179);
+        geoValues[2] = new GeoPoint(-24, 170);
+        geoValues[3] = new GeoPoint(32, -175);
+        geoValues[4] = new GeoPoint(-11, 178);
+        
+        for (int i = 0; i < 5; i++) {
+            builders.add(client().prepareIndex("idx_dateline", "type").setSource(jsonBuilder()
+                    .startObject()
+                    .array(SINGLE_VALUED_FIELD_NAME, geoValues[i].lon(), geoValues[i].lat())
+                    .field(NUMBER_FIELD_NAME, i)
+                    .field("tag", "tag" + i)
+                    .endObject()));
+        }
+        
+        indexRandom(true, builders);
+        ensureSearchable();
+    }
+
+    private void updateBoundsBottomRight(GeoPoint geoPoint, GeoPoint currentBound) {
+        if (geoPoint.lat() < currentBound.lat()) {
+            currentBound.resetLat(geoPoint.lat());
+        }
+        if (geoPoint.lon() > currentBound.lon()) {
+            currentBound.resetLon(geoPoint.lon());
+        }
+    }
+
+    private void updateBoundsTopLeft(GeoPoint geoPoint, GeoPoint currentBound) {
+        if (geoPoint.lat() > currentBound.lat()) {
+            currentBound.resetLat(geoPoint.lat());
+        }
+        if (geoPoint.lon() < currentBound.lon()) {
+            currentBound.resetLon(geoPoint.lon());
+        }
+    }
+
+    private GeoPoint randomGeoPoint() {
+        return new GeoPoint((randomDouble() * 180) - 90, (randomDouble() * 360) - 180);
+    }
+
+    @Test
+    public void singleValuedField() throws Exception {
+        SearchResponse response = client().prepareSearch("idx")
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME)
+                        .wrapLongitude(false))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(singleTopLeft.lat()));
+        assertThat(topLeft.lon(), equalTo(singleTopLeft.lon()));
+        assertThat(bottomRight.lat(), equalTo(singleBottomRight.lat()));
+        assertThat(bottomRight.lon(), equalTo(singleBottomRight.lon()));
+    }
+
+    @Test
+    public void multiValuedField() throws Exception {
+        SearchResponse response = client().prepareSearch("idx")
+                .addAggregation(geoBounds("geoBounds").field(MULTI_VALUED_FIELD_NAME)
+                        .wrapLongitude(false))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(multiTopLeft.lat()));
+        assertThat(topLeft.lon(), equalTo(multiTopLeft.lon()));
+        assertThat(bottomRight.lat(), equalTo(multiBottomRight.lat()));
+        assertThat(bottomRight.lon(), equalTo(multiBottomRight.lon()));
+    }
+
+    @Test
+    public void unmapped() throws Exception {
+        SearchResponse response = client().prepareSearch("idx_unmapped")
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME)
+                        .wrapLongitude(false))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft, equalTo(null));
+        assertThat(bottomRight, equalTo(null));
+    }
+
+    @Test
+    public void partiallyUnmapped() throws Exception {
+        SearchResponse response = client().prepareSearch("idx", "idx_unmapped")
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME)
+                        .wrapLongitude(false))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(singleTopLeft.lat()));
+        assertThat(topLeft.lon(), equalTo(singleTopLeft.lon()));
+        assertThat(bottomRight.lat(), equalTo(singleBottomRight.lat()));
+        assertThat(bottomRight.lon(), equalTo(singleBottomRight.lon()));
+    }
+
+    @Test
+    public void emptyAggregation() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("empty_idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME)
+                        .wrapLongitude(false))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        GeoBounds geoBounds = searchResponse.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft, equalTo(null));
+        assertThat(bottomRight, equalTo(null));
+    }
+
+    @Test
+    public void singleValuedFieldNearDateLine() throws Exception {        
+        SearchResponse response = client().prepareSearch("idx_dateline")
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME)
+                        .wrapLongitude(false))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        GeoPoint geoValuesTopLeft = new GeoPoint(38, -179);
+        GeoPoint geoValuesBottomRight = new GeoPoint(-24, 178);
+
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(geoValuesTopLeft.lat()));
+        assertThat(topLeft.lon(), equalTo(geoValuesTopLeft.lon()));
+        assertThat(bottomRight.lat(), equalTo(geoValuesBottomRight.lat()));
+        assertThat(bottomRight.lon(), equalTo(geoValuesBottomRight.lon()));
+    }
+
+    @Test
+    public void singleValuedFieldNearDateLineWrapLongitude() throws Exception {
+
+        GeoPoint geoValuesTopLeft = new GeoPoint(38, 170);
+        GeoPoint geoValuesBottomRight = new GeoPoint(-24, -175);
+        
+        SearchResponse response = client().prepareSearch("idx_dateline")
+                .addAggregation(geoBounds("geoBounds").field(SINGLE_VALUED_FIELD_NAME).wrapLongitude(true))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+        
+        GeoBounds geoBounds = response.getAggregations().get("geoBounds");
+        assertThat(geoBounds, notNullValue());
+        assertThat(geoBounds.getName(), equalTo("geoBounds"));
+        GeoPoint topLeft = geoBounds.topLeft();
+        GeoPoint bottomRight = geoBounds.bottomRight();
+        assertThat(topLeft.lat(), equalTo(geoValuesTopLeft.lat()));
+        assertThat(topLeft.lon(), equalTo(geoValuesTopLeft.lon()));
+        assertThat(bottomRight.lat(), equalTo(geoValuesBottomRight.lat()));
+        assertThat(bottomRight.lon(), equalTo(geoValuesBottomRight.lon()));
+    }
+
+}


### PR DESCRIPTION
The GeoBounds Aggregation is a new single bucket aggregation which outputs the coordinates of a bounding box containing all the points from all the documents passed to the aggregation as well as the doc count.

Closes #5634
