### PR TITLE
Indices stats options

### DIFF
--- a/rest-api-spec/test/indices.stats/10_basic.yaml
+++ b/rest-api-spec/test/indices.stats/10_basic.yaml
@@ -1,4 +1,0 @@
----
-"stats test":
-  - do:
-      indices.stats: {}

--- a/rest-api-spec/test/indices.stats/10_index.yaml
+++ b/rest-api-spec/test/indices.stats/10_index.yaml
@@ -1,0 +1,78 @@
+---
+  setup:
+
+    - do:
+        index:
+            index: test1
+            type:  bar
+            id:    1
+            body:  { "foo": "bar" }
+
+    - do:
+        index:
+            index: test2
+            type:  baz
+            id:    1
+            body:  { "foo": "baz" }
+
+---
+"Index - blank":
+  - do:
+      indices.stats: {}
+
+  - match: { _shards.total: 20 }
+  - is_true: _all
+  - is_true: indices.test1
+  - is_true: indices.test2
+
+---
+"Index - all":
+  - do:
+      indices.stats: { index: _all }
+
+  - match: { _shards.total: 20 }
+  - is_true: _all
+  - is_true: indices.test1
+  - is_true: indices.test2
+
+
+---
+"Index - star":
+  - do:
+      indices.stats: { index: '*' }
+
+  - match: { _shards.total: 20 }
+  - is_true: _all
+  - is_true: indices.test1
+  - is_true: indices.test2
+
+---
+"Index - one index":
+  - do:
+      indices.stats: { index: 'test1' }
+
+  - match: { _shards.total: 10 }
+  - is_true: _all
+  - is_true: indices.test1
+  - is_false: indices.test2
+
+---
+"Index - multi-index":
+  - do:
+      indices.stats: { index: 'test1,test2' }
+
+  - match: { _shards.total: 20 }
+  - is_true: _all
+  - is_true: indices.test1
+  - is_true: indices.test2
+
+---
+"Index - pattern":
+  - do:
+      indices.stats: { index: '*2' }
+
+  - match: { _shards.total: 10 }
+  - is_true: _all
+  - is_false: indices.test1
+  - is_true: indices.test2
+

--- a/rest-api-spec/test/indices.stats/10_index.yaml
+++ b/rest-api-spec/test/indices.stats/10_index.yaml
@@ -1,6 +1,20 @@
 ---
   setup:
+    - do:
+        indices.create:
+            index: test1
+            body:
+                settings:
+                    number_of_shards: 5
+                    number_of_replicas: 1
 
+    - do:
+        indices.create:
+            index: test2
+            body:
+                settings:
+                    number_of_shards: 4
+                    number_of_replicas: 1
     - do:
         index:
             index: test1
@@ -20,7 +34,7 @@
   - do:
       indices.stats: {}
 
-  - match: { _shards.total: 20 }
+  - match: { _shards.total: 18 }
   - is_true: _all
   - is_true: indices.test1
   - is_true: indices.test2
@@ -30,7 +44,7 @@
   - do:
       indices.stats: { index: _all }
 
-  - match: { _shards.total: 20 }
+  - match: { _shards.total: 18 }
   - is_true: _all
   - is_true: indices.test1
   - is_true: indices.test2
@@ -41,7 +55,7 @@
   - do:
       indices.stats: { index: '*' }
 
-  - match: { _shards.total: 20 }
+  - match: { _shards.total: 18 }
   - is_true: _all
   - is_true: indices.test1
   - is_true: indices.test2
@@ -59,9 +73,9 @@
 ---
 "Index - multi-index":
   - do:
-      indices.stats: { index: 'test1,test2' }
+      indices.stats: { index: [test1, test2] }
 
-  - match: { _shards.total: 20 }
+  - match: { _shards.total: 18 }
   - is_true: _all
   - is_true: indices.test1
   - is_true: indices.test2
@@ -71,7 +85,7 @@
   - do:
       indices.stats: { index: '*2' }
 
-  - match: { _shards.total: 10 }
+  - match: { _shards.total: 8 }
   - is_true: _all
   - is_false: indices.test1
   - is_true: indices.test2

--- a/rest-api-spec/test/indices.stats/11_metric.yaml
+++ b/rest-api-spec/test/indices.stats/11_metric.yaml
@@ -20,91 +20,91 @@
   - do:
       indices.stats: {}
 
-  - is_true:  _all.primaries.docs
-  - is_true:  _all.primaries.store
-  - is_true:  _all.primaries.indexing
-  - is_true:  _all.primaries.get
-  - is_true:  _all.primaries.search
-  - is_true:  _all.primaries.merges
-  - is_true:  _all.primaries.refresh
-  - is_true:  _all.primaries.flush
-  - is_true:  _all.primaries.warmer
-  - is_true:  _all.primaries.filter_cache
-  - is_true:  _all.primaries.id_cache
-  - is_true:  _all.primaries.fielddata
-  - is_true:  _all.primaries.percolate
-  - is_true:  _all.primaries.completion
-  - is_true:  _all.primaries.segments
-  - is_true:  _all.primaries.translog
-  - is_true:  _all.primaries.suggest
+  - is_true:  _all.total.docs
+  - is_true:  _all.total.store
+  - is_true:  _all.total.indexing
+  - is_true:  _all.total.get
+  - is_true:  _all.total.search
+  - is_true:  _all.total.merges
+  - is_true:  _all.total.refresh
+  - is_true:  _all.total.flush
+  - is_true:  _all.total.warmer
+  - is_true:  _all.total.filter_cache
+  - is_true:  _all.total.id_cache
+  - is_true:  _all.total.fielddata
+  - is_true:  _all.total.percolate
+  - is_true:  _all.total.completion
+  - is_true:  _all.total.segments
+  - is_true:  _all.total.translog
+  - is_true:  _all.total.suggest
 
 ---
 "Metric - _all":
   - do:
       indices.stats: { metric: _all }
 
