### PR TITLE
Change the top_hits to be a metric aggregation

### DIFF
--- a/docs/reference/search/aggregations/bucket.asciidoc
+++ b/docs/reference/search/aggregations/bucket.asciidoc
@@ -27,5 +27,3 @@ include::bucket/datehistogram-aggregation.asciidoc[]
 include::bucket/geodistance-aggregation.asciidoc[]
 
 include::bucket/geohashgrid-aggregation.asciidoc[]
-
-include::bucket/tophits-aggregation.asciidoc[]

--- a/docs/reference/search/aggregations/metrics.asciidoc
+++ b/docs/reference/search/aggregations/metrics.asciidoc
@@ -19,3 +19,5 @@ include::metrics/percentile-aggregation.asciidoc[]
 include::metrics/cardinality-aggregation.asciidoc[]
 
 include::metrics/geobounds-aggregation.asciidoc[]
+
+include::metrics/tophits-aggregation.asciidoc[]

--- a/docs/reference/search/aggregations/metrics/tophits-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/metrics/tophits-aggregation.asciidoc
@@ -1,15 +1,13 @@
-[[search-aggregations-bucket-top-hits-aggregation]]
+[[search-aggregations-metrics-top-hits-aggregation]]
 === Top hits Aggregation
 
 coming[1.3.0]
 
-The `top_hits` aggregator keeps track of the most relevant document being aggregated. This aggregator is intended to be
-used as a sub aggregator, so that the top matching documents can be aggregated per bucket.
+A `top_hits` metric aggregator keeps track of the most relevant document being aggregated. This aggregator is intended
+to be used as a sub aggregator, so that the top matching documents can be aggregated per bucket.
 
 The `top_hits` aggregator can effectively be used to group result sets by certain fields via a bucket aggregator.
 One or more bucket aggregators determines by which properties a result set get sliced into.
-
-This aggregator can't hold any sub-aggregators and therefor can only be used as a leaf aggregator.
 
 ==== Options
 

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilders.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilders.java
@@ -32,7 +32,7 @@ import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanc
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IPv4RangeBuilder;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
-import org.elasticsearch.search.aggregations.bucket.tophits.TopHitsBuilder;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.AvgBuilder;
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityBuilder;
 import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsBuilder;

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationModule.java
@@ -35,7 +35,7 @@ import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanc
 import org.elasticsearch.search.aggregations.bucket.range.ipv4.IpRangeParser;
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsParser;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsParser;
-import org.elasticsearch.search.aggregations.bucket.tophits.TopHitsParser;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsParser;
 import org.elasticsearch.search.aggregations.metrics.avg.AvgParser;
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityParser;
 import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsParser;

--- a/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/TransportAggregationModule.java
@@ -38,7 +38,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
-import org.elasticsearch.search.aggregations.bucket.tophits.InternalTopHits;
+import org.elasticsearch.search.aggregations.metrics.tophits.InternalTopHits;
 import org.elasticsearch.search.aggregations.metrics.avg.InternalAvg;
 import org.elasticsearch.search.aggregations.metrics.cardinality.InternalCardinality;
 import org.elasticsearch.search.aggregations.metrics.geobounds.InternalGeoBounds;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.tophits;
+package org.elasticsearch.search.aggregations.metrics.tophits;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
@@ -25,13 +25,12 @@ import org.apache.lucene.search.TopFieldDocs;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHits;
 
@@ -40,7 +39,7 @@ import java.util.List;
 
 /**
  */
-public class InternalTopHits extends InternalAggregation implements TopHits, ToXContent, Streamable {
+public class InternalTopHits extends InternalMetricsAggregation implements TopHits {
 
     public static final InternalAggregation.Type TYPE = new Type("top_hits");
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHits.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHits.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.tophits;
+package org.elasticsearch.search.aggregations.metrics.tophits;
 
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregation;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.search.aggregations.bucket.tophits;
+package org.elasticsearch.search.aggregations.metrics.tophits;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.*;
@@ -27,7 +27,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.search.aggregations.*;
-import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
+import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
@@ -38,7 +38,7 @@ import java.io.IOException;
 
 /**
  */
-public class TopHitsAggregator extends BucketsAggregator implements ScorerAware {
+public class TopHitsAggregator extends MetricsAggregator implements ScorerAware {
 
     private final FetchPhase fetchPhase;
     private final TopHitsContext topHitsContext;
@@ -48,7 +48,7 @@ public class TopHitsAggregator extends BucketsAggregator implements ScorerAware 
     private AtomicReaderContext currentContext;
 
     public TopHitsAggregator(FetchPhase fetchPhase, TopHitsContext topHitsContext, String name, long estimatedBucketsCount, AggregationContext context, Aggregator parent) {
-        super(name, BucketAggregationMode.MULTI_BUCKETS, AggregatorFactories.EMPTY, estimatedBucketsCount, context, parent);
+        super(name, estimatedBucketsCount, context, parent);
         this.fetchPhase = fetchPhase;
         topDocsCollectors = new LongObjectPagedHashMap<>(estimatedBucketsCount, context.bigArrays());
         this.topHitsContext = topHitsContext;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsBuilder.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.tophits;
+package org.elasticsearch.search.aggregations.metrics.tophits;
 
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.xcontent.XContentBuilder;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsContext.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.tophits;
+package org.elasticsearch.search.aggregations.metrics.tophits;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsParser.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.tophits;
+package org.elasticsearch.search.aggregations.metrics.tophits;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.inject.Inject;

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
-import org.elasticsearch.search.aggregations.bucket.tophits.TopHits;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHits;
 import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.elasticsearch.search.highlight.HighlightField;
 import org.elasticsearch.search.sort.SortBuilders;


### PR DESCRIPTION
Now that there is a distinction between metric aggregation and numeric aggregation, the top_hits aggregation can be a metric aggregation instead of a bucket aggregation that can't hold sub aggregations.
