### PR TITLE
Improve deletion of corrupted snapshots

### DIFF
--- a/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -259,7 +259,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     @Override
     public void deleteSnapshot(SnapshotId snapshotId) {
         Snapshot snapshot = readSnapshot(snapshotId);
-        MetaData metaData = readSnapshotMetaData(snapshotId, snapshot.indices());
+        MetaData metaData = readSnapshotMetaData(snapshotId, snapshot.indices(), true);
         try {
             String blobName = snapshotBlobName(snapshotId);
             // Delete snapshot file first so we wouldn't end up with partially deleted snapshot that looks OK
@@ -284,11 +284,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                 try {
                     indexMetaDataBlobContainer.deleteBlob(blobName);
                 } catch (IOException ex) {
-                    throw new SnapshotException(snapshotId, "failed to delete metadata", ex);
+                    logger.warn("[{}] failed to delete metadata for index [{}]", ex, snapshotId, index);
                 }
                 IndexMetaData indexMetaData = metaData.index(index);
-                for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
-                    indexShardRepository.delete(snapshotId, new ShardId(index, i));
+                if (indexMetaData != null) {
+                    for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
+                        indexShardRepository.delete(snapshotId, new ShardId(index, i));
+                    }
                 }
             }
         } catch (IOException ex) {
@@ -367,41 +369,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      */
     @Override
     public MetaData readSnapshotMetaData(SnapshotId snapshotId, ImmutableList<String> indices) {
-        MetaData metaData;
-        try {
-            byte[] data = snapshotsBlobContainer.readBlobFully(metaDataBlobName(snapshotId));
-            metaData = readMetaData(data);
-        } catch (FileNotFoundException | NoSuchFileException ex) {
-            throw new SnapshotMissingException(snapshotId, ex);
-        } catch (IOException ex) {
-            throw new SnapshotException(snapshotId, "failed to get snapshots", ex);
-        }
-        MetaData.Builder metaDataBuilder = MetaData.builder(metaData);
-        for (String index : indices) {
-            BlobPath indexPath = basePath().add("indices").add(index);
-            ImmutableBlobContainer indexMetaDataBlobContainer = blobStore().immutableBlobContainer(indexPath);
-            XContentParser parser = null;
-            try {
-                byte[] data = indexMetaDataBlobContainer.readBlobFully(snapshotBlobName(snapshotId));
-                parser = XContentHelper.createParser(data, 0, data.length);
-                XContentParser.Token token;
-                if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
-                    IndexMetaData indexMetaData = IndexMetaData.Builder.fromXContent(parser);
-                    if ((token = parser.nextToken()) == XContentParser.Token.END_OBJECT) {
-                        metaDataBuilder.put(indexMetaData, false);
-                        continue;
-                    }
-                }
-                throw new ElasticsearchParseException("unexpected token  [" + token + "]");
-            } catch (IOException ex) {
-                throw new SnapshotException(snapshotId, "failed to read metadata", ex);
-            } finally {
-                if (parser != null) {
-                    parser.close();
-                }
-            }
-        }
-        return metaDataBuilder.build();
+        return readSnapshotMetaData(snapshotId, indices, false);
     }
 
     /**
@@ -439,6 +407,48 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         }
     }
 
+    private MetaData readSnapshotMetaData(SnapshotId snapshotId, ImmutableList<String> indices, boolean ignoreIndexErrors) {
+        MetaData metaData;
+        try {
+            byte[] data = snapshotsBlobContainer.readBlobFully(metaDataBlobName(snapshotId));
+            metaData = readMetaData(data);
+        } catch (FileNotFoundException | NoSuchFileException ex) {
+            throw new SnapshotMissingException(snapshotId, ex);
+        } catch (IOException ex) {
+            throw new SnapshotException(snapshotId, "failed to get snapshots", ex);
+        }
+        MetaData.Builder metaDataBuilder = MetaData.builder(metaData);
+        for (String index : indices) {
+            BlobPath indexPath = basePath().add("indices").add(index);
+            ImmutableBlobContainer indexMetaDataBlobContainer = blobStore().immutableBlobContainer(indexPath);
+            try {
+                byte[] data = indexMetaDataBlobContainer.readBlobFully(snapshotBlobName(snapshotId));
+                try (XContentParser parser = XContentHelper.createParser(data, 0, data.length)) {
+                    XContentParser.Token token;
+                    if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
+                        IndexMetaData indexMetaData = IndexMetaData.Builder.fromXContent(parser);
+                        if ((token = parser.nextToken()) == XContentParser.Token.END_OBJECT) {
+                            metaDataBuilder.put(indexMetaData, false);
+                            continue;
+                        }
+                    }
+                    if (!ignoreIndexErrors) {
+                        throw new ElasticsearchParseException("unexpected token  [" + token + "]");
+                    } else {
+                        logger.warn("[{}] [{}] unexpected token while reading snapshot metadata [{}]", snapshotId, index, token);
+                    }
+                }
+            } catch (IOException ex) {
+                if (!ignoreIndexErrors) {
+                    throw new SnapshotException(snapshotId, "failed to read metadata", ex);
+                } else {
+                    logger.warn("[{}] [{}] failed to read metadata for index", snapshotId, index, ex);
+                }
+            }
+        }
+        return metaDataBuilder.build();
+    }
+
     /**
      * Configures RateLimiter based on repository and global settings
      *
@@ -465,9 +475,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      * @throws IOException parse exceptions
      */
     private BlobStoreSnapshot readSnapshot(byte[] data) throws IOException {
-        XContentParser parser = null;
-        try {
-            parser = XContentHelper.createParser(data, 0, data.length);
+        try (XContentParser parser = XContentHelper.createParser(data, 0, data.length)) {
             XContentParser.Token token;
             if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
                 if ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
@@ -479,10 +487,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                 }
             }
             throw new ElasticsearchParseException("unexpected token  [" + token + "]");
-        } finally {
-            if (parser != null) {
-                parser.close();
-            }
         }
     }
 
@@ -494,9 +498,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      * @throws IOException parse exceptions
      */
     private MetaData readMetaData(byte[] data) throws IOException {
-        XContentParser parser = null;
-        try {
-            parser = XContentHelper.createParser(data, 0, data.length);
+        try (XContentParser parser = XContentHelper.createParser(data, 0, data.length)) {
             XContentParser.Token token;
             if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
                 if ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
@@ -508,10 +510,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                 }
             }
             throw new ElasticsearchParseException("unexpected token  [" + token + "]");
-        } finally {
-            if (parser != null) {
-                parser.close();
-            }
         }
     }
 
@@ -615,9 +613,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     protected ImmutableList<SnapshotId> readSnapshotList() throws IOException {
         byte[] data = snapshotsBlobContainer.readBlobFully(SNAPSHOTS_FILE);
         ArrayList<SnapshotId> snapshots = new ArrayList<>();
-        XContentParser parser = null;
-        try {
-            parser = XContentHelper.createParser(data, 0, data.length);
+        try (XContentParser parser = XContentHelper.createParser(data, 0, data.length)) {
             if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
                 if (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
                     String currentFieldName = parser.currentName();
@@ -629,10 +625,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                         }
                     }
                 }
-            }
-        } finally {
-            if (parser != null) {
-                parser.close();
             }
         }
         return ImmutableList.copyOf(snapshots);


### PR DESCRIPTION
Makes it possible to delete snapshots that are missing some of the metadata files. This can happen if snapshot creation failed because repository drive ran out of disk space.

Closes #6383
