### PR TITLE
Memory management: do not enforce the BigArrays limit on the network layer and the tranlog.

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -33,7 +33,7 @@ abstract class AbstractArray implements BigArray {
 
     @Override
     public final void close() {
-        bigArrays.ramBytesUsed.addAndGet(-sizeInBytes());
+        bigArrays.updateMemoryUsage(-sizeInBytes());
         assert !released : "double release";
         released = true;
         doClose();

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -115,7 +115,9 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
     public NettyHttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays) {
         super(settings);
         this.networkService = networkService;
-        this.bigArrays = bigArrays;
+        // We ignore the default limit in the transport layer so that monitoring APIs remain accessible even in case of high
+        // memory usage
+        this.bigArrays = bigArrays.limit(Long.MAX_VALUE);
 
         if (settings.getAsBoolean("netty.epollBugWorkaround", false)) {
             System.setProperty("org.jboss.netty.epollBugWorkaround", "true");

--- a/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/FsTranslog.java
@@ -85,7 +85,8 @@ public class FsTranslog extends AbstractIndexShardComponent implements Translog 
     public FsTranslog(ShardId shardId, @IndexSettings Settings indexSettings, IndexSettingsService indexSettingsService, NodeEnvironment nodeEnv, BigArrays bigArrays) {
         super(shardId, indexSettings);
         this.indexSettingsService = indexSettingsService;
-        this.bigArrays = bigArrays;
+        // Ignore the default limit
+        this.bigArrays = bigArrays.limit(Long.MAX_VALUE);
         File[] shardLocations = nodeEnv.shardLocations(shardId);
         this.locations = new File[shardLocations.length];
         for (int i = 0; i < shardLocations.length; i++) {

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -175,7 +175,9 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
         super(settings);
         this.threadPool = threadPool;
         this.networkService = networkService;
-        this.bigArrays = bigArrays;
+        // We ignore the default limit in the netty layer in order to always be able to handle cluster management
+        // operations such as pings, etc.
+        this.bigArrays = bigArrays.limit(Long.MAX_VALUE);
         this.version = version;
 
         if (settings.getAsBoolean("netty.epollBugWorkaround", false)) {

--- a/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
+++ b/src/test/java/org/elasticsearch/test/cache/recycler/MockBigArrays.java
@@ -35,6 +35,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class MockBigArrays extends BigArrays {
 
@@ -99,6 +100,17 @@ public class MockBigArrays extends BigArrays {
         }
         random = new Random(seed);
         INSTANCES.add(this);
+    }
+
+    private MockBigArrays(Settings settings, PageCacheRecycler recycler, long maxSizeInBytes, AtomicLong counter, Random random) {
+        super(settings, recycler, maxSizeInBytes, counter);
+        this.random = random;
+        INSTANCES.add(this);
+    }
+
+    @Override
+    public BigArrays limit(long newMaxSizeInBytes) {
+        return new MockBigArrays(settings, recycler, newMaxSizeInBytes, ramBytesUsed, random);
     }
 
     @Override


### PR DESCRIPTION
This commit disables memory circuit breaking in BigArrays on FsTranslog,
NettyHttpServerTransport and NettyTransport so that these components are not
impacted by heavy search requests.

Close #6332