-  - is_true:  _all.primaries.docs
-  - is_true:  _all.primaries.store
-  - is_true:  _all.primaries.indexing
-  - is_true:  _all.primaries.get
-  - is_true:  _all.primaries.search
-  - is_true:  _all.primaries.merges
-  - is_true:  _all.primaries.refresh
-  - is_true:  _all.primaries.flush
-  - is_true:  _all.primaries.warmer
-  - is_true:  _all.primaries.filter_cache
-  - is_true:  _all.primaries.id_cache
-  - is_true:  _all.primaries.fielddata
-  - is_true:  _all.primaries.percolate
-  - is_true:  _all.primaries.completion
-  - is_true:  _all.primaries.segments
-  - is_true:  _all.primaries.translog
-  - is_true:  _all.primaries.suggest
+  - is_true:  _all.total.docs
+  - is_true:  _all.total.store
+  - is_true:  _all.total.indexing
+  - is_true:  _all.total.get
+  - is_true:  _all.total.search
+  - is_true:  _all.total.merges
+  - is_true:  _all.total.refresh
+  - is_true:  _all.total.flush
+  - is_true:  _all.total.warmer
+  - is_true:  _all.total.filter_cache
+  - is_true:  _all.total.id_cache
+  - is_true:  _all.total.fielddata
+  - is_true:  _all.total.percolate
+  - is_true:  _all.total.completion
+  - is_true:  _all.total.segments
+  - is_true:  _all.total.translog
+  - is_true:  _all.total.suggest
 
 ---
 "Metric - one":
   - do:
       indices.stats: { metric: docs }
 
-  - is_true:   _all.primaries.docs
-  - is_false:  _all.primaries.store
-  - is_false:  _all.primaries.indexing
-  - is_false:  _all.primaries.get
-  - is_false:  _all.primaries.search
-  - is_false:  _all.primaries.merges
-  - is_false:  _all.primaries.refresh
-  - is_false:  _all.primaries.flush
-  - is_false:  _all.primaries.warmer
-  - is_false:  _all.primaries.filter_cache
-  - is_false:  _all.primaries.id_cache
-  - is_false:  _all.primaries.fielddata
-  - is_false:  _all.primaries.percolate
-  - is_false:  _all.primaries.completion
-  - is_false:  _all.primaries.segments
-  - is_false:  _all.primaries.translog
-  - is_false:  _all.primaries.suggest
+  - is_true:   _all.total.docs
+  - is_false:  _all.total.store
+  - is_false:  _all.total.indexing
+  - is_false:  _all.total.get
+  - is_false:  _all.total.search
+  - is_false:  _all.total.merges
+  - is_false:  _all.total.refresh
+  - is_false:  _all.total.flush
+  - is_false:  _all.total.warmer
+  - is_false:  _all.total.filter_cache
+  - is_false:  _all.total.id_cache
+  - is_false:  _all.total.fielddata
+  - is_false:  _all.total.percolate
+  - is_false:  _all.total.completion
+  - is_false:  _all.total.segments
+  - is_false:  _all.total.translog
+  - is_false:  _all.total.suggest
 
 ---
 "Metric - multi":
   - do:
       indices.stats: { metric: [ store, get, merge ] }
 
-  - is_false:  _all.primaries.docs
-  - is_true:   _all.primaries.store
-  - is_false:  _all.primaries.indexing
-  - is_true:   _all.primaries.get
-  - is_false:  _all.primaries.search
-  - is_true:   _all.primaries.merges
-  - is_false:  _all.primaries.refresh
-  - is_false:  _all.primaries.flush
-  - is_false:  _all.primaries.warmer
-  - is_false:  _all.primaries.filter_cache
-  - is_false:  _all.primaries.id_cache
-  - is_false:  _all.primaries.fielddata
-  - is_false:  _all.primaries.percolate
-  - is_false:  _all.primaries.completion
-  - is_false:  _all.primaries.segments
-  - is_false:  _all.primaries.translog
-  - is_false:  _all.primaries.suggest
+  - is_false:  _all.total.docs
+  - is_true:   _all.total.store
+  - is_false:  _all.total.indexing
+  - is_true:   _all.total.get
+  - is_false:  _all.total.search
+  - is_true:   _all.total.merges
+  - is_false:  _all.total.refresh
+  - is_false:  _all.total.flush
+  - is_false:  _all.total.warmer
+  - is_false:  _all.total.filter_cache
+  - is_false:  _all.total.id_cache
+  - is_false:  _all.total.fielddata
+  - is_false:  _all.total.percolate
+  - is_false:  _all.total.completion
+  - is_false:  _all.total.segments
+  - is_false:  _all.total.translog
+  - is_false:  _all.total.suggest
 
 

