### PR TITLE
The `ignore_unavailable` option should also ignore indices that are closed

### DIFF
--- a/src/main/java/org/elasticsearch/action/percolate/MultiPercolateRequest.java
+++ b/src/main/java/org/elasticsearch/action/percolate/MultiPercolateRequest.java
@@ -48,7 +48,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
 
     private String[] indices;
     private String documentType;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
     private List<PercolateRequest> requests = Lists.newArrayList();
 
     public MultiPercolateRequest add(PercolateRequestBuilder requestBuilder) {
@@ -62,7 +62,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
         if (request.documentType() == null && documentType != null) {
             request.documentType(documentType);
         }
-        if (request.indicesOptions() == IndicesOptions.strictExpandOpen() && indicesOptions != IndicesOptions.strictExpandOpen()) {
+        if (request.indicesOptions() == IndicesOptions.strictExpandOpenAndForbidClosed() && indicesOptions != IndicesOptions.strictExpandOpenAndForbidClosed()) {
             request.indicesOptions(indicesOptions);
         }
         requests.add(request);
@@ -96,7 +96,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
             if (documentType != null) {
                 percolateRequest.documentType(documentType);
             }
-            if (indicesOptions != IndicesOptions.strictExpandOpen()) {
+            if (indicesOptions != IndicesOptions.strictExpandOpenAndForbidClosed()) {
                 percolateRequest.indicesOptions(indicesOptions);
             }
 
@@ -165,10 +165,11 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
             }
         }
 
-        boolean ignoreUnavailable = IndicesOptions.strictExpandOpen().ignoreUnavailable();
-        boolean allowNoIndices = IndicesOptions.strictExpandOpen().allowNoIndices();
-        boolean expandWildcardsOpen = IndicesOptions.strictExpandOpen().expandWildcardsOpen();
-        boolean expandWildcardsClosed = IndicesOptions.strictExpandOpen().expandWildcardsClosed();
+        IndicesOptions defaultOptions = indicesOptions;
+        boolean ignoreUnavailable = defaultOptions.ignoreUnavailable();
+        boolean allowNoIndices = defaultOptions.allowNoIndices();
+        boolean expandWildcardsOpen = defaultOptions.expandWildcardsOpen();
+        boolean expandWildcardsClosed = defaultOptions.expandWildcardsClosed();
 
         if (header.containsKey("id")) {
             GetRequest getRequest = new GetRequest(globalIndex);
@@ -280,7 +281,7 @@ public class MultiPercolateRequest extends ActionRequest<MultiPercolateRequest> 
                 }
             }
         }
