### PR TITLE
Exposed _uid, _id and _type fields as stored fields (_fields notation)

### DIFF
--- a/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -136,7 +136,7 @@ public abstract class FieldsVisitor extends StoredFieldVisitor {
         uid = null;
     }
 
-    private void addValue(String name, Object value) {
+    void addValue(String name, Object value) {
         if (fieldsValues == null) {
             fieldsValues = newHashMap();
         }


### PR DESCRIPTION
The `_uid` field wasn't available in a script despite it's always stored. Made it available and made available also `_id` and `_type` fields that are deducted from it.