--- a/rest-api-spec/test/indices.stats/11_metric.yaml
+++ b/rest-api-spec/test/indices.stats/11_metric.yaml
@@ -1,0 +1,110 @@
+---
+  setup:
+
+    - do:
+        index:
+            index: test1
+            type:  bar
+            id:    1
+            body:  { "foo": "bar" }
+
+    - do:
+        index:
+            index: test2
+            type:  baz
+            id:    1
+            body:  { "foo": "baz" }
+
+---
+"Metric - blank":
+  - do:
+      indices.stats: {}
+
+  - is_true:  _all.primaries.docs
+  - is_true:  _all.primaries.store
+  - is_true:  _all.primaries.indexing
+  - is_true:  _all.primaries.get
+  - is_true:  _all.primaries.search
+  - is_true:  _all.primaries.merges
+  - is_true:  _all.primaries.refresh
+  - is_true:  _all.primaries.flush
+  - is_true:  _all.primaries.warmer
+  - is_true:  _all.primaries.filter_cache
+  - is_true:  _all.primaries.id_cache
+  - is_true:  _all.primaries.fielddata
+  - is_true:  _all.primaries.percolate
+  - is_true:  _all.primaries.completion
+  - is_true:  _all.primaries.segments
+  - is_true:  _all.primaries.translog
+  - is_true:  _all.primaries.suggest
+
+---
+"Metric - _all":
+  - do:
+      indices.stats: { metric: _all }
+
+  - is_true:  _all.primaries.docs
+  - is_true:  _all.primaries.store
+  - is_true:  _all.primaries.indexing
+  - is_true:  _all.primaries.get
+  - is_true:  _all.primaries.search
+  - is_true:  _all.primaries.merges
+  - is_true:  _all.primaries.refresh
+  - is_true:  _all.primaries.flush
+  - is_true:  _all.primaries.warmer
+  - is_true:  _all.primaries.filter_cache
+  - is_true:  _all.primaries.id_cache
+  - is_true:  _all.primaries.fielddata
+  - is_true:  _all.primaries.percolate
+  - is_true:  _all.primaries.completion
+  - is_true:  _all.primaries.segments
+  - is_true:  _all.primaries.translog
+  - is_true:  _all.primaries.suggest
+
+---
+"Metric - one":
+  - do:
+      indices.stats: { metric: docs }
+
+  - is_true:   _all.primaries.docs
+  - is_false:  _all.primaries.store
+  - is_false:  _all.primaries.indexing
+  - is_false:  _all.primaries.get
+  - is_false:  _all.primaries.search
+  - is_false:  _all.primaries.merges
+  - is_false:  _all.primaries.refresh
+  - is_false:  _all.primaries.flush
+  - is_false:  _all.primaries.warmer
+  - is_false:  _all.primaries.filter_cache
+  - is_false:  _all.primaries.id_cache
+  - is_false:  _all.primaries.fielddata
+  - is_false:  _all.primaries.percolate
+  - is_false:  _all.primaries.completion
+  - is_false:  _all.primaries.segments
+  - is_false:  _all.primaries.translog
+  - is_false:  _all.primaries.suggest
+
+---
+"Metric - multi":
+  - do:
+      indices.stats: { metric: [ store, get, merge ] }
+
+  - is_false:  _all.primaries.docs
+  - is_true:   _all.primaries.store
+  - is_false:  _all.primaries.indexing
+  - is_true:   _all.primaries.get
+  - is_false:  _all.primaries.search
+  - is_true:   _all.primaries.merges
+  - is_false:  _all.primaries.refresh
+  - is_false:  _all.primaries.flush
+  - is_false:  _all.primaries.warmer
+  - is_false:  _all.primaries.filter_cache
+  - is_false:  _all.primaries.id_cache
+  - is_false:  _all.primaries.fielddata
+  - is_false:  _all.primaries.percolate
+  - is_false:  _all.primaries.completion
+  - is_false:  _all.primaries.segments
+  - is_false:  _all.primaries.translog
+  - is_false:  _all.primaries.suggest
+
+

--- a/rest-api-spec/test/indices.stats/12_level.yaml
+++ b/rest-api-spec/test/indices.stats/12_level.yaml
@@ -1,0 +1,69 @@
+---
+  setup:
+
+    - do:
+        index:
+            index: test1
+            type:  bar
+            id:    1
+            body:  { "foo": "bar" }
+
+    - do:
+        index:
+            index: test2
+            type:  baz
+            id:    1
+            body:  { "foo": "baz" }
+
+---
+"Level - blank":
+  - do:
+      indices.stats: {}
+
+  - is_true:  _all.primaries.docs
+  - is_true:  _all.total.docs
+  - is_true:  indices.test1.primaries.docs
+  - is_true:  indices.test1.total.docs
+  - is_false: indices.test1.shards
+  - is_true:  indices.test2.primaries.docs
+  - is_true:  indices.test2.total.docs
+  - is_false: indices.test2.shards
+
+---
+"Level - indices":
+  - do:
+      indices.stats: { level: indices }
+
+  - is_true:  _all.primaries.docs
+  - is_true:  _all.total.docs
+  - is_true:  indices.test1.primaries.docs
+  - is_true:  indices.test1.total.docs
+  - is_false: indices.test1.shards
+  - is_true:  indices.test2.primaries.docs
+  - is_true:  indices.test2.total.docs
+  - is_false: indices.test2.shards
+
+---
+"Level - cluster":
+  - do:
+      indices.stats: { level: cluster }
+
+  - is_true:  _all.primaries.docs
+  - is_true:  _all.total.docs
+  - is_false: indices
+
+
+---
+"Level - shards":
+  - do:
+      indices.stats: { level: shards }
+
+  - is_true:  _all.primaries.docs
+  - is_true:  _all.total.docs
+  - is_true:  indices.test1.primaries.docs
+  - is_true:  indices.test1.total.docs
+  - is_true:  indices.test1.shards.0.0.docs
+  - is_true:  indices.test2.primaries.docs
+  - is_true:  indices.test2.total.docs
+  - is_true:  indices.test2.shards.0.0.docs
+

--- a/rest-api-spec/test/indices.stats/12_level.yaml
+++ b/rest-api-spec/test/indices.stats/12_level.yaml
@@ -20,12 +20,12 @@
   - do:
       indices.stats: {}
 
-  - is_true:  _all.primaries.docs
   - is_true:  _all.total.docs
-  - is_true:  indices.test1.primaries.docs
+  - is_true:  _all.total.docs
+  - is_true:  indices.test1.total.docs
   - is_true:  indices.test1.total.docs
   - is_false: indices.test1.shards
-  - is_true:  indices.test2.primaries.docs
+  - is_true:  indices.test2.total.docs
   - is_true:  indices.test2.total.docs
   - is_false: indices.test2.shards
 
@@ -34,12 +34,12 @@
   - do:
       indices.stats: { level: indices }
 
-  - is_true:  _all.primaries.docs
   - is_true:  _all.total.docs
-  - is_true:  indices.test1.primaries.docs
+  - is_true:  _all.total.docs
+  - is_true:  indices.test1.total.docs
   - is_true:  indices.test1.total.docs
   - is_false: indices.test1.shards
-  - is_true:  indices.test2.primaries.docs
+  - is_true:  indices.test2.total.docs
   - is_true:  indices.test2.total.docs
   - is_false: indices.test2.shards
 
@@ -48,7 +48,7 @@
   - do:
       indices.stats: { level: cluster }
 
-  - is_true:  _all.primaries.docs
+  - is_true:  _all.total.docs
   - is_true:  _all.total.docs
   - is_false: indices
 
@@ -58,12 +58,12 @@
   - do:
       indices.stats: { level: shards }
 
-  - is_true:  _all.primaries.docs
   - is_true:  _all.total.docs
-  - is_true:  indices.test1.primaries.docs
+  - is_true:  _all.total.docs
+  - is_true:  indices.test1.total.docs
   - is_true:  indices.test1.total.docs
   - is_true:  indices.test1.shards.0.0.docs
