### PR TITLE
Mapping API: Added portuguese stem token filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
@@ -48,7 +48,7 @@ http://www.illc.uva.nl/Publications/ResearchReports/MoL-2003-02.text.pdf[indones
 http://www.ercim.eu/publication/ws-proceedings/CLEF2/savoy.pdf[light_italian],
 http://dl.acm.org/citation.cfm?id=1141523&dl=ACM&coll=DL&CFID=179095584&CFTOKEN=80067181[light_portuguese],
 http://www.inf.ufrgs.br/\~buriol/papers/Orengo_CLEF07.pdf[minimal_portuguese],
-http://www.inf.ufrgs.br/\~viviane/rslp/index.htm[portuguese],
+http://www.inf.ufrgs.br/\~viviane/rslp/index.htm[rslp_portuguese],
 http://doc.rero.ch/lm.php?url=1000%2C43%2C4%2C20091209094227-CA%2FDolamic_Ljiljana_-_Indexing_and_Searching_Strategies_for_the_Russian_20091209.pdf[light_russian],
 http://www.ercim.eu/publication/ws-proceedings/CLEF2/savoy.pdf[light_spanish],
 http://clef.isti.cnr.it/2003/WN_web/22.pdf[light_swedish].

--- a/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/StemmerTokenFilterFactory.java
@@ -158,7 +158,7 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
             return new PortugueseLightStemFilter(tokenStream);
         } else if ("minimal_portuguese".equalsIgnoreCase(language) || "minimalPortuguese".equalsIgnoreCase(language)) {
             return new PortugueseMinimalStemFilter(tokenStream);
-        } else if ("portuguese".equalsIgnoreCase(language)) {
+        } else if ("rslp_portuguese".equalsIgnoreCase(language)  || "rslpPortuguese".equalsIgnoreCase(language)) {
             return new PortugueseStemFilter(tokenStream);
         } else if ("light_russian".equalsIgnoreCase(language) || "lightRussian".equalsIgnoreCase(language)) {
             return new RussianLightStemFilter(tokenStream);

--- a/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/AnalysisFactoryTests.java
@@ -126,6 +126,7 @@ public class AnalysisFactoryTests extends ElasticsearchTestCase {
         put("porterstem",                PorterStemTokenFilterFactory.class);
         put("portugueselightstem",       StemmerTokenFilterFactory.class);
         put("portugueseminimalstem",     StemmerTokenFilterFactory.class);
+        put("portuguesestem",            StemmerTokenFilterFactory.class);
         put("reversestring",             ReverseTokenFilterFactory.class);
         put("russianlightstem",          StemmerTokenFilterFactory.class);
         put("shingle",                   ShingleTokenFilterFactory.class);
@@ -171,8 +172,6 @@ public class AnalysisFactoryTests extends ElasticsearchTestCase {
         put("limittokenposition",        Void.class);
         // ???
         put("numericpayload",            Void.class);
-        // RSLP stemmer for portuguese
-        put("portuguesestem",            Void.class);
         // light stemming for norwegian (has nb/nn options too)
         put("norwegianlightstem",        Void.class);
         // removes duplicates at the same position (this should be used by the existing factory)


### PR DESCRIPTION
The stem token filter was cloaked, due to a wrong if-else chain and could
never be loaded. Added it as `rslp_portuguese`, the existing `portuguese` token filter
is the one based on snowball in order to retain backwards compatibility.

Closes #6330
