### PR TITLE
Stats: Make "groups" and "types" accept wildcards

### DIFF
--- a/src/main/java/org/elasticsearch/index/indexing/ShardIndexingService.java
+++ b/src/main/java/org/elasticsearch/index/indexing/ShardIndexingService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.indexing.slowlog.ShardSlowLogIndexingService;
@@ -63,17 +64,17 @@ public class ShardIndexingService extends AbstractIndexShardComponent {
         IndexingStats.Stats total = totalStats.stats();
         Map<String, IndexingStats.Stats> typesSt = null;
         if (types != null && types.length > 0) {
+            typesSt = new HashMap<>(typesStats.size());
             if (types.length == 1 && types[0].equals("_all")) {
-                typesSt = new HashMap<>(typesStats.size());
                 for (Map.Entry<String, StatsHolder> entry : typesStats.entrySet()) {
                     typesSt.put(entry.getKey(), entry.getValue().stats());
                 }
             } else {
-                typesSt = new HashMap<>(types.length);
-                for (String type : types) {
-                    StatsHolder statsHolder = typesStats.get(type);
-                    if (statsHolder != null) {
-                        typesSt.put(type, statsHolder.stats());
+                for (Map.Entry<String, StatsHolder> entry : typesStats.entrySet()) {
+                    for (String type : types) {
+                        if (Regex.simpleMatch(type, entry.getKey())) {
+                            typesSt.put(entry.getKey(), entry.getValue().stats());
+                        }
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
+++ b/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.search.slowlog.ShardSlowLogSearchService;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -61,17 +62,17 @@ public class ShardSearchService extends AbstractIndexShardComponent {
         SearchStats.Stats total = totalStats.stats();
         Map<String, SearchStats.Stats> groupsSt = null;
         if (groups != null && groups.length > 0) {
+            groupsSt = new HashMap<>(groupsStats.size());
             if (groups.length == 1 && groups[0].equals("_all")) {
-                groupsSt = new HashMap<>(groupsStats.size());
                 for (Map.Entry<String, StatsHolder> entry : groupsStats.entrySet()) {
                     groupsSt.put(entry.getKey(), entry.getValue().stats());
                 }
             } else {
-                groupsSt = new HashMap<>(groups.length);
-                for (String group : groups) {
-                    StatsHolder statsHolder = groupsStats.get(group);
-                    if (statsHolder != null) {
-                        groupsSt.put(group, statsHolder.stats());
+                for (Map.Entry<String, StatsHolder> entry : groupsStats.entrySet()) {
+                    for (String group : groups) {
+                        if (Regex.simpleMatch(group, entry.getKey())) {
+                            groupsSt.put(entry.getKey(), entry.getValue().stats());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The "fields" parameter to indices stats accepts wildcards, but
the "groups" and "types" parameters don't.
