### PR TITLE
Guard the auto expand replicas setting against improper values

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -34,8 +34,9 @@ settings API:
 `index.number_of_replicas`::
     The number of replicas each shard has.
 
-`index.auto_expand_replicas`::
-    Set to an actual value (like `0-all`) or `false` to disable it.
+`index.auto_expand_replicas` (string)::
+    Set to a dash delimited lower and upper bound (e.g. `0-5`)
+    or one may use `all` as the upper bound (e.g. `0-all`), or `false` to disable it.
 
 `index.blocks.read_only`::
     Set to `true` to have the index read only, `false` to allow writes

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -83,10 +83,11 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                     try {
                         final int dash = autoExpandReplicas.indexOf('-');
                         if (-1 == dash) {
-                            logger.warn("Unexpected value [{}] for setting [{}]; it should be dash delimited",
-                                    autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
-                            throw new IllegalArgumentException(String.format(
-                                    "Cannot parse [%s] into upper and lower", autoExpandReplicas));
+                            final String errorMessage = String.format(
+                                    "Unexpected value [%s] for setting [%s]; it should be dash delimited",
+                            autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
+                            logger.warn(errorMessage);
+                            throw new ElasticsearchIllegalArgumentException(errorMessage);
                         }
                         min = Integer.parseInt(autoExpandReplicas.substring(0, dash));
                         String sMax = autoExpandReplicas.substring(dash + 1);

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -96,7 +96,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                     try {
                         min = Integer.parseInt(sMin);
                     } catch (NumberFormatException e) {
-                        logger.warn("failed to set [{}], minimum value is non-numeric [{}]",
+                        logger.warn("failed to set [{}], minimum value is not a number [{}]",
                                 e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, sMin);
                         continue;
                     }

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -75,8 +75,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
         // we need to do this each time in case it was changed by update settings
         for (final IndexMetaData indexMetaData : event.state().metaData()) {
-            final String autoExpandSettingName = IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
-            String autoExpandReplicas = indexMetaData.settings().get(autoExpandSettingName);
+            String autoExpandReplicas = indexMetaData.settings().get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
             if (autoExpandReplicas != null && Booleans.parseBoolean(autoExpandReplicas, true)) { // Booleans only work for false values, just as we want it here
                 try {
                     int min;
@@ -85,7 +84,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         final int dash = autoExpandReplicas.indexOf('-');
                         if (-1 == dash) {
                             logger.warn("Unexpected value [{}] for setting [{}]; it should be dash delimited",
-                                    autoExpandReplicas, autoExpandSettingName);
+                                    autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
                             throw new IllegalArgumentException(String.format(
                                     "Cannot parse [%s] into upper and lower", autoExpandReplicas));
                         }
@@ -97,7 +96,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                             max = Integer.parseInt(sMax);
                         }
                     } catch (Exception e) {
-                        logger.warn("failed to set [{}], wrong format [{}]", e, autoExpandSettingName, autoExpandReplicas);
+                        logger.warn("failed to set [{}], wrong format [{}]", e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, autoExpandReplicas);
                         continue;
                     }
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -70,6 +70,8 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
         if (!event.state().nodes().localNodeMaster()) {
             return;
         }
+        // we will want to know this for translating "all" to a number
+        final int dataNodeCount = event.state().nodes().dataNodes().size();
 
         Map<Integer, List<String>> nrReplicasChanged = new HashMap<>();
 
@@ -92,7 +94,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         min = Integer.parseInt(autoExpandReplicas.substring(0, dash));
                         String sMax = autoExpandReplicas.substring(dash + 1);
                         if (sMax.equals("all")) {
-                            max = event.state().nodes().dataNodes().size() - 1;
+                            max = dataNodeCount - 1;
                         } else {
                             max = Integer.parseInt(sMax);
                         }
@@ -101,7 +103,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         continue;
                     }
 
-                    int numberOfReplicas = event.state().nodes().dataNodes().size() - 1;
+                    int numberOfReplicas = dataNodeCount - 1;
                     if (numberOfReplicas < min) {
                         numberOfReplicas = min;
                     } else if (numberOfReplicas > max) {

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -88,10 +88,8 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
                     final int dash = autoExpandReplicas.indexOf('-');
                     if (-1 == dash) {
-                        final String errorMessage = String.format(
-                                "Unexpected value [%s] for setting [%s]; it should be dash delimited",
-                        autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
-                        logger.warn(errorMessage);
+                        logger.warn("Unexpected value [{}] for setting [{}]; it should be dash delimited",
+                                autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
                         continue;
                     }
                     final String sMin = autoExpandReplicas.substring(0, dash);

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -73,6 +73,9 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
         // we will want to know this for translating "all" to a number
         final int dataNodeCount = event.state().nodes().dataNodes().size();
 
+        // the value we recognize in the "max" position to mean all the nodes
+        final String ALL_NODES_VALUE = "all";  // class constant?
+
         Map<Integer, List<String>> nrReplicasChanged = new HashMap<>();
 
         // we need to do this each time in case it was changed by update settings
@@ -93,7 +96,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         }
                         min = Integer.parseInt(autoExpandReplicas.substring(0, dash));
                         String sMax = autoExpandReplicas.substring(dash + 1);
-                        if (sMax.equals("all")) {
+                        if (sMax.equals(ALL_NODES_VALUE)) {
                             max = dataNodeCount - 1;
                         } else {
                             max = Integer.parseInt(sMax);

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -92,7 +92,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                                     "Unexpected value [%s] for setting [%s]; it should be dash delimited",
                             autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
                             logger.warn(errorMessage);
-                            throw new ElasticsearchIllegalArgumentException(errorMessage);
+                            continue;
                         }
                         min = Integer.parseInt(autoExpandReplicas.substring(0, dash));
                         String sMax = autoExpandReplicas.substring(dash + 1);

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -85,34 +85,35 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                 try {
                     final int min;
                     final int max;
-                        final int dash = autoExpandReplicas.indexOf('-');
-                        if (-1 == dash) {
-                            final String errorMessage = String.format(
-                                    "Unexpected value [%s] for setting [%s]; it should be dash delimited",
-                            autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
-                            logger.warn(errorMessage);
-                            continue;
-                        }
-                        final String sMin = autoExpandReplicas.substring(0, dash);
+
+                    final int dash = autoExpandReplicas.indexOf('-');
+                    if (-1 == dash) {
+                        final String errorMessage = String.format(
+                                "Unexpected value [%s] for setting [%s]; it should be dash delimited",
+                        autoExpandReplicas, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
+                        logger.warn(errorMessage);
+                        continue;
+                    }
+                    final String sMin = autoExpandReplicas.substring(0, dash);
+                    try {
+                        min = Integer.parseInt(sMin);
+                    } catch (NumberFormatException e) {
+                        logger.warn("failed to set [{}], minimum value is non-numeric [{}]",
+                                e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, sMin);
+                        continue;
+                    }
+                    String sMax = autoExpandReplicas.substring(dash + 1);
+                    if (sMax.equals(ALL_NODES_VALUE)) {
+                        max = dataNodeCount - 1;
+                    } else {
                         try {
-                            min = Integer.parseInt(sMin);
+                            max = Integer.parseInt(sMax);
                         } catch (NumberFormatException e) {
-                            logger.warn("failed to set [{}], minimum value is non-numeric [{}]",
-                                    e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, sMin);
+                            logger.warn("failed to set [{}], maximum value is neither \"{}\" nor a number [{}]",
+                                    e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, ALL_NODES_VALUE, sMin);
                             continue;
                         }
-                        String sMax = autoExpandReplicas.substring(dash + 1);
-                        if (sMax.equals(ALL_NODES_VALUE)) {
-                            max = dataNodeCount - 1;
-                        } else {
-                            try {
-                                max = Integer.parseInt(sMax);
-                            } catch (NumberFormatException e) {
-                                logger.warn("failed to set [{}], maximum value is neither \"{}\" nor a number [{}]",
-                                        e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, ALL_NODES_VALUE, sMin);
-                                continue;
-                            }
-                        }
+                    }
 
                     int numberOfReplicas = dataNodeCount - 1;
                     if (numberOfReplicas < min) {

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -107,7 +107,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         try {
                             max = Integer.parseInt(sMax);
                         } catch (NumberFormatException e) {
-                            logger.warn("failed to set [{}], maximum value is neither \"{}\" nor a number [{}]",
+                            logger.warn("failed to set [{}], maximum value is neither [{}] nor a number [{}]",
                                     e, IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, ALL_NODES_VALUE, sMin);
                             continue;
                         }


### PR DESCRIPTION
This is the PR for Issue #5752

It updates the documentation to be more precise, and adds guards in the code to ensure the values are recognized, and if not it emits a log message and throws an exception with a more helpful message.
