### PR TITLE
Bulk request which try and fail to create multiple indices may never return

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -134,7 +134,7 @@ public class TransportBulkAction extends TransportAction<BulkRequest, BulkRespon
                                 // fail all requests involving this index, if create didnt work
                                 for (int i = 0; i < bulkRequest.requests.size(); i++) {
                                     ActionRequest request = bulkRequest.requests.get(i);
-                                    if (setResponseFailureIfIndexMatches(responses, i, request, index, e)) {
+                                    if (request != null && setResponseFailureIfIndexMatches(responses, i, request, index, e)) {
                                         bulkRequest.requests.set(i, null);
                                     }
                                 }

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -624,10 +624,17 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         int bulkEntryCount = randomIntBetween(10, 50);
         BulkRequestBuilder builder = client().prepareBulk();
         boolean[] expectedFailures = new boolean[bulkEntryCount];
+        String[] twoBadNames = new String[]{"INVALID.NAME1", "INVALID.NAME2"};
         boolean expectFailure = false;
         for (int i = 0; i < bulkEntryCount; i++) {
             expectFailure |= expectedFailures[i] = randomBoolean();
-            builder.add(client().prepareIndex().setIndex(expectedFailures[i] ? "INVALID.NAME" : "test").setType("type1").setId("1").setSource("field", 1));
+            String name;
+            if (expectedFailures[i]) {
+                name = twoBadNames[randomIntBetween(0, 1)];
+            } else {
+                name = "test";
+            }
+            builder.add(client().prepareIndex().setIndex(name).setType("type1").setId("1").setSource("field", 1));
         }
         BulkResponse bulkResponse = builder.get();
         assertThat(bulkResponse.hasFailures(), is(expectFailure));

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -624,13 +624,13 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         int bulkEntryCount = randomIntBetween(10, 50);
         BulkRequestBuilder builder = client().prepareBulk();
         boolean[] expectedFailures = new boolean[bulkEntryCount];
-        String[] twoBadNames = new String[]{"INVALID.NAME1", "INVALID.NAME2"};
+        String[] badIndexNames = new String[]{"INVALID.NAME1", "INVALID.NAME2"};
         boolean expectFailure = false;
         for (int i = 0; i < bulkEntryCount; i++) {
             expectFailure |= expectedFailures[i] = randomBoolean();
             String name;
             if (expectedFailures[i]) {
-                name = twoBadNames[randomIntBetween(0, 1)];
+                name = randomFrom(badIndexNames);
             } else {
                 name = "test";
             }

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -626,7 +626,7 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         BulkRequestBuilder builder = client().prepareBulk();
         boolean[] expectedFailures = new boolean[bulkEntryCount];
         ArrayList<String> badIndexNames = new ArrayList<>();
-        for (int i = 1; i < randomIntBetween(1, 5); i++) {
+        for (int i = randomIntBetween(1, 5); i > 0; i--) {
             badIndexNames.add("INVALID.NAME" + i);
         }
         boolean expectFailure = false;

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -624,7 +625,10 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         int bulkEntryCount = randomIntBetween(10, 50);
         BulkRequestBuilder builder = client().prepareBulk();
         boolean[] expectedFailures = new boolean[bulkEntryCount];
-        String[] badIndexNames = new String[]{"INVALID.NAME1", "INVALID.NAME2"};
+        ArrayList<String> badIndexNames = new ArrayList<>();
+        for (int i = 1; i < randomIntBetween(1, 5); i++) {
+            badIndexNames.add("INVALID.NAME" + i);
+        }
         boolean expectFailure = false;
         for (int i = 0; i < bulkEntryCount; i++) {
             expectFailure |= expectedFailures[i] = randomBoolean();


### PR DESCRIPTION
This is caused by an NPE in the error handling code. All is well if only 1 index fails (or none).
