### PR TITLE
Make the HighlightQuery class public

### DIFF
--- a/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
+++ b/src/main/java/org/elasticsearch/search/highlight/HighlighterContext.java
@@ -47,12 +47,12 @@ public class HighlighterContext {
         this.query = query;
     }
 
-    static class HighlightQuery {
+    public static class HighlightQuery {
         private final Query originalQuery;
         private final Query query;
         private final boolean queryRewritten;
 
-        HighlightQuery(Query originalQuery, Query query, boolean queryRewritten) {
+        protected HighlightQuery(Query originalQuery, Query query, boolean queryRewritten) {
             this.originalQuery = originalQuery;
             this.query = query;
             this.queryRewritten = queryRewritten;


### PR DESCRIPTION
We're using the highlighter directly in our code, and the introduction of the package-scoped HighlightQuery in 4aa59aff0058b05e822592431eda4a469a6b9eef has made this impossible without building our own little fork.
