### PR TITLE
Memory management: Raise the default max memory usage for BigArrays to 50%.

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -368,7 +368,7 @@ public class BigArrays extends AbstractComponent {
 
     @Inject
     public BigArrays(Settings settings, PageCacheRecycler recycler) {
-        this(settings, recycler, settings.getAsMemory(MAX_SIZE_IN_BYTES_SETTING, "20%").bytes());
+        this(settings, recycler, settings.getAsMemory(MAX_SIZE_IN_BYTES_SETTING, "50%").bytes());
     }
 
     private BigArrays(Settings settings, PageCacheRecycler recycler, final long maxSizeInBytes) {


### PR DESCRIPTION
The value had been chosen by taking into account the fact that eg. the filter
cache takes 10% and field data 60%. However, if you either don't need field
data or if you use doc values to store data on disk, then this would just leave
a lot of memory unused on your node. We will fortunately have a better story
for this once able to share memory accounting across several breakers.
