### PR TITLE
Create only one MLT query per field for all queried items

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
@@ -27,11 +27,13 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.similarities.DefaultSimilarity;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.search.similarities.TFIDFSimilarity;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.FastStringReader;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -174,11 +176,15 @@ public class MoreLikeThisQuery extends Query {
     }
 
     public void setLikeText(String likeText) {
-        this.likeText = new String[]{likeText};
+        setLikeText(new String[]{likeText});
     }
 
     public void setLikeText(String... likeText) {
         this.likeText = likeText;
+    }
+
+    public void setLikeText(List<String> likeText) {
+        setLikeText(likeText.toArray(Strings.EMPTY_ARRAY));
     }
 
     public String[] getMoreLikeFields() {

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queries.TermsFilter;
@@ -208,10 +209,10 @@ public class MoreLikeThisQueryParser implements QueryParser {
             // fetching the items with multi-get
             List<LikeText> likeTexts = fetchService.fetch(items);
             // collapse the text onto the same field name
-            collapseTextOnField(likeTexts);
+            Collection<LikeText> likeTextsCollapsed = collapseTextOnField(likeTexts);
             // right now we are just building a boolean query
             BooleanQuery boolQuery = new BooleanQuery();
-            for (LikeText likeText : likeTexts) {
+            for (LikeText likeText : likeTextsCollapsed) {
                 addMoreLikeThis(boolQuery, mltQuery, likeText);
             }
             // exclude the items from the search
@@ -233,7 +234,7 @@ public class MoreLikeThisQueryParser implements QueryParser {
     private void addMoreLikeThis(BooleanQuery boolQuery, MoreLikeThisQuery mltQuery, LikeText likeText) {
         MoreLikeThisQuery mlt = new MoreLikeThisQuery();
         mlt.setMoreLikeFields(new String[] {likeText.field});
-        mlt.setLikeText(likeText.getText());
+        mlt.setLikeText(likeText.text);
         mlt.setAnalyzer(mltQuery.getAnalyzer());
         mlt.setPercentTermsToMatch(mltQuery.getPercentTermsToMatch());
         mlt.setBoostTerms(mltQuery.isBoostTerms());
@@ -262,17 +263,17 @@ public class MoreLikeThisQueryParser implements QueryParser {
         return moreLikeFields;
     }
 
-    public static void collapseTextOnField (Collection<LikeText> likeTexts) {
-        Map<String, LikeText> keptLikeTexts = new HashMap<>();
-        for (Iterator<LikeText> it = likeTexts.iterator(); it.hasNext();) {
-            final LikeText likeText = it.next();
-            if (keptLikeTexts.containsKey(likeText.field)) {
-                keptLikeTexts.get(likeText.field).addText(likeText.getText());
-                it.remove();
-            } else {
-                keptLikeTexts.put(likeText.field, likeText);
+    public static Collection<LikeText> collapseTextOnField (Collection<LikeText> likeTexts) {
+        Map<String, LikeText> collapsedTexts = new HashMap<>();
+        for (LikeText likeText : likeTexts) {
+            String field = likeText.field;
+            String[] text = likeText.text;
+            if (collapsedTexts.containsKey(field)) {
+                text = ObjectArrays.concat(collapsedTexts.get(field).text, text, String.class);
             }
+            collapsedTexts.put(field, new LikeText(field, text));
         }
+        return collapsedTexts.values();
     }
 
     private void removeUnsupportedFields(MultiGetRequest.Item item, Analyzer analyzer, boolean failOnUnsupportedField) throws IOException {

--- a/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
+++ b/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
@@ -31,7 +31,6 @@ import org.elasticsearch.index.get.GetField;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -41,30 +40,16 @@ public class MoreLikeThisFetchService extends AbstractComponent {
 
     public static final class LikeText {
         public final String field;
-        private List<String> text;
+        public final String[] text;
 
         public LikeText(String field, String text) {
             this.field = field;
-            this.text = new ArrayList<>();
-            addText(text);
+            this.text = new String[]{text};
         }
 
         public LikeText(String field, String... text) {
             this.field = field;
-            this.text = new ArrayList<>();
-            addText(text);
-        }
-
-        public List<String> getText() {
-            return text;
-        }
-
-        public void addText(List<String> text) {
-            this.text.addAll(text);
-        }
-
-        public void addText(String... text) {
-            addText(Arrays.asList(text));
+            this.text = text;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
+++ b/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.get.GetField;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -40,16 +41,30 @@ public class MoreLikeThisFetchService extends AbstractComponent {
 
     public static final class LikeText {
         public final String field;
-        public final String[] text;
+        private List<String> text;
 
         public LikeText(String field, String text) {
             this.field = field;
-            this.text = new String[]{text};
+            this.text = new ArrayList<>();
+            addText(text);
         }
 
         public LikeText(String field, String... text) {
             this.field = field;
-            this.text = text;
+            this.text = new ArrayList<>();
+            addText(text);
+        }
+
+        public List<String> getText() {
+            return text;
+        }
+
+        public void addText(List<String> text) {
+            this.text.addAll(text);
+        }
+
+        public void addText(String... text) {
+            addText(Arrays.asList(text));
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1702,7 +1702,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchTestCase {
             assertThat(booleanClause.getOccur(), is(BooleanClause.Occur.SHOULD));
             assertThat(booleanClause.getQuery(), instanceOf(MoreLikeThisQuery.class));
             MoreLikeThisQuery mltQuery = (MoreLikeThisQuery) booleanClause.getQuery();
-            assertThat(mltQuery.getLikeTexts(), is(likeTexts.get(i).getText().toArray(Strings.EMPTY_ARRAY)));
+            assertThat(mltQuery.getLikeTexts(), is(likeTexts.get(i).text));
             assertThat(mltQuery.getMoreLikeFields()[0], equalTo(likeTexts.get(i).field));
         }
 


### PR DESCRIPTION
Previously, one MLT query per field was created for each item. One issue with
this method is that the maximum number of selected terms was equal to the
number of items times 'max_query_terms'. Instead, users should have direct control
over the maximum number of selected terms allowed, regardless of the number of
queried items.

Another issue related to the previous method is that it could lead to the
selection of rather uninteresting terms, that because they were found in a
particular queried item. Instead, this new procedure enforces the selection of
interesting terms across ALL items, not within each item. This could lead to
search results where the best matching items share commonalities amongst the
best characteristics of all the items.
