### PR TITLE
TransportClient: Improve logging, fix minor issue

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/NoNodeAvailableException.java
+++ b/src/main/java/org/elasticsearch/client/transport/NoNodeAvailableException.java
@@ -27,8 +27,12 @@ import org.elasticsearch.rest.RestStatus;
  */
 public class NoNodeAvailableException extends ElasticsearchException {
 
-    public NoNodeAvailableException() {
-        super("No node available");
+    public NoNodeAvailableException(String message) {
+        super(message);
+    }
+
+    public NoNodeAvailableException(String message, Throwable t) {
+        super(message, t);
     }
 
     @Override


### PR DESCRIPTION
In order to return more information to the client, in case a TransportClient
can not connect to the cluster, this commit adds logging and also returns the
configured nodes in the NoNodeAvailableException

Also a minor bug has been fixed, which propagated exceptions wrong, so that an
invalid request was actually tried on every node, if a regular connection failure
on the first tried node had happened.