-  - is_true:  indices.test2.primaries.docs
+  - is_true:  indices.test2.total.docs
   - is_true:  indices.test2.total.docs
   - is_true:  indices.test2.shards.0.0.docs
 

--- a/rest-api-spec/test/indices.stats/13_fields.yaml
+++ b/rest-api-spec/test/indices.stats/13_fields.yaml
@@ -1,0 +1,175 @@
+---
+  setup:
+
+    - do:
+        indices.create:
+            index:  test1
+            body:
+                mappings:
+                    bar:
+                        properties:
+                            bar:
+                                type: string
+                                fields:
+                                    completion:
+                                        type: completion
+                            baz:
+                                type: string
+                                fields:
+                                    completion:
+                                        type: completion
+    - do:
+        index:
+            index: test1
+            type:  bar
+            id:    1
+            body:  { "bar": "bar", "baz": "baz" }
+
+    - do:
+        index:
+            index: test2
+            type:  baz
+            id:    1
+            body:  { "bar": "bar", "baz": "baz" }
+
+    - do:
+        indices.refresh: {}
+
+    - do:
+        search:
+            sort: bar,baz
+
+---
+"Fields - blank":
+  - do:
+      indices.stats: {}
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields
+
+---
+"Fields - one":
+  - do:
+      indices.stats: { fields: bar }
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.bar
+
+---
+"Fields - multi":
+  - do:
+      indices.stats: { fields: "bar,baz.completion" }
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.bar\\.completion
+  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
+
+---
+"Fields - star":
+  - do:
+      indices.stats: { fields: "*" }
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.baz.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
+
+---
+"Fields - pattern":
+  - do:
+      indices.stats: { fields: "bar*" }
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+
+---
+"Fielddata fields - one":
+  - do:
+      indices.stats: { fielddata_fields: bar }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - is_false:   _all.primaries.completion.fields
+
+---
+"Fielddata fields - multi":
+  - do:
+      indices.stats: { fielddata_fields: "bar,baz,baz.completion" }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.baz.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields
+
+---
+"Fielddata fields - star":
+  - do:
+      indices.stats: { fielddata_fields: "*" }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.baz.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields
+
+---
+"Fields - pattern":
+  - do:
+      indices.stats: { fielddata_fields: "*r" }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - is_false:   _all.primaries.completion.fields
+
+
+
+
+---
+"Completion fields - one":
+  - do:
+      indices.stats: { completion_fields: bar.completion }
+
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - is_false:   _all.primaries.fielddata.fields
+
+---
+"Completion fields - multi":
+  - do:
+      indices.stats: { completion_fields: "bar.completion,baz,baz.completion" }
+
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields
+
+---
+"Completion fields - star":
+  - do:
+      indices.stats: { completion_fields: "*" }
+
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields
+
+---
+"Completion - pattern":
+  - do:
+      indices.stats: { completion_fields: "*r*" }
+
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - is_false:   _all.primaries.fielddata.fields
+
+
+

--- a/rest-api-spec/test/indices.stats/13_fields.yaml
+++ b/rest-api-spec/test/indices.stats/13_fields.yaml
@@ -44,137 +44,137 @@
   - do:
       indices.stats: {}
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields
 
 ---
 "Fields - one":
   - do:
       indices.stats: { fields: bar }
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.bar
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.bar
 
 ---
 "Fields - multi":
   - do:
       indices.stats: { fields: "bar,baz.completion" }
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.bar\\.completion
-  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.bar\\.completion
+  - gt:       { _all.total.completion.fields.baz\\.completion.size_in_bytes: 0 }
 
 ---
 "Fields - star":
   - do:
       indices.stats: { fields: "*" }
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.baz.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.baz.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.baz\\.completion.size_in_bytes: 0 }
 
 ---
 "Fields - pattern":
   - do:
       indices.stats: { fields: "bar*" }
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
 
 ---
 "Fields - _all metric":
   - do:
       indices.stats: { fields: "bar*", metric: _all }
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
 
 ---
 "Fields - fielddata metric":
   - do:
       indices.stats: { fields: "bar*", metric: fielddata }
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - is_false:   _all.primaries.completion
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - is_false:   _all.total.completion
 
 ---
 "Fields - completion metric":
   - do:
       indices.stats: { fields: "bar*", metric: completion }
 
-  - is_false:   _all.primaries.fielddata
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - is_false:   _all.total.fielddata
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
 
 ---
 "Fields - multi metric":
   - do:
       indices.stats: { fields: "bar*" , metric: [ completion, fielddata, search ]}
 
