### PR TITLE
Fix cardinality aggregation when doc values field is empty

### DIFF
--- a/src/main/java/org/elasticsearch/index/fielddata/ordinals/EmptyOrdinals.java
+++ b/src/main/java/org/elasticsearch/index/fielddata/ordinals/EmptyOrdinals.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.fielddata.ordinals;
 
-import org.apache.lucene.util.LongsRef;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 
 /**
@@ -39,7 +38,7 @@ public enum EmptyOrdinals implements Ordinals {
 
     @Override
     public long getMaxOrd() {
-        return 1;
+        return 0;
     }
 
     @Override
@@ -48,7 +47,6 @@ public enum EmptyOrdinals implements Ordinals {
     }
 
     public static class Docs extends Ordinals.AbstractDocs {
-        public static final LongsRef EMPTY_LONGS_REF = new LongsRef();
 
         public Docs(EmptyOrdinals parent) {
             super(parent);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -93,6 +93,10 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
         if (bytesValues instanceof BytesValues.WithOrdinals) {
             BytesValues.WithOrdinals values = (BytesValues.WithOrdinals) bytesValues;
             final long maxOrd = values.ordinals().getMaxOrd();
+            if (maxOrd == 0) {
+                return new EmptyCollector();
+            }
+
             final long ordinalsMemoryUsage = OrdinalsCollector.memoryOverhead(maxOrd);
             final long countsMemoryUsage = HyperLogLogPlusPlus.memoryUsage(precision);
             // only use ordinals if they don't increase memory usage by more than 25%
@@ -164,6 +168,24 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
         void postCollect();
 
+    }
+
+    private static class EmptyCollector implements Collector {
+
+        @Override
+        public void collect(int doc, long bucketOrd) {
+            // no-op
+        }
+
+        @Override
+        public void postCollect() {
+            // no-op
+        }
+
+        @Override
+        public void close() throws ElasticsearchException {
+            // no-op
+        }
     }
 
     private static class DirectCollector implements Collector {

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
@@ -123,6 +123,13 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
         }
         indexRandom(true, builders);
         createIndex("idx_unmapped");
+
+        IndexRequestBuilder[] dummyDocsBuilder = new IndexRequestBuilder[10];
+        for (int i = 0; i < dummyDocsBuilder.length; i++) {
+            dummyDocsBuilder[i] = client().prepareIndex("idx", "type").setSource("a_field", "1");
+        }
+        indexRandom(true, dummyDocsBuilder);
+
         ensureSearchable();
     }
 


### PR DESCRIPTION
In case a doc values field doesn't have values all the time the cardinality aggregation can fail with a ArrayIndexOutOfBoundsException.
