### PR TITLE
Object and Type parsing: Fix include_in_all in type

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -211,6 +211,9 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
                     parseProperties(builder, (Map<String, Object>) fieldNode, parserContext);
                 }
                 return true;
+            } else if (fieldName.equals("include_in_all")) {
+                builder.includeInAll(nodeBooleanValue(fieldNode));
+                return true;
             }
             return false;
         }
@@ -218,8 +221,6 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
         protected static void parseObjectProperties(String name, String fieldName, Object fieldNode, ObjectMapper.Builder builder) {
            if (fieldName.equals("path")) {
                 builder.pathType(parsePathType(name, fieldNode.toString()));
-            } else if (fieldName.equals("include_in_all")) {
-                builder.includeInAll(nodeBooleanValue(fieldNode));
             }
         }
 

--- a/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -413,6 +413,13 @@ public class SimpleAllMapperTests extends ElasticsearchTestCase {
         rootTypes.put(IndexFieldMapper.NAME, "{\"enabled\" : true}");
         rootTypes.put(SourceFieldMapper.NAME, "{\"enabled\" : true}");
         rootTypes.put(TypeFieldMapper.NAME, "{\"store\" : true}");
+        rootTypes.put("include_in_all", "true");
+        rootTypes.put("index_analyzer", "\"standard\"");
+        rootTypes.put("search_analyzer", "\"standard\"");
+        rootTypes.put("analyzer", "\"standard\"");
+        rootTypes.put("dynamic_date_formats", "[\"yyyy-MM-dd\", \"dd-MM-yyyy\"]");
+        rootTypes.put("numeric_detection", "true");
+        rootTypes.put("dynamic_templates", "[]");
         for (String key : rootTypes.keySet()) {
             mapping += "\"" + key+ "\"" + ":" + rootTypes.get(key) + ",\n";
         }


### PR DESCRIPTION
include_in_all can also be set on type level (root object).
This fixes a regression introduced  in #6093

closes #6304