-        percolateRequest.indicesOptions(IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed));
+        percolateRequest.indicesOptions(IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed, defaultOptions));
     }
 
     private String[] parseArray(XContentParser parser) throws IOException {

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -48,7 +48,7 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
 
     private List<SearchRequest> requests = Lists.newArrayList();
 
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
 
     /**
      * Add a search request to execute. Note, the order is important, the search response will be returned in the
@@ -70,7 +70,7 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
 
     public MultiSearchRequest add(byte[] data, int from, int length, boolean contentUnsafe,
                                   @Nullable String[] indices, @Nullable String[] types, @Nullable String searchType) throws Exception {
-        return add(new BytesArray(data, from, length), contentUnsafe, indices, types, searchType, null, IndicesOptions.strictExpandOpen(), true);
+        return add(new BytesArray(data, from, length), contentUnsafe, indices, types, searchType, null, IndicesOptions.strictExpandOpenAndForbidClosed(), true);
     }
 
     public MultiSearchRequest add(BytesReference data, boolean contentUnsafe, @Nullable String[] indices, @Nullable String[] types, @Nullable String searchType, IndicesOptions indicesOptions) throws Exception {
@@ -108,10 +108,11 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
             }
             searchRequest.searchType(searchType);
 
-            boolean ignoreUnavailable = IndicesOptions.strictExpandOpen().ignoreUnavailable();
-            boolean allowNoIndices = IndicesOptions.strictExpandOpen().allowNoIndices();
-            boolean expandWildcardsOpen = IndicesOptions.strictExpandOpen().expandWildcardsOpen();
-            boolean expandWildcardsClosed = IndicesOptions.strictExpandOpen().expandWildcardsClosed();
+            IndicesOptions defaultOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
+            boolean ignoreUnavailable = defaultOptions.ignoreUnavailable();
+            boolean allowNoIndices = defaultOptions.allowNoIndices();
+            boolean expandWildcardsOpen = defaultOptions.expandWildcardsOpen();
+            boolean expandWildcardsClosed = defaultOptions.expandWildcardsClosed();
 
             // now parse the action
             if (nextMarker - from > 0) {
@@ -181,7 +182,7 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> {
                     }
                 }
             }
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed));
+            searchRequest.indicesOptions(IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandWildcardsOpen, expandWildcardsClosed, defaultOptions));
 
             // move pointers
             from = nextMarker + 1;

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
@@ -41,7 +41,7 @@ public class MultiSearchRequestBuilder extends ActionRequestBuilder<MultiSearchR
      * will not be used (if set).
      */
     public MultiSearchRequestBuilder add(SearchRequest request) {
-        if (request.indicesOptions() == IndicesOptions.strictExpandOpen() && request().indicesOptions() != IndicesOptions.strictExpandOpen()) {
+        if (request.indicesOptions() == IndicesOptions.strictExpandOpenAndForbidClosed() && request().indicesOptions() != IndicesOptions.strictExpandOpenAndForbidClosed()) {
             request.indicesOptions(request().indicesOptions());
         }
 
@@ -54,7 +54,7 @@ public class MultiSearchRequestBuilder extends ActionRequestBuilder<MultiSearchR
      * same order as the search requests.
      */
     public MultiSearchRequestBuilder add(SearchRequestBuilder request) {
-        if (request.request().indicesOptions() == IndicesOptions.strictExpandOpen() && request().indicesOptions() != IndicesOptions.strictExpandOpen()) {
+        if (request.request().indicesOptions() == IndicesOptions.strictExpandOpenAndForbidClosed() && request().indicesOptions() != IndicesOptions.strictExpandOpenAndForbidClosed()) {
             request.request().indicesOptions(request().indicesOptions());
         }
 

--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -83,7 +83,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> {
 
     private String[] types = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
 
     public SearchRequest() {
     }

--- a/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -40,9 +40,10 @@ public class IndicesOptions {
     private static final byte EXPAND_WILDCARDS_OPEN = 4;
     private static final byte EXPAND_WILDCARDS_CLOSED = 8;
     private static final byte FORBID_ALIASES_TO_MULTIPLE_INDICES = 16;
+    private static final byte FORBID_CLOSED_INDICES = 32;
 
     static {
-        byte max = 1 << 5;
+        byte max = 1 << 6;
         VALUES = new IndicesOptions[max];
         for (byte id = 0; id < max; id++) {
             VALUES[id] = new IndicesOptions(id);
@@ -85,6 +86,13 @@ public class IndicesOptions {
     }
 
     /**
+     * @return Whether execution on closed indices is allowed.
+     */
+    public boolean forbidClosedIndices() {
+        return (id & FORBID_CLOSED_INDICES) != 0;
+    }
+
+    /**
      * @return whether aliases pointing to multiple indices are allowed
      */
     public boolean allowAliasesToMultipleIndices() {
@@ -94,12 +102,16 @@ public class IndicesOptions {
     }
 
     public void writeIndicesOptions(StreamOutput out) throws IOException {
-        if (allowAliasesToMultipleIndices() || out.getVersion().onOrAfter(Version.V_1_2_0)) {
+        if (out.getVersion().onOrAfter(Version.V_1_2_2)) {
             out.write(id);
-        } else {
-            //if we are talking to a node that doesn't support the newly added flag (allowAliasesToMultipleIndices)
-            //flip to 0 all the bits starting from the 5th
+        } else if (out.getVersion().before(Version.V_1_2_0)) {
+            // Target node doesn't know about the FORBID_CLOSED_INDICES and FORBID_ALIASES_TO_MULTIPLE_INDICES flags,
+            // so unset the bits starting from the 5th position.
             out.write(id & 0xf);
+        } else {
+            // Target node doesn't know about the FORBID_CLOSED_INDICES flag,
+            // so unset the bits starting from the 6th position.
+            out.write(id & 0x1f);
         }
     }
 
@@ -114,11 +126,15 @@ public class IndicesOptions {
     }
 
     public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices) {
-        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, true);
+        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, true, false);
     }
 
-    static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices, boolean allowAliasesToMultipleIndices) {
-        byte id = toByte(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices);
+    public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices, IndicesOptions defaultOptions) {
+        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, defaultOptions.allowAliasesToMultipleIndices(), defaultOptions.forbidClosedIndices());
+    }
+
+    static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices) {
+        byte id = toByte(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices, forbidClosedIndices);
         return VALUES[id];
     }
 
@@ -150,7 +166,9 @@ public class IndicesOptions {
                 toBool(sIgnoreUnavailable, defaultSettings.ignoreUnavailable()),
                 toBool(sAllowNoIndices, defaultSettings.allowNoIndices()),
                 expandWildcardsOpen,
-                expandWildcardsClosed
+                expandWildcardsClosed,
+                defaultSettings.allowAliasesToMultipleIndices(),
+                defaultSettings.forbidClosedIndices()
         );
     }
 
@@ -160,6 +178,15 @@ public class IndicesOptions {
      */
     public static IndicesOptions strictExpandOpen() {
         return VALUES[6];
+    }
+
+    /**
+     * @return indices options that requires every specified index to exist, expands wildcards only to open indices,
+     *         allows that no indices are resolved from wildcard expressions (not returning an error) and forbids the
+     *         use of closed indices by throwing an error.
+     */
+    public static IndicesOptions strictExpandOpenAndForbidClosed() {
+        return VALUES[38];
     }
 
     /**
@@ -186,7 +213,8 @@ public class IndicesOptions {
         return VALUES[7];
     }
 
-    private static byte toByte(boolean ignoreUnavailable, boolean allowNoIndices, boolean wildcardExpandToOpen, boolean wildcardExpandToClosed, boolean allowAliasesToMultipleIndices) {
+    private static byte toByte(boolean ignoreUnavailable, boolean allowNoIndices, boolean wildcardExpandToOpen,
+                               boolean wildcardExpandToClosed, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices) {
         byte id = 0;
         if (ignoreUnavailable) {
             id |= IGNORE_UNAVAILABLE;
@@ -204,6 +232,9 @@ public class IndicesOptions {
         //in the array same as before + the default value for the new flag
         if (!allowAliasesToMultipleIndices) {
             id |= FORBID_ALIASES_TO_MULTIPLE_INDICES;
+        }
+        if (forbidClosedIndices) {
+            id |= FORBID_CLOSED_INDICES;
         }
         return id;
     }

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastOperationRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 public abstract class BroadcastOperationRequest<T extends BroadcastOperationRequest> extends ActionRequest<T> {
 
     protected String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
 
     protected BroadcastOperationRequest() {
 

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
@@ -623,8 +624,10 @@ public class MetaData implements Iterable<IndexMetaData> {
         return null;
     }
 
+
     /**
      * Translates the provided indices or aliases, eventually containing wildcard expressions, into actual indices.
+     *
      * @param indicesOptions how the aliases or indices need to be resolved to concrete indices
      * @param aliasesOrIndices the aliases or indices to be resolved to concrete indices
      * @return the obtained concrete indices
@@ -635,7 +638,6 @@ public class MetaData implements Iterable<IndexMetaData> {
      * indices options don't allow such a case.
      */
     public String[] concreteIndices(IndicesOptions indicesOptions, String... aliasesOrIndices) throws IndexMissingException, ElasticsearchIllegalArgumentException {
-
         if (indicesOptions.expandWildcardsOpen() || indicesOptions.expandWildcardsClosed()) {
             if (isAllIndices(aliasesOrIndices)) {
                 String[] concreteIndices;
@@ -655,27 +657,44 @@ public class MetaData implements Iterable<IndexMetaData> {
 
             aliasesOrIndices = convertFromWildcards(aliasesOrIndices, indicesOptions);
         }
+        boolean failClosed = indicesOptions.forbidClosedIndices() && !indicesOptions.ignoreUnavailable();
 
         // optimize for single element index (common case)
         if (aliasesOrIndices.length == 1) {
-            return concreteIndices(aliasesOrIndices[0], indicesOptions.allowNoIndices(), indicesOptions.allowAliasesToMultipleIndices());
+            return concreteIndices(aliasesOrIndices[0], indicesOptions.allowNoIndices(), failClosed, indicesOptions.allowAliasesToMultipleIndices());
         }
 
         // check if its a possible aliased index, if not, just return the passed array
         boolean possiblyAliased = false;
+        boolean closedIndices = false;
         for (String index : aliasesOrIndices) {
-            if (!this.indices.containsKey(index)) {
+            IndexMetaData indexMetaData = indices.get(index);
+            if (indexMetaData == null) {
                 possiblyAliased = true;
                 break;
+            } else {
+                if (indicesOptions.forbidClosedIndices() && indexMetaData.getState() == IndexMetaData.State.CLOSE) {
+                    if (failClosed) {
+                        throw new IndexClosedException(new Index(index));
+                    } else {
+                        closedIndices = true;
+                    }
+                }
             }
         }
         if (!possiblyAliased) {
-            return aliasesOrIndices;
+            if (closedIndices) {
+                Set<String> actualIndices = new HashSet<>(Arrays.asList(aliasesOrIndices));
+                actualIndices.retainAll(new HashSet<Object>(Arrays.asList(allOpenIndices)));
+                return actualIndices.toArray(new String[actualIndices.size()]);
+            } else {
+                return aliasesOrIndices;
+            }
         }
 
         Set<String> actualIndices = new HashSet<>();
         for (String aliasOrIndex : aliasesOrIndices) {
-            String[] indices = concreteIndices(aliasOrIndex, indicesOptions.ignoreUnavailable(), indicesOptions.allowAliasesToMultipleIndices());
+            String[] indices = concreteIndices(aliasOrIndex, indicesOptions.ignoreUnavailable(), failClosed, indicesOptions.allowAliasesToMultipleIndices());
             Collections.addAll(actualIndices, indices);
         }
 
@@ -691,10 +710,15 @@ public class MetaData implements Iterable<IndexMetaData> {
         return indices[0];
     }
 
-    private String[] concreteIndices(String aliasOrIndex, boolean allowNoIndices, boolean allowMultipleIndices) throws IndexMissingException, ElasticsearchIllegalArgumentException {
+    private String[] concreteIndices(String aliasOrIndex, boolean allowNoIndices, boolean failClosed, boolean allowMultipleIndices) throws IndexMissingException, ElasticsearchIllegalArgumentException {
         // a quick check, if this is an actual index, if so, return it
-        if (indices.containsKey(aliasOrIndex)) {
-            return new String[]{aliasOrIndex};
+        IndexMetaData indexMetaData = indices.get(aliasOrIndex);
+        if (indexMetaData != null) {
+            if (indexMetaData.getState() == IndexMetaData.State.CLOSE && failClosed) {
+               throw new IndexClosedException(new Index(aliasOrIndex));
+            } else {
+               return new String[]{aliasOrIndex};
+            }
         }
         // not an actual index, fetch from an alias
         String[] indices = aliasAndIndexToIndexMap.getOrDefault(aliasOrIndex, Strings.EMPTY_ARRAY);
@@ -703,6 +727,11 @@ public class MetaData implements Iterable<IndexMetaData> {
         }
         if (indices.length > 1 && !allowMultipleIndices) {
             throw new ElasticsearchIllegalArgumentException("Alias [" + aliasOrIndex + "] has more than one indices associated with it [" + Arrays.toString(indices) + "], can't execute a single index op");
+        }
+
+        indexMetaData = this.indices.get(aliasOrIndex);
+        if (indexMetaData != null && indexMetaData.getState() == IndexMetaData.State.CLOSE && failClosed) {
+            throw new IndexClosedException(new Index(aliasOrIndex));
         }
         return indices;
     }

--- a/src/main/java/org/elasticsearch/indices/IndexClosedException.java
+++ b/src/main/java/org/elasticsearch/indices/IndexClosedException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexException;
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ * Exception indicating that one or more requested indices are closed.
+ */
+public class IndexClosedException extends IndexException {
+
+    public IndexClosedException(Index index) {
+        super(index, "closed");
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.FORBIDDEN;
+    }
+}

--- a/src/test/java/org/elasticsearch/action/percolate/MultiPercolatorRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/percolate/MultiPercolatorRequestTests.java
@@ -44,7 +44,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpen()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpenAndForbidClosed()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -57,7 +57,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.lenientExpandOpen()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.fromOptions(true, true, true, false, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -70,7 +70,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true)));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(percolateRequest.onlyCount(), equalTo(true));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());
@@ -82,7 +82,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true)));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), notNullValue());
         assertThat(percolateRequest.getRequest().id(), equalTo("1"));
@@ -96,7 +96,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("_local"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpen()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpenAndForbidClosed()));
         assertThat(percolateRequest.onlyCount(), equalTo(true));
         assertThat(percolateRequest.getRequest(), notNullValue());
         assertThat(percolateRequest.getRequest().id(), equalTo("2"));
@@ -110,7 +110,7 @@ public class MultiPercolatorRequestTests extends ElasticsearchTestCase {
         assertThat(percolateRequest.documentType(), equalTo("my-type1"));
         assertThat(percolateRequest.routing(), equalTo("my-routing-1"));
         assertThat(percolateRequest.preference(), equalTo("primary"));
-        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpen()));
+        assertThat(percolateRequest.indicesOptions(), equalTo(IndicesOptions.strictExpandOpenAndForbidClosed()));
         assertThat(percolateRequest.onlyCount(), equalTo(false));
         assertThat(percolateRequest.getRequest(), nullValue());
         assertThat(percolateRequest.source(), notNullValue());

--- a/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -37,10 +37,10 @@ public class MultiSearchRequestTests extends ElasticsearchTestCase {
         MultiSearchRequest request = new MultiSearchRequest().add(data, 0, data.length, false, null, null, null);
         assertThat(request.requests().size(), equalTo(5));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
-        assertThat(request.requests().get(0).indicesOptions(), equalTo(IndicesOptions.fromOptions(true, true, true, true)));
+        assertThat(request.requests().get(0).indicesOptions(), equalTo(IndicesOptions.fromOptions(true, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(request.requests().get(0).types().length, equalTo(0));
         assertThat(request.requests().get(1).indices()[0], equalTo("test"));
-        assertThat(request.requests().get(1).indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true)));
+        assertThat(request.requests().get(1).indicesOptions(), equalTo(IndicesOptions.fromOptions(false, true, true, true, IndicesOptions.strictExpandOpenAndForbidClosed())));
         assertThat(request.requests().get(1).types()[0], equalTo("type1"));
         assertThat(request.requests().get(2).indices(), nullValue());
         assertThat(request.requests().get(2).types().length, equalTo(0));

--- a/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -33,7 +33,7 @@ public class IndicesOptionsTests extends ElasticsearchTestCase {
     public void testSerialization() throws Exception {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
             BytesStreamOutput output = new BytesStreamOutput();
             Version outputVersion = randomVersion();
@@ -49,11 +49,16 @@ public class IndicesOptionsTests extends ElasticsearchTestCase {
             assertThat(indicesOptions2.expandWildcardsOpen(), equalTo(indicesOptions.expandWildcardsOpen()));
             assertThat(indicesOptions2.expandWildcardsClosed(), equalTo(indicesOptions.expandWildcardsClosed()));
 
-            if (outputVersion.onOrAfter(Version.V_1_2_0)) {
+            if (outputVersion.onOrAfter(Version.V_1_2_2)) {
+                assertThat(indicesOptions2.forbidClosedIndices(), equalTo(indicesOptions.forbidClosedIndices()));
                 assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
+            } else if (outputVersion.onOrAfter(Version.V_1_2_0)) {
+                assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
+                assertThat(indicesOptions2.forbidClosedIndices(), equalTo(false));
             } else {
                 //default value (true) if the node version doesn't support the allowAliasesToMultipleIndices flag
                 assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(true));
+                assertThat(indicesOptions2.forbidClosedIndices(), equalTo(false));
             }
         }
     }
@@ -67,13 +72,19 @@ public class IndicesOptionsTests extends ElasticsearchTestCase {
             boolean expandToOpenIndices = randomBoolean();
             boolean expandToClosedIndices = randomBoolean();
             boolean allowAliasesToMultipleIndices = randomBoolean();
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices);
+            boolean forbidClosedIndices = randomBoolean();
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(
+                    ignoreUnavailable, allowNoIndices,expandToOpenIndices, expandToClosedIndices,
+                    allowAliasesToMultipleIndices, forbidClosedIndices
+            );
 
             assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
             assertThat(indicesOptions.allowNoIndices(), equalTo(allowNoIndices));
             assertThat(indicesOptions.expandWildcardsOpen(), equalTo(expandToOpenIndices));
             assertThat(indicesOptions.expandWildcardsClosed(), equalTo(expandToClosedIndices));
             assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
+            assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
+            assertThat(indicesOptions.forbidClosedIndices(), equalTo(forbidClosedIndices));
         }
     }
 }


### PR DESCRIPTION
The `ignore_unavailable` option should also ignore indices that are closed, but it doesn't at the moment. The PR makes sure that `ignore_unavailable` also ignores specified indices that are closed.

PR for #6471
