### PR TITLE
Force refresh when versionMap is using too much RAM

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/DeleteVersionValue.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/DeleteVersionValue.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.engine.internal;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.index.translog.Translog;
 
 /** Holds a deleted version, which just adds a timestmap to {@link VersionValue} so we know when we can expire the deletion. */
@@ -39,5 +40,10 @@ class DeleteVersionValue extends VersionValue {
     @Override
     public boolean delete() {
         return true;
+    }
+
+    // @Override
+    public long ramBytesUsed() {
+        return super.ramBytesUsed() + RamUsageEstimator.NUM_BYTES_LONG;
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -751,7 +751,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
         // TODO: maybe we should just put a scheduled job in threadPool?
         // We check for pruning in each delete request, but we also prune here e.g. in case a delete burst comes in and then no more deletes
-        // for a long time:
+        // for a long time, and also to protect against wall-clock time shifts possibly preventing us from pruning:
         if (enableGcDeletes) {
             pruneDeletedTombstones();
         }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -547,7 +547,6 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             }
             Translog.Location translogLocation = translog.add(new Translog.Index(index));
 
-            // TODO: expose versionMap's RAM usage in ShardStats?
             versionMap.putUnderLock(index.uid().bytes(), new VersionValue(updatedVersion, translogLocation));
 
             indexingService.postIndexUnderLock(index);

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -607,9 +607,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
             delete.updateVersion(updatedVersion, found);
             Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
-            if (gcDeletesInMillis > 0) {
-                versionMap.putDeleteUnderLock(delete.uid().bytes(), new DeleteVersionValue(updatedVersion, threadPool.estimatedTimeInMillis(), translogLocation));
-            }
+            versionMap.putDeleteUnderLock(delete.uid().bytes(), new DeleteVersionValue(updatedVersion, threadPool.estimatedTimeInMillis(), translogLocation));
 
             indexingService.postDeleteUnderLock(delete);
         }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -489,7 +489,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     /** Forces a refresh if the versionMap is using too much RAM (currently > 25% of IndexWriter's RAM buffer). */
     private void checkVersionMapRefresh() {
         // TODO: we force refresh when versionMap is using > 25% of IW's RAM buffer; should we make this separately configurable?
-        if (versionMap.ramBytesUsed.get()/1024/1024. > 0.25*this.indexWriter.getConfig().getRAMBufferSizeMB()) {
+        if (versionMap.ramBytesUsed()/1024/1024. > 0.25*this.indexWriter.getConfig().getRAMBufferSizeMB()) {
             // Now refresh to clear versionMap adds:
             // TODO: should we instead ask refresh threadPool to do this?
             refresh(new Refresh("version_table_full"));

--- a/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
@@ -37,14 +37,14 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         assert Version.CURRENT.luceneVersion == org.apache.lucene.util.Version.LUCENE_48 : "Add 'implements Accountable' here";
     }
 
-    // All writes go into here:
-    private volatile Map<BytesRef,VersionValue> addsCurrent = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    // All writes (adds and deletes) go into here:
+    private volatile Map<BytesRef,VersionValue> current = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
-    // Only used while refresh is running:
-    private volatile Map<BytesRef,VersionValue> addsOld = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    // Used while refresh is running, and to hold adds/deletes until refresh finishes.  We read from both current and old on lookup:
+    private volatile Map<BytesRef,VersionValue> old = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
-    // Holds tombstones for deleted docs, expiring by their own schedule; not private so InternalEngine can prune:
-    private final Map<BytesRef,VersionValue> deletes = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    // All deletes also go here, and delete "tombstones" are retained after refresh:
+    private volatile Map<BytesRef,VersionValue> tombstones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
     private ReferenceManager mgr;
 
@@ -80,85 +80,75 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
 
     @Override
     public void beforeRefresh() throws IOException {
-        addsOld = addsCurrent;
+        old = current;
         ramBytesUsed.set(0);
         // Start sending all updates after this point to the new
         // map.  While reopen is running, any lookup will first
         // try this new map, then fallback to old, then to the
         // current searcher:
-        addsCurrent = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        current = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
     }
 
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
-        // Now drop all the old values because they are now
-        // visible via the searcher that was just opened; if
-        // didRefresh is false, it's possible old has some
-        // entries in it, which is fine: it means they were
-        // actually already included in the previously opened
-        // reader.  So we can safely clear old here:
-        addsOld = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        // We can now drop old because these operations are now visible via the newly opened searcher.  Even if didRefresh is false, it's
+        // possible old has some entries in it, which is fien: it means they were actually already included in the previously opened reader,
+        // so we can still safely drop them in that case.  We don't touch deletes here: they expire on their own index.gc_deletes
+        // timeframe:
+        old = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
     }
 
-    /** Caller has a lock, so that this uid will not be concurrently added/deleted by another thread. */
+    /** If includeDeletes is true we also check and return a tombstone delete. */
     public VersionValue getUnderLock(BytesRef uid) {
         // First try to get the "live" value:
-        VersionValue value = addsCurrent.get(uid);
+        VersionValue value = current.get(uid);
         if (value != null) {
             return value;
         }
 
-        value = addsOld.get(uid);
+        value = old.get(uid);
         if (value != null) {
             return value;
         }
 
-        value = deletes.get(uid);
-        if (value != null) {
-            return value;
-        }
-
-        return null;
+        return tombstones.get(uid);
     }
 
     /** Adds this uid/version to the pending adds map. */
     public void putUnderLock(BytesRef uid, VersionValue version) {
-        deletes.remove(uid);
-        if (addsCurrent.put(uid, version) == null) {
-            ramBytesUsed.addAndGet(BASE_BYTES_PER_ADD + uid.bytes.length + version.ramBytesUsed());
+        VersionValue prev = current.put(uid, version);
+        if (prev != null) {
+            ramBytesUsed.addAndGet(-(BASE_BYTES_PER_ADD + uid.bytes.length + prev.ramBytesUsed()));
         }
-    }
-
-    /** Adds this uid/version to the pending deletes map. */
-    public void putDeleteUnderLock(BytesRef uid, VersionValue version) {
-        VersionValue oldVersion = addsCurrent.remove(uid);
-        if (oldVersion != null) {
-            ramBytesUsed.addAndGet(-(BASE_BYTES_PER_ADD + uid.bytes.length - oldVersion.ramBytesUsed()));
+        ramBytesUsed.addAndGet(BASE_BYTES_PER_ADD + uid.bytes.length + version.ramBytesUsed());
+        if (version.delete()) {
+            tombstones.put(uid, version);
+        } else {
+            // UID came back to life so we remove the tombstone:
+            tombstones.remove(uid);
         }
-        addsOld.remove(uid);
-        deletes.put(uid, version);
-    }
-
-    /** Returns the current deleted version for this uid. */
-    public VersionValue getDeleteUnderLock(BytesRef uid) {
-        return deletes.get(uid);
     }
 
     /** Removes this uid from the pending deletes map. */
-    public void removeDeleteUnderLock(BytesRef uid) {
-        deletes.remove(uid);
+    public void removeTombstoneUnderLock(BytesRef uid) {
+        tombstones.remove(uid);
     }
 
-    /** Iterates over all pending deletions. */
-    public Iterable<Map.Entry<BytesRef,VersionValue>> getAllDeletes() {
-        return deletes.entrySet();
+    /** Caller has a lock, so that this uid will not be concurrently added/deleted by another thread. */
+    public VersionValue getTombstoneUnderLock(BytesRef uid) {
+        return tombstones.get(uid);
+    }
+
+    /** Iterates over all old versions, i.e. versions that have already been exposed in a reader. */
+    public Iterable<Map.Entry<BytesRef,VersionValue>> getAllTombstones() {
+        return tombstones.entrySet();
     }
 
     /** Called when this index is closed. */
     public void clear() {
-        addsCurrent.clear();
-        addsOld.clear();
-        deletes.clear();
+        current.clear();
+        old.clear();
+        tombstones.clear();
         ramBytesUsed.set(0);
         if (mgr != null) {
             mgr.removeListener(this);

--- a/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
@@ -61,18 +61,30 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
      * CHM's pointer to CHM.Entry, double for approx load factor:
      *     + 2*NUM_BYTES_OBJECT_REF */
 
-    private static final int BASE_BYTES_PER_ADD = 2*RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
+    private static final int BASE_BYTES_PER_ENTRY = 2*RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
         3*RamUsageEstimator.NUM_BYTES_INT +
         6*RamUsageEstimator.NUM_BYTES_OBJECT_REF + 
         RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 
-    final AtomicLong ramBytesUsed = new AtomicLong();
+    /** Tracks bytes used by add ops in current */
+    final AtomicLong ramBytesUsedAdds = new AtomicLong();
+
+    /** Tracks bytes used by delete ops in current */
+    final AtomicLong ramBytesUsedDeletes = new AtomicLong();
+
+    /** Tracks bytes used by tombstones (deletes) */
+    final AtomicLong ramBytesUsedTombstones = new AtomicLong();
 
     public void setManager(ReferenceManager newMgr) {
         if (mgr != null) {
             mgr.removeListener(this);
         }
         mgr = newMgr;
+
+        // In case InternalEngine closes & opens a new IndexWriter/SearcherManager, all deletes are made visible, so we clear old and
+        // current here.  This is safe because caller holds writeLock here (so no concurrent adds/deletes can be happeninge):
+        old = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();        
+        current = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
         // So we are notified when reopen starts and finishes
         mgr.addListener(this);
@@ -81,7 +93,12 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
     @Override
     public void beforeRefresh() throws IOException {
         old = current;
-        ramBytesUsed.set(0);
+
+        // This is not 100% correct, since concurrent indexing ops can change these counters in between our execution of the following 3
+        // lines, but that should be minor, and the error won't accumulate over time:
+        ramBytesUsedAdds.set(0);
+        ramBytesUsedDeletes.set(0);
+
         // Start sending all updates after this point to the new
         // map.  While reopen is running, any lookup will first
         // try this new map, then fallback to old, then to the
@@ -91,14 +108,16 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
 
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
-        // We can now drop old because these operations are now visible via the newly opened searcher.  Even if didRefresh is false, it's
-        // possible old has some entries in it, which is fien: it means they were actually already included in the previously opened reader,
-        // so we can still safely drop them in that case.  We don't touch deletes here: they expire on their own index.gc_deletes
-        // timeframe:
+        // We can now drop old because these operations are now visible via the newly opened searcher.  Even if didRefresh is false, which
+        // means Lucene did not actually open a new reader because it detected no changes, it's possible old has some entries in it, which
+        // is fine: it means they were actually already included in the previously opened reader, so we can still safely drop them in that
+        // case.  This is because we assign a new "current" (in beforeRefresh) slightly before Lucene actually flushes any segments for the
+        // reopen, and so any concurrent indexing requests can still sneak in a few additions to that current map that are in fact reflected
+        // in the previous reader.   We don't touch deletes here: they expire on their own index.gc_deletes timeframe:
         old = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
     }
 
-    /** If includeDeletes is true we also check and return a tombstone delete. */
+    /** Returns the live version (add or delete) for this uid. */
     public VersionValue getUnderLock(BytesRef uid) {
         // First try to get the "live" value:
         VersionValue value = current.get(uid);
@@ -114,24 +133,66 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         return tombstones.get(uid);
     }
 
+    private void updateRAM(BytesRef uid, VersionValue oldVersion, VersionValue newVersion) {
+        if (oldVersion != null) {
+            long bytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + oldVersion.ramBytesUsed();
+            if (oldVersion.delete()) {
+                ramBytesUsedDeletes.addAndGet(-bytes);
+            } else {
+                ramBytesUsedAdds.addAndGet(-bytes);
+            }
+        }
+
+        long bytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + newVersion.ramBytesUsed();
+        if (newVersion.delete()) {
+            ramBytesUsedDeletes.addAndGet(bytes);
+        } else {
+            ramBytesUsedAdds.addAndGet(bytes);
+        }
+    }
+
     /** Adds this uid/version to the pending adds map. */
     public void putUnderLock(BytesRef uid, VersionValue version) {
         VersionValue prev = current.put(uid, version);
         if (prev != null) {
-            ramBytesUsed.addAndGet(-(BASE_BYTES_PER_ADD + uid.bytes.length + prev.ramBytesUsed()));
+            // Deduct RAM for the version we just replaced:
+            long bytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + prev.ramBytesUsed();
+            if (prev.delete()) {
+                ramBytesUsedDeletes.addAndGet(-bytes);
+            } else {
+                ramBytesUsedAdds.addAndGet(-bytes);
+            }
         }
-        ramBytesUsed.addAndGet(BASE_BYTES_PER_ADD + uid.bytes.length + version.ramBytesUsed());
+
+        long newBytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + version.ramBytesUsed();
+        VersionValue prevTombstone;
         if (version.delete()) {
-            tombstones.put(uid, version);
+            // Add RAM for the new version:
+            ramBytesUsedDeletes.addAndGet(newBytes);
+
+            // Also enroll the delete into tombstones, and account for its RAM too:
+            prevTombstone = tombstones.put(uid, version);
+            ramBytesUsedTombstones.addAndGet(newBytes);
         } else {
+            // Add RAM for the new version:
+            ramBytesUsedAdds.addAndGet(newBytes);
+
             // UID came back to life so we remove the tombstone:
-            tombstones.remove(uid);
+            prevTombstone = tombstones.remove(uid);
+        }
+
+        // Deduct tombstones bytes used for the version we just removed or replaced:
+        if (prevTombstone != null) {
+            ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_ENTRY + uid.bytes.length + prevTombstone.ramBytesUsed()));
         }
     }
 
     /** Removes this uid from the pending deletes map. */
     public void removeTombstoneUnderLock(BytesRef uid) {
-        tombstones.remove(uid);
+        VersionValue prev = tombstones.remove(uid);
+        if (prev != null) {
+            ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_ENTRY + uid.bytes.length + prev.ramBytesUsed()));
+        }
     }
 
     /** Caller has a lock, so that this uid will not be concurrently added/deleted by another thread. */
@@ -139,7 +200,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         return tombstones.get(uid);
     }
 
-    /** Iterates over all old versions, i.e. versions that have already been exposed in a reader. */
+    /** Iterates over all deleted versions, including new ones (not yet exposed via reader) and old ones (exposed via reader but not yet GC'd). */
     public Iterable<Map.Entry<BytesRef,VersionValue>> getAllTombstones() {
         return tombstones.entrySet();
     }
@@ -149,15 +210,27 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         current.clear();
         old.clear();
         tombstones.clear();
-        ramBytesUsed.set(0);
+        ramBytesUsedAdds.set(0);
+        ramBytesUsedDeletes.set(0);
+        ramBytesUsedTombstones.set(0);
         if (mgr != null) {
             mgr.removeListener(this);
             mgr = null;
         }
     }
 
+    // Not until we implement Accountable interface (Lucene 4.9):
     // @Override
     public long ramBytesUsed() {
-        return ramBytesUsed.get();
+        // Deletes are in both current and tombstones
+        // nocommit we are undercounting here because we don't count BASE_BYTES_PER_ENTRY for the deletes in current
+        // nocommit also, if index.gc_deletes is lower than refresh interval, this can undercount because tombstones can be cleared before
+        // current map is ... but w/ defaults it's OK
+        return ramBytesUsedAdds.get() + ramBytesUsedTombstones.get();
+    }
+
+    /** Same as {@link ramBytesUsed} except does not include tombstones because they don't clear on refresh. */
+    public long ramBytesUsedForRefresh() {
+        return ramBytesUsedAdds.get() + ramBytesUsedDeletes.get();
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
@@ -48,29 +48,28 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
 
     private ReferenceManager mgr;
 
-    /** Bytes consumed for each added UID + version, not including UID's bytes.
+    /** Bytes consumed for each BytesRef UID:
      *
-     * VersionValue.ramBytesUsed() +
-     *
-     * BytesRef:
-     *     + NUM_BYTES_OBJECT_HEADER + 2*NUM_BYTES_INT + NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER [ + uid.text().length()]
-     *
-     * CHM.Entry:
-     *     + NUM_BYTES_OBJECT_HEADER + 3*NUM_BYTES_OBJECT_REF + NUM_BYTES_INT
-     *
-     * CHM's pointer to CHM.Entry, double for approx load factor:
-     *     + 2*NUM_BYTES_OBJECT_REF */
-
-    private static final int BASE_BYTES_PER_ENTRY = 2*RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
-        3*RamUsageEstimator.NUM_BYTES_INT +
-        6*RamUsageEstimator.NUM_BYTES_OBJECT_REF + 
+     *  NUM_BYTES_OBJECT_HEADER + 2*NUM_BYTES_INT + NUM_BYTES_OBJECT_REF + NUM_BYTES_ARRAY_HEADER [ + bytes.length] */
+    private static final int BASE_BYTES_PER_BYTESREF = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
+        2*RamUsageEstimator.NUM_BYTES_INT +
+        RamUsageEstimator.NUM_BYTES_OBJECT_REF + 
         RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 
-    /** Tracks bytes used by add ops in current */
-    final AtomicLong ramBytesUsedAdds = new AtomicLong();
+    /** Bytes used by having CHM point to a key/value:
+     *
+     *  CHM.Entry:
+     *     + NUM_BYTES_OBJECT_HEADER + 3*NUM_BYTES_OBJECT_REF + NUM_BYTES_INT
+     *
+     *  CHM's pointer to CHM.Entry, double for approx load factor:
+     *     + 2*NUM_BYTES_OBJECT_REF */
+    private static final int BASE_BYTES_PER_CHM_ENTRY = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER +
+        RamUsageEstimator.NUM_BYTES_INT +
+        5*RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 
-    /** Tracks bytes used by delete ops in current */
-    final AtomicLong ramBytesUsedDeletes = new AtomicLong();
+    /** Tracks bytes used by current map, i.e. what is freed on refresh. For deletes, which are also added to tombstones, we only account
+     *  for the CHM entry here, and account for BytesRef/VersionValue against the tombstones, since refresh would not clear this RAM. */
+    final AtomicLong ramBytesUsedCurrent = new AtomicLong();
 
     /** Tracks bytes used by tombstones (deletes) */
     final AtomicLong ramBytesUsedTombstones = new AtomicLong();
@@ -94,10 +93,9 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
     public void beforeRefresh() throws IOException {
         old = current;
 
-        // This is not 100% correct, since concurrent indexing ops can change these counters in between our execution of the following 3
+        // This is not 100% correct, since concurrent indexing ops can change these counters in between our execution of the following 2
         // lines, but that should be minor, and the error won't accumulate over time:
-        ramBytesUsedAdds.set(0);
-        ramBytesUsedDeletes.set(0);
+        ramBytesUsedCurrent.set(0);
 
         // Start sending all updates after this point to the new
         // map.  While reopen is running, any lookup will first
@@ -113,7 +111,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         // is fine: it means they were actually already included in the previously opened reader, so we can still safely drop them in that
         // case.  This is because we assign a new "current" (in beforeRefresh) slightly before Lucene actually flushes any segments for the
         // reopen, and so any concurrent indexing requests can still sneak in a few additions to that current map that are in fact reflected
-        // in the previous reader.   We don't touch deletes here: they expire on their own index.gc_deletes timeframe:
+        // in the previous reader.   We don't touch tombstones here: they expire on their own index.gc_deletes timeframe:
         old = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
     }
 
@@ -135,45 +133,70 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
 
     /** Adds this uid/version to the pending adds map. */
     public void putUnderLock(BytesRef uid, VersionValue version) {
+
+        long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
+
         VersionValue prev = current.put(uid, version);
         if (prev != null) {
             // Deduct RAM for the version we just replaced:
-            long bytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + prev.ramBytesUsed();
-            if (prev.delete()) {
-                ramBytesUsedDeletes.addAndGet(-bytes);
-            } else {
-                ramBytesUsedAdds.addAndGet(-bytes);
+            long prevBytes = BASE_BYTES_PER_CHM_ENTRY;
+            if (prev.delete() == false) {
+                prevBytes += prev.ramBytesUsed() + uidRAMBytesUsed;
             }
+            ramBytesUsedCurrent.addAndGet(-prevBytes);
         }
 
-        long newBytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + version.ramBytesUsed();
+        // Add RAM for the new version:
+        long newBytes = BASE_BYTES_PER_CHM_ENTRY;
+        if (version.delete() == false) {
+            newBytes += version.ramBytesUsed() + uidRAMBytesUsed;
+        }
+        ramBytesUsedCurrent.addAndGet(newBytes);
+
         VersionValue prevTombstone;
         if (version.delete()) {
-            // Add RAM for the new version:
-            ramBytesUsedDeletes.addAndGet(newBytes);
-
             // Also enroll the delete into tombstones, and account for its RAM too:
             prevTombstone = tombstones.put(uid, version);
-            ramBytesUsedTombstones.addAndGet(newBytes);
-        } else {
-            // Add RAM for the new version:
-            ramBytesUsedAdds.addAndGet(newBytes);
 
+            // We initially account for BytesRef/VersionValue RAM for a delete against the tombstones, because this RAM will not be freed up
+            // on refresh. Later, in removeTombstoneUnderLock, if we clear the tombstone entry but the delete remains in current, we shift
+            // the accounting to current:
+            ramBytesUsedTombstones.addAndGet(BASE_BYTES_PER_CHM_ENTRY + version.ramBytesUsed() + uidRAMBytesUsed);
+
+            if (prevTombstone == null && prev != null && prev.delete()) {
+                // If prev was a delete that had already been removed from tombstones, then current was already accounting for the
+                // BytesRef/VersionValue RAM, so we now deduct that as well:
+                ramBytesUsedCurrent.addAndGet(-(prev.ramBytesUsed() + uidRAMBytesUsed));
+            }
+        } else {
             // UID came back to life so we remove the tombstone:
             prevTombstone = tombstones.remove(uid);
         }
 
         // Deduct tombstones bytes used for the version we just removed or replaced:
         if (prevTombstone != null) {
-            ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_ENTRY + uid.bytes.length + prevTombstone.ramBytesUsed()));
+            long v = ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_CHM_ENTRY + prevTombstone.ramBytesUsed() + uidRAMBytesUsed));
+            assert v >= 0;
         }
     }
 
     /** Removes this uid from the pending deletes map. */
     public void removeTombstoneUnderLock(BytesRef uid) {
+
+        long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
+
         VersionValue prev = tombstones.remove(uid);
         if (prev != null) {
-            ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_ENTRY + uid.bytes.length + prev.ramBytesUsed()));
+            assert prev.delete();
+            long v = ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_CHM_ENTRY + prev.ramBytesUsed() + uidRAMBytesUsed));
+            assert v >= 0;
+        }
+        VersionValue curVersion = current.get(uid);
+        if (curVersion != null && curVersion.delete()) {
+            // We now shift accounting of the BytesRef from tombstones to current, because a refresh would clear this RAM.  This should be
+            // uncommon, because with the default refresh=1s and gc_deletes=60s, deletes should be cleared from current long before we drop
+            // them from tombstones:
+            ramBytesUsedCurrent.addAndGet(curVersion.ramBytesUsed() + uidRAMBytesUsed);
         }
     }
 