-  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - gt:       { _all.total.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - gt:       { _all.total.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
 
 ---
 "Fielddata fields - one":
   - do:
       indices.stats: { fielddata_fields: bar }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - is_false:   _all.total.completion.fields
 
 ---
 "Fielddata fields - multi":
   - do:
       indices.stats: { fielddata_fields: "bar,baz,baz.completion" }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.baz.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.baz.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields
 
 ---
 "Fielddata fields - star":
   - do:
       indices.stats: { fielddata_fields: "*" }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - gt:       { _all.primaries.fielddata.fields.baz.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - gt:       { _all.total.fielddata.fields.baz.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields
 
 ---
 "Fielddata fields - pattern":
   - do:
       indices.stats: { fielddata_fields: "*r" }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - is_false:   _all.total.completion.fields
 
 
 ---
@@ -182,18 +182,18 @@
   - do:
       indices.stats: { fielddata_fields: "*r", metric: _all }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - is_false:   _all.total.completion.fields
 
 ---
 "Fielddata fields - one metric":
   - do:
       indices.stats: { fielddata_fields: "*r", metric: fielddata }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - is_false:   _all.total.completion.fields
 
 
 ---
@@ -201,9 +201,9 @@
   - do:
       indices.stats: { fielddata_fields: "*r", metric: [ fielddata, search] }
 
-  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields.baz
-  - is_false:   _all.primaries.completion.fields
+  - gt:       { _all.total.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields.baz
+  - is_false:   _all.total.completion.fields
 
 
 ---
@@ -211,61 +211,61 @@
   - do:
       indices.stats: { completion_fields: bar.completion }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
+  - is_false:   _all.total.fielddata.fields
 
 ---
 "Completion fields - multi":
   - do:
       indices.stats: { completion_fields: "bar.completion,baz,baz.completion" }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.baz\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields
 
 ---
 "Completion fields - star":
   - do:
       indices.stats: { completion_fields: "*" }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - gt:       { _all.primaries.completion.fields.baz\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - gt:       { _all.total.completion.fields.baz\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.fielddata.fields
 
 ---
 "Completion - pattern":
   - do:
       indices.stats: { completion_fields: "*r*" }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
+  - is_false:   _all.total.fielddata.fields
 
 ---
 "Completion - all metric":
   - do:
       indices.stats: { completion_fields: "*r*", metric: _all }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
+  - is_false:   _all.total.fielddata.fields
 
 ---
 "Completion - one metric":
   - do:
       indices.stats: { completion_fields: "*r*", metric: completion }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
+  - is_false:   _all.total.fielddata.fields
 
 ---
 "Completion - multi metric":
   - do:
       indices.stats: { completion_fields: "*r*", metric: [ completion, search ] }
 
-  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
-  - is_false:   _all.primaries.completion.fields.baz\\.completion
-  - is_false:   _all.primaries.fielddata.fields
+  - gt:       { _all.total.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.total.completion.fields.baz\\.completion
+  - is_false:   _all.total.fielddata.fields
 

--- a/rest-api-spec/test/indices.stats/13_fields.yaml
+++ b/rest-api-spec/test/indices.stats/13_fields.yaml
@@ -97,6 +97,50 @@
   - is_false:   _all.primaries.completion.fields.baz\\.completion
 
 ---
+"Fields - _all metric":
+  - do:
+      indices.stats: { fields: "bar*", metric: _all }
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+
+---
+"Fields - fielddata metric":
+  - do:
+      indices.stats: { fields: "bar*", metric: fielddata }
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - is_false:   _all.primaries.completion
+
+---
+"Fields - completion metric":
+  - do:
+      indices.stats: { fields: "bar*", metric: completion }
+
+  - is_false:   _all.primaries.fielddata
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+
+---
+"Fields - multi metric":
+  - do:
+      indices.stats: { fields: "bar*" , metric: [ completion, fielddata, search ]}
+
+  - gt:       { _all.primaries.fielddata.memory_size_in_bytes: 0 }
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - gt:       { _all.primaries.completion.size_in_bytes: 0 }
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+
+---
 "Fielddata fields - one":
   - do:
       indices.stats: { fielddata_fields: bar }
@@ -124,7 +168,7 @@
   - is_false:   _all.primaries.completion.fields
 
 ---
-"Fields - pattern":
+"Fielddata fields - pattern":
   - do:
       indices.stats: { fielddata_fields: "*r" }
 
@@ -133,6 +177,33 @@
   - is_false:   _all.primaries.completion.fields
 
 
+---
+"Fielddata fields - all metric":
+  - do:
+      indices.stats: { fielddata_fields: "*r", metric: _all }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - is_false:   _all.primaries.completion.fields
+
+---
+"Fielddata fields - one metric":
+  - do:
+      indices.stats: { fielddata_fields: "*r", metric: fielddata }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - is_false:   _all.primaries.completion.fields
+
+
+---
+"Fielddata fields - multi metric":
+  - do:
+      indices.stats: { fielddata_fields: "*r", metric: [ fielddata, search] }
+
+  - gt:       { _all.primaries.fielddata.fields.bar.memory_size_in_bytes: 0 }
+  - is_false:   _all.primaries.fielddata.fields.baz
+  - is_false:   _all.primaries.completion.fields
 
 
 ---
@@ -171,5 +242,30 @@
   - is_false:   _all.primaries.completion.fields.baz\\.completion
   - is_false:   _all.primaries.fielddata.fields
 
+---
+"Completion - all metric":
+  - do:
+      indices.stats: { completion_fields: "*r*", metric: _all }
 
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - is_false:   _all.primaries.fielddata.fields
+
+---
+"Completion - one metric":
+  - do:
+      indices.stats: { completion_fields: "*r*", metric: completion }
+
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - is_false:   _all.primaries.fielddata.fields
+
+---
+"Completion - multi metric":
+  - do:
+      indices.stats: { completion_fields: "*r*", metric: [ completion, search ] }
+
+  - gt:       { _all.primaries.completion.fields.bar\\.completion.size_in_bytes: 0 }
+  - is_false:   _all.primaries.completion.fields.baz\\.completion
+  - is_false:   _all.primaries.fielddata.fields
 

--- a/rest-api-spec/test/indices.stats/14_groups.yaml
+++ b/rest-api-spec/test/indices.stats/14_groups.yaml
@@ -52,3 +52,28 @@
 
   - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
   - is_false:   _all.primaries.search.groups.baz
+
+---
+"Groups - _all metric":
+  - do:
+      indices.stats: { groups: bar, metric: _all }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - is_false:   _all.primaries.search.groups.baz
+
+---
+"Groups - search metric":
+  - do:
+      indices.stats: { groups: bar, metric: search }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - is_false:   _all.primaries.search.groups.baz
+
+---
+"Groups - multi metric":
+  - do:
+      indices.stats: { groups: bar, metric: [ indexing, search] }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - is_false:   _all.primaries.search.groups.baz
+

--- a/rest-api-spec/test/indices.stats/14_groups.yaml
+++ b/rest-api-spec/test/indices.stats/14_groups.yaml
@@ -1,0 +1,54 @@
+---
+  setup:
+
+    - do:
+        index:
+            index: test1
+            type:  bar
+            id:    1
+            body:  { "bar": "bar", "baz": "baz" }
+
+    - do:
+        search:
+            body:
+                stats:  [ bar, baz ]
+
+---
+"Groups - blank":
+  - do:
+      indices.stats: {}
+
+  - gt:       { _all.primaries.search.query_total: 0 }
+  - is_false:   _all.primaries.search.groups
+
+---
+"Groups - one":
+  - do:
+      indices.stats: { groups: bar }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - is_false:   _all.primaries.search.groups.baz
+
+---
+"Groups - multi":
+  - do:
+      indices.stats: { groups: "bar,baz" }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - gt:       { _all.primaries.search.groups.baz.query_total: 0 }
+
+---
+"Groups - star":
+  - do:
+      indices.stats: { groups: "*" }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - gt:       { _all.primaries.search.groups.baz.query_total: 0 }
+
+---
+"Groups - pattern":
+  - do:
+      indices.stats: { groups: "*r" }
+
+  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
+  - is_false:   _all.primaries.search.groups.baz

--- a/rest-api-spec/test/indices.stats/14_groups.yaml
+++ b/rest-api-spec/test/indices.stats/14_groups.yaml
@@ -18,62 +18,62 @@
   - do:
       indices.stats: {}
 
-  - gt:       { _all.primaries.search.query_total: 0 }
-  - is_false:   _all.primaries.search.groups
+  - gt:       { _all.total.search.query_total: 0 }
+  - is_false:   _all.total.search.groups
 
 ---
 "Groups - one":
   - do:
       indices.stats: { groups: bar }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - is_false:   _all.primaries.search.groups.baz
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - is_false:   _all.total.search.groups.baz
 
 ---
 "Groups - multi":
   - do:
       indices.stats: { groups: "bar,baz" }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - gt:       { _all.primaries.search.groups.baz.query_total: 0 }
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - gt:       { _all.total.search.groups.baz.query_total: 0 }
 
 ---
 "Groups - star":
   - do:
       indices.stats: { groups: "*" }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - gt:       { _all.primaries.search.groups.baz.query_total: 0 }
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - gt:       { _all.total.search.groups.baz.query_total: 0 }
 
 ---
 "Groups - pattern":
   - do:
       indices.stats: { groups: "*r" }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - is_false:   _all.primaries.search.groups.baz
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - is_false:   _all.total.search.groups.baz
 
 ---
 "Groups - _all metric":
   - do:
       indices.stats: { groups: bar, metric: _all }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - is_false:   _all.primaries.search.groups.baz
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - is_false:   _all.total.search.groups.baz
 
 ---
 "Groups - search metric":
   - do:
       indices.stats: { groups: bar, metric: search }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - is_false:   _all.primaries.search.groups.baz
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - is_false:   _all.total.search.groups.baz
 
 ---
 "Groups - multi metric":
   - do:
       indices.stats: { groups: bar, metric: [ indexing, search] }
 
-  - gt:       { _all.primaries.search.groups.bar.query_total: 0 }
-  - is_false:   _all.primaries.search.groups.baz
+  - gt:       { _all.total.search.groups.bar.query_total: 0 }
+  - is_false:   _all.total.search.groups.baz
 

--- a/rest-api-spec/test/indices.stats/15_types.yaml
+++ b/rest-api-spec/test/indices.stats/15_types.yaml
@@ -55,3 +55,28 @@
 
   - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
   - is_false:   _all.primaries.indexing.types.baz
+
+---
+"Types - _all metric":
+  - do:
+      indices.stats: { types: bar, metric: _all }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.primaries.indexing.types.baz
+
+---
+"Types - indexing metric":
+  - do:
+      indices.stats: { types: bar, metric: indexing }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.primaries.indexing.types.baz
+
+---
+"Types - multi metric":
+  - do:
+      indices.stats: { types: bar, metric: [ indexing, search ] }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.primaries.indexing.types.baz
+

--- a/rest-api-spec/test/indices.stats/15_types.yaml
+++ b/rest-api-spec/test/indices.stats/15_types.yaml
@@ -1,0 +1,57 @@
+---
+  setup:
+
+    - do:
+        index:
+            index: test1
+            type:  bar
+            id:    1
+            body:  { "bar": "bar", "baz": "baz" }
+
+    - do:
+        index:
+            index: test2
+            type:  baz
+            id:    1
+            body:  { "bar": "bar", "baz": "baz" }
+
+
+---
+"Types - blank":
+  - do:
+      indices.stats: {}
+
+  - match:    { _all.primaries.indexing.index_total: 2 }
+  - is_false:   _all.primaries.indexing.types
+
+---
+"Types - one":
+  - do:
+      indices.stats: { types: bar }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.primaries.indexing.types.baz
+
+---
+"Types - multi":
+  - do:
+      indices.stats: { types: "bar,baz" }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - match:    { _all.primaries.indexing.types.baz.index_total: 1 }
+
+---
+"Types - star":
+  - do:
+      indices.stats: { types: "*" }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - match:    { _all.primaries.indexing.types.baz.index_total: 1 }
+
+---
+"Types - pattern":
+  - do:
+      indices.stats: { types: "*r" }
+
+  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.primaries.indexing.types.baz

--- a/rest-api-spec/test/indices.stats/15_types.yaml
+++ b/rest-api-spec/test/indices.stats/15_types.yaml
@@ -21,62 +21,62 @@
   - do:
       indices.stats: {}
 
-  - match:    { _all.primaries.indexing.index_total: 2 }
-  - is_false:   _all.primaries.indexing.types
+  - match:    { _all.total.indexing.index_total: 2 }
+  - is_false:   _all.total.indexing.types
 
 ---
 "Types - one":
   - do:
       indices.stats: { types: bar }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - is_false:   _all.primaries.indexing.types.baz
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.total.indexing.types.baz
 
 ---
 "Types - multi":
   - do:
       indices.stats: { types: "bar,baz" }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - match:    { _all.primaries.indexing.types.baz.index_total: 1 }
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - match:    { _all.total.indexing.types.baz.index_total: 1 }
 
 ---
 "Types - star":
   - do:
       indices.stats: { types: "*" }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - match:    { _all.primaries.indexing.types.baz.index_total: 1 }
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - match:    { _all.total.indexing.types.baz.index_total: 1 }
 
 ---
 "Types - pattern":
   - do:
       indices.stats: { types: "*r" }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - is_false:   _all.primaries.indexing.types.baz
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.total.indexing.types.baz
 
 ---
 "Types - _all metric":
   - do:
       indices.stats: { types: bar, metric: _all }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - is_false:   _all.primaries.indexing.types.baz
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.total.indexing.types.baz
 
 ---
 "Types - indexing metric":
   - do:
       indices.stats: { types: bar, metric: indexing }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - is_false:   _all.primaries.indexing.types.baz
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.total.indexing.types.baz
 
 ---
 "Types - multi metric":
   - do:
       indices.stats: { types: bar, metric: [ indexing, search ] }
 
-  - match:    { _all.primaries.indexing.types.bar.index_total: 1 }
-  - is_false:   _all.primaries.indexing.types.baz
+  - match:    { _all.total.indexing.types.bar.index_total: 1 }
+  - is_false:   _all.total.indexing.types.baz
 

--- a/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
@@ -53,10 +53,8 @@ public class ShardFieldData extends AbstractIndexShardComponent implements Index
         if (fields != null && fields.length > 0) {
             fieldTotals = new ObjectLongOpenHashMap<>();
             for (Map.Entry<String, CounterMetric> entry : perFieldTotals.entrySet()) {
-                for (String field : fields) {
-                    if (Regex.simpleMatch(field, entry.getKey())) {
-                        fieldTotals.put(entry.getKey(), entry.getValue().count());
-                    }
+                if (Regex.simpleMatch(fields, entry.getKey())) {
+                    fieldTotals.put(entry.getKey(), entry.getValue().count());
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/index/indexing/ShardIndexingService.java
+++ b/src/main/java/org/elasticsearch/index/indexing/ShardIndexingService.java
@@ -71,10 +71,8 @@ public class ShardIndexingService extends AbstractIndexShardComponent {
                 }
             } else {
                 for (Map.Entry<String, StatsHolder> entry : typesStats.entrySet()) {
-                    for (String type : types) {
-                        if (Regex.simpleMatch(type, entry.getKey())) {
-                            typesSt.put(entry.getKey(), entry.getValue().stats());
-                        }
+                    if (Regex.simpleMatch(types, entry.getKey())) {
+                        typesSt.put(entry.getKey(), entry.getValue().stats());
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/index/indexing/ShardIndexingService.java
+++ b/src/main/java/org/elasticsearch/index/indexing/ShardIndexingService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.indexing.slowlog.ShardSlowLogIndexingService;
@@ -63,17 +64,17 @@ public class ShardIndexingService extends AbstractIndexShardComponent {
         IndexingStats.Stats total = totalStats.stats();
         Map<String, IndexingStats.Stats> typesSt = null;
         if (types != null && types.length > 0) {
+            typesSt = new HashMap<>(typesStats.size());
             if (types.length == 1 && types[0].equals("_all")) {
-                typesSt = new HashMap<>(typesStats.size());
                 for (Map.Entry<String, StatsHolder> entry : typesStats.entrySet()) {
                     typesSt.put(entry.getKey(), entry.getValue().stats());
                 }
             } else {
-                typesSt = new HashMap<>(types.length);
-                for (String type : types) {
-                    StatsHolder statsHolder = typesStats.get(type);
-                    if (statsHolder != null) {
-                        typesSt.put(type, statsHolder.stats());
+                for (Map.Entry<String, StatsHolder> entry : typesStats.entrySet()) {
+                    for (String type : types) {
+                        if (Regex.simpleMatch(type, entry.getKey())) {
+                            typesSt.put(entry.getKey(), entry.getValue().stats());
+                        }
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
+++ b/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
@@ -69,10 +69,8 @@ public class ShardSearchService extends AbstractIndexShardComponent {
                 }
             } else {
                 for (Map.Entry<String, StatsHolder> entry : groupsStats.entrySet()) {
-                    for (String group : groups) {
-                        if (Regex.simpleMatch(group, entry.getKey())) {
-                            groupsSt.put(entry.getKey(), entry.getValue().stats());
-                        }
+                    if (Regex.simpleMatch(groups, entry.getKey())) {
+                        groupsSt.put(entry.getKey(), entry.getValue().stats());
                     }
                 }
             }
@@ -128,7 +126,6 @@ public class ShardSearchService extends AbstractIndexShardComponent {
             }
         }
     }
-
 
     public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
         totalStats.fetchMetric.inc(tookInNanos);
@@ -188,8 +185,7 @@ public class ShardSearchService extends AbstractIndexShardComponent {
         public final CounterMetric fetchCurrent = new CounterMetric();
 
         public SearchStats.Stats stats() {
-            return new SearchStats.Stats(
-                    queryMetric.count(), TimeUnit.NANOSECONDS.toMillis(queryMetric.sum()), queryCurrent.count(),
+            return new SearchStats.Stats(queryMetric.count(), TimeUnit.NANOSECONDS.toMillis(queryMetric.sum()), queryCurrent.count(),
                     fetchMetric.count(), TimeUnit.NANOSECONDS.toMillis(fetchMetric.sum()), fetchCurrent.count());
         }
 

--- a/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
+++ b/src/main/java/org/elasticsearch/index/search/stats/ShardSearchService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.search.slowlog.ShardSlowLogSearchService;
 import org.elasticsearch.index.settings.IndexSettings;
@@ -61,17 +62,17 @@ public class ShardSearchService extends AbstractIndexShardComponent {
         SearchStats.Stats total = totalStats.stats();
         Map<String, SearchStats.Stats> groupsSt = null;
         if (groups != null && groups.length > 0) {
+            groupsSt = new HashMap<>(groupsStats.size());
             if (groups.length == 1 && groups[0].equals("_all")) {
-                groupsSt = new HashMap<>(groupsStats.size());
                 for (Map.Entry<String, StatsHolder> entry : groupsStats.entrySet()) {
                     groupsSt.put(entry.getKey(), entry.getValue().stats());
                 }
             } else {
-                groupsSt = new HashMap<>(groups.length);
-                for (String group : groups) {
-                    StatsHolder statsHolder = groupsStats.get(group);
-                    if (statsHolder != null) {
-                        groupsSt.put(group, statsHolder.stats());
+                for (Map.Entry<String, StatsHolder> entry : groupsStats.entrySet()) {
+                    for (String group : groups) {
+                        if (Regex.simpleMatch(group, entry.getKey())) {
+                            groupsSt.put(entry.getKey(), entry.getValue().stats());
+                        }
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
-import java.io.IOException;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -59,14 +58,6 @@ public class RestIndicesStatsAction extends BaseRestHandler {
         indicesStatsRequest.indices(Strings.splitStringByCommaToArray(request.param("index")));
         indicesStatsRequest.types(Strings.splitStringByCommaToArray(request.param("types")));
 
-        if (request.hasParam("groups")) {
-            indicesStatsRequest.groups(Strings.splitStringByCommaToArray(request.param("groups")));
-        }
-
-        if (request.hasParam("types")) {
-            indicesStatsRequest.types(Strings.splitStringByCommaToArray(request.param("types")));
-        }
-
         Set<String> metrics = Strings.splitStringByCommaToSet(request.param("metric", "_all"));
         // short cut, if no metrics have been specified in URI
         if (metrics.size() == 1 && metrics.contains("_all")) {
@@ -89,6 +80,14 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             indicesStatsRequest.fieldData(metrics.contains("fielddata"));
             indicesStatsRequest.completion(metrics.contains("completion"));
             indicesStatsRequest.suggest(metrics.contains("suggest"));
+        }
+
+        if (request.hasParam("groups")) {
+            indicesStatsRequest.groups(Strings.splitStringByCommaToArray(request.param("groups")));
+        }
+
+        if (request.hasParam("types")) {
+            indicesStatsRequest.types(Strings.splitStringByCommaToArray(request.param("types")));
         }
 
         if (indicesStatsRequest.completion() && (request.hasParam("fields") || request.hasParam("completion_fields"))) {

--- a/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
@@ -32,11 +32,8 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.automaton.Automaton;
-import org.apache.lucene.util.fst.ByteSequenceOutputs;
-import org.apache.lucene.util.fst.FST;
-import org.apache.lucene.util.fst.PairOutputs;
+import org.apache.lucene.util.fst.*;
 import org.apache.lucene.util.fst.PairOutputs.Pair;
-import org.apache.lucene.util.fst.PositiveIntOutputs;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.search.suggest.completion.Completion090PostingsFormat.CompletionLookupProvider;
@@ -303,12 +300,9 @@ public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider 
                     if (fields == null || fields.length == 0) {
                         continue;
                     }
-                    for (String field : fields) {
-                        // support for getting fields by regex as in fielddata
-                        if (Regex.simpleMatch(field, entry.getKey())) {
-                            long fstSize = entry.getValue().fst.sizeInBytes();
-                            completionFields.addTo(entry.getKey(), fstSize);
-                        }
+                    if (Regex.simpleMatch(fields, entry.getKey())) {
+                        long fstSize = entry.getValue().fst.sizeInBytes();
+                        completionFields.addTo(entry.getKey(), fstSize);
                     }
                 }
 

--- a/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
+++ b/src/main/java/org/elasticsearch/search/suggest/completion/AnalyzingCompletionLookupProvider.java
@@ -307,7 +307,7 @@ public class AnalyzingCompletionLookupProvider extends CompletionLookupProvider 
                         // support for getting fields by regex as in fielddata
                         if (Regex.simpleMatch(field, entry.getKey())) {
                             long fstSize = entry.getValue().fst.sizeInBytes();
-                            completionFields.addTo(field, fstSize);
+                            completionFields.addTo(entry.getKey(), fstSize);
                         }
                     }
                 }

--- a/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
@@ -332,8 +332,8 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test1", "type1", Integer.toString(1)).setSource("field", "value").execute().actionGet();
         client().prepareIndex("test1", "type2", Integer.toString(1)).setSource("field", "value").execute().actionGet();
         client().prepareIndex("test2", "type", Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        refresh();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
         int numShards1 = getNumShards("test1").totalNumShards;
         int numShards2 = getNumShards("test2").totalNumShards;
 
@@ -371,8 +371,8 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
         client().prepareIndex("test1", "bar", Integer.toString(1)).setSource("{\"bar\":\"bar\",\"baz\":\"baz\"}").execute().actionGet();
         client().prepareIndex("test1", "baz", Integer.toString(1)).setSource("{\"bar\":\"bar\",\"baz\":\"baz\"}").execute().actionGet();
+        refresh();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
         client().prepareSearch("_all").addSort("bar", SortOrder.ASC).addSort("baz", SortOrder.ASC).execute().actionGet();
 
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
@@ -412,20 +412,15 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
     @Test
     public void testCompletionFieldsParam() throws Exception {
 
-        client().admin()
-                .indices()
-                .prepareCreate("test1")
-                .setSettings(indexSettings())
+        assertAcked(prepareCreate("test1")
                 .addMapping(
                         "bar",
-                        "{ \"properties\": { \"bar\": { \"type\": \"string\", \"fields\": { \"completion\": { \"type\": \"completion\" }}},\"baz\": { \"type\": \"string\", \"fields\": { \"completion\": { \"type\": \"completion\" }}}}}")
-                .execute().actionGet();
+                        "{ \"properties\": { \"bar\": { \"type\": \"string\", \"fields\": { \"completion\": { \"type\": \"completion\" }}},\"baz\": { \"type\": \"string\", \"fields\": { \"completion\": { \"type\": \"completion\" }}}}}"));
         ensureGreen();
 
         client().prepareIndex("test1", "bar", Integer.toString(1)).setSource("{\"bar\":\"bar\",\"baz\":\"baz\"}").execute().actionGet();
         client().prepareIndex("test1", "baz", Integer.toString(1)).setSource("{\"bar\":\"bar\",\"baz\":\"baz\"}").execute().actionGet();
-
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
         IndicesStatsResponse stats = builder.execute().actionGet();
@@ -469,8 +464,8 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         client().prepareIndex("test1", "bar", Integer.toString(1)).setSource("foo","bar").execute().actionGet();
+        refresh();
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
         client().prepareSearch("_all").setStats("bar", "baz").execute().actionGet();
 
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
@@ -507,8 +502,7 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
 
         client().prepareIndex("test1", "bar", Integer.toString(1)).setSource("foo","bar").execute().actionGet();
         client().prepareIndex("test2", "baz", Integer.toString(1)).setSource("foo","bar").execute().actionGet();
-
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        refresh();
 
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
         IndicesStatsResponse stats = builder.execute().actionGet();


### PR DESCRIPTION
This PR fixes two bugs in indices stats:
-  `groups` and `types` were being ignored
- `completion_fields` with wildcards were not resolving the real field names

It also allows `groups` and `types` to accept wildcards, like `fields`, `completion_fields` and `fielddata_fields`

Added YAML tests for indices stats for: indices, metrics, level, fields, types, groups
