### PR TITLE
Unified PUT/POST behaviour in relation to create parameter

### DIFF
--- a/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/api/indices.put_template.json
@@ -17,6 +17,11 @@
           "type" : "number",
           "description" : "The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"
         },
+        "create" : {
+            "type" : "boolean",
+            "description" : "Whether the index template should only be added if new or can also replace an existing one",
+            "default" : false
+        },
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"
@@ -25,10 +30,10 @@
           "type" : "time",
           "description" : "Specify timeout for connection to master"
         },
-          "flat_settings": {
-              "type": "boolean",
-              "description": "Return settings in flat format (default: false)"
-          }
+        "flat_settings": {
+           "type": "boolean",
+           "description": "Return settings in flat format (default: false)"
+        }
       }
     },
     "body": {

--- a/rest-api-spec/test/indices.put_template/10_basic.yaml
+++ b/rest-api-spec/test/indices.put_template/10_basic.yaml
@@ -39,3 +39,33 @@
   - match: { test.aliases.test_blias.search_routing: "b" }
   - match: { test.aliases.test_clias.filter.term.user: "kimchy" }
 
+---
+"Put template create":
+  - do:
+      indices.put_template:
+        name: test
+        create: true
+        body:
+          template: test-*
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      indices.get_template:
+        name: test
+
+  - match: {test.template: "test-*"}
+  - match: {test.settings: {index.number_of_shards: '1', index.number_of_replicas: '0'}}
+
+  - do:
+      catch: request
+      indices.put_template:
+        name: test
+        create: true
+        body:
+          template: test-*
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
@@ -26,8 +26,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
-import java.io.IOException;
-
 /**
  *
  */
@@ -37,15 +35,7 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
     public RestPutIndexTemplateAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
         controller.registerHandler(RestRequest.Method.PUT, "/_template/{name}", this);
-        controller.registerHandler(RestRequest.Method.POST, "/_template/{name}", new CreateHandler());
-    }
-
-    final class CreateHandler implements RestHandler {
-        @Override
-        public void handleRequest(RestRequest request, RestChannel channel) {
-            request.params().put("create", "true");
-            RestPutIndexTemplateAction.this.handleRequest(request, channel);
-        }
+        controller.registerHandler(RestRequest.Method.POST, "/_template/{name}", this);
     }
 
     @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
The put index template api supports the `create` parameter (defaults to false), which tells whether the template can replace an existing one with same name or not. When invoked through REST using the POST method, the `create` is currently forced to `true`, which is not consistent with our other apis.

Unified its behaviour between PUT and POST method. Also added create parameter to the rest spec (was missing before) and a REST test for create true scenario.
