### PR TITLE
Transport: copied over REST headers from RestRequest to TransportRequest

### DIFF
--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequest.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkRequest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  * A request to abort a specified benchmark
  */
-public class AbortBenchmarkRequest extends AcknowledgedRequest {
+public class AbortBenchmarkRequest extends AcknowledgedRequest<AbortBenchmarkRequest> {
 
     private String[] benchmarkNames = Strings.EMPTY_ARRAY;
 

--- a/src/main/java/org/elasticsearch/rest/BaseActionRequestRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseActionRequestRestHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * Base handlers for {@link org.elasticsearch.rest.RestRequest}s that map to an {@link org.elasticsearch.action.ActionRequest}s
+ */
+public abstract class BaseActionRequestRestHandler<Request extends ActionRequest<Request>> extends BaseRestHandler {
+
+    protected BaseActionRequestRestHandler(Settings settings, Client client) {
+        super(settings, client);
+    }
+
+    @Override
+    public final void handleRequest(RestRequest restRequest, RestChannel channel) throws Exception {
+        Request actionRequest = newRequest(restRequest);
+        doHandleRequest(restRequest, channel, copyHeaders(restRequest, actionRequest));
+    }
+
+    /**
+     * Creates a new {@link org.elasticsearch.action.ActionRequest} based on the current {@link org.elasticsearch.rest.RestRequest}
+     */
+    protected abstract Request newRequest(RestRequest request) throws Exception;
+
+    /**
+     * Executes the request
+     */
+    protected abstract void doHandleRequest(RestRequest restRequest, RestChannel restChannel, Request request);
+}

--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.rest;
 
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 
 /**
- *
+ * Base implementation for REST requests handling
  */
 public abstract class BaseRestHandler extends AbstractComponent implements RestHandler {
 
@@ -33,5 +34,10 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
     protected BaseRestHandler(Settings settings, Client client) {
         super(settings);
         this.client = client;
+    }
+
+    protected static <Request extends ActionRequest> Request copyHeaders(RestRequest restRequest, Request actionRequest) {
+        actionRequest.putHeaders(restRequest.headers());
+        return actionRequest;
     }
 }

--- a/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.rest;
 
 /**
- *
+ * Handler for REST requests
  */
 public interface RestHandler {
 

--- a/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -64,6 +64,7 @@ import org.elasticsearch.rest.action.admin.indices.mapping.get.RestGetMappingAct
 import org.elasticsearch.rest.action.admin.indices.mapping.put.RestPutMappingAction;
 import org.elasticsearch.rest.action.admin.indices.open.RestOpenIndexAction;
 import org.elasticsearch.rest.action.admin.indices.optimize.RestOptimizeAction;
+import org.elasticsearch.rest.action.admin.indices.recovery.RestRecoveryAction;
 import org.elasticsearch.rest.action.admin.indices.refresh.RestRefreshAction;
 import org.elasticsearch.rest.action.admin.indices.segments.RestIndicesSegmentsAction;
 import org.elasticsearch.rest.action.admin.indices.settings.RestGetSettingsAction;
@@ -77,8 +78,9 @@ import org.elasticsearch.rest.action.admin.indices.validate.query.RestValidateQu
 import org.elasticsearch.rest.action.admin.indices.warmer.delete.RestDeleteWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.get.RestGetWarmerAction;
 import org.elasticsearch.rest.action.admin.indices.warmer.put.RestPutWarmerAction;
-import org.elasticsearch.rest.action.admin.indices.recovery.RestRecoveryAction;
-import org.elasticsearch.rest.action.bench.RestBenchAction;
+import org.elasticsearch.rest.action.bench.RestBenchAbortAction;
+import org.elasticsearch.rest.action.bench.RestBenchStatusAction;
+import org.elasticsearch.rest.action.bench.RestBenchSubmitAction;
 import org.elasticsearch.rest.action.bulk.RestBulkAction;
 import org.elasticsearch.rest.action.cat.*;
 import org.elasticsearch.rest.action.delete.RestDeleteAction;
@@ -211,7 +213,9 @@ public class RestActionModule extends AbstractModule {
 
         bind(RestRecoveryAction.class).asEagerSingleton();
         // Benchmark API
-        bind(RestBenchAction.class).asEagerSingleton();
+        bind(RestBenchSubmitAction.class).asEagerSingleton();
+        bind(RestBenchStatusAction.class).asEagerSingleton();
+        bind(RestBenchAbortAction.class).asEagerSingleton();
 
         // cat API
         Multibinder<AbstractCatAction> catActionMultibinder = Multibinder.newSetBinder(binder(), AbstractCatAction.class);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -39,7 +39,7 @@ import static org.elasticsearch.client.Requests.clusterHealthRequest;
 /**
  *
  */
-public class RestClusterHealthAction extends BaseRestHandler {
+public class RestClusterHealthAction extends BaseActionRequestRestHandler<ClusterHealthRequest> {
 
     @Inject
     public RestClusterHealthAction(Settings settings, Client client, RestController controller) {
@@ -50,7 +50,7 @@ public class RestClusterHealthAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected ClusterHealthRequest newRequest(RestRequest request) {
         ClusterHealthRequest clusterHealthRequest = clusterHealthRequest(Strings.splitStringByCommaToArray(request.param("index")));
         clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
         clusterHealthRequest.listenerThreaded(false);
@@ -63,7 +63,11 @@ public class RestClusterHealthAction extends BaseRestHandler {
         clusterHealthRequest.waitForRelocatingShards(request.paramAsInt("wait_for_relocating_shards", clusterHealthRequest.waitForRelocatingShards()));
         clusterHealthRequest.waitForActiveShards(request.paramAsInt("wait_for_active_shards", clusterHealthRequest.waitForActiveShards()));
         clusterHealthRequest.waitForNodes(request.param("wait_for_nodes", clusterHealthRequest.waitForNodes()));
+        return clusterHealthRequest;
+    }
 
-        client.admin().cluster().health(clusterHealthRequest, new RestToXContentListener<ClusterHealthResponse>(channel));
+    @Override
+    protected void doHandleRequest(RestRequest restRequest, RestChannel restChannel, ClusterHealthRequest request) {
+        client.admin().cluster().health(request, new RestToXContentListener<ClusterHealthResponse>(restChannel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
@@ -33,7 +33,7 @@ import org.elasticsearch.rest.action.support.RestResponseListener;
 
 /**
  */
-public class RestNodesHotThreadsAction extends BaseRestHandler {
+public class RestNodesHotThreadsAction extends BaseActionRequestRestHandler<NodesHotThreadsRequest> {
 
     @Inject
     public RestNodesHotThreadsAction(Settings settings, Client client, RestController controller) {
@@ -50,14 +50,19 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected NodesHotThreadsRequest newRequest(RestRequest request) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(nodesIds);
         nodesHotThreadsRequest.threads(request.paramAsInt("threads", nodesHotThreadsRequest.threads()));
         nodesHotThreadsRequest.type(request.param("type", nodesHotThreadsRequest.type()));
         nodesHotThreadsRequest.interval(TimeValue.parseTimeValue(request.param("interval"), nodesHotThreadsRequest.interval()));
         nodesHotThreadsRequest.snapshots(request.paramAsInt("snapshots", nodesHotThreadsRequest.snapshots()));
-        client.admin().cluster().nodesHotThreads(nodesHotThreadsRequest, new RestResponseListener<NodesHotThreadsResponse>(channel) {
+        return nodesHotThreadsRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, NodesHotThreadsRequest request) {
+        client.admin().cluster().nodesHotThreads(request, new RestResponseListener<NodesHotThreadsResponse>(channel) {
             @Override
             public RestResponse buildResponse(NodesHotThreadsResponse response) throws Exception {
                 StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 /**
  *
  */
-public class RestNodesInfoAction extends BaseRestHandler {
+public class RestNodesInfoAction extends BaseActionRequestRestHandler<NodesInfoRequest> {
 
     private final SettingsFilter settingsFilter;
     private final static Set<String> ALLOWED_METRICS = Sets.newHashSet("http", "jvm", "network", "os", "plugins", "process", "settings", "thread_pool", "transport");
@@ -59,7 +59,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected NodesInfoRequest newRequest(RestRequest request) {
         String[] nodeIds;
         Set<String> metrics;
 
@@ -99,14 +99,17 @@ public class RestNodesInfoAction extends BaseRestHandler {
             nodesInfoRequest.http(metrics.contains("http"));
             nodesInfoRequest.plugins(metrics.contains("plugins"));
         }
+        return nodesInfoRequest;
+    }
 
-        client.admin().cluster().nodesInfo(nodesInfoRequest, new RestBuilderListener<NodesInfoResponse>(channel) {
-
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, NodesInfoRequest request) {
+        client.admin().cluster().nodesInfo(request, new RestBuilderListener<NodesInfoResponse>(channel) {
             @Override
             public RestResponse buildResponse(NodesInfoResponse response, XContentBuilder builder) throws Exception {
                 response.settingsFilter(settingsFilter);
                 builder.startObject();
-                response.toXContent(builder, request);
+                response.toXContent(builder, restRequest);
                 builder.endObject();
                 return new BytesRestResponse(RestStatus.OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 /**
  *
  */
-public class RestNodesRestartAction extends BaseRestHandler {
+public class RestNodesRestartAction extends BaseActionRequestRestHandler<NodesRestartRequest> {
 
     @Inject
     public RestNodesRestartAction(Settings settings, Client client, RestController controller) {
@@ -43,12 +43,17 @@ public class RestNodesRestartAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected NodesRestartRequest newRequest(RestRequest request) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesRestartRequest nodesRestartRequest = new NodesRestartRequest(nodesIds);
         nodesRestartRequest.listenerThreaded(false);
         nodesRestartRequest.delay(request.paramAsTime("delay", nodesRestartRequest.delay()));
-        client.admin().cluster().nodesRestart(nodesRestartRequest, new RestBuilderListener<NodesRestartResponse>(channel) {
+        return nodesRestartRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, NodesRestartRequest request) {
+        client.admin().cluster().nodesRestart(request, new RestBuilderListener<NodesRestartResponse>(channel) {
             @Override
             public RestResponse buildResponse(NodesRestartResponse result, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
@@ -33,7 +33,7 @@ import org.elasticsearch.rest.action.support.RestBuilderListener;
 /**
  *
  */
-public class RestNodesShutdownAction extends BaseRestHandler {
+public class RestNodesShutdownAction extends BaseActionRequestRestHandler<NodesShutdownRequest> {
 
     @Inject
     public RestNodesShutdownAction(Settings settings, Client client, RestController controller) {
@@ -45,13 +45,18 @@ public class RestNodesShutdownAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected NodesShutdownRequest newRequest(RestRequest request) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesShutdownRequest nodesShutdownRequest = new NodesShutdownRequest(nodesIds);
         nodesShutdownRequest.listenerThreaded(false);
         nodesShutdownRequest.delay(request.paramAsTime("delay", nodesShutdownRequest.delay()));
         nodesShutdownRequest.exit(request.paramAsBoolean("exit", nodesShutdownRequest.exit()));
-        client.admin().cluster().nodesShutdown(nodesShutdownRequest, new RestBuilderListener<NodesShutdownResponse>(channel) {
+        return nodesShutdownRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, NodesShutdownRequest request) {
+        client.admin().cluster().nodesShutdown(request, new RestBuilderListener<NodesShutdownResponse>(channel) {
             @Override
             public RestResponse buildResponse(NodesShutdownResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -41,7 +41,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 /**
  *
  */
-public class RestNodesStatsAction extends BaseRestHandler {
+public class RestNodesStatsAction extends BaseActionRequestRestHandler<NodesStatsRequest> {
 
     @Inject
     public RestNodesStatsAction(Settings settings, Client client, RestController controller) {
@@ -58,7 +58,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected NodesStatsRequest newRequest(RestRequest request) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         Set<String> metrics = Strings.splitStringByCommaToSet(request.param("metric", "_all"));
 
@@ -108,7 +108,11 @@ public class RestNodesStatsAction extends BaseRestHandler {
         if (nodesStatsRequest.indices().isSet(Flag.Indexing) && (request.hasParam("types"))) {
             nodesStatsRequest.indices().types(request.paramAsStringArray("types", null));
         }
+        return nodesStatsRequest;
+    }
 
-        client.admin().cluster().nodesStats(nodesStatsRequest, new RestToXContentListener<NodesStatsResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, NodesStatsRequest request) {
+        client.admin().cluster().nodesStats(request, new RestToXContentListener<NodesStatsResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
@@ -24,7 +24,10 @@ import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteReposito
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.client.Requests.deleteRepositoryRequest;
@@ -33,7 +36,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 /**
  * Unregisters a repository
  */
-public class RestDeleteRepositoryAction extends BaseRestHandler {
+public class RestDeleteRepositoryAction extends BaseActionRequestRestHandler<DeleteRepositoryRequest> {
 
     @Inject
     public RestDeleteRepositoryAction(Settings settings, Client client, RestController controller) {
@@ -42,12 +45,17 @@ public class RestDeleteRepositoryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteRepositoryRequest newRequest(RestRequest request) {
         DeleteRepositoryRequest deleteRepositoryRequest = deleteRepositoryRequest(request.param("repository"));
         deleteRepositoryRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteRepositoryRequest.masterNodeTimeout()));
         deleteRepositoryRequest.listenerThreaded(false);
         deleteRepositoryRequest.timeout(request.paramAsTime("timeout", deleteRepositoryRequest.timeout()));
         deleteRepositoryRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteRepositoryRequest.masterNodeTimeout()));
-        client.admin().cluster().deleteRepository(deleteRepositoryRequest, new AcknowledgedRestListener<DeleteRepositoryResponse>(channel));
+        return deleteRepositoryRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteRepositoryRequest request) {
+        client.admin().cluster().deleteRepository(request, new AcknowledgedRestListener<DeleteRepositoryResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
@@ -24,7 +24,10 @@ import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResp
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.client.Requests.putRepositoryRequest;
@@ -34,7 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 /**
  * Registers repositories
  */
-public class RestPutRepositoryAction extends BaseRestHandler {
+public class RestPutRepositoryAction extends BaseActionRequestRestHandler<PutRepositoryRequest> {
 
     @Inject
     public RestPutRepositoryAction(Settings settings, Client client, RestController controller) {
@@ -43,14 +46,18 @@ public class RestPutRepositoryAction extends BaseRestHandler {
         controller.registerHandler(POST, "/_snapshot/{repository}", this);
     }
 
-
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected PutRepositoryRequest newRequest(RestRequest request) {
         PutRepositoryRequest putRepositoryRequest = putRepositoryRequest(request.param("repository"));
         putRepositoryRequest.listenerThreaded(false);
         putRepositoryRequest.source(request.content().toUtf8());
         putRepositoryRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putRepositoryRequest.masterNodeTimeout()));
         putRepositoryRequest.timeout(request.paramAsTime("timeout", putRepositoryRequest.timeout()));
-        client.admin().cluster().putRepository(putRepositoryRequest, new AcknowledgedRestListener<PutRepositoryResponse>(channel));
+        return putRepositoryRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, PutRepositoryRequest request) {
+        client.admin().cluster().putRepository(request, new AcknowledgedRestListener<PutRepositoryResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -38,7 +38,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 /**
  */
-public class RestClusterSearchShardsAction extends BaseRestHandler {
+public class RestClusterSearchShardsAction extends BaseActionRequestRestHandler<ClusterSearchShardsRequest> {
 
     @Inject
     public RestClusterSearchShardsAction(Settings settings, Client client, RestController controller) {
@@ -52,7 +52,7 @@ public class RestClusterSearchShardsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected ClusterSearchShardsRequest newRequest(RestRequest request) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final ClusterSearchShardsRequest clusterSearchShardsRequest = Requests.clusterSearchShardsRequest(indices);
         clusterSearchShardsRequest.local(request.paramAsBoolean("local", clusterSearchShardsRequest.local()));
@@ -62,7 +62,11 @@ public class RestClusterSearchShardsAction extends BaseRestHandler {
         clusterSearchShardsRequest.routing(request.param("routing"));
         clusterSearchShardsRequest.preference(request.param("preference"));
         clusterSearchShardsRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterSearchShardsRequest.indicesOptions()));
+        return clusterSearchShardsRequest;
+    }
 
-        client.admin().cluster().searchShards(clusterSearchShardsRequest, new RestToXContentListener<ClusterSearchShardsResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, ClusterSearchShardsRequest request) {
+        client.admin().cluster().searchShards(request, new RestToXContentListener<ClusterSearchShardsResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -37,7 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 /**
  * Creates a new snapshot
  */
-public class RestCreateSnapshotAction extends BaseRestHandler {
+public class RestCreateSnapshotAction extends BaseActionRequestRestHandler<CreateSnapshotRequest> {
 
     @Inject
     public RestCreateSnapshotAction(Settings settings, Client client, RestController controller) {
@@ -47,12 +47,17 @@ public class RestCreateSnapshotAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected CreateSnapshotRequest newRequest(RestRequest request) {
         CreateSnapshotRequest createSnapshotRequest = createSnapshotRequest(request.param("repository"), request.param("snapshot"));
         createSnapshotRequest.listenerThreaded(false);
         createSnapshotRequest.source(request.content().toUtf8());
         createSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", createSnapshotRequest.masterNodeTimeout()));
         createSnapshotRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
-        client.admin().cluster().createSnapshot(createSnapshotRequest, new RestToXContentListener<CreateSnapshotResponse>(channel));
+        return createSnapshotRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, CreateSnapshotRequest request) {
+        client.admin().cluster().createSnapshot(request, new RestToXContentListener<CreateSnapshotResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
@@ -24,7 +24,10 @@ import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRes
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.client.Requests.deleteSnapshotRequest;
@@ -33,7 +36,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 /**
  * Deletes a snapshot
  */
-public class RestDeleteSnapshotAction extends BaseRestHandler {
+public class RestDeleteSnapshotAction extends BaseActionRequestRestHandler<DeleteSnapshotRequest> {
 
     @Inject
     public RestDeleteSnapshotAction(Settings settings, Client client, RestController controller) {
@@ -42,9 +45,14 @@ public class RestDeleteSnapshotAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteSnapshotRequest newRequest(RestRequest request) {
         DeleteSnapshotRequest deleteSnapshotRequest = deleteSnapshotRequest(request.param("repository"), request.param("snapshot"));
         deleteSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteSnapshotRequest.masterNodeTimeout()));
-        client.admin().cluster().deleteSnapshot(deleteSnapshotRequest, new AcknowledgedRestListener<DeleteSnapshotResponse>(channel));
+        return deleteSnapshotRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteSnapshotRequest request) {
+        client.admin().cluster().deleteSnapshot(request, new AcknowledgedRestListener<DeleteSnapshotResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -37,7 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 /**
  * Returns information about snapshot
  */
-public class RestGetSnapshotsAction extends BaseRestHandler {
+public class RestGetSnapshotsAction extends BaseActionRequestRestHandler<GetSnapshotsRequest> {
 
     @Inject
     public RestGetSnapshotsAction(Settings settings, Client client, RestController controller) {
@@ -45,9 +45,8 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
         controller.registerHandler(GET, "/_snapshot/{repository}/{snapshot}", this);
     }
 
-
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected GetSnapshotsRequest newRequest(RestRequest request) {
         String repository = request.param("repository");
         String[] snapshots = request.paramAsStringArray("snapshot", Strings.EMPTY_ARRAY);
         if (snapshots.length == 1 && "_all".equalsIgnoreCase(snapshots[0])) {
@@ -55,6 +54,11 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
         }
         GetSnapshotsRequest getSnapshotsRequest = getSnapshotsRequest(repository).snapshots(snapshots);
         getSnapshotsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getSnapshotsRequest.masterNodeTimeout()));
-        client.admin().cluster().getSnapshots(getSnapshotsRequest, new RestToXContentListener<GetSnapshotsResponse>(channel));
+        return getSnapshotsRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, GetSnapshotsRequest request) {
+        client.admin().cluster().getSnapshots(request, new RestToXContentListener<GetSnapshotsResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -36,7 +36,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 /**
  * Restores a snapshot
  */
-public class RestRestoreSnapshotAction extends BaseRestHandler {
+public class RestRestoreSnapshotAction extends BaseActionRequestRestHandler<RestoreSnapshotRequest> {
 
     @Inject
     public RestRestoreSnapshotAction(Settings settings, Client client, RestController controller) {
@@ -45,11 +45,16 @@ public class RestRestoreSnapshotAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected RestoreSnapshotRequest newRequest(RestRequest request) {
         RestoreSnapshotRequest restoreSnapshotRequest = restoreSnapshotRequest(request.param("repository"), request.param("snapshot"));
         restoreSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", restoreSnapshotRequest.masterNodeTimeout()));
         restoreSnapshotRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
         restoreSnapshotRequest.source(request.content().toUtf8());
-        client.admin().cluster().restoreSnapshot(restoreSnapshotRequest, new RestToXContentListener<RestoreSnapshotResponse>(channel));
+        return restoreSnapshotRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, RestoreSnapshotRequest request) {
+        client.admin().cluster().restoreSnapshot(request, new RestToXContentListener<RestoreSnapshotResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -34,7 +34,7 @@ import org.elasticsearch.rest.action.support.RestToXContentListener;
 /**
  *
  */
-public class RestClusterStatsAction extends BaseRestHandler {
+public class RestClusterStatsAction extends BaseActionRequestRestHandler<ClusterStatsRequest> {
 
     @Inject
     public RestClusterStatsAction(Settings settings, Client client, RestController controller) {
@@ -44,9 +44,14 @@ public class RestClusterStatsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected ClusterStatsRequest newRequest(RestRequest request) {
         ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
         clusterStatsRequest.listenerThreaded(false);
-        client.admin().cluster().clusterStats(clusterStatsRequest, new RestToXContentListener<ClusterStatsResponse>(channel));
+        return clusterStatsRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, ClusterStatsRequest request) {
+        client.admin().cluster().clusterStats(request, new RestToXContentListener<ClusterStatsResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -28,7 +28,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import java.util.Map;
@@ -39,7 +42,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 /**
  *
  */
-public class RestIndicesAliasesAction extends BaseRestHandler {
+public class RestIndicesAliasesAction extends BaseActionRequestRestHandler<IndicesAliasesRequest> {
 
     @Inject
     public RestIndicesAliasesAction(Settings settings, Client client, RestController controller) {
@@ -48,7 +51,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected IndicesAliasesRequest newRequest(RestRequest request) throws Exception {
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
         indicesAliasesRequest.listenerThreaded(false);
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", indicesAliasesRequest.masterNodeTimeout()));
@@ -132,6 +135,11 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
                 }
             }
         }
-        client.admin().indices().aliases(indicesAliasesRequest, new AcknowledgedRestListener<IndicesAliasesResponse>(channel));
+        return indicesAliasesRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, IndicesAliasesRequest request) {
+        client.admin().indices().aliases(request, new AcknowledgedRestListener<IndicesAliasesResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
@@ -24,14 +24,17 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
 /**
  */
-public class RestIndexDeleteAliasesAction extends BaseRestHandler {
+public class RestIndexDeleteAliasesAction extends BaseActionRequestRestHandler<IndicesAliasesRequest> {
 
     @Inject
     public RestIndexDeleteAliasesAction(Settings settings, Client client, RestController controller) {
@@ -41,14 +44,18 @@ public class RestIndexDeleteAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected IndicesAliasesRequest newRequest(RestRequest request) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] aliases = Strings.splitStringByCommaToArray(request.param("name"));
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
         indicesAliasesRequest.timeout(request.paramAsTime("timeout", indicesAliasesRequest.timeout()));
         indicesAliasesRequest.removeAlias(indices, aliases);
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", indicesAliasesRequest.masterNodeTimeout()));
+        return indicesAliasesRequest;
+    }
 
-        client.admin().indices().aliases(indicesAliasesRequest, new AcknowledgedRestListener<IndicesAliasesResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, IndicesAliasesRequest request) {
+        client.admin().indices().aliases(request, new AcknowledgedRestListener<IndicesAliasesResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
@@ -29,7 +29,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import java.util.Map;
@@ -39,7 +42,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 /**
  */
-public class RestIndexPutAliasAction extends BaseRestHandler {
+public class RestIndexPutAliasAction extends BaseActionRequestRestHandler<IndicesAliasesRequest> {
 
     @Inject
     public RestIndexPutAliasAction(Settings settings, Client client, RestController controller) {
@@ -60,7 +63,7 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected IndicesAliasesRequest newRequest(RestRequest request) throws Exception {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         String alias = request.param("name");
         Map<String, Object> filter = null;
@@ -119,6 +122,11 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
         if (filter != null) {
             aliasAction.filter(filter);
         }
-        client.admin().indices().aliases(indicesAliasesRequest, new AcknowledgedRestListener<IndicesAliasesResponse>(channel));
+        return indicesAliasesRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, IndicesAliasesRequest request) {
+        client.admin().indices().aliases(request, new AcknowledgedRestListener<IndicesAliasesResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -36,7 +36,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 /**
  *
  */
-public class RestAnalyzeAction extends BaseRestHandler {
+public class RestAnalyzeAction extends BaseActionRequestRestHandler<AnalyzeRequest> {
 
     @Inject
     public RestAnalyzeAction(Settings settings, Client client, RestController controller) {
@@ -48,7 +48,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected AnalyzeRequest newRequest(RestRequest request) {
         String text = request.param("text");
         if (text == null && request.hasContent()) {
             text = request.content().toUtf8();
@@ -65,6 +65,11 @@ public class RestAnalyzeAction extends BaseRestHandler {
         analyzeRequest.tokenizer(request.param("tokenizer"));
         analyzeRequest.tokenFilters(request.paramAsStringArray("token_filters", request.paramAsStringArray("filters", analyzeRequest.tokenFilters())));
         analyzeRequest.charFilters(request.paramAsStringArray("char_filters", analyzeRequest.charFilters()));
-        client.admin().indices().analyze(analyzeRequest, new RestToXContentListener<AnalyzeResponse>(channel));
+        return analyzeRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, AnalyzeRequest request) {
+        client.admin().indices().analyze(request, new RestToXContentListener<AnalyzeResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 /**
  *
  */
-public class RestClearIndicesCacheAction extends BaseRestHandler {
+public class RestClearIndicesCacheAction extends BaseActionRequestRestHandler<ClearIndicesCacheRequest> {
 
     @Inject
     public RestClearIndicesCacheAction(Settings settings, Client client, RestController controller) {
@@ -54,12 +54,17 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected ClearIndicesCacheRequest newRequest(RestRequest request) {
         ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(Strings.splitStringByCommaToArray(request.param("index")));
         clearIndicesCacheRequest.listenerThreaded(false);
         clearIndicesCacheRequest.indicesOptions(IndicesOptions.fromRequest(request, clearIndicesCacheRequest.indicesOptions()));
         fromRequest(request, clearIndicesCacheRequest);
-        client.admin().indices().clearCache(clearIndicesCacheRequest, new RestBuilderListener<ClearIndicesCacheResponse>(channel) {
+        return clearIndicesCacheRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, ClearIndicesCacheRequest request) {
+        client.admin().indices().clearCache(request, new RestBuilderListener<ClearIndicesCacheResponse>(channel) {
             @Override
             public RestResponse buildResponse(ClearIndicesCacheResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 /**
  *
  */
-public class RestCloseIndexAction extends BaseRestHandler {
+public class RestCloseIndexAction extends BaseActionRequestRestHandler<CloseIndexRequest> {
 
     @Inject
     public RestCloseIndexAction(Settings settings, Client client, RestController controller) {
@@ -42,12 +42,17 @@ public class RestCloseIndexAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected CloseIndexRequest newRequest(RestRequest request) {
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         closeIndexRequest.listenerThreaded(false);
         closeIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", closeIndexRequest.masterNodeTimeout()));
         closeIndexRequest.timeout(request.paramAsTime("timeout", closeIndexRequest.timeout()));
         closeIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, closeIndexRequest.indicesOptions()));
-        client.admin().indices().close(closeIndexRequest, new AcknowledgedRestListener<CloseIndexResponse>(channel));
+        return closeIndexRequest;
+    }
+
+    @Override
+    protected void doHandleRequest(RestRequest restRequest, RestChannel restChannel, CloseIndexRequest request) {
+        client.admin().indices().close(request, new AcknowledgedRestListener<CloseIndexResponse>(restChannel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -33,7 +33,7 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 /**
  *
  */
-public class RestCreateIndexAction extends BaseRestHandler {
+public class RestCreateIndexAction extends BaseActionRequestRestHandler<CreateIndexRequest> {
 
     @Inject
     public RestCreateIndexAction(Settings settings, Client client, RestController controller) {
@@ -42,9 +42,8 @@ public class RestCreateIndexAction extends BaseRestHandler {
         controller.registerHandler(RestRequest.Method.POST, "/{index}", this);
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected CreateIndexRequest newRequest(RestRequest request) {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest(request.param("index"));
         createIndexRequest.listenerThreaded(false);
         if (request.hasContent()) {
@@ -52,6 +51,11 @@ public class RestCreateIndexAction extends BaseRestHandler {
         }
         createIndexRequest.timeout(request.paramAsTime("timeout", createIndexRequest.timeout()));
         createIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", createIndexRequest.masterNodeTimeout()));
-        client.admin().indices().create(createIndexRequest, new AcknowledgedRestListener<CreateIndexResponse>(channel));
+        return createIndexRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, CreateIndexRequest request) {
+        client.admin().indices().create(request, new AcknowledgedRestListener<CreateIndexResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
@@ -26,13 +26,16 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 /**
  *
  */
-public class RestDeleteIndexAction extends BaseRestHandler {
+public class RestDeleteIndexAction extends BaseActionRequestRestHandler<DeleteIndexRequest> {
 
     @Inject
     public RestDeleteIndexAction(Settings settings, Client client, RestController controller) {
@@ -42,12 +45,17 @@ public class RestDeleteIndexAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteIndexRequest newRequest(RestRequest request) {
         DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteIndexRequest.listenerThreaded(false);
         deleteIndexRequest.timeout(request.paramAsTime("timeout", deleteIndexRequest.timeout()));
         deleteIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteIndexRequest.masterNodeTimeout()));
         deleteIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteIndexRequest.indicesOptions()));
-        client.admin().indices().delete(deleteIndexRequest, new AcknowledgedRestListener<DeleteIndexResponse>(channel));
+        return deleteIndexRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteIndexRequest request) {
+        client.admin().indices().delete(request, new AcknowledgedRestListener<DeleteIndexResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  *
  */
-public class RestIndicesExistsAction extends BaseRestHandler {
+public class RestIndicesExistsAction extends BaseActionRequestRestHandler<IndicesExistsRequest> {
 
     private final SettingsFilter settingsFilter;
 
@@ -51,12 +51,17 @@ public class RestIndicesExistsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected IndicesExistsRequest newRequest(RestRequest request) {
         IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         indicesExistsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesExistsRequest.indicesOptions()));
         indicesExistsRequest.local(request.paramAsBoolean("local", indicesExistsRequest.local()));
         indicesExistsRequest.listenerThreaded(false);
-        client.admin().indices().exists(indicesExistsRequest, new RestResponseListener<IndicesExistsResponse>(channel) {
+        return indicesExistsRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, IndicesExistsRequest request) {
+        client.admin().indices().exists(request, new RestResponseListener<IndicesExistsResponse>(channel) {
             @Override
             public RestResponse buildResponse(IndicesExistsResponse response) {
                 if (response.isExists()) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  * Rest api for checking if a type exists.
  */
-public class RestTypesExistsAction extends BaseRestHandler {
+public class RestTypesExistsAction extends BaseActionRequestRestHandler<TypesExistsRequest> {
 
     @Inject
     public RestTypesExistsAction(Settings settings, Client client, RestController controller) {
@@ -44,14 +44,19 @@ public class RestTypesExistsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected TypesExistsRequest newRequest(RestRequest request) {
         TypesExistsRequest typesExistsRequest = new TypesExistsRequest(
                 Strings.splitStringByCommaToArray(request.param("index")), Strings.splitStringByCommaToArray(request.param("type"))
         );
         typesExistsRequest.listenerThreaded(false);
         typesExistsRequest.local(request.paramAsBoolean("local", typesExistsRequest.local()));
         typesExistsRequest.indicesOptions(IndicesOptions.fromRequest(request, typesExistsRequest.indicesOptions()));
-        client.admin().indices().typesExists(typesExistsRequest, new RestResponseListener<TypesExistsResponse>(channel) {
+        return typesExistsRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, TypesExistsRequest request) {
+        client.admin().indices().typesExists(request, new RestResponseListener<TypesExistsResponse>(channel) {
             @Override
             public RestResponse buildResponse(TypesExistsResponse response) throws Exception {
                 if (response.isExists()) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 /**
  *
  */
-public class RestFlushAction extends BaseRestHandler {
+public class RestFlushAction extends BaseActionRequestRestHandler<FlushRequest> {
 
     @Inject
     public RestFlushAction(Settings settings, Client client, RestController controller) {
@@ -51,13 +51,18 @@ public class RestFlushAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected FlushRequest newRequest(RestRequest request) {
         FlushRequest flushRequest = new FlushRequest(Strings.splitStringByCommaToArray(request.param("index")));
         flushRequest.listenerThreaded(false);
         flushRequest.indicesOptions(IndicesOptions.fromRequest(request, flushRequest.indicesOptions()));
         flushRequest.full(request.paramAsBoolean("full", flushRequest.full()));
         flushRequest.force(request.paramAsBoolean("force", flushRequest.force()));
-        client.admin().indices().flush(flushRequest, new RestBuilderListener<FlushResponse>(channel) {
+        return flushRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, FlushRequest request) {
+        client.admin().indices().flush(request, new RestBuilderListener<FlushResponse>(channel) {
             @Override
             public RestResponse buildResponse(FlushResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
@@ -26,7 +26,10 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.client.Requests.deleteMappingRequest;
@@ -35,7 +38,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 /**
  *
  */
-public class RestDeleteMappingAction extends BaseRestHandler {
+public class RestDeleteMappingAction extends BaseActionRequestRestHandler<DeleteMappingRequest> {
 
     @Inject
     public RestDeleteMappingAction(Settings settings, Client client, RestController controller) {
@@ -50,13 +53,18 @@ public class RestDeleteMappingAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteMappingRequest newRequest(RestRequest request) {
         DeleteMappingRequest deleteMappingRequest = deleteMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteMappingRequest.listenerThreaded(false);
         deleteMappingRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         deleteMappingRequest.timeout(request.paramAsTime("timeout", deleteMappingRequest.timeout()));
         deleteMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteMappingRequest.masterNodeTimeout()));
         deleteMappingRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteMappingRequest.indicesOptions()));
-        client.admin().indices().deleteMapping(deleteMappingRequest, new AcknowledgedRestListener<DeleteMappingResponse>(channel));
+        return deleteMappingRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteMappingRequest request) {
+        client.admin().indices().deleteMapping(request, new AcknowledgedRestListener<DeleteMappingResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -26,7 +26,10 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import static org.elasticsearch.client.Requests.putMappingRequest;
@@ -36,8 +39,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 /**
  *
  */
-public class RestPutMappingAction extends BaseRestHandler {
-
+public class RestPutMappingAction extends BaseActionRequestRestHandler<PutMappingRequest> {
 
     @Inject
     public RestPutMappingAction(Settings settings, Client client, RestController controller) {
@@ -65,7 +67,7 @@ public class RestPutMappingAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected PutMappingRequest newRequest(RestRequest request) {
         PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         putMappingRequest.listenerThreaded(false);
         putMappingRequest.type(request.param("type"));
@@ -74,6 +76,11 @@ public class RestPutMappingAction extends BaseRestHandler {
         putMappingRequest.ignoreConflicts(request.paramAsBoolean("ignore_conflicts", putMappingRequest.ignoreConflicts()));
         putMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putMappingRequest.masterNodeTimeout()));
         putMappingRequest.indicesOptions(IndicesOptions.fromRequest(request, putMappingRequest.indicesOptions()));
-        client.admin().indices().putMapping(putMappingRequest, new AcknowledgedRestListener<PutMappingResponse>(channel));
+        return putMappingRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, PutMappingRequest request) {
+        client.admin().indices().putMapping(request, new AcknowledgedRestListener<PutMappingResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
@@ -26,13 +26,16 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 /**
  *
  */
-public class RestOpenIndexAction extends BaseRestHandler {
+public class RestOpenIndexAction extends BaseActionRequestRestHandler<OpenIndexRequest> {
 
     @Inject
     public RestOpenIndexAction(Settings settings, Client client, RestController controller) {
@@ -42,12 +45,17 @@ public class RestOpenIndexAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected OpenIndexRequest newRequest(RestRequest request) {
         OpenIndexRequest openIndexRequest = new OpenIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         openIndexRequest.listenerThreaded(false);
         openIndexRequest.timeout(request.paramAsTime("timeout", openIndexRequest.timeout()));
         openIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", openIndexRequest.masterNodeTimeout()));
         openIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, openIndexRequest.indicesOptions()));
-        client.admin().indices().open(openIndexRequest, new AcknowledgedRestListener<OpenIndexResponse>(channel));
+        return openIndexRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, OpenIndexRequest request) {
+        client.admin().indices().open(request, new AcknowledgedRestListener<OpenIndexResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 /**
  *
  */
-public class RestOptimizeAction extends BaseRestHandler {
+public class RestOptimizeAction extends BaseActionRequestRestHandler<OptimizeRequest> {
 
     @Inject
     public RestOptimizeAction(Settings settings, Client client, RestController controller) {
@@ -51,7 +51,7 @@ public class RestOptimizeAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected OptimizeRequest newRequest(RestRequest request) {
         OptimizeRequest optimizeRequest = new OptimizeRequest(Strings.splitStringByCommaToArray(request.param("index")));
         optimizeRequest.listenerThreaded(false);
         optimizeRequest.indicesOptions(IndicesOptions.fromRequest(request, optimizeRequest.indicesOptions()));
@@ -60,7 +60,12 @@ public class RestOptimizeAction extends BaseRestHandler {
         optimizeRequest.onlyExpungeDeletes(request.paramAsBoolean("only_expunge_deletes", optimizeRequest.onlyExpungeDeletes()));
         optimizeRequest.flush(request.paramAsBoolean("flush", optimizeRequest.flush()));
         optimizeRequest.force(request.paramAsBoolean("force", optimizeRequest.force()));
-        client.admin().indices().optimize(optimizeRequest, new RestBuilderListener<OptimizeResponse>(channel) {
+        return optimizeRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, OptimizeRequest request) {
+        client.admin().indices().optimize(request, new RestBuilderListener<OptimizeResponse>(channel) {
             @Override
             public RestResponse buildResponse(OptimizeResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 /**
  *
  */
-public class RestRefreshAction extends BaseRestHandler {
+public class RestRefreshAction extends BaseActionRequestRestHandler<RefreshRequest> {
 
     @Inject
     public RestRefreshAction(Settings settings, Client client, RestController controller) {
@@ -51,12 +51,17 @@ public class RestRefreshAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected RefreshRequest newRequest(RestRequest request) {
         RefreshRequest refreshRequest = new RefreshRequest(Strings.splitStringByCommaToArray(request.param("index")));
         refreshRequest.listenerThreaded(false);
         refreshRequest.force(request.paramAsBoolean("force", refreshRequest.force()));
         refreshRequest.indicesOptions(IndicesOptions.fromRequest(request, refreshRequest.indicesOptions()));
-        client.admin().indices().refresh(refreshRequest, new RestBuilderListener<RefreshResponse>(channel) {
+        return refreshRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, RefreshRequest request) {
+        client.admin().indices().refresh(request, new RestBuilderListener<RefreshResponse>(channel) {
             @Override
             public RestResponse buildResponse(RefreshResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 
 /**
  */
-public class RestIndicesSegmentsAction extends BaseRestHandler {
+public class RestIndicesSegmentsAction extends BaseActionRequestRestHandler<IndicesSegmentsRequest> {
 
     @Inject
     public RestIndicesSegmentsAction(Settings settings, Client client, RestController controller) {
@@ -46,16 +46,21 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected IndicesSegmentsRequest newRequest(RestRequest request) {
         IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         indicesSegmentsRequest.listenerThreaded(false);
         indicesSegmentsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesSegmentsRequest.indicesOptions()));
-        client.admin().indices().segments(indicesSegmentsRequest, new RestBuilderListener<IndicesSegmentResponse>(channel) {
+        return indicesSegmentsRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, IndicesSegmentsRequest request) {
+        client.admin().indices().segments(request, new RestBuilderListener<IndicesSegmentResponse>(channel) {
             @Override
             public RestResponse buildResponse(IndicesSegmentResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
                 buildBroadcastShardsHeader(builder, response);
-                response.toXContent(builder, request);
+                response.toXContent(builder, restRequest);
                 builder.endObject();
                 return new BytesRestResponse(OK, builder);
             }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -27,7 +27,10 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
 import java.util.Map;
@@ -37,7 +40,7 @@ import static org.elasticsearch.client.Requests.updateSettingsRequest;
 /**
  *
  */
-public class RestUpdateSettingsAction extends BaseRestHandler {
+public class RestUpdateSettingsAction extends BaseActionRequestRestHandler<UpdateSettingsRequest> {
 
     @Inject
     public RestUpdateSettingsAction(Settings settings, Client client, RestController controller) {
@@ -47,7 +50,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected UpdateSettingsRequest newRequest(RestRequest request) {
         UpdateSettingsRequest updateSettingsRequest = updateSettingsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         updateSettingsRequest.listenerThreaded(false);
         updateSettingsRequest.timeout(request.paramAsTime("timeout", updateSettingsRequest.timeout()));
@@ -75,7 +78,11 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
             updateSettings.put(entry.getKey(), entry.getValue());
         }
         updateSettingsRequest.settings(updateSettings);
+        return updateSettingsRequest;
+    }
 
-        client.admin().indices().updateSettings(updateSettingsRequest, new AcknowledgedRestListener<UpdateSettingsResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, UpdateSettingsRequest request) {
+        client.admin().indices().updateSettings(request, new AcknowledgedRestListener<UpdateSettingsResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  *
  */
-public class RestHeadIndexTemplateAction extends BaseRestHandler {
+public class RestHeadIndexTemplateAction extends BaseActionRequestRestHandler<GetIndexTemplatesRequest> {
 
     @Inject
     public RestHeadIndexTemplateAction(Settings settings, Client client, RestController controller) {
@@ -43,10 +43,15 @@ public class RestHeadIndexTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected GetIndexTemplatesRequest newRequest(RestRequest request) {
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
         getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
-        client.admin().indices().getTemplates(getIndexTemplatesRequest, new RestResponseListener<GetIndexTemplatesResponse>(channel) {
+        return getIndexTemplatesRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, GetIndexTemplatesRequest request) {
+        client.admin().indices().getTemplates(request, new RestResponseListener<GetIndexTemplatesResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetIndexTemplatesResponse getIndexTemplatesResponse) {
                 boolean templateExists = getIndexTemplatesResponse.getIndexTemplates().size() > 0;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
@@ -29,7 +29,7 @@ import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 /**
  *
  */
-public class RestPutIndexTemplateAction extends BaseRestHandler {
+public class RestPutIndexTemplateAction extends BaseActionRequestRestHandler<PutIndexTemplateRequest> {
 
     @Inject
     public RestPutIndexTemplateAction(Settings settings, Client client, RestController controller) {
@@ -38,9 +38,8 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
         controller.registerHandler(RestRequest.Method.POST, "/_template/{name}", this);
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected PutIndexTemplateRequest newRequest(RestRequest request) {
         PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(request.param("name"));
         putRequest.listenerThreaded(false);
         putRequest.template(request.param("template", putRequest.template()));
@@ -49,6 +48,11 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", ""));
         putRequest.source(request.content());
-        client.admin().indices().putTemplate(putRequest, new AcknowledgedRestListener<PutIndexTemplateResponse>(channel));
+        return putRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, PutIndexTemplateRequest request) {
+        client.admin().indices().putTemplate(request, new AcknowledgedRestListener<PutIndexTemplateResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 /**
  *
  */
-public class RestValidateQueryAction extends BaseRestHandler {
+public class RestValidateQueryAction extends BaseActionRequestRestHandler<ValidateQueryRequest> {
 
     @Inject
     public RestValidateQueryAction(Settings settings, Client client, RestController controller) {
@@ -55,7 +55,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected ValidateQueryRequest newRequest(RestRequest request) {
         ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest(Strings.splitStringByCommaToArray(request.param("index")));
         validateQueryRequest.listenerThreaded(false);
         validateQueryRequest.indicesOptions(IndicesOptions.fromRequest(request, validateQueryRequest.indicesOptions()));
@@ -78,8 +78,12 @@ public class RestValidateQueryAction extends BaseRestHandler {
         } else {
             validateQueryRequest.explain(false);
         }
+        return validateQueryRequest;
+    }
 
-        client.admin().indices().validateQuery(validateQueryRequest, new RestBuilderListener<ValidateQueryResponse>(channel) {
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, ValidateQueryRequest request) {
+        client.admin().indices().validateQuery(request, new RestBuilderListener<ValidateQueryResponse>(channel) {
             @Override
             public RestResponse buildResponse(ValidateQueryResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -35,7 +35,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
 /**
  */
-public class RestDeleteWarmerAction extends BaseRestHandler {
+public class RestDeleteWarmerAction extends BaseActionRequestRestHandler<DeleteWarmerRequest> {
 
     @Inject
     public RestDeleteWarmerAction(Settings settings, Client client, RestController controller) {
@@ -47,13 +47,18 @@ public class RestDeleteWarmerAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteWarmerRequest newRequest(RestRequest request) {
         DeleteWarmerRequest deleteWarmerRequest = new DeleteWarmerRequest(Strings.splitStringByCommaToArray(request.param("name")))
                 .indices(Strings.splitStringByCommaToArray(request.param("index")));
         deleteWarmerRequest.listenerThreaded(false);
         deleteWarmerRequest.timeout(request.paramAsTime("timeout", deleteWarmerRequest.timeout()));
         deleteWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteWarmerRequest.masterNodeTimeout()));
         deleteWarmerRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteWarmerRequest.indicesOptions()));
-        client.admin().indices().deleteWarmer(deleteWarmerRequest, new AcknowledgedRestListener<DeleteWarmerResponse>(channel));
+        return deleteWarmerRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteWarmerRequest request) {
+        client.admin().indices().deleteWarmer(request, new AcknowledgedRestListener<DeleteWarmerResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -37,7 +37,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 /**
  */
-public class RestPutWarmerAction extends BaseRestHandler {
+public class RestPutWarmerAction extends BaseActionRequestRestHandler<PutWarmerRequest> {
 
     @Inject
     public RestPutWarmerAction(Settings settings, Client client, RestController controller) {
@@ -60,7 +60,7 @@ public class RestPutWarmerAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected PutWarmerRequest newRequest(RestRequest request) {
         PutWarmerRequest putWarmerRequest = new PutWarmerRequest(request.param("name"));
         putWarmerRequest.listenerThreaded(false);
         SearchRequest searchRequest = new SearchRequest(Strings.splitStringByCommaToArray(request.param("index")))
@@ -70,6 +70,11 @@ public class RestPutWarmerAction extends BaseRestHandler {
         putWarmerRequest.searchRequest(searchRequest);
         putWarmerRequest.timeout(request.paramAsTime("timeout", putWarmerRequest.timeout()));
         putWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putWarmerRequest.masterNodeTimeout()));
-        client.admin().indices().putWarmer(putWarmerRequest, new AcknowledgedRestListener<PutWarmerResponse>(channel));
+        return putWarmerRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, PutWarmerRequest request) {
+        client.admin().indices().putWarmer(request, new AcknowledgedRestListener<PutWarmerResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAbortAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAbortAction.java
@@ -16,11 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.rest.action.admin.indices.template.delete;
 
-import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
-import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateResponse;
+package org.elasticsearch.rest.action.bench;
+
+import org.elasticsearch.action.bench.AbortBenchmarkRequest;
+import org.elasticsearch.action.bench.AbortBenchmarkResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseActionRequestRestHandler;
@@ -29,27 +31,27 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
 
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
 /**
- *
+ * REST handler for benchmark abort action.
  */
-public class RestDeleteIndexTemplateAction extends BaseActionRequestRestHandler<DeleteIndexTemplateRequest> {
+public class RestBenchAbortAction extends BaseActionRequestRestHandler<AbortBenchmarkRequest> {
 
     @Inject
-    public RestDeleteIndexTemplateAction(Settings settings, Client client, RestController controller) {
+    public RestBenchAbortAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
-        controller.registerHandler(RestRequest.Method.DELETE, "/_template/{name}", this);
+        controller.registerHandler(POST, "/_bench/abort/{name}", this);
     }
 
     @Override
-    protected DeleteIndexTemplateRequest newRequest(RestRequest request) {
-        DeleteIndexTemplateRequest deleteIndexTemplateRequest = new DeleteIndexTemplateRequest(request.param("name"));
-        deleteIndexTemplateRequest.listenerThreaded(false);
-        deleteIndexTemplateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteIndexTemplateRequest.masterNodeTimeout()));
-        return deleteIndexTemplateRequest;
+    protected AbortBenchmarkRequest newRequest(RestRequest request) {
+        final String[] benchmarkNames = Strings.splitStringByCommaToArray(request.param("name"));
+        return new AbortBenchmarkRequest(benchmarkNames);
     }
 
     @Override
-    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteIndexTemplateRequest request) {
-        client.admin().indices().deleteTemplate(request, new AcknowledgedRestListener<DeleteIndexTemplateResponse>(channel));
+    protected void doHandleRequest(RestRequest restRequest, RestChannel restChannel, AbortBenchmarkRequest request) {
+        client.abortBench(request, new AcknowledgedRestListener<AbortBenchmarkResponse>(restChannel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchStatusAction.java
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-package org.elasticsearch.rest.action.admin.cluster.tasks;
+package org.elasticsearch.rest.action.bench;
 
-import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksRequest;
-import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
+import org.elasticsearch.action.bench.BenchmarkStatusRequest;
+import org.elasticsearch.action.bench.BenchmarkStatusResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -30,26 +30,29 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 /**
+ * REST handler for benchmarks status action.
  */
-public class RestPendingClusterTasksAction extends BaseActionRequestRestHandler<PendingClusterTasksRequest> {
+public class RestBenchStatusAction extends BaseActionRequestRestHandler<BenchmarkStatusRequest> {
 
     @Inject
-    public RestPendingClusterTasksAction(Settings settings, Client client, RestController controller) {
+    public RestBenchStatusAction(Settings settings, Client client, RestController controller) {
         super(settings, client);
-        controller.registerHandler(RestRequest.Method.GET, "/_cluster/pending_tasks", this);
+        controller.registerHandler(GET, "/_bench", this);
+        controller.registerHandler(GET, "/{index}/_bench", this);
+        controller.registerHandler(GET, "/{index}/{type}/_bench", this);
     }
 
     @Override
-    protected PendingClusterTasksRequest newRequest(RestRequest request) {
-        PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
-        pendingClusterTasksRequest.masterNodeTimeout(request.paramAsTime("master_timeout", pendingClusterTasksRequest.masterNodeTimeout()));
-        pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
-        return pendingClusterTasksRequest;
+    protected BenchmarkStatusRequest newRequest(RestRequest request) {
+        //Reports on the status of all actively running benchmarks
+        return new BenchmarkStatusRequest();
     }
 
     @Override
-    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, PendingClusterTasksRequest request) {
-        client.admin().cluster().pendingClusterTasks(request, new RestToXContentListener<PendingClusterTasksResponse>(channel));
+    protected void doHandleRequest(RestRequest restRequest, RestChannel restChannel, BenchmarkStatusRequest request) {
+        client.benchStatus(request, new RestToXContentListener<BenchmarkStatusResponse> (restChannel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -56,6 +56,7 @@ public class RestAliasAction extends AbstractCatAction {
         final GetAliasesRequest getAliasesRequest = request.hasParam("alias") ?
                 new GetAliasesRequest(request.param("alias")) :
                 new GetAliasesRequest();
+        copyHeaders(request, getAliasesRequest);
         getAliasesRequest.local(request.paramAsBoolean("local", getAliasesRequest.local()));
 
         client.admin().indices().getAliases(getAliasesRequest, new RestResponseListener<GetAliasesResponse>(channel) {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -61,7 +61,7 @@ public class RestAllocationAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] nodes = Strings.splitStringByCommaToArray(request.param("nodes"));
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.clear().routingTable(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
@@ -69,7 +69,7 @@ public class RestAllocationAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse state) {
-                NodesStatsRequest statsRequest = new NodesStatsRequest(nodes);
+                NodesStatsRequest statsRequest = copyHeaders(request, new NodesStatsRequest(nodes));
                 statsRequest.clear().fs(true);
 
                 client.admin().cluster().nodesStats(statsRequest, new RestResponseListener<NodesStatsResponse>(channel) {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
 
-import java.io.IOException;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -48,7 +47,7 @@ public class RestCatAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest restRequest, final RestChannel channel) throws Exception {
         channel.sendResponse(new BytesRestResponse(RestStatus.OK, HELP));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -59,7 +59,7 @@ public class RestCountAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        CountRequest countRequest = new CountRequest(indices);
+        CountRequest countRequest = copyHeaders(request, new CountRequest(indices));
         String source = request.param("source");
         if (source != null) {
             countRequest.source(source);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -58,7 +58,7 @@ public class RestFielddataAction extends AbstractCatAction {
     @Override
     void doRequest(final RestRequest request, final RestChannel channel) {
 
-        final NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
+        final NodesStatsRequest nodesStatsRequest = copyHeaders(request, new NodesStatsRequest());
         nodesStatsRequest.clear();
         nodesStatsRequest.indices(true);
         String[] fields = request.paramAsStringArray("fields", null);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -54,7 +54,7 @@ public class RestHealthAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest();
+        ClusterHealthRequest clusterHealthRequest = copyHeaders(request, new ClusterHealthRequest());
 
         client.admin().cluster().health(clusterHealthRequest, new RestResponseListener<ClusterHealthResponse>(channel) {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -64,7 +64,7 @@ public class RestIndicesAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.clear().indices(indices).metaData(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
@@ -73,12 +73,12 @@ public class RestIndicesAction extends AbstractCatAction {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 final String[] concreteIndices = clusterStateResponse.getState().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
-                ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest(concreteIndices);
+                ClusterHealthRequest clusterHealthRequest = copyHeaders(request, Requests.clusterHealthRequest(concreteIndices));
                 clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
                 client.admin().cluster().health(clusterHealthRequest, new RestActionListener<ClusterHealthResponse>(channel) {
                     @Override
                     public void processResponse(final ClusterHealthResponse clusterHealthResponse) {
-                        IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
+                        IndicesStatsRequest indicesStatsRequest = copyHeaders(request, new IndicesStatsRequest());
                         indicesStatsRequest.all();
                         client.admin().indices().stats(indicesStatsRequest, new RestResponseListener<IndicesStatsResponse>(channel) {
                             @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -51,7 +51,7 @@ public class RestMasterAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -62,7 +62,7 @@ public class RestNodesAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
@@ -70,12 +70,12 @@ public class RestNodesAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
+                NodesInfoRequest nodesInfoRequest = copyHeaders(request, new NodesInfoRequest());
                 nodesInfoRequest.clear().jvm(true).os(true).process(true);
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestActionListener<NodesInfoResponse>(channel) {
                     @Override
                     public void processResponse(final NodesInfoResponse nodesInfoResponse) {
-                        NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
+                        NodesStatsRequest nodesStatsRequest = copyHeaders(request, new NodesStatsRequest());
                         nodesStatsRequest.clear().jvm(true).os(true).fs(true).indices(true);
                         client.admin().cluster().nodesStats(nodesStatsRequest, new RestResponseListener<NodesStatsResponse>(channel) {
                             @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -49,7 +49,7 @@ public class RestPendingClusterTasksAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
+        PendingClusterTasksRequest pendingClusterTasksRequest = copyHeaders(request, new PendingClusterTasksRequest());
         pendingClusterTasksRequest.masterNodeTimeout(request.paramAsTime("master_timeout", pendingClusterTasksRequest.masterNodeTimeout()));
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         client.admin().cluster().pendingClusterTasks(pendingClusterTasksRequest, new RestResponseListener<PendingClusterTasksResponse>(channel) {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -56,7 +56,7 @@ public class RestPluginsAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
@@ -64,7 +64,7 @@ public class RestPluginsAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) throws Exception {
-                NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
+                NodesInfoRequest nodesInfoRequest = copyHeaders(request, new NodesInfoRequest());
                 nodesInfoRequest.clear().plugins(true);
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestResponseListener<NodesInfoResponse>(channel) {
                     @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -66,6 +66,7 @@ public class RestRecoveryAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final RecoveryRequest recoveryRequest = new RecoveryRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        copyHeaders(request, recoveryRequest);
         recoveryRequest.detailed(request.paramAsBoolean("detailed", false));
         recoveryRequest.activeOnly(request.paramAsBoolean("active_only", false));
         recoveryRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.segments.*;
@@ -30,12 +29,14 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Segment;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +55,7 @@ public class RestSegmentsAction extends AbstractCatAction {
     void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices);
@@ -62,7 +63,7 @@ public class RestSegmentsAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                final IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest();
+                final IndicesSegmentsRequest indicesSegmentsRequest = copyHeaders(request, new IndicesSegmentsRequest());
                 indicesSegmentsRequest.indices(indices);
                 client.admin().indices().segments(indicesSegmentsRequest, new RestResponseListener<IndicesSegmentResponse>(channel) {
                     @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -58,14 +58,14 @@ public class RestShardsAction extends AbstractCatAction {
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices);
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
+                IndicesStatsRequest indicesStatsRequest = copyHeaders(request, new IndicesStatsRequest());
                 indicesStatsRequest.all();
                 client.admin().indices().stats(indicesStatsRequest, new RestResponseListener<IndicesStatsResponse>(channel) {
                     @Override

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -121,7 +121,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
 
     @Override
     public void doRequest(final RestRequest request, final RestChannel channel) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = copyHeaders(request, new ClusterStateRequest());
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()));
@@ -129,12 +129,12 @@ public class RestThreadPoolAction extends AbstractCatAction {
         client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
-                NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
+                NodesInfoRequest nodesInfoRequest = copyHeaders(request ,new NodesInfoRequest());
                 nodesInfoRequest.clear().process(true).threadPool(true);
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestActionListener<NodesInfoResponse>(channel) {
                     @Override
                     public void processResponse(final NodesInfoResponse nodesInfoResponse) {
-                        NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
+                        NodesStatsRequest nodesStatsRequest = copyHeaders(request, new NodesStatsRequest());
                         nodesStatsRequest.clear().threadPool(true);
                         client.admin().cluster().nodesStats(nodesStatsRequest, new RestResponseListener<NodesStatsResponse>(channel) {
                             @Override

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.rest.action.support.RestActions.buildBroadcastSh
 /**
  *
  */
-public class RestCountAction extends BaseRestHandler {
+public class RestCountAction extends BaseActionRequestRestHandler<CountRequest> {
 
     @Inject
     public RestCountAction(Settings settings, Client client, RestController controller) {
@@ -54,7 +54,7 @@ public class RestCountAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected CountRequest newRequest(RestRequest request) {
         CountRequest countRequest = new CountRequest(Strings.splitStringByCommaToArray(request.param("index")));
         countRequest.indicesOptions(IndicesOptions.fromRequest(request, countRequest.indicesOptions()));
         countRequest.listenerThreaded(false);
@@ -75,8 +75,12 @@ public class RestCountAction extends BaseRestHandler {
         countRequest.minScore(request.paramAsFloat("min_score", DEFAULT_MIN_SCORE));
         countRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         countRequest.preference(request.param("preference"));
+        return countRequest;
+    }
 
-        client.count(countRequest, new RestBuilderListener<CountResponse>(channel) {
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, CountRequest request) {
+        client.count(request, new RestBuilderListener<CountResponse>(channel) {
             @Override
             public RestResponse buildResponse(CountResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();

--- a/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  *
  */
-public class RestDeleteAction extends BaseRestHandler {
+public class RestDeleteAction extends BaseActionRequestRestHandler<DeleteRequest> {
 
     @Inject
     public RestDeleteAction(Settings settings, Client client, RestController controller) {
@@ -49,7 +49,7 @@ public class RestDeleteAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteRequest newRequest(RestRequest request) {
         DeleteRequest deleteRequest = new DeleteRequest(request.param("index"), request.param("type"), request.param("id"));
 
         deleteRequest.listenerThreaded(false);
@@ -70,8 +70,12 @@ public class RestDeleteAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             deleteRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
+        return deleteRequest;
+    }
 
-        client.delete(deleteRequest, new RestBuilderListener<DeleteResponse>(channel) {
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteRequest request) {
+        client.delete(request, new RestBuilderListener<DeleteResponse>(channel) {
             @Override
             public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
                 builder.startObject()

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 /**
  *
  */
-public class RestDeleteByQueryAction extends BaseRestHandler {
+public class RestDeleteByQueryAction extends BaseActionRequestRestHandler<DeleteByQueryRequest> {
 
     @Inject
     public RestDeleteByQueryAction(Settings settings, Client client, RestController controller) {
@@ -53,7 +53,7 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected DeleteByQueryRequest newRequest(RestRequest request) {
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteByQueryRequest.listenerThreaded(false);
         if (request.hasContent()) {
@@ -82,7 +82,12 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
             deleteByQueryRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
         deleteByQueryRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteByQueryRequest.indicesOptions()));
-        client.deleteByQuery(deleteByQueryRequest, new RestBuilderListener<DeleteByQueryResponse>(channel) {
+        return deleteByQueryRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, DeleteByQueryRequest request) {
+        client.deleteByQuery(request, new RestBuilderListener<DeleteByQueryResponse>(channel) {
             @Override
             public RestResponse buildResponse(DeleteByQueryResponse result, XContentBuilder builder) throws Exception {
                 RestStatus restStatus = result.status();

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  *
  */
-public class RestGetAction extends BaseRestHandler {
+public class RestGetAction extends BaseActionRequestRestHandler<GetRequest> {
 
     @Inject
     public RestGetAction(Settings settings, Client client, RestController controller) {
@@ -48,7 +48,7 @@ public class RestGetAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected GetRequest newRequest(RestRequest request) {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);
@@ -70,12 +70,16 @@ public class RestGetAction extends BaseRestHandler {
         getRequest.versionType(VersionType.fromString(request.param("version_type"), getRequest.versionType()));
 
         getRequest.fetchSourceContext(FetchSourceContext.parseFromRestRequest(request));
+        return getRequest;
+    }
 
-        client.get(getRequest, new RestBuilderListener<GetResponse>(channel) {
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, GetRequest request) {
+        client.get(request, new RestBuilderListener<GetResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                response.toXContent(builder, request);
+                response.toXContent(builder, restRequest);
                 builder.endObject();
                 if (!response.isExists()) {
                     return new BytesRestResponse(NOT_FOUND, builder);

--- a/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  *
  */
-public class RestHeadAction extends BaseRestHandler {
+public class RestHeadAction extends BaseActionRequestRestHandler<GetRequest> {
 
     @Inject
     public RestHeadAction(Settings settings, Client client, RestController controller) {
@@ -45,7 +45,7 @@ public class RestHeadAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected GetRequest newRequest(RestRequest request) {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);
@@ -56,9 +56,13 @@ public class RestHeadAction extends BaseRestHandler {
         getRequest.realtime(request.paramAsBoolean("realtime", null));
         // don't get any fields back...
         getRequest.fields(Strings.EMPTY_ARRAY);
-        // TODO we can also just return the document size as Content-Length
+        return getRequest;
+    }
 
-        client.get(getRequest, new RestResponseListener<GetResponse>(channel) {
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, GetRequest request) {
+        // TODO we can also just return the document size as Content-Length
+        client.get(request, new RestResponseListener<GetResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetResponse response) {
                 if (!response.isExists()) {

--- a/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
@@ -19,27 +19,24 @@
 
 package org.elasticsearch.rest.action.get;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
-import java.io.IOException;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
-public class RestMultiGetAction extends BaseRestHandler {
+public class RestMultiGetAction extends BaseActionRequestRestHandler<MultiGetRequest> {
 
     private final boolean allowExplicitIndex;
 
@@ -57,7 +54,7 @@ public class RestMultiGetAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected MultiGetRequest newRequest(RestRequest request) throws Exception {
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         multiGetRequest.listenerThreaded(false);
         multiGetRequest.refresh(request.paramAsBoolean("refresh", multiGetRequest.refresh()));
@@ -72,7 +69,11 @@ public class RestMultiGetAction extends BaseRestHandler {
 
         FetchSourceContext defaultFetchSource = FetchSourceContext.parseFromRestRequest(request);
         multiGetRequest.add(request.param("index"), request.param("type"), sFields, defaultFetchSource, request.param("routing"), RestActions.getRestContent(request), allowExplicitIndex);
+        return multiGetRequest;
+    }
 
-        client.multiGet(multiGetRequest, new RestToXContentListener<MultiGetResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, MultiGetRequest request) {
+        client.multiGet(request, new RestToXContentListener<MultiGetResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -19,30 +19,28 @@
 
 package org.elasticsearch.rest.action.mlt;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.mlt.MoreLikeThisRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.Scroll;
-
-import java.io.IOException;
 
 import static org.elasticsearch.client.Requests.moreLikeThisRequest;
 import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  *
  */
-public class RestMoreLikeThisAction extends BaseRestHandler {
+public class RestMoreLikeThisAction extends BaseActionRequestRestHandler<MoreLikeThisRequest> {
 
     @Inject
     public RestMoreLikeThisAction(Settings settings, Client client, RestController controller) {
@@ -52,7 +50,7 @@ public class RestMoreLikeThisAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected MoreLikeThisRequest newRequest(RestRequest request) {
         MoreLikeThisRequest mltRequest = moreLikeThisRequest(request.param("index")).type(request.param("type")).id(request.param("id"));
         mltRequest.routing(request.param("routing"));
 
@@ -90,7 +88,11 @@ public class RestMoreLikeThisAction extends BaseRestHandler {
                 mltRequest.searchSource(searchSource);
             }
         }
+        return mltRequest;
+    }
 
-        client.moreLikeThis(mltRequest, new RestToXContentListener<SearchResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, MoreLikeThisRequest request) {
+        client.moreLikeThis(request, new RestToXContentListener<SearchResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.rest.action.percolate;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.percolate.MultiPercolateRequest;
 import org.elasticsearch.action.percolate.MultiPercolateResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -26,21 +25,20 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
-import java.io.IOException;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  *
  */
-public class RestMultiPercolateAction extends BaseRestHandler {
+public class RestMultiPercolateAction extends BaseActionRequestRestHandler<MultiPercolateRequest> {
 
     private final boolean allowExplicitIndex;
 
@@ -59,14 +57,18 @@ public class RestMultiPercolateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest restRequest, final RestChannel restChannel) throws Exception {
+    protected MultiPercolateRequest newRequest(RestRequest request) throws Exception {
         MultiPercolateRequest multiPercolateRequest = new MultiPercolateRequest();
-        multiPercolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, multiPercolateRequest.indicesOptions()));
-        multiPercolateRequest.indices(Strings.splitStringByCommaToArray(restRequest.param("index")));
-        multiPercolateRequest.documentType(restRequest.param("type"));
-        multiPercolateRequest.add(RestActions.getRestContent(restRequest), restRequest.contentUnsafe(), allowExplicitIndex);
+        multiPercolateRequest.indicesOptions(IndicesOptions.fromRequest(request, multiPercolateRequest.indicesOptions()));
+        multiPercolateRequest.indices(Strings.splitStringByCommaToArray(request.param("index")));
+        multiPercolateRequest.documentType(request.param("type"));
+        multiPercolateRequest.add(RestActions.getRestContent(request), request.contentUnsafe(), allowExplicitIndex);
+        return multiPercolateRequest;
+    }
 
-        client.multiPercolate(multiPercolateRequest, new RestToXContentListener<MultiPercolateResponse>(restChannel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel restChannel, MultiPercolateRequest request) {
+        client.multiPercolate(request, new RestToXContentListener<MultiPercolateResponse>(restChannel));
     }
 
 }

--- a/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -25,7 +25,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -38,7 +38,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
 /**
  */
-public class RestClearScrollAction extends BaseRestHandler {
+public class RestClearScrollAction extends BaseActionRequestRestHandler<ClearScrollRequest> {
 
     @Inject
     public RestClearScrollAction(Settings settings, Client client, RestController controller) {
@@ -49,7 +49,7 @@ public class RestClearScrollAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected ClearScrollRequest newRequest(RestRequest request) {
         String scrollIds = request.param("scroll_id");
         if (scrollIds == null) {
             scrollIds = RestActions.getRestContent(request).toUtf8();
@@ -57,7 +57,12 @@ public class RestClearScrollAction extends BaseRestHandler {
 
         ClearScrollRequest clearRequest = new ClearScrollRequest();
         clearRequest.setScrollIds(Arrays.asList(splitScrollIds(scrollIds)));
-        client.clearScroll(clearRequest, new RestStatusToXContentListener<ClearScrollResponse>(channel));
+        return clearRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, ClearScrollRequest request) {
+        client.clearScroll(request, new RestStatusToXContentListener<ClearScrollResponse>(channel));
     }
 
     public static String[] splitScrollIds(String scrollIds) {

--- a/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.search;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,21 +26,16 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
-import java.io.IOException;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  */
-public class RestMultiSearchAction extends BaseRestHandler {
+public class RestMultiSearchAction extends BaseActionRequestRestHandler<MultiSearchRequest> {
 
     private final boolean allowExplicitIndex;
 
@@ -60,7 +54,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected MultiSearchRequest newRequest(RestRequest request) throws Exception {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.listenerThreaded(false);
 
@@ -68,7 +62,11 @@ public class RestMultiSearchAction extends BaseRestHandler {
         String[] types = Strings.splitStringByCommaToArray(request.param("type"));
         IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, multiSearchRequest.indicesOptions());
         multiSearchRequest.add(RestActions.getRestContent(request), request.contentUnsafe(), indices, types, request.param("search_type"), request.param("routing"), indicesOptions, allowExplicitIndex);
+        return multiSearchRequest;
+    }
 
-        client.multiSearch(multiSearchRequest, new RestToXContentListener<MultiSearchResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, MultiSearchRequest request) {
+        client.multiSearch(request, new RestToXContentListener<MultiSearchResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -29,12 +29,11 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
-import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -48,7 +47,7 @@ import static org.elasticsearch.search.suggest.SuggestBuilder.termSuggestion;
 /**
  *
  */
-public class RestSearchAction extends BaseRestHandler {
+public class RestSearchAction extends BaseActionRequestRestHandler<SearchRequest> {
 
     @Inject
     public RestSearchAction(Settings settings, Client client, RestController controller) {
@@ -68,11 +67,15 @@ public class RestSearchAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
-        SearchRequest searchRequest;
-        searchRequest = RestSearchAction.parseSearchRequest(request);
+    protected SearchRequest newRequest(RestRequest request) {
+        SearchRequest searchRequest = RestSearchAction.parseSearchRequest(request);
         searchRequest.listenerThreaded(false);
-        client.search(searchRequest, new RestStatusToXContentListener<SearchResponse>(channel));
+        return searchRequest;
+    }
+
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, SearchRequest request) {
+        client.search(request, new RestStatusToXContentListener<SearchResponse>(channel));
     }
 
     public static SearchRequest parseSearchRequest(RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.rest.action.search;
 
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -38,7 +39,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 /**
  *
  */
-public class RestSearchScrollAction extends BaseRestHandler {
+public class RestSearchScrollAction extends BaseActionRequestRestHandler<SearchScrollRequest> {
 
     @Inject
     public RestSearchScrollAction(Settings settings, Client client, RestController controller) {
@@ -51,7 +52,7 @@ public class RestSearchScrollAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    protected SearchScrollRequest newRequest(RestRequest request) {
         String scrollId = request.param("scroll_id");
         if (scrollId == null) {
             scrollId = RestActions.getRestContent(request).toUtf8();
@@ -62,7 +63,11 @@ public class RestSearchScrollAction extends BaseRestHandler {
         if (scroll != null) {
             searchScrollRequest.scroll(new Scroll(parseTimeValue(scroll, null)));
         }
+        return searchScrollRequest;
+    }
 
-        client.searchScroll(searchScrollRequest, new RestStatusToXContentListener(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, SearchScrollRequest request) {
+        client.searchScroll(request, new RestStatusToXContentListener<SearchResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.termvector;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.termvector.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvector.MultiTermVectorsResponse;
 import org.elasticsearch.action.termvector.TermVectorRequest;
@@ -27,16 +26,17 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
-public class RestMultiTermVectorsAction extends BaseRestHandler {
+public class RestMultiTermVectorsAction extends BaseActionRequestRestHandler<MultiTermVectorsRequest> {
 
     @Inject
     public RestMultiTermVectorsAction(Settings settings, Client client, RestController controller) {
@@ -50,7 +50,7 @@ public class RestMultiTermVectorsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected MultiTermVectorsRequest newRequest(RestRequest request) throws Exception {
         MultiTermVectorsRequest multiTermVectorsRequest = new MultiTermVectorsRequest();
         multiTermVectorsRequest.listenerThreaded(false);
         TermVectorRequest template = new TermVectorRequest();
@@ -59,7 +59,11 @@ public class RestMultiTermVectorsAction extends BaseRestHandler {
         RestTermVectorAction.readURIParameters(template, request);
         multiTermVectorsRequest.ids(Strings.commaDelimitedListToStringArray(request.param("ids")));
         multiTermVectorsRequest.add(template, RestActions.getRestContent(request));
+        return multiTermVectorsRequest;
+    }
 
-        client.multiTermVectors(multiTermVectorsRequest, new RestToXContentListener<MultiTermVectorsResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, MultiTermVectorsRequest request) {
+        client.multiTermVectors(request, new RestToXContentListener<MultiTermVectorsResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BaseActionRequestRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -43,7 +43,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
  * This class parses the json request and translates it into a
  * TermVectorRequest.
  */
-public class RestTermVectorAction extends BaseRestHandler {
+public class RestTermVectorAction extends BaseActionRequestRestHandler<TermVectorRequest> {
 
     @Inject
     public RestTermVectorAction(Settings settings, Client client, RestController controller) {
@@ -53,7 +53,7 @@ public class RestTermVectorAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected TermVectorRequest newRequest(RestRequest request) throws Exception {
         TermVectorRequest termVectorRequest = new TermVectorRequest(request.param("index"), request.param("type"), request.param("id"));
         XContentParser parser = null;
         if (request.hasContent()) {
@@ -67,8 +67,12 @@ public class RestTermVectorAction extends BaseRestHandler {
             }
         }
         readURIParameters(termVectorRequest, request);
+        return termVectorRequest;
+    }
 
-        client.termVector(termVectorRequest, new RestToXContentListener<TermVectorResponse>(channel));
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, TermVectorRequest request) {
+        client.termVector(request, new RestToXContentListener<TermVectorResponse>(channel));
     }
 
     static public void readURIParameters(TermVectorRequest termVectorRequest, RestRequest request) {

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  */
-public class RestUpdateAction extends BaseRestHandler {
+public class RestUpdateAction extends BaseActionRequestRestHandler<UpdateRequest> {
 
     @Inject
     public RestUpdateAction(Settings settings, Client client, RestController controller) {
@@ -52,7 +52,7 @@ public class RestUpdateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    protected UpdateRequest newRequest(RestRequest request) throws Exception {
         UpdateRequest updateRequest = new UpdateRequest(request.param("index"), request.param("type"), request.param("id"));
         updateRequest.listenerThreaded(false);
         updateRequest.routing(request.param("routing"));
@@ -113,8 +113,12 @@ public class RestUpdateAction extends BaseRestHandler {
                 doc.versionType(VersionType.fromString(request.param("version_type"), doc.versionType()));
             }
         }
+        return updateRequest;
+    }
 
-        client.update(updateRequest, new RestBuilderListener<UpdateResponse>(channel) {
+    @Override
+    public void doHandleRequest(final RestRequest restRequest, final RestChannel channel, UpdateRequest request) {
+        client.update(request, new RestBuilderListener<UpdateResponse>(channel) {
             @Override
             public RestResponse buildResponse(UpdateResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject()
@@ -125,7 +129,7 @@ public class RestUpdateAction extends BaseRestHandler {
 
                 if (response.getGetResult() != null) {
                     builder.startObject(Fields.GET);
-                    response.getGetResult().toXContentEmbedded(builder, request);
+                    response.getGetResult().toXContentEmbedded(builder, restRequest);
                     builder.endObject();
                 }
 

--- a/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -59,12 +59,24 @@ public abstract class TransportRequest implements Streamable {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public final TransportRequest putHeader(String key, Object value) {
         if (headers == null) {
             headers = Maps.newHashMap();
         }
         headers.put(key, value);
+        return this;
+    }
+
+    /**
+     * Adds all the headers provided as arguments to the current request headers
+     */
+    public final TransportRequest putHeaders(Iterable<Map.Entry<String, String>> headers) {
+        if (this.headers == null) {
+            this.headers = Maps.newHashMap();
+        }
+        for (Map.Entry<String, String> header : headers) {
+            this.headers.put(header.getKey(), header.getValue());
+        }
         return this;
     }
 


### PR DESCRIPTION
Made sure that the REST headers are copied over from each `RestRequest` to the related `TransportRequest`(s).

Introduced new base class (`BaseActionRequestRestHandler`) for all the REST actions that map to a single `TransportRequest` (most of them). Split the existing `handleRequest` method in two phases: 1) request creation 2) request execution. Between the two we can automatically copy the headers to the transport request in the base class so we don't have to do it manually all the time.

Also added a utility method to copy the headers in `BaseRestHandler`, to be used by all the actions that don't extend the newly introduced `BaseActionRequestRestHandler` (e.g. cat api as each `RestRequest` maps to multiple `TransportRequest`s).

The following changes have been made as well:
 1) split benchmark actions into different RestAction classes (submit, abort, status)
 2) modified a couple of actions that were doing some validation during transport request creation to throw `ActionRequestValidationException` instead of directly sending the error through the channel (`RestGetSourceAction` and `RestIndexAction`)
