### PR TITLE
[Aggregations] Added _meta construct to inject metadata

### DIFF
--- a/docs/reference/search/aggregations.asciidoc
+++ b/docs/reference/search/aggregations.asciidoc
@@ -60,7 +60,7 @@ The following snippet captures the basic structure of aggregations:
         "<aggregation_type>" : {
             <aggregation_body>
         }
-        [,"_meta" : [<meta_data_object>] ]?
+        [,"meta" : [<meta_data_object>] ]?
         [,"aggregations" : { [<sub_aggregation>]+ } ]?
     }
     [,"<aggregation_name_2>" : { ... } ]*
@@ -151,7 +151,7 @@ Consider this example where we want to associate the color blue with our `terms`
             "terms": {
                 "field": "title"
             },
-            "_meta": {
+            "meta": {
                 "color": "blue"
             },
         }
@@ -167,7 +167,7 @@ Then that piece of metadata will be returned in place for our `titles` terms agg
     ...
     "aggregations": {
         "titles": {
-            "_meta": {
+            "meta": {
                 "color" : "blue"
             },
             "buckets": [

--- a/docs/reference/search/aggregations.asciidoc
+++ b/docs/reference/search/aggregations.asciidoc
@@ -60,6 +60,7 @@ The following snippet captures the basic structure of aggregations:
         "<aggregation_type>" : {
             <aggregation_body>
         }
+        [,"_meta" : [<meta_data_object>] ]?
         [,"aggregations" : { [<sub_aggregation>]+ } ]?
     }
     [,"<aggregation_name_2>" : { ... } ]*
@@ -133,6 +134,48 @@ aggregated for the buckets created by their "parent" bucket aggregation.
 There are different bucket aggregators, each with a different "bucketing" strategy. Some define a single bucket, some
 define fixed number of multiple buckets, and others dynamically create the buckets during the aggregation process.
 
+[float]
+=== Metadata
+
+You can associate a piece of metadata with individual aggregations at request time that will be returned in place
+at response time.
+
+Consider this example where we want to associate the color blue with our `terms` aggregation.
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+    aggs": {
+        "titles": {
+            "terms": {
+                "field": "title"
+            },
+            "_meta": {
+                "color": "blue"
+            },
+        }
+    }
+}
+--------------------------------------------------
+
+Then that piece of metadata will be returned in place for our `titles` terms aggregation
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+    "aggregations": {
+        "titles": {
+            "_meta": {
+                "color" : "blue"
+            },
+            "buckets": [
+            ]
+        }
+    }
+}
+--------------------------------------------------
 
 include::aggregations/metrics.asciidoc[]
 

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -28,4 +28,13 @@ public interface Aggregation {
      */
     String getName();
 
+    /**
+     * Set an optional byte array of additional meta data to be rendered in the response
+     */
+    void setMetaData(byte[] bytes);
+
+    /**
+     * Get the optional byte array metadata that was set on the aggregation
+     */
+    byte[] getMetaData();
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.search.aggregations;
 
+import java.util.Map;
+
 /**
  * An aggregation
  */
@@ -31,5 +33,5 @@ public interface Aggregation {
     /**
      * Get the optional byte array metadata that was set on the aggregation
      */
-    byte[] getMetaData();
+    Map<String, Object> getMetaData();
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -29,11 +29,6 @@ public interface Aggregation {
     String getName();
 
     /**
-     * Set an optional byte array of additional meta data to be rendered in the response
-     */
-    void setMetaData(byte[] bytes);
-
-    /**
      * Get the optional byte array metadata that was set on the aggregation
      */
     byte[] getMetaData();

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,6 +39,8 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
 
     private List<AbstractAggregationBuilder> aggregations;
     private BytesReference aggregationsBinary;
+
+    private Object metaData;
 
     protected AggregationBuilder(String name, String type) {
         super(name, type);
@@ -98,11 +101,23 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
         }
     }
 
+    /**
+     *
+     */
+    public B setMetaData(Object metaData) {
+        this.metaData = metaData;
+        return (B)this;
+    }
+
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(name);
 
+        if (this.metaData != null) {
+            builder.field("_meta", this.metaData);
+        }
         builder.field(type);
+
         internalXContent(builder, params);
 
         if (aggregations != null || aggregationsBinary != null) {
@@ -124,6 +139,8 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
 
             builder.endObject();
         }
+
+
 
         return builder.endObject();
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -114,7 +114,7 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
         builder.startObject(name);
 
         if (this.metaData != null) {
-            builder.field("_meta", this.metaData);
+            builder.field("meta", this.metaData);
         }
         builder.field(type);
 

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -40,7 +40,7 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
     private List<AbstractAggregationBuilder> aggregations;
     private BytesReference aggregationsBinary;
 
-    private Object metaData;
+    private Map<String, Object> metaData;
 
     protected AggregationBuilder(String name, String type) {
         super(name, type);
@@ -104,7 +104,7 @@ public abstract class AggregationBuilder<B extends AggregationBuilder<B>> extend
     /**
      *
      */
-    public B setMetaData(Object metaData) {
+    public B setMetaData(Map<String, Object> metaData) {
         this.metaData = metaData;
         return (B)this;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -270,9 +270,7 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
     public void setMetaData(byte[] metaData) {
         this.metaData = metaData;
     }
-    public byte[] metaData() {
-        return this.metaData;
-    }
+
     /**
      * @return  The name of the aggregation.
      */

--- a/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -22,7 +22,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.lease.Releasable;
@@ -362,30 +361,15 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
     protected void doPostCollection() throws IOException {
     }
 
-    /**
-     * @return  The aggregated & built aggregation
-     */
-    public InternalAggregation buildAggregation(long owningBucketOrdinal)
-    {
-        InternalAggregation agg = buildInternalAggregation(owningBucketOrdinal);
-        agg.setMetaData(this.metaData);
-        return agg;
-    }
-    protected abstract InternalAggregation buildInternalAggregation(long owningBucketOrdinal);
+
+    public abstract InternalAggregation buildAggregation(long owningBucketOrdinal);
     
     @Override
     public void gatherAnalysis(BucketAnalysisCollector results, long bucketOrdinal) {
         results.add(buildAggregation(bucketOrdinal));
     }
 
-    public InternalAggregation buildEmptyAggregation()
-    {
-        InternalAggregation agg = buildEmptyInternalAggregation();
-        agg.setMetaData(this.metaData);
-        return agg;
-    }
-
-    protected abstract InternalAggregation buildEmptyInternalAggregation();
+    public abstract InternalAggregation buildEmptyAggregation();
 
     protected final InternalAggregations buildEmptySubAggregations() {
         List<InternalAggregation> aggs = new ArrayList<>();

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -119,12 +119,12 @@ public class AggregatorFactories {
                 }
 
                 @Override
-                public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+                public InternalAggregation buildAggregation(long owningBucketOrdinal) {
                     throw new ElasticsearchIllegalStateException("Invalid context - aggregation must use addResults() to collect child results");
                 }
 
                 @Override
-                public InternalAggregation buildEmptyInternalAggregation() {
+                public InternalAggregation buildEmptyAggregation() {
                     return first.buildEmptyAggregation();
                 }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -119,12 +119,12 @@ public class AggregatorFactories {
                 }
 
                 @Override
-                public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+                public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
                     throw new ElasticsearchIllegalStateException("Invalid context - aggregation must use addResults() to collect child results");
                 }
 
                 @Override
-                public InternalAggregation buildEmptyAggregation() {
+                public InternalAggregation buildEmptyInternalAggregation() {
                     return first.buildEmptyAggregation();
                 }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 /**
@@ -27,6 +28,7 @@ public abstract class AggregatorFactory {
 
     protected String name;
     protected String type;
+    protected byte[] metaData;
     protected AggregatorFactory parent;
     protected AggregatorFactories factories = AggregatorFactories.EMPTY;
 
@@ -79,9 +81,18 @@ public abstract class AggregatorFactory {
      *
      * @return                      The created aggregator
      */
-    public abstract Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount);
+    protected abstract Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount);
+    public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount)
+    {
+        Aggregator aggregator = createInternal(context, parent, expectedBucketsCount);
+        aggregator.setMetaData(this.metaData);
+        return aggregator;
+    }
 
     public void doValidate() {
     }
 
+    public void setMetaData(byte[] metaData) {
+        this.metaData = metaData;
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -82,6 +82,7 @@ public abstract class AggregatorFactory {
      * @return                      The created aggregator
      */
     protected abstract Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount);
+
     public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
         Aggregator aggregator = createInternal(context, parent, expectedBucketsCount);
         aggregator.setMetaData(this.metaData);

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -82,8 +82,7 @@ public abstract class AggregatorFactory {
      * @return                      The created aggregator
      */
     protected abstract Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount);
-    public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount)
-    {
+    public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
         Aggregator aggregator = createInternal(context, parent, expectedBucketsCount);
         aggregator.setMetaData(this.metaData);
         return aggregator;

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
@@ -141,8 +141,10 @@ public class AggregatorParsers {
             if (factory == null) {
                 throw new SearchParseException(context, "Missing definition for aggregation [" + aggregationName + "]");
             }
-            if (metaData != null)
+
+            if (metaData != null) {
                 factory.setMetaData(metaData);
+            }
 
             if (subFactories != null) {
                 factory.subFactories(subFactories);

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
@@ -109,12 +109,12 @@ public class AggregatorParsers {
                 final String fieldName = parser.currentName();
 
                 token = parser.nextToken();
-                if (token != XContentParser.Token.START_OBJECT && !fieldName.equals("_meta")) {
+                if (token != XContentParser.Token.START_OBJECT && !fieldName.equals("meta")) {
                     throw new SearchParseException(context, "Expected [" + XContentParser.Token.START_OBJECT + "] under [" + fieldName + "], but got a [" + token + "] in [" + aggregationName + "]");
                 }
 
                 switch (fieldName) {
-                    case "_meta":
+                    case "meta":
                         XContentBuilder xContentBuilder = XContentFactory.smileBuilder().copyCurrentStructure(parser);
                         metaData =  xContentBuilder.bytes().toBytes();
                         parser.skipChildren();

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -24,8 +24,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.common.xcontent.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -103,6 +102,8 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
 
     protected String name;
 
+    protected byte[] metaData;
+
     /** Constructs an un initialized addAggregation (used for serialization) **/
     protected InternalAggregation() {}
 
@@ -120,6 +121,13 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
         return name;
     }
 
+    public void setMetaData(byte[] metaData) {
+        this.metaData = metaData;
+    }
+
+    public byte[] getMetaData() {
+        return this.metaData;
+    }
     /**
      * @return The {@link Type} of this aggregation
      */
@@ -152,9 +160,22 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
     }
 
     /**
+     * Writes the opening of the aggregation result optionally with metaData property
+     */
+    protected void startAggregationObject(XContentBuilder builder) throws IOException {
+        builder.startObject(name);
+        if (this.metaData != null) {
+            XContentParser parser = XContentHelper.createParser(new BytesArray(this.metaData));
+            builder.field(CommonFields.META);
+            builder.copyCurrentStructure(parser);
+        }
+    }
+
+    /**
      * Common xcontent fields that are shared among addAggregation
      */
     public static final class CommonFields {
+        public static final XContentBuilderString META = new XContentBuilderString("_meta");
         public static final XContentBuilderString BUCKETS = new XContentBuilderString("buckets");
         public static final XContentBuilderString VALUE = new XContentBuilderString("value");
         public static final XContentBuilderString VALUES = new XContentBuilderString("values");

--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -112,8 +112,9 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
      *
      * @param name The name of the get.
      */
-    protected InternalAggregation(String name) {
+    protected InternalAggregation(String name, byte[] metaData) {
         this.name = name;
+        this.metaData = metaData;
     }
 
     @Override
@@ -175,7 +176,7 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
      * Common xcontent fields that are shared among addAggregation
      */
     public static final class CommonFields {
-        public static final XContentBuilderString META = new XContentBuilderString("_meta");
+        public static final XContentBuilderString META = new XContentBuilderString("meta");
         public static final XContentBuilderString BUCKETS = new XContentBuilderString("buckets");
         public static final XContentBuilderString VALUE = new XContentBuilderString("value");
         public static final XContentBuilderString VALUES = new XContentBuilderString("values");

--- a/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
@@ -54,7 +54,7 @@ public abstract class NonCollectingAggregator extends Aggregator {
     }
 
     @Override
-    public final InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public final InternalAggregation buildAggregation(long owningBucketOrdinal) {
         return buildEmptyAggregation();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
@@ -54,7 +54,7 @@ public abstract class NonCollectingAggregator extends Aggregator {
     }
 
     @Override
-    public final InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public final InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         return buildEmptyAggregation();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -99,7 +99,7 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.field(CommonFields.DOC_COUNT, docCount);
         aggregations.toXContentInternal(builder, params);
         return builder.endObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -45,8 +45,8 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
      * @param docCount      The document count in the single bucket.
      * @param aggregations  The already built sub-aggregations that are associated with the bucket.
      */
-    protected InternalSingleBucketAggregation(String name, long docCount, InternalAggregations aggregations) {
-        super(name);
+    protected InternalSingleBucketAggregation(String name, long docCount, InternalAggregations aggregations, byte[] metaData) {
+        super(name, metaData);
         this.docCount = docCount;
         this.aggregations = aggregations;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -98,10 +98,8 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.DOC_COUNT, docCount);
         aggregations.toXContentInternal(builder, params);
-        return builder.endObject();
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
@@ -63,13 +63,13 @@ public class FilterAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
-        return new InternalFilter(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        return new InternalFilter(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalFilter(name, 0, buildEmptySubAggregations());
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalFilter(name, 0, buildEmptySubAggregations(), metaData);
     }
 
     public static class Factory extends AggregatorFactory {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
@@ -63,12 +63,12 @@ public class FilterAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         return new InternalFilter(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalFilter(name, 0, buildEmptySubAggregations());
     }
 
@@ -82,7 +82,7 @@ public class FilterAggregator extends SingleBucketAggregator {
         }
 
         @Override
-        public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
+        protected Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
             return new FilterAggregator(name, filter, factories, context, parent);
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
@@ -47,8 +47,8 @@ public class InternalFilter extends InternalSingleBucketAggregation implements F
 
     InternalFilter() {} // for serialization
 
-    InternalFilter(String name, long docCount, InternalAggregations subAggregations) {
-        super(name, docCount, subAggregations);
+    InternalFilter(String name, long docCount, InternalAggregations subAggregations, byte[] metaData) {
+        super(name, docCount, subAggregations, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -96,7 +96,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalGeoHashGrid buildAggregation(long owningBucketOrdinal) {
+    public InternalGeoHashGrid buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
         final int size = (int) Math.min(bucketOrds.size(), shardSize);
 
@@ -123,7 +123,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalGeoHashGrid buildEmptyAggregation() {
+    public InternalGeoHashGrid buildEmptyInternalAggregation() {
         return new InternalGeoHashGrid(name, requiredSize, Collections.<InternalGeoHashGrid.Bucket>emptyList());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -96,7 +96,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalGeoHashGrid buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalGeoHashGrid buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
         final int size = (int) Math.min(bucketOrds.size(), shardSize);
 
@@ -119,12 +119,12 @@ public class GeoHashGridAggregator extends BucketsAggregator {
             bucket.aggregations = bucketAggregations(bucket.bucketOrd);
             list[i] = bucket;
         }
-        return new InternalGeoHashGrid(name, requiredSize, Arrays.asList(list));
+        return new InternalGeoHashGrid(name, requiredSize, Arrays.asList(list), metaData);
     }
 
     @Override
-    public InternalGeoHashGrid buildEmptyInternalAggregation() {
-        return new InternalGeoHashGrid(name, requiredSize, Collections.<InternalGeoHashGrid.Bucket>emptyList());
+    public InternalGeoHashGrid buildEmptyAggregation() {
+        return new InternalGeoHashGrid(name, requiredSize, Collections.<InternalGeoHashGrid.Bucket>emptyList(), metaData);
     }
 
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParser.java
@@ -118,7 +118,7 @@ public class GeoHashGridParser implements Aggregator.Parser {
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent) {
             final InternalAggregation aggregation = new InternalGeoHashGrid(name, requiredSize, Collections.<InternalGeoHashGrid.Bucket>emptyList());
             return new NonCollectingAggregator(name, aggregationContext, parent) {
-                public InternalAggregation buildEmptyAggregation() {
+                public InternalAggregation buildEmptyInternalAggregation() {
                     return aggregation;
                 }
             };

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParser.java
@@ -116,9 +116,9 @@ public class GeoHashGridParser implements Aggregator.Parser {
 
         @Override
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent) {
-            final InternalAggregation aggregation = new InternalGeoHashGrid(name, requiredSize, Collections.<InternalGeoHashGrid.Bucket>emptyList());
+            final InternalAggregation aggregation = new InternalGeoHashGrid(name, requiredSize, Collections.<InternalGeoHashGrid.Bucket>emptyList(), metaData);
             return new NonCollectingAggregator(name, aggregationContext, parent) {
-                public InternalAggregation buildEmptyInternalAggregation() {
+                public InternalAggregation buildEmptyAggregation() {
                     return aggregation;
                 }
             };

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -275,7 +275,7 @@ public class InternalGeoHashGrid extends InternalAggregation implements GeoHashG
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.startArray(CommonFields.BUCKETS);
         for (Bucket bucket : buckets) {
             builder.startObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -140,8 +140,8 @@ public class InternalGeoHashGrid extends InternalAggregation implements GeoHashG
     InternalGeoHashGrid() {
     } // for serialization
 
-    public InternalGeoHashGrid(String name, int requiredSize, Collection<Bucket> buckets) {
-        super(name);
+    public InternalGeoHashGrid(String name, int requiredSize, Collection<Bucket> buckets, byte[] metaData) {
+        super(name, metaData);
         this.requiredSize = requiredSize;
         this.buckets = buckets;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -274,8 +274,7 @@ public class InternalGeoHashGrid extends InternalAggregation implements GeoHashG
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS);
         for (Bucket bucket : buckets) {
             builder.startObject();
@@ -285,8 +284,6 @@ public class InternalGeoHashGrid extends InternalAggregation implements GeoHashG
             builder.endObject();
         }
         builder.endArray();
-        builder.endObject();
-        return builder;
     }
 
     static class BucketPriorityQueue extends PriorityQueue<Bucket> {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -45,13 +45,13 @@ public class GlobalAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0 : "global aggregator can only be a top level aggregator";
         return new InternalGlobal(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         throw new UnsupportedOperationException("global aggregations cannot serve as sub-aggregations, hence should never be called on #buildEmptyAggregations");
     }
 
@@ -62,7 +62,7 @@ public class GlobalAggregator extends SingleBucketAggregator {
         }
 
         @Override
-        public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
+        protected Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
             if (parent != null) {
                 throw new AggregationExecutionException("Aggregation [" + parent.name() + "] cannot have a global " +
                         "sub-aggregation [" + name + "]. Global aggregations can only be defined as top level aggregations");

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -45,13 +45,13 @@ public class GlobalAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0 : "global aggregator can only be a top level aggregator";
-        return new InternalGlobal(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
+        return new InternalGlobal(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
+    public InternalAggregation buildEmptyAggregation() {
         throw new UnsupportedOperationException("global aggregations cannot serve as sub-aggregations, hence should never be called on #buildEmptyAggregations");
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobal.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobal.java
@@ -48,8 +48,8 @@ public class InternalGlobal extends InternalSingleBucketAggregation implements G
 
     InternalGlobal() {} // for serialization
 
-    InternalGlobal(String name, long docCount, InternalAggregations aggregations) {
-        super(name, docCount, aggregations);
+    InternalGlobal(String name, long docCount, InternalAggregations aggregations, byte[] metaData) {
+        super(name, docCount, aggregations, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -109,7 +109,7 @@ public class HistogramAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
         List<InternalHistogram.Bucket> buckets = new ArrayList<>((int) bucketOrds.size());
         for (long i = 0; i < bucketOrds.size(); i++) {
@@ -124,7 +124,7 @@ public class HistogramAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         InternalHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0 ? new InternalHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds) : null;
         return histogramFactory.create(name, Collections.emptyList(), order, minDocCount, emptyBucketInfo, formatter, keyed);
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -109,7 +109,7 @@ public class HistogramAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
         List<InternalHistogram.Bucket> buckets = new ArrayList<>((int) bucketOrds.size());
         for (long i = 0; i < bucketOrds.size(); i++) {
@@ -120,13 +120,13 @@ public class HistogramAggregator extends BucketsAggregator {
 
         // value source will be null for unmapped fields
         InternalHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0 ? new InternalHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds) : null;
-        return histogramFactory.create(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed);
+        return histogramFactory.create(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed, metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
+    public InternalAggregation buildEmptyAggregation() {
         InternalHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0 ? new InternalHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds) : null;
-        return histogramFactory.create(name, Collections.emptyList(), order, minDocCount, emptyBucketInfo, formatter, keyed);
+        return histogramFactory.create(name, Collections.emptyList(), order, minDocCount, emptyBucketInfo, formatter, keyed, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -85,8 +85,8 @@ public class InternalDateHistogram extends InternalHistogram<InternalDateHistogr
 
         @Override
         public InternalDateHistogram create(String name, List<InternalDateHistogram.Bucket> buckets, InternalOrder order,
-                                            long minDocCount, EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed) {
-            return new InternalDateHistogram(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed);
+                                            long minDocCount, EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed, byte[] metaData) {
+            return new InternalDateHistogram(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed, metaData);
         }
 
         @Override
@@ -100,8 +100,8 @@ public class InternalDateHistogram extends InternalHistogram<InternalDateHistogr
     InternalDateHistogram() {} // for serialization
 
     InternalDateHistogram(String name, List<InternalDateHistogram.Bucket> buckets, InternalOrder order, long minDocCount,
-                          EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed) {
-        super(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed);
+                          EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed, byte[] metaData) {
+        super(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -484,8 +484,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         if (keyed) {
             builder.startObject(CommonFields.BUCKETS);
         } else {
@@ -499,7 +498,6 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
         } else {
             builder.endArray();
         }
-        return builder.endObject();
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -198,8 +198,8 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
         }
 
         public InternalHistogram<B> create(String name, List<B> buckets, InternalOrder order, long minDocCount,
-                                           EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed) {
-            return new InternalHistogram<>(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed);
+                                           EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed, byte[] metaData) {
+            return new InternalHistogram<>(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed, metaData);
         }
 
         public B createBucket(long key, long docCount, InternalAggregations aggregations, @Nullable ValueFormatter formatter) {
@@ -219,8 +219,8 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
     InternalHistogram() {} // for serialization
 
     InternalHistogram(String name, List<B> buckets, InternalOrder order, long minDocCount,
-                      EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed) {
-        super(name);
+                      EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed, byte[] metaData) {
+        super(name, metaData);
         this.buckets = buckets;
         this.order = order;
         assert (minDocCount == 0) == (emptyBucketInfo != null);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -485,7 +485,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         if (keyed) {
             builder.startObject(CommonFields.BUCKETS);
         } else {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
@@ -49,8 +49,8 @@ public class InternalMissing extends InternalSingleBucketAggregation implements 
     InternalMissing() {
     }
 
-    InternalMissing(String name, long docCount, InternalAggregations aggregations) {
-        super(name, docCount, aggregations);
+    InternalMissing(String name, long docCount, InternalAggregations aggregations, byte[] metaData) {
+        super(name, docCount, aggregations, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
@@ -60,13 +60,13 @@ public class MissingAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
-        return new InternalMissing(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        return new InternalMissing(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalMissing(name, 0, buildEmptySubAggregations());
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalMissing(name, 0, buildEmptySubAggregations(), metaData);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
@@ -60,12 +60,12 @@ public class MissingAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         return new InternalMissing(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalMissing(name, 0, buildEmptySubAggregations());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNested.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNested.java
@@ -48,8 +48,8 @@ public class InternalNested extends InternalSingleBucketAggregation implements N
     public InternalNested() {
     }
 
-    public InternalNested(String name, long docCount, InternalAggregations aggregations) {
-        super(name, docCount, aggregations);
+    public InternalNested(String name, long docCount, InternalAggregations aggregations, byte[] metaData) {
+        super(name, docCount, aggregations, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNested.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNested.java
@@ -48,8 +48,8 @@ public class InternalReverseNested extends InternalSingleBucketAggregation imple
     public InternalReverseNested() {
     }
 
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations) {
-        super(name, docCount, aggregations);
+    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations, byte[] metaData) {
+        super(name, docCount, aggregations, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -122,13 +122,13 @@ public class NestedAggregator extends SingleBucketAggregator implements ReaderCo
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
-        return new InternalNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        return new InternalNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalNested(name, 0, buildEmptySubAggregations());
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalNested(name, 0, buildEmptySubAggregations(), metaData);
     }
 
     public String getNestedPath() {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -122,12 +122,12 @@ public class NestedAggregator extends SingleBucketAggregator implements ReaderCo
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         return new InternalNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalNested(name, 0, buildEmptySubAggregations());
     }
 
@@ -154,7 +154,7 @@ public class NestedAggregator extends SingleBucketAggregator implements ReaderCo
         }
 
         @Override
-        public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
+        protected Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
             return new NestedAggregator(name, factories, path, context, parent);
         }
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -130,12 +130,12 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
 
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         return new InternalReverseNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalReverseNested(name, 0, buildEmptySubAggregations());
     }
 
@@ -154,7 +154,7 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
         }
 
         @Override
-        public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
+        protected Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
             return new ReverseNestedAggregator(name, factories, path, context, parent);
         }
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -130,13 +130,13 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
 
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
-        return new InternalReverseNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal));
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        return new InternalReverseNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalReverseNested(name, 0, buildEmptySubAggregations());
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalReverseNested(name, 0, buildEmptySubAggregations(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -290,8 +290,7 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalAggre
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         if (keyed) {
             builder.startObject(CommonFields.BUCKETS);
         } else {
@@ -305,7 +304,6 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalAggre
         } else {
             builder.endArray();
         }
-        return builder.endObject();
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -291,7 +291,7 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalAggre
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         if (keyed) {
             builder.startObject(CommonFields.BUCKETS);
         } else {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -164,8 +164,8 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalAggre
             return TYPE.name();
         }
 
-        public R create(String name, List<B> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return (R) new InternalRange<>(name, ranges, formatter, keyed, unmapped);
+        public R create(String name, List<B> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+            return (R) new InternalRange<>(name, ranges, formatter, keyed, unmapped, metaData);
         }
 
 
@@ -182,8 +182,8 @@ public class InternalRange<B extends InternalRange.Bucket> extends InternalAggre
 
     public InternalRange() {} // for serialization
 
-    public InternalRange(String name, List<B> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-        super(name);
+    public InternalRange(String name, List<B> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+        super(name, metaData);
         this.ranges = ranges;
         this.formatter = formatter;
         this.keyed = keyed;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -193,7 +193,7 @@ public class RangeAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = Lists.newArrayListWithCapacity(ranges.length);
         for (int i = 0; i < ranges.length; i++) {
             Range range = ranges[i];
@@ -207,7 +207,7 @@ public class RangeAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         InternalAggregations subAggs = buildEmptySubAggregations();
         List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = Lists.newArrayListWithCapacity(ranges.length);
         for (int i = 0; i < ranges.length; i++) {
@@ -268,7 +268,7 @@ public class RangeAggregator extends BucketsAggregator {
         }
 
         @Override
-        public InternalAggregation buildEmptyAggregation() {
+        public InternalAggregation buildEmptyInternalAggregation() {
             InternalAggregations subAggs = buildEmptySubAggregations();
             List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = new ArrayList<>(ranges.size());
             for (RangeAggregator.Range range : ranges) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -193,7 +193,7 @@ public class RangeAggregator extends BucketsAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = Lists.newArrayListWithCapacity(ranges.length);
         for (int i = 0; i < ranges.length; i++) {
             Range range = ranges[i];
@@ -203,11 +203,11 @@ public class RangeAggregator extends BucketsAggregator {
             buckets.add(bucket);
         }
         // value source can be null in the case of unmapped fields
-        return rangeFactory.create(name, buckets, formatter, keyed, false);
+        return rangeFactory.create(name, buckets, formatter, keyed, false, metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
+    public InternalAggregation buildEmptyAggregation() {
         InternalAggregations subAggs = buildEmptySubAggregations();
         List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = Lists.newArrayListWithCapacity(ranges.length);
         for (int i = 0; i < ranges.length; i++) {
@@ -217,7 +217,7 @@ public class RangeAggregator extends BucketsAggregator {
             buckets.add(bucket);
         }
         // value source can be null in the case of unmapped fields
-        return rangeFactory.create(name, buckets, formatter, keyed, false);
+        return rangeFactory.create(name, buckets, formatter, keyed, false, metaData);
     }
 
     private static final void sortRanges(final Range[] ranges) {
@@ -268,13 +268,13 @@ public class RangeAggregator extends BucketsAggregator {
         }
 
         @Override
-        public InternalAggregation buildEmptyInternalAggregation() {
+        public InternalAggregation buildEmptyAggregation() {
             InternalAggregations subAggs = buildEmptySubAggregations();
             List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = new ArrayList<>(ranges.size());
             for (RangeAggregator.Range range : ranges) {
                 buckets.add(factory.createBucket(range.key, range.from, range.to, 0, subAggs, formatter));
             }
-            return factory.create(name, buckets, formatter, keyed, true);
+            return factory.create(name, buckets, formatter, keyed, true, metaData);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
@@ -82,8 +82,8 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket> i
         }
 
         @Override
-        public InternalDateRange create(String name, List<InternalDateRange.Bucket> ranges, ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return new InternalDateRange(name, ranges, formatter, keyed, unmapped);
+        public InternalDateRange create(String name, List<InternalDateRange.Bucket> ranges, ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+            return new InternalDateRange(name, ranges, formatter, keyed, unmapped, metaData);
         }
 
         @Override
@@ -94,8 +94,8 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket> i
 
     InternalDateRange() {} // for serialization
 
-    InternalDateRange(String name, List<InternalDateRange.Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-        super(name, ranges, formatter, keyed, unmapped);
+    InternalDateRange(String name, List<InternalDateRange.Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+        super(name, ranges, formatter, keyed, unmapped, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistance.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistance.java
@@ -71,8 +71,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
         }
 
         @Override
-        public InternalGeoDistance create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return new InternalGeoDistance(name, ranges, formatter, keyed, unmapped);
+        public InternalGeoDistance create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+            return new InternalGeoDistance(name, ranges, formatter, keyed, unmapped, metaData);
         }
 
         @Override
@@ -83,8 +83,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     InternalGeoDistance() {} // for serialization
 
-    public InternalGeoDistance(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-        super(name, ranges, formatter, keyed, unmapped);
+    public InternalGeoDistance(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+        super(name, ranges, formatter, keyed, unmapped, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
@@ -84,8 +84,8 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket> i
         }
 
         @Override
-        public InternalIPv4Range create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return new InternalIPv4Range(name, ranges, keyed, unmapped);
+        public InternalIPv4Range create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped, byte[] metaData) {
+            return new InternalIPv4Range(name, ranges, keyed, unmapped, metaData);
         }
 
         @Override
@@ -96,8 +96,8 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket> i
 
     public InternalIPv4Range() {} // for serialization
 
-    public InternalIPv4Range(String name, List<InternalIPv4Range.Bucket> ranges, boolean keyed, boolean unmapped) {
-        super(name, ranges, ValueFormatter.IPv4, keyed, unmapped);
+    public InternalIPv4Range(String name, List<InternalIPv4Range.Bucket> ranges, boolean keyed, boolean unmapped, byte[] metaData) {
+        super(name, ranges, ValueFormatter.IPv4, keyed, unmapped, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/GlobalOrdinalsSignificantTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/GlobalOrdinalsSignificantTermsAggregator.java
@@ -59,10 +59,10 @@ public class GlobalOrdinalsSignificantTermsAggregator extends GlobalOrdinalsStri
     }
 
     @Override
-    public SignificantStringTerms buildAggregation(long owningBucketOrdinal) {
+    public SignificantStringTerms buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
         if (globalOrdinals == null) { // no context in this reader
-            return buildEmptyAggregation();
+            return buildEmptyInternalAggregation();
         }
 
         final int size;
@@ -118,7 +118,7 @@ public class GlobalOrdinalsSignificantTermsAggregator extends GlobalOrdinalsStri
     }
 
     @Override
-    public SignificantStringTerms buildEmptyAggregation() {
+    public SignificantStringTerms buildEmptyInternalAggregation() {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
         ContextIndexSearcher searcher = context.searchContext().searcher();
         IndexReader topReader = searcher.getIndexReader();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/GlobalOrdinalsSignificantTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/GlobalOrdinalsSignificantTermsAggregator.java
@@ -59,10 +59,10 @@ public class GlobalOrdinalsSignificantTermsAggregator extends GlobalOrdinalsStri
     }
 
     @Override
-    public SignificantStringTerms buildInternalAggregation(long owningBucketOrdinal) {
+    public SignificantStringTerms buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
         if (globalOrdinals == null) { // no context in this reader
-            return buildEmptyInternalAggregation();
+            return buildEmptyAggregation();
         }
 
         final int size;
@@ -114,16 +114,16 @@ public class GlobalOrdinalsSignificantTermsAggregator extends GlobalOrdinalsStri
             list[i] = bucket;
         }
 
-        return new SignificantStringTerms(subsetSize, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new SignificantStringTerms(subsetSize, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
 
     @Override
-    public SignificantStringTerms buildEmptyInternalAggregation() {
+    public SignificantStringTerms buildEmptyAggregation() {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
         ContextIndexSearcher searcher = context.searchContext().searcher();
         IndexReader topReader = searcher.getIndexReader();
         int supersetSize = topReader.numDocs();
-        return new SignificantStringTerms(0, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalSignificantTerms.Bucket>emptyList());
+        return new SignificantStringTerms(0, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalSignificantTerms.Bucket>emptyList(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
@@ -168,8 +168,8 @@ public abstract class InternalSignificantTerms extends InternalAggregation imple
         }
     }
 
-    protected InternalSignificantTerms(long subsetSize, long supersetSize, String name, int requiredSize, long minDocCount, Collection<Bucket> buckets) {
-        super(name);
+    protected InternalSignificantTerms(long subsetSize, long supersetSize, String name, int requiredSize, long minDocCount, Collection<Bucket> buckets, byte[] metaData) {
+        super(name, metaData);
         this.requiredSize = requiredSize;
         this.minDocCount = minDocCount;
         this.buckets = buckets;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -140,8 +140,7 @@ public class SignificantLongTerms extends InternalSignificantTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field("doc_count", subsetSize);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalSignificantTerms.Bucket bucket : buckets) {
@@ -157,8 +156,6 @@ public class SignificantLongTerms extends InternalSignificantTerms {
             builder.endObject();
         }
         builder.endArray();
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -90,9 +90,9 @@ public class SignificantLongTerms extends InternalSignificantTerms {
     SignificantLongTerms() {} // for serialization
 
     public SignificantLongTerms(long subsetSize, long supersetSize, String name, @Nullable ValueFormatter formatter,
-                                int requiredSize, long minDocCount, Collection<InternalSignificantTerms.Bucket> buckets) {
+                                int requiredSize, long minDocCount, Collection<InternalSignificantTerms.Bucket> buckets, byte[] metaData) {
 
-        super(subsetSize, supersetSize, name, requiredSize, minDocCount, buckets);
+        super(subsetSize, supersetSize, name, requiredSize, minDocCount, buckets, metaData);
         this.formatter = formatter;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -141,7 +141,7 @@ public class SignificantLongTerms extends InternalSignificantTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.field("doc_count", subsetSize);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalSignificantTerms.Bucket bucket : buckets) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -56,7 +56,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
     }
 
     @Override
-    public SignificantLongTerms buildInternalAggregation(long owningBucketOrdinal) {
+    public SignificantLongTerms buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         final int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
@@ -92,16 +92,16 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
             bucket.aggregations = bucketAggregations(bucket.bucketOrd);
             list[i] = bucket;
         }
-        return new SignificantLongTerms(subsetSize, supersetSize, name, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new SignificantLongTerms(subsetSize, supersetSize, name, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
 
     @Override
-    public SignificantLongTerms buildEmptyInternalAggregation() {
+    public SignificantLongTerms buildEmptyAggregation() {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
         ContextIndexSearcher searcher = context.searchContext().searcher();
         IndexReader topReader = searcher.getIndexReader();
         int supersetSize = topReader.numDocs();
-        return new SignificantLongTerms(0, supersetSize, name, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalSignificantTerms.Bucket>emptyList());
+        return new SignificantLongTerms(0, supersetSize, name, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalSignificantTerms.Bucket>emptyList(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -56,7 +56,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
     }
 
     @Override
-    public SignificantLongTerms buildAggregation(long owningBucketOrdinal) {
+    public SignificantLongTerms buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         final int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
@@ -96,7 +96,7 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
     }
 
     @Override
-    public SignificantLongTerms buildEmptyAggregation() {
+    public SignificantLongTerms buildEmptyInternalAggregation() {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
         ContextIndexSearcher searcher = context.searchContext().searcher();
         IndexReader topReader = searcher.getIndexReader();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -90,8 +90,8 @@ public class SignificantStringTerms extends InternalSignificantTerms {
     SignificantStringTerms() {} // for serialization
 
     public SignificantStringTerms(long subsetSize, long supersetSize, String name, int requiredSize,
-            long minDocCount, Collection<InternalSignificantTerms.Bucket> buckets) {
-        super(subsetSize, supersetSize, name, requiredSize, minDocCount, buckets);
+            long minDocCount, Collection<InternalSignificantTerms.Bucket> buckets, byte[] metaData) {
+        super(subsetSize, supersetSize, name, requiredSize, minDocCount, buckets, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -136,7 +136,7 @@ public class SignificantStringTerms extends InternalSignificantTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.field("doc_count", subsetSize);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalSignificantTerms.Bucket bucket : buckets) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -135,8 +135,7 @@ public class SignificantStringTerms extends InternalSignificantTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field("doc_count", subsetSize);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalSignificantTerms.Bucket bucket : buckets) {
@@ -153,8 +152,6 @@ public class SignificantStringTerms extends InternalSignificantTerms {
             }
         }
         builder.endArray();
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -62,7 +62,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
     }
 
     @Override
-    public SignificantStringTerms buildAggregation(long owningBucketOrdinal) {
+    public SignificantStringTerms buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         final int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
@@ -106,7 +106,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
     }
 
     @Override
-    public SignificantStringTerms buildEmptyAggregation() {
+    public SignificantStringTerms buildEmptyInternalAggregation() {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
         ContextIndexSearcher searcher = context.searchContext().searcher();
         IndexReader topReader = searcher.getIndexReader();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -62,7 +62,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
     }
 
     @Override
-    public SignificantStringTerms buildInternalAggregation(long owningBucketOrdinal) {
+    public SignificantStringTerms buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         final int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
@@ -102,16 +102,16 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
             list[i] = bucket;
         }
 
-        return new SignificantStringTerms(subsetSize, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new SignificantStringTerms(subsetSize, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
 
     @Override
-    public SignificantStringTerms buildEmptyInternalAggregation() {
+    public SignificantStringTerms buildEmptyAggregation() {
         // We need to account for the significance of a miss in our global stats - provide corpus size as context
         ContextIndexSearcher searcher = context.searchContext().searcher();
         IndexReader topReader = searcher.getIndexReader();
         int supersetSize = topReader.numDocs();
-        return new SignificantStringTerms(0, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalSignificantTerms.Bucket>emptyList());
+        return new SignificantStringTerms(0, supersetSize, name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalSignificantTerms.Bucket>emptyList(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -166,10 +166,10 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
 
     @Override
     protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent) {
-        final InternalAggregation aggregation = new UnmappedSignificantTerms(name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount());
+        final InternalAggregation aggregation = new UnmappedSignificantTerms(name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), metaData);
         return new NonCollectingAggregator(name, aggregationContext, parent) {
             @Override
-            public InternalAggregation buildEmptyInternalAggregation() {
+            public InternalAggregation buildEmptyAggregation() {
                 return aggregation;
             }
         };

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -169,7 +169,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         final InternalAggregation aggregation = new UnmappedSignificantTerms(name, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount());
         return new NonCollectingAggregator(name, aggregationContext, parent) {
             @Override
-            public InternalAggregation buildEmptyAggregation() {
+            public InternalAggregation buildEmptyInternalAggregation() {
                 return aggregation;
             }
         };

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
@@ -81,11 +81,8 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS).endArray();
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
@@ -82,7 +82,7 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.startArray(CommonFields.BUCKETS).endArray();
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
@@ -53,10 +53,10 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms {
 
     UnmappedSignificantTerms() {} // for serialization
 
-    public UnmappedSignificantTerms(String name, int requiredSize, long minDocCount) {
+    public UnmappedSignificantTerms(String name, int requiredSize, long minDocCount, byte[] metaData) {
         //We pass zero for index/subset sizes because for the purpose of significant term analysis 
         // we assume an unmapped index's size is irrelevant to the proceedings. 
-        super(0, 0, name, requiredSize, minDocCount, BUCKETS);
+        super(0, 0, name, requiredSize, minDocCount, BUCKETS, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -41,8 +41,8 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
+    public InternalAggregation buildEmptyAggregation() {
+        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList(), metaData);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -41,7 +41,7 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -191,8 +191,7 @@ public class DoubleTerms extends InternalTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();
@@ -205,8 +204,6 @@ public class DoubleTerms extends InternalTerms {
             builder.endObject();
         }
         builder.endArray();
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -93,8 +93,8 @@ public class DoubleTerms extends InternalTerms {
 
     DoubleTerms() {} // for serialization
 
-    public DoubleTerms(String name, InternalOrder order, @Nullable ValueFormatter formatter, int requiredSize, long minDocCount, Collection<InternalTerms.Bucket> buckets) {
-        super(name, order, requiredSize, minDocCount, buckets);
+    public DoubleTerms(String name, InternalOrder order, @Nullable ValueFormatter formatter, int requiredSize, long minDocCount, Collection<InternalTerms.Bucket> buckets, byte[] metaData) {
+        super(name, order, requiredSize, minDocCount, buckets, metaData);
         this.formatter = formatter;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -192,7 +192,7 @@ public class DoubleTerms extends InternalTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -82,7 +82,7 @@ public class DoubleTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public DoubleTerms buildAggregation(long owningBucketOrdinal) {
+    public DoubleTerms buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
@@ -135,7 +135,7 @@ public class DoubleTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public DoubleTerms buildEmptyAggregation() {
+    public DoubleTerms buildEmptyInternalAggregation() {
         return new DoubleTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -82,7 +82,7 @@ public class DoubleTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public DoubleTerms buildInternalAggregation(long owningBucketOrdinal) {
+    public DoubleTerms buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
@@ -131,12 +131,12 @@ public class DoubleTermsAggregator extends TermsAggregator {
         }        
         
         
-        return new DoubleTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new DoubleTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
 
     @Override
-    public DoubleTerms buildEmptyInternalAggregation() {
-        return new DoubleTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
+    public DoubleTerms buildEmptyAggregation() {
+        return new DoubleTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -110,7 +110,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (globalOrdinals == null) { // no context in this reader
             return buildEmptyAggregation();
         }
@@ -162,7 +162,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         
         
 
-        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -110,7 +110,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (globalOrdinals == null) { // no context in this reader
             return buildEmptyAggregation();
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -87,8 +87,8 @@ public abstract class InternalTerms extends InternalAggregation implements Terms
 
     protected InternalTerms() {} // for serialization
 
-    protected InternalTerms(String name, InternalOrder order, int requiredSize, long minDocCount, Collection<Bucket> buckets) {
-        super(name);
+    protected InternalTerms(String name, InternalOrder order, int requiredSize, long minDocCount, Collection<Bucket> buckets, byte[] metaData) {
+        super(name, metaData);
         this.order = order;
         this.requiredSize = requiredSize;
         this.minDocCount = minDocCount;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -191,8 +191,7 @@ public class LongTerms extends InternalTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();
@@ -205,8 +204,6 @@ public class LongTerms extends InternalTerms {
             builder.endObject();
         }
         builder.endArray();
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -93,8 +93,8 @@ public class LongTerms extends InternalTerms {
 
     LongTerms() {} // for serialization
 
-    public LongTerms(String name, InternalOrder order, @Nullable ValueFormatter formatter, int requiredSize, long minDocCount, Collection<InternalTerms.Bucket> buckets) {
-        super(name, order, requiredSize, minDocCount, buckets);
+    public LongTerms(String name, InternalOrder order, @Nullable ValueFormatter formatter, int requiredSize, long minDocCount, Collection<InternalTerms.Bucket> buckets, byte[] metaData) {
+        super(name, order, requiredSize, minDocCount, buckets, metaData);
         this.formatter = formatter;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -192,7 +192,7 @@ public class LongTerms extends InternalTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -85,7 +85,7 @@ public class LongTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
@@ -140,7 +140,7 @@ public class LongTermsAggregator extends TermsAggregator {
     
     
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new LongTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -85,7 +85,7 @@ public class LongTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
@@ -135,13 +135,13 @@ public class LongTermsAggregator extends TermsAggregator {
         for (int i = 0; i < list.length; i++) {
           list[i].aggregations = bucketAggregations(list[i].bucketOrd);
         }
-        return new LongTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new LongTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
     
     
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new LongTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
+    public InternalAggregation buildEmptyAggregation() {
+        return new LongTerms(name, order, formatter, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -20,11 +20,12 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.BytesText;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -128,7 +129,7 @@ public class StringTerms extends InternalTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -89,8 +89,8 @@ public class StringTerms extends InternalTerms {
 
     StringTerms() {} // for serialization
 
-    public StringTerms(String name, InternalOrder order, int requiredSize, long minDocCount, Collection<InternalTerms.Bucket> buckets) {
-        super(name, order, requiredSize, minDocCount, buckets);
+    public StringTerms(String name, InternalOrder order, int requiredSize, long minDocCount, Collection<InternalTerms.Bucket> buckets, byte[] metaData) {
+        super(name, order, requiredSize, minDocCount, buckets, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -128,8 +128,7 @@ public class StringTerms extends InternalTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS);
         for (InternalTerms.Bucket bucket : buckets) {
             builder.startObject();
@@ -139,8 +138,6 @@ public class StringTerms extends InternalTerms {
             builder.endObject();
         }
         builder.endArray();
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -135,7 +135,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
@@ -248,7 +248,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -135,7 +135,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         assert owningBucketOrdinal == 0;
 
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
@@ -244,12 +244,12 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
         }        
         
         
-        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list));
+        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Arrays.asList(list), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList());
+    public InternalAggregation buildEmptyAggregation() {
+        return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), Collections.<InternalTerms.Bucket>emptyList(), metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -160,10 +160,10 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent) {
-        final InternalAggregation aggregation = new UnmappedTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount());
+        final InternalAggregation aggregation = new UnmappedTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(), metaData);
         return new NonCollectingAggregator(name, aggregationContext, parent) {
             @Override
-            public InternalAggregation buildEmptyInternalAggregation() {
+            public InternalAggregation buildEmptyAggregation() {
                 return aggregation;
             }
         };

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -163,7 +163,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         final InternalAggregation aggregation = new UnmappedTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount());
         return new NonCollectingAggregator(name, aggregationContext, parent) {
             @Override
-            public InternalAggregation buildEmptyAggregation() {
+            public InternalAggregation buildEmptyInternalAggregation() {
                 return aggregation;
             }
         };

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -84,13 +84,8 @@ public class UnmappedTerms extends InternalTerms {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS).endArray();
-        builder.endObject();
-        return builder;
     }
-
-
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -56,8 +56,8 @@ public class UnmappedTerms extends InternalTerms {
 
     UnmappedTerms() {} // for serialization
 
-    public UnmappedTerms(String name, InternalOrder order, int requiredSize, long minDocCount) {
-        super(name, order, requiredSize, minDocCount, BUCKETS);
+    public UnmappedTerms(String name, InternalOrder order, int requiredSize, long minDocCount, byte[] metaData) {
+        super(name, order, requiredSize, minDocCount, BUCKETS, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -18,9 +18,12 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 
 import java.io.IOException;
@@ -82,10 +85,12 @@ public class UnmappedTerms extends InternalTerms {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.startArray(CommonFields.BUCKETS).endArray();
         builder.endObject();
         return builder;
     }
+
+
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMetricsAggregation.java
@@ -25,7 +25,7 @@ public abstract class InternalMetricsAggregation extends InternalAggregation {
 
     protected InternalMetricsAggregation() {} // for serialization
 
-    protected InternalMetricsAggregation(String name) {
-        super(name);
+    protected InternalMetricsAggregation(String name, byte[] metaData) {
+        super(name, metaData);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -31,8 +31,8 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
         protected SingleValue() {}
 
-        protected SingleValue(String name) {
-            super(name);
+        protected SingleValue(String name, byte[] metaData) {
+            super(name, metaData);
         }
 
         public abstract double value();
@@ -42,8 +42,8 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
         protected MultiValue() {}
 
-        protected MultiValue(String name) {
-            super(name);
+        protected MultiValue(String name, byte[] metaData) {
+            super(name, metaData);
         }
 
         public abstract double value(String name);
@@ -52,8 +52,8 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
     protected InternalNumericMetricsAggregation() {} // for serialization
 
-    protected InternalNumericMetricsAggregation(String name) {
-        super(name);
+    protected InternalNumericMetricsAggregation(String name, byte[] metaData) {
+        super(name, metaData);
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -84,7 +84,7 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null || owningBucketOrdinal >= counts.size()) {
             return new InternalAvg(name, 0l, 0);
         }
@@ -92,7 +92,7 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalAvg(name, 0.0, 0l);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -84,16 +84,16 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null || owningBucketOrdinal >= counts.size()) {
-            return new InternalAvg(name, 0l, 0);
+            return new InternalAvg(name, 0l, 0, metaData);
         }
-        return new InternalAvg(name, sums.get(owningBucketOrdinal), counts.get(owningBucketOrdinal));
+        return new InternalAvg(name, sums.get(owningBucketOrdinal), counts.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalAvg(name, 0.0, 0l);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalAvg(name, 0.0, 0l, metaData);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -54,8 +54,8 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalAvg() {} // for serialization
 
-    public InternalAvg(String name, double sum, long count) {
-        super(name);
+    public InternalAvg(String name, double sum, long count, byte[] metaData) {
+        super(name, metaData);
         this.sum = sum;
         this.count = count;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -109,14 +109,11 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.VALUE, count != 0 ? getValue() : null);
         if (count != 0 && valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(getValue()));
         }
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -110,7 +110,7 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.field(CommonFields.VALUE, count != 0 ? getValue() : null);
         if (count != 0 && valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(getValue()));

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -141,7 +141,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (counts == null || owningBucketOrdinal >= counts.maxBucket() || counts.cardinality(owningBucketOrdinal) == 0) {
             return buildEmptyAggregation();
         }
@@ -149,12 +149,12 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
         // this Aggregator (and its HLL++ counters) is released.
         HyperLogLogPlusPlus copy = new HyperLogLogPlusPlus(precision, BigArrays.NON_RECYCLING_INSTANCE, 1);
         copy.merge(0, counts, owningBucketOrdinal);
-        return new InternalCardinality(name, copy);
+        return new InternalCardinality(name, copy, metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalCardinality(name, null);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalCardinality(name, null, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -141,7 +141,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (counts == null || owningBucketOrdinal >= counts.maxBucket() || counts.cardinality(owningBucketOrdinal) == 0) {
             return buildEmptyAggregation();
         }
@@ -153,7 +153,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalCardinality(name, null);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -125,7 +125,7 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         final long cardinality = getValue();
         builder.field(CommonFields.VALUE, cardinality);
         if (valueFormatter != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -124,15 +124,12 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         final long cardinality = getValue();
         builder.field(CommonFields.VALUE, cardinality);
         if (valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(cardinality));
         }
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -50,8 +50,8 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
 
     private HyperLogLogPlusPlus counts;
 
-    InternalCardinality(String name, HyperLogLogPlusPlus counts) {
-        super(name);
+    InternalCardinality(String name, HyperLogLogPlusPlus counts, byte[] metaData) {
+        super(name, metaData);
         this.counts = counts;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -79,7 +79,7 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return buildEmptyAggregation();
         }
@@ -89,13 +89,13 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
         double posRight = posRights.get(owningBucketOrdinal);
         double negLeft = negLefts.get(owningBucketOrdinal);
         double negRight = negRights.get(owningBucketOrdinal);
-        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude);
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
+    public InternalAggregation buildEmptyAggregation() {
         return new InternalGeoBounds(name, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
-                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude);
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -79,7 +79,7 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return buildEmptyAggregation();
         }
@@ -93,7 +93,7 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalGeoBounds(name, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
                 Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude);
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -54,8 +54,8 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
     }
     
     InternalGeoBounds(String name, double top, double bottom, double posLeft, double posRight,
-            double negLeft, double negRight, boolean wrapLongitude) {
-        super(name);
+            double negLeft, double negRight, boolean wrapLongitude, byte[] metaData) {
+        super(name, metaData);
         this.top = top;
         this.bottom = bottom;
         this.posLeft = posLeft;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -106,6 +106,7 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
     
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        this.startAggregationObject(builder);
         GeoPoint topLeft = topLeft();
         GeoPoint bottomRight = bottomRight();
         if (topLeft != null) {
@@ -117,6 +118,7 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
             builder.startObject("bottom_right");
             builder.field("lat", bottomRight.lat());
             builder.field("lon", bottomRight.lon());
+            builder.endObject();
             builder.endObject();
         }
         return builder.endObject();

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -105,8 +105,7 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
     }
     
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         GeoPoint topLeft = topLeft();
         GeoPoint bottomRight = bottomRight();
         if (topLeft != null) {
@@ -121,7 +120,6 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
             builder.endObject();
             builder.endObject();
         }
-        return builder.endObject();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -53,8 +53,8 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalMax() {} // for serialization
 
-    public InternalMax(String name, double max) {
-        super(name);
+    public InternalMax(String name, double max, byte[] metaData) {
+        super(name, metaData);
         this.max = max;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -108,7 +108,7 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         boolean hasValue = !Double.isInfinite(max);
         builder.field(CommonFields.VALUE, hasValue ? max : null);
         if (hasValue && valueFormatter != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -107,14 +107,11 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         boolean hasValue = !Double.isInfinite(max);
         builder.field(CommonFields.VALUE, hasValue ? max : null);
         if (hasValue && valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(max));
         }
-        builder.endObject();
-        return builder;
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -84,17 +84,17 @@ public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalMax(name, Double.NEGATIVE_INFINITY);
+            return new InternalMax(name, Double.NEGATIVE_INFINITY, metaData);
         }
         assert owningBucketOrdinal < maxes.size();
-        return new InternalMax(name, maxes.get(owningBucketOrdinal));
+        return new InternalMax(name, maxes.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalMax(name, Double.NEGATIVE_INFINITY);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalMax(name, Double.NEGATIVE_INFINITY, metaData);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -84,7 +84,7 @@ public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return new InternalMax(name, Double.NEGATIVE_INFINITY);
         }
@@ -93,7 +93,7 @@ public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalMax(name, Double.NEGATIVE_INFINITY);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -109,7 +109,7 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         boolean hasValue = !Double.isInfinite(min);
         builder.field(CommonFields.VALUE, hasValue ? min : null);
         if (hasValue && valueFormatter != null) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -108,15 +108,12 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         boolean hasValue = !Double.isInfinite(min);
         builder.field(CommonFields.VALUE, hasValue ? min : null);
         if (hasValue && valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(min));
         }
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -54,8 +54,8 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalMin() {} // for serialization
 
-    public InternalMin(String name, double min) {
-        super(name);
+    public InternalMin(String name, double min, byte[] metaData) {
+        super(name, metaData);
         this.min = min;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -83,17 +83,17 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalMin(name, Double.POSITIVE_INFINITY);
+            return new InternalMin(name, Double.POSITIVE_INFINITY, metaData);
         }
         assert owningBucketOrdinal < mins.size();
-        return new InternalMin(name, mins.get(owningBucketOrdinal));
+        return new InternalMin(name, mins.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalMin(name, Double.POSITIVE_INFINITY);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalMin(name, Double.POSITIVE_INFINITY, metaData);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -83,7 +83,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return new InternalMin(name, Double.POSITIVE_INFINITY);
         }
@@ -92,7 +92,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalMin(name, Double.POSITIVE_INFINITY);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -60,8 +60,8 @@ public class InternalPercentiles extends InternalNumericMetricsAggregation.Multi
 
     InternalPercentiles() {} // for serialization
 
-    public InternalPercentiles(String name, double[] percents, TDigestState state, boolean keyed) {
-        super(name);
+    public InternalPercentiles(String name, double[] percents, TDigestState state, boolean keyed, byte[] metaData) {
+        super(name, metaData);
         this.percents = percents;
         this.state = state;
         this.keyed = keyed;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -136,8 +136,7 @@ public class InternalPercentiles extends InternalNumericMetricsAggregation.Multi
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         if (keyed) {
             builder.startObject(CommonFields.VALUES);
             for(int i = 0; i < percents.length; ++i) {
@@ -163,8 +162,6 @@ public class InternalPercentiles extends InternalNumericMetricsAggregation.Multi
             }
             builder.endArray();
         }
-        builder.endObject();
-        return builder;
     }
 
     public static class Iter extends UnmodifiableIterator<Percentiles.Percentile> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -137,7 +137,7 @@ public class InternalPercentiles extends InternalNumericMetricsAggregation.Multi
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         if (keyed) {
             builder.startObject(CommonFields.VALUES);
             for(int i = 0; i < percents.length; ++i) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -112,18 +112,18 @@ public class PercentilesAggregator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         TDigestState state = getState(owningBucketOrdinal);
         if (state == null) {
             return buildEmptyAggregation();
         } else {
-            return new InternalPercentiles(name, percents, state, keyed);
+            return new InternalPercentiles(name, percents, state, keyed, metaData);
         }
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalPercentiles(name, percents, new TDigestState(compression), keyed);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalPercentiles(name, percents, new TDigestState(compression), keyed, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -112,7 +112,7 @@ public class PercentilesAggregator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         TDigestState state = getState(owningBucketOrdinal);
         if (state == null) {
             return buildEmptyAggregation();
@@ -122,7 +122,7 @@ public class PercentilesAggregator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalPercentiles(name, percents, new TDigestState(compression), keyed);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -190,8 +190,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(Fields.COUNT, count);
         builder.field(Fields.MIN, count != 0 ? min : null);
         builder.field(Fields.MAX, count != 0 ? max : null);
@@ -204,8 +203,6 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
             builder.field(Fields.SUM_AS_STRING, valueFormatter.format(sum));
         }
         otherStatsToXCotent(builder, params);
-        builder.endObject();
-        return builder;
     }
 
     protected XContentBuilder otherStatsToXCotent(XContentBuilder builder, Params params) throws IOException {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -66,8 +66,8 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
 
     protected InternalStats() {} // for serialization
 
-    public InternalStats(String name, long count, double sum, double min, double max) {
-        super(name);
+    public InternalStats(String name, long count, double sum, double min, double max, byte[] metaData) {
+        super(name, metaData);
         this.count = count;
         this.sum = sum;
         this.min = min;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -191,7 +191,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.field(Fields.COUNT, count);
         builder.field(Fields.MIN, count != 0 ? min : null);
         builder.field(Fields.MAX, count != 0 ? max : null);

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -125,17 +125,17 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+            return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, metaData);
         }
         assert owningBucketOrdinal < counts.size();
-        return new InternalStats(name, counts.get(owningBucketOrdinal), sums.get(owningBucketOrdinal), mins.get(owningBucketOrdinal), maxes.get(owningBucketOrdinal));
+        return new InternalStats(name, counts.get(owningBucketOrdinal), sums.get(owningBucketOrdinal), mins.get(owningBucketOrdinal), maxes.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, metaData);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -125,7 +125,7 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
         }
@@ -134,7 +134,7 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -140,7 +140,7 @@ public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d);
         }
@@ -150,7 +150,7 @@ public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -140,18 +140,18 @@ public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d);
+            return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, metaData);
         }
         assert owningBucketOrdinal < counts.size();
         return new InternalExtendedStats(name, counts.get(owningBucketOrdinal), sums.get(owningBucketOrdinal), mins.get(owningBucketOrdinal),
-                maxes.get(owningBucketOrdinal), sumOfSqrs.get(owningBucketOrdinal));
+                maxes.get(owningBucketOrdinal), sumOfSqrs.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
@@ -61,8 +61,8 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
 
     InternalExtendedStats() {} // for serialization
 
-    public InternalExtendedStats(String name, long count, double sum, double min, double max, double sumOfSqrs) {
-        super(name, count, sum, min, max);
+    public InternalExtendedStats(String name, long count, double sum, double min, double max, double sumOfSqrs, byte[] metaData) {
+        super(name, count, sum, min, max, metaData);
         this.sumOfSqrs = sumOfSqrs;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -53,8 +53,8 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalSum() {} // for serialization
 
-    InternalSum(String name, double sum) {
-        super(name);
+    InternalSum(String name, double sum, byte[] metaData) {
+        super(name, metaData);
         this.sum = sum;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -107,14 +107,11 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.VALUE, sum);
         if (valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(sum));
         }
-        builder.endObject();
-        return builder;
     }
 
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -108,7 +108,7 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         builder.field(CommonFields.VALUE, sum);
         if (valueFormatter != null) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(sum));

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -79,7 +79,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return new InternalSum(name, 0);
         }
@@ -87,7 +87,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalSum(name, 0.0);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -79,16 +79,16 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalSum(name, 0);
+            return new InternalSum(name, 0, metaData);
         }
-        return new InternalSum(name, sums.get(owningBucketOrdinal));
+        return new InternalSum(name, sums.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalSum(name, 0.0);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalSum(name, 0.0, metaData);
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
@@ -147,7 +147,7 @@ public class InternalTopHits extends InternalMetricsAggregation implements TopHi
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name);
+        this.startAggregationObject(builder);
         searchHits.toXContent(builder, params);
         builder.endObject();
         return builder;

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
@@ -146,10 +146,7 @@ public class InternalTopHits extends InternalMetricsAggregation implements TopHi
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         searchHits.toXContent(builder, params);
-        builder.endObject();
-        return builder;
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
@@ -61,7 +61,7 @@ public class TopHitsAggregator extends MetricsAggregator implements ScorerAware 
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         TopDocsCollector topDocsCollector = topDocsCollectors.get(owningBucketOrdinal);
         if (topDocsCollector == null) {
             return buildEmptyAggregation();
@@ -95,7 +95,7 @@ public class TopHitsAggregator extends MetricsAggregator implements ScorerAware 
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
+    public InternalAggregation buildEmptyAggregation() {
         return new InternalTopHits(name, topHitsContext.from(), topHitsContext.size(), topHitsContext.sort(), Lucene.EMPTY_TOP_DOCS, InternalSearchHits.empty());
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
@@ -61,7 +61,7 @@ public class TopHitsAggregator extends MetricsAggregator implements ScorerAware 
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         TopDocsCollector topDocsCollector = topDocsCollectors.get(owningBucketOrdinal);
         if (topDocsCollector == null) {
             return buildEmptyAggregation();
@@ -95,7 +95,7 @@ public class TopHitsAggregator extends MetricsAggregator implements ScorerAware 
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalTopHits(name, topHitsContext.from(), topHitsContext.size(), topHitsContext.sort(), Lucene.EMPTY_TOP_DOCS, InternalSearchHits.empty());
     }
 
@@ -156,7 +156,7 @@ public class TopHitsAggregator extends MetricsAggregator implements ScorerAware 
         }
 
         @Override
-        public Aggregator create(AggregationContext aggregationContext, Aggregator parent, long expectedBucketsCount) {
+        protected Aggregator createInternal(AggregationContext aggregationContext, Aggregator parent, long expectedBucketsCount) {
             return new TopHitsAggregator(fetchPhase, topHitsContext, name, expectedBucketsCount, aggregationContext, parent);
         }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
@@ -98,7 +98,8 @@ public class InternalValueCount extends InternalNumericMetricsAggregation implem
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject(name)
+        this.startAggregationObject(builder);
+        return builder
                 .field(CommonFields.VALUE, value)
                 .endObject();
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
@@ -52,8 +52,8 @@ public class InternalValueCount extends InternalNumericMetricsAggregation implem
 
     InternalValueCount() {} // for serialization
 
-    public InternalValueCount(String name, long value) {
-        super(name);
+    public InternalValueCount(String name, long value, byte[] metaData) {
+        super(name, metaData);
         this.value = value;
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
@@ -97,11 +97,8 @@ public class InternalValueCount extends InternalNumericMetricsAggregation implem
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        this.startAggregationObject(builder);
-        return builder
-                .field(CommonFields.VALUE, value)
-                .endObject();
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        builder.field(CommonFields.VALUE, value);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -78,7 +78,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
             return new InternalValueCount(name, 0);
         }
@@ -87,7 +87,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildEmptyAggregation() {
+    public InternalAggregation buildEmptyInternalAggregation() {
         return new InternalValueCount(name, 0l);
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -78,17 +78,17 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public InternalAggregation buildInternalAggregation(long owningBucketOrdinal) {
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
         if (valuesSource == null) {
-            return new InternalValueCount(name, 0);
+            return new InternalValueCount(name, 0, metaData);
         }
         assert owningBucketOrdinal < counts.size();
-        return new InternalValueCount(name, counts.get(owningBucketOrdinal));
+        return new InternalValueCount(name, counts.get(owningBucketOrdinal), metaData);
     }
 
     @Override
-    public InternalAggregation buildEmptyInternalAggregation() {
-        return new InternalValueCount(name, 0l);
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalValueCount(name, 0l, metaData);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
@@ -46,7 +46,7 @@ public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource> ext
     }
 
     @Override
-    public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
+    protected Aggregator createInternal(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
         if (config.unmapped()) {
             return createUnmapped(context, parent);
         }

--- a/src/test/java/org/elasticsearch/search/aggregations/MetaDataTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/MetaDataTests.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import com.carrotsearch.hppc.IntIntMap;
+import com.carrotsearch.hppc.IntIntOpenHashMap;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.missing.Missing;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import sun.security.util.BigInt;
+
+import java.math.BigInteger;
+import java.util.Collection;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+/**
+ *
+ */
+public class MetaDataTests extends ElasticsearchIntegrationTest {
+
+    /**
+     * Making sure that if there are multiple aggregations, working on the same field, yet require different
+     * value source type, they can all still work. It used to fail as we used to cache the ValueSource by the
+     * field name. If the cached value source was of type "bytes" and another aggregation on the field required to see
+     * it as "numeric", it didn't work. Now we cache the Value Sources by a custom key (field name + ValueSource type)
+     * so there's no conflict there.
+     */
+    @Test
+    public void meta_data_set_on_aggregation_result() throws Exception {
+
+        createIndex("idx");
+        IndexRequestBuilder[] builders = new IndexRequestBuilder[randomInt(30)];
+        IntIntMap values = new IntIntOpenHashMap();
+        long missingValues = 0;
+        for (int i = 0; i < builders.length; i++) {
+            String name = "name_" + randomIntBetween(1, 10);
+            if (rarely()) {
+                missingValues++;
+                builders[i] = client().prepareIndex("idx", "type").setSource(jsonBuilder()
+                        .startObject()
+                        .field("name", name)
+                        .endObject());
+            } else {
+                int value = randomIntBetween(1, 10);
+                values.put(value, values.getOrDefault(value, 0) + 1);
+                builders[i] = client().prepareIndex("idx", "type").setSource(jsonBuilder()
+                        .startObject()
+                        .field("name", name)
+                        .field("value", value)
+                        .endObject());
+            }
+        }
+        indexRandom(true, builders);
+        ensureSearchable();
+
+        Integer missingValueMetaData = 1;
+        SearchResponse response = client().prepareSearch("idx")
+                .addAggregation(missing("missing_values").field("value").setMetaData(missingValueMetaData))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Aggregations aggs = response.getAggregations();
+
+        Missing missing = aggs.get("missing_values");
+        assertNotNull(missing);
+        assertThat(missing.getDocCount(), equalTo(missingValues));
+        assertNotNull(missing.getMetaData());
+    }
+
+
+}


### PR DESCRIPTION
This PR adds the ability to associate a bit of state with each individual aggregation.

Use cases:
- Typed clients can inject some state so that the deserialization
  process has enough information to deserialize the aggregations into
  the correct type. Facets return `_type` to signal what kind of facet the
  response corresponds with.
- UI state, since aggregations can be nested at arbitrary depths
  injecting pieces of UI state can greatly simplify programming with
  aggregations since there are no two tree data-structures to walk anymore only the aggregation data.

thank you @martijnvg for the help reading the `byte[]` representation of _meta properly
- this PR also fixes the response format of the new `geo_bounds` aggregation to wrap the result in a `"aggregationname" : {}`

[Here's a gist of a sense session](https://gist.github.com/Mpdreamz/785a3347d4415e1fe6bb#file-aggs-metada) you can use to review this branch

Example request:

``` json
{
"aggs": {
    "name": {
      "terms": {
        "field": "title"
      },
      "meta": 2,
      "aggs": {
        "viewport" : {
          "meta" : {
               "complex" : "object"
          },
          "geo_bounds" : {
            "field" : "location"
          }
        },
        "empty_agg" : {
          "meta" : "should still be returned",
          "sum": {
            "field": "i_do_not_exist"
          }
        },
```

Example response:

``` json
{
   "aggregations": {
      "name": {
         "meta": 2,
         "buckets": [
            {
               "key": "banner",
               "doc_count": 1,
               "viewport": {
                  "meta": {
                    "complex": "object"
                  },
                  "bounds": {
                     "top_left": {
                        "lat": 28,
                        "lon": 21
                     },
                     "bottom_right": {
                        "lat": 28,
                        "lon": 21
                     }
                  }
               },
               "nested_terms": {
                  "meta": {
                     "complex": "object",
                     "nuber": 1
                  },
                  "buckets": [
                     {
                        "key": "a",
                        "doc_count": 1,
                        "counter": {
                           "meta": 4.1,
                           "value": 40
                        }
                     },
```