@@ -192,8 +215,7 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         current.clear();
         old.clear();
         tombstones.clear();
-        ramBytesUsedAdds.set(0);
-        ramBytesUsedDeletes.set(0);
+        ramBytesUsedCurrent.set(0);
         ramBytesUsedTombstones.set(0);
         if (mgr != null) {
             mgr.removeListener(this);
@@ -204,19 +226,12 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
     // Not until we implement Accountable interface (Lucene 4.9):
     // @Override
     public long ramBytesUsed() {
-        // Deletes are in both current and tombstones
-
-        // TODO: this isn't 100% accurate, because we fail to count BASE_BYTES_PER_ENTRY for deletes in current when pointing to a
-        // VersionValue also held in the tombstones, but since we do max(deletes) below, in the worst case (deletes in current using more
-        // RAM than tombstones) it will be correct
-
-        // We take max(deletes) in case the index.gc_deletes is lower than the refresh interval (which is not the default settings).  In
-        // that case, tombstones can be cleaned out but we still have many deletes buffered in RAM:
-        return ramBytesUsedAdds.get() + Math.max(ramBytesUsedDeletes.get(), ramBytesUsedTombstones.get());
+        return ramBytesUsedCurrent.get() + ramBytesUsedTombstones.get();
     }
 
-    /** Same as {@link ramBytesUsed} except does not include tombstones because they don't clear on refresh. */
+    /** Returns how much RAM would be freed up by refreshing. This is {@link ramBytesUsed} except does not include tombstones because they
+     *  don't clear on refresh. */
     public long ramBytesUsedForRefresh() {
-        return ramBytesUsedAdds.get() + ramBytesUsedDeletes.get();
+        return ramBytesUsedCurrent.get();
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/LiveVersionMap.java
@@ -133,24 +133,6 @@ class LiveVersionMap implements ReferenceManager.RefreshListener {
         return tombstones.get(uid);
     }
 
-    private void updateRAM(BytesRef uid, VersionValue oldVersion, VersionValue newVersion) {
-        if (oldVersion != null) {
-            long bytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + oldVersion.ramBytesUsed();
-            if (oldVersion.delete()) {
-                ramBytesUsedDeletes.addAndGet(-bytes);
-            } else {
-                ramBytesUsedAdds.addAndGet(-bytes);
-            }
-        }
-
-        long bytes = BASE_BYTES_PER_ENTRY + uid.bytes.length + newVersion.ramBytesUsed();
-        if (newVersion.delete()) {
-            ramBytesUsedDeletes.addAndGet(bytes);
-        } else {
-            ramBytesUsedAdds.addAndGet(bytes);
-        }
-    }
-
     /** Adds this uid/version to the pending adds map. */
     public void putUnderLock(BytesRef uid, VersionValue version) {
         VersionValue prev = current.put(uid, version);

--- a/src/main/java/org/elasticsearch/index/engine/internal/VersionValue.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/VersionValue.java
@@ -19,9 +19,16 @@
 
 package org.elasticsearch.index.engine.internal;
 
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.Version;
 import org.elasticsearch.index.translog.Translog;
 
 class VersionValue {
+    // TODO: add implements Accountable with Lucene 4.9
+    static {
+        assert Version.CURRENT.luceneVersion == org.apache.lucene.util.Version.LUCENE_48 : "Add 'implements Accountable' here";
+    }
+
     private final long version;
     private final Translog.Location translogLocation;
 
@@ -44,5 +51,10 @@ class VersionValue {
 
     public Translog.Location translogLocation() {
         return this.translogLocation;
+    }
+
+    // @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.NUM_BYTES_LONG + RamUsageEstimator.NUM_BYTES_OBJECT_REF + translogLocation.ramBytesUsed();
     }
 }

--- a/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -19,8 +19,13 @@
 
 package org.elasticsearch.index.translog;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.apache.lucene.index.Term;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -35,9 +40,6 @@ import org.elasticsearch.index.CloseableIndexComponent;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShardComponent;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  *
@@ -138,6 +140,12 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent {
     TranslogStats stats();
 
     static class Location {
+
+        // TODO: add implements Accountable with Lucene 4.9
+        static {
+            assert Version.CURRENT.luceneVersion == org.apache.lucene.util.Version.LUCENE_48 : "Add 'implements Accountable' here";
+        }
+
         public final long translogId;
         public final long translogLocation;
         public final int size;
@@ -146,6 +154,11 @@ public interface Translog extends IndexShardComponent, CloseableIndexComponent {
             this.translogId = translogId;
             this.translogLocation = translogLocation;
             this.size = size;
+        }
+
+        // @Override
+        public long ramBytesUsed() {
+            return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 2*RamUsageEstimator.NUM_BYTES_LONG + RamUsageEstimator.NUM_BYTES_INT;
         }
     }
 

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -79,7 +79,7 @@ public class TranslogService extends AbstractIndexShardComponent {
         this.indexShard = indexShard;
         this.translog = translog;
 
-        this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", 5000));
+        this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
         this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(200, ByteSizeUnit.MB));
         this.flushThresholdPeriod = componentSettings.getAsTime(FLUSH_THRESHOLD_PERIOD_KEY, TimeValue.timeValueMinutes(30));
         this.interval = componentSettings.getAsTime(FLUSH_THRESHOLD_INTERVAL_KEY, timeValueMillis(5000));

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -78,7 +78,6 @@ public class TranslogService extends AbstractIndexShardComponent {
         this.indexSettingsService = indexSettingsService;
         this.indexShard = indexShard;
         this.translog = translog;
-
         this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
         this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(200, ByteSizeUnit.MB));
         this.flushThresholdPeriod = componentSettings.getAsTime(FLUSH_THRESHOLD_PERIOD_KEY, TimeValue.timeValueMinutes(30));

--- a/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -78,7 +78,7 @@ public class TranslogService extends AbstractIndexShardComponent {
         this.indexSettingsService = indexSettingsService;
         this.indexShard = indexShard;
         this.translog = translog;
-        this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", Integer.MAX_VALUE));
+        this.flushThresholdOperations = componentSettings.getAsInt(FLUSH_THRESHOLD_OPS_KEY, componentSettings.getAsInt("flush_threshold", 5000));
         this.flushThresholdSize = componentSettings.getAsBytesSize(FLUSH_THRESHOLD_SIZE_KEY, new ByteSizeValue(200, ByteSizeUnit.MB));
         this.flushThresholdPeriod = componentSettings.getAsTime(FLUSH_THRESHOLD_PERIOD_KEY, TimeValue.timeValueMinutes(30));
         this.interval = componentSettings.getAsTime(FLUSH_THRESHOLD_INTERVAL_KEY, timeValueMillis(5000));

--- a/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
+++ b/src/test/java/org/elasticsearch/index/engine/internal/InternalEngineTests.java
@@ -31,6 +31,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexDeletionPolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -1181,6 +1182,77 @@ public class InternalEngineTests extends ElasticsearchTestCase {
             rootLogger.removeAppender(mockAppender);
             rootLogger.setLevel(savedLevel);
         }
+    }
+
+    @Slow
+    @Test
+    public void testEnableGcDeletes() throws Exception {
+
+        // Make sure enableGCDeletes == false works:
+        Settings settings = ImmutableSettings.builder()
+                .put(InternalEngine.INDEX_GC_DELETES, "0ms")
+                .build();
+
+        Engine engine = new InternalEngine(shardId, settings, threadPool,
+                                           engineSettingsService,
+                                           new ShardIndexingService(shardId, settings,
+                                                                    new ShardSlowLogIndexingService(shardId, EMPTY_SETTINGS, engineSettingsService)),
+                                           null, store, createSnapshotDeletionPolicy(), createTranslog(), createMergePolicy(), createMergeScheduler(engineSettingsService),
+                                           new AnalysisService(shardId.index()), new SimilarityService(shardId.index()), new CodecService(shardId.index()));
+        engine.start();
+        engine.enableGcDeletes(false);
+
+        // Add document
+        Document document = testDocument();
+        document.add(new TextField("value", "test1", Field.Store.YES));
+
+        ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, document, Lucene.STANDARD_ANALYZER, B_2, false);
+        engine.index(new Engine.Index(null, newUid("1"), doc, 1, VersionType.EXTERNAL, Engine.Operation.Origin.PRIMARY, System.nanoTime(), false));
+
+        // Delete document we just added:
+        engine.delete(new Engine.Delete("test", "1", newUid("1"), 10, VersionType.EXTERNAL, Engine.Operation.Origin.PRIMARY, System.nanoTime(), false));
+        
+        // Get should not find the document
+        Engine.GetResult getResult = engine.get(new Engine.Get(true, newUid("1")));
+        assertThat(getResult.exists(), equalTo(false));
+
+        // Give the gc pruning logic a chance to kick in
+        Thread.sleep(1000);
+
+        if (randomBoolean()) {
+            engine.refresh(new Engine.Refresh("test"));
+        }
+
+        // Delete non-existent document
+        engine.delete(new Engine.Delete("test", "2", newUid("2"), 10, VersionType.EXTERNAL, Engine.Operation.Origin.PRIMARY, System.nanoTime(), false));
+
+        // Get should not find the document (we never indexed uid=2):
+        getResult = engine.get(new Engine.Get(true, newUid("2")));
+        assertThat(getResult.exists(), equalTo(false));
+
+        // Try to index uid=1 with a too-old version, should fail:
+        try {
+            engine.index(new Engine.Index(null, newUid("1"), doc, 2, VersionType.EXTERNAL, Engine.Operation.Origin.PRIMARY, System.nanoTime()));
+            fail("did not hit expected exception");
+        } catch (VersionConflictEngineException vcee) {
+            // expected
+        }
+
+        // Get should still not find the document
+        getResult = engine.get(new Engine.Get(true, newUid("1")));        
+        assertThat(getResult.exists(), equalTo(false));
+
+        // Try to index uid=2 with a too-old version, should fail:
+        try {
+            engine.index(new Engine.Index(null, newUid("2"), doc, 2, VersionType.EXTERNAL, Engine.Operation.Origin.PRIMARY, System.nanoTime()));
+            fail("did not hit expected exception");
+        } catch (VersionConflictEngineException vcee) {
+            // expected
+        }
+
+        // Get should not find the document
+        getResult = engine.get(new Engine.Get(true, newUid("2")));
+        assertThat(getResult.exists(), equalTo(false));
     }
 
     protected Term newUid(String id) {

--- a/src/test/java/org/elasticsearch/versioning/SimpleVersioningTests.java
+++ b/src/test/java/org/elasticsearch/versioning/SimpleVersioningTests.java
@@ -675,7 +675,7 @@ public class SimpleVersioningTests extends ElasticsearchIntegrationTest {
 
         HashMap<String,Object> newSettings = new HashMap<>();
         newSettings.put("index.gc_deletes", "10ms");
-        newSettings.put("index.refresh_interval", "10000s");
+        newSettings.put("index.refresh_interval", "-1");
         client()
             .admin()
             .indices()
@@ -694,8 +694,10 @@ public class SimpleVersioningTests extends ElasticsearchIntegrationTest {
             .execute()
             .actionGet();
 
-        // Force refresh so the add is visible in the searcher:
-        refresh();
+        if (randomBoolean()) {
+            // Force refresh so the add is sometimes visible in the searcher:
+            refresh();
+        }
 
         // Delete it
         client()
@@ -763,8 +765,10 @@ public class SimpleVersioningTests extends ElasticsearchIntegrationTest {
             .execute()
             .actionGet();
 
-        // Force refresh so the add is visible in the searcher:
-        refresh();
+        if (randomBoolean()) {
+            // Force refresh so the add is sometimes visible in the searcher:
+            refresh();
+        }
 
         // Delete it
         client()

--- a/src/test/java/org/elasticsearch/versioning/SimpleVersioningTests.java
+++ b/src/test/java/org/elasticsearch/versioning/SimpleVersioningTests.java
@@ -454,6 +454,11 @@ public class SimpleVersioningTests extends ElasticsearchIntegrationTest {
         public String id;
         public long version;
         public boolean delete;
+
+        @Override
+        public String toString() {
+            return "id=" + id + " version=" + version + " delete?=" + delete;
+        }
     }
 
 


### PR DESCRIPTION
If the user sets a high refresh interval, the versionMap can use
unbounded RAM.  I fixed LiveVersionMap to track its RAM used, and
trigger refresh if it's > 25% of IW's RAM buffer.  (We could add
another setting for this but we have so many settings already?).

I also fixed deletes to prune every index.gc_deletes/4 msec, and I
only save a delete tombstone if index.gc_deletes > 0.

I think we could expose the RAM used by versionMap somewhere
(Marvel?  _cat?), but we can do that separately ... I put a TODO.

Closes #6378
