### PR TITLE
Delegation of nextReader calls

### DIFF
--- a/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -96,6 +96,7 @@ abstract class QueryCollector extends Collector {
             List<Aggregator> aggregatorCollectors = new ArrayList<>();
             Aggregator[] aggregators = context.aggregations().factories().createTopLevelAggregators(aggregationContext);
             for (int i = 0; i < aggregators.length; i++) {
+                aggregators[i].setNextReader(context.searcher().getIndexReader().getContext());
                 if (!(aggregators[i] instanceof GlobalAggregator)) {
                     Aggregator aggregator = aggregators[i];
                     if (aggregator.shouldCollect()) {
@@ -107,7 +108,6 @@ abstract class QueryCollector extends Collector {
             if (!aggregatorCollectors.isEmpty()) {
                 facetAggCollectorBuilder.add(new AggregationPhase.AggregationsCollector(aggregatorCollectors, aggregationContext));
             }
-            aggregationContext.setNextReader(context.searcher().getIndexReader().getContext());
         }
         facetAndAggregatorCollector = facetAggCollectorBuilder.build();
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -78,6 +78,7 @@ public class AggregationPhase implements SearchPhase {
             List<Aggregator> collectors = new ArrayList<>();
             Aggregator[] aggregators = context.aggregations().factories().createTopLevelAggregators(aggregationContext);
             for (int i = 0; i < aggregators.length; i++) {
+                aggregators[i].setNextReader(context.searcher().getIndexReader().getContext());
                 if (!(aggregators[i] instanceof GlobalAggregator)) {
                     Aggregator aggregator = aggregators[i];
                     if (aggregator.shouldCollect()) {
@@ -89,7 +90,6 @@ public class AggregationPhase implements SearchPhase {
             if (!collectors.isEmpty()) {
                 context.searcher().addMainQueryCollector(new AggregationsCollector(collectors, aggregationContext));
             }
-            aggregationContext.setNextReader(context.searcher().getIndexReader().getContext());
         }
     }
 
@@ -148,7 +148,9 @@ public class AggregationPhase implements SearchPhase {
 
         @Override
         public void setScorer(Scorer scorer) throws IOException {
-            aggregationContext.setScorer(scorer);
+            for (Aggregator collector : collectors) {
+                collector.setScorer(scorer);
+            }
         }
 
         @Override
@@ -160,7 +162,9 @@ public class AggregationPhase implements SearchPhase {
 
         @Override
         public void setNextReader(AtomicReaderContext context) throws IOException {
-            aggregationContext.setNextReader(context);
+            for (Aggregator collector : collectors) {
+                collector.setNextReader(context);
+            }
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/FilteringBucketCollector.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/FilteringBucketCollector.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.search.aggregations;
 
 import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.search.Scorer;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.lease.Releasable;
@@ -54,6 +56,16 @@ public class FilteringBucketCollector extends BucketCollector implements Releasa
     @Override
     public final void setNextReader(AtomicReaderContext reader) {
         delegate.setNextReader(reader);
+    }
+
+    @Override
+    public void setNextReader(IndexReaderContext reader) {
+        delegate.setNextReader(reader);
+    }
+
+    @Override
+    public void setScorer(Scorer scorer) {
+        delegate.setScorer(scorer);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
@@ -39,7 +39,7 @@ public abstract class NonCollectingAggregator extends Aggregator {
     }
 
     @Override
-    public final void setNextReader(AtomicReaderContext reader) {
+    public final void doSetNextReader(AtomicReaderContext reader) {
         fail();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/RecordingBucketCollector.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/RecordingBucketCollector.java
@@ -39,5 +39,5 @@ public abstract class RecordingBucketCollector extends BucketCollector implement
     @Override
     public void gatherAnalysis(BucketAnalysisCollector analysisCollector, long bucketOrdinal) {
         throw new ElasticsearchIllegalStateException("gatherAnalysis not supported");
-    }    
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
@@ -47,7 +47,7 @@ public class FilterAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         try {
             bits = DocIdSets.toSafeBits(reader.reader(), filter.getDocIdSet(reader, reader.reader().getLiveDocs()));
         } catch (IOException ioe) {

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -63,7 +63,7 @@ public class GeoHashGridAggregator extends BucketsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.longValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -35,7 +35,7 @@ public class GlobalAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -80,7 +80,7 @@ public class HistogramAggregator extends BucketsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.longValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
@@ -46,7 +46,7 @@ public class MissingAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         if (valuesSource != null) {
             values = valuesSource.bytesValues();
         }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -69,7 +69,7 @@ public class NestedAggregator extends SingleBucketAggregator implements ReaderCo
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         if (parentFilter == null) {
             NestedAggregator closestNestedAggregator = findClosestNestedAggregator(parentAggregator);
             final Filter parentFilterNotCached;

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -82,7 +82,7 @@ public class ReverseNestedAggregator extends SingleBucketAggregator implements R
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         bucketOrdToLastCollectedParentDoc.clear();
         try {
             // In ES if parent is deleted, then also the children are deleted, so the child docs this agg receives

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -126,7 +126,7 @@ public class RangeAggregator extends BucketsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -137,7 +137,7 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
         }
 
         @Override
-        public void setNextReader(AtomicReaderContext reader) {
+        public void doSetNextReader(AtomicReaderContext reader) {
             bytesValues = valuesSource.bytesValues();
             ordinals = bytesValues.ordinals();
             final long maxOrd = ordinals.getMaxOrd();

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -59,7 +59,7 @@ public class DoubleTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 
@@ -88,7 +88,7 @@ public class DoubleTermsAggregator extends TermsAggregator {
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
             // we need to fill-in the blanks
             for (AtomicReaderContext ctx : context.searchContext().searcher().getTopReaderContext().leaves()) {
-                context.setNextReader(ctx);
+                setNextReader(ctx);
                 final DoubleValues values = valuesSource.doubleValues();
                 for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
                     final int valueCount = values.setDocument(docId);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -80,7 +80,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         globalValues = valuesSource.globalBytesValues();
         globalOrdinals = globalValues.ordinals();
         if (acceptedGlobalOrdinals != null) {
@@ -236,7 +236,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         }
 
         @Override
-        public void setNextReader(AtomicReaderContext reader) {
+        public void doSetNextReader(AtomicReaderContext reader) {
             if (segmentOrdinals != null && segmentOrdinals.getMaxOrd() != globalOrdinals.getMaxOrd()) {
                 mapSegmentCountsToGlobalCounts();
             }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -62,7 +62,7 @@ public class LongTermsAggregator extends TermsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.longValues();
     }
 
@@ -91,7 +91,7 @@ public class LongTermsAggregator extends TermsAggregator {
         if (bucketCountThresholds.getMinDocCount() == 0 && (order != InternalOrder.COUNT_DESC || bucketOrds.size() < bucketCountThresholds.getRequiredSize())) {
             // we need to fill-in the blanks
             for (AtomicReaderContext ctx : context.searchContext().searcher().getTopReaderContext().leaves()) {
-                context.setNextReader(ctx);
+                setNextReader(ctx);
                 final LongValues values = valuesSource.longValues();
                 for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
                     final int valueCount = values.setDocument(docId);

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -68,7 +68,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.bytesValues();
     }
 
@@ -142,7 +142,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
             // we need to fill-in the blanks
             List<BytesValues.WithOrdinals> valuesWithOrdinals = Lists.newArrayList();
             for (AtomicReaderContext ctx : context.searchContext().searcher().getTopReaderContext().leaves()) {
-                context.setNextReader(ctx);
+                setNextReader(ctx);
                 final BytesValues values = valuesSource.bytesValues();
                 if (values instanceof BytesValues.WithOrdinals) {
                     valuesWithOrdinals.add((BytesValues.WithOrdinals) values);
@@ -274,7 +274,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        public void setNextReader(AtomicReaderContext reader) {
+        public void doSetNextReader(AtomicReaderContext reader) {
             bytesValues = valuesSource.bytesValues();
             ordinals = bytesValues.ordinals();
             final long maxOrd = ordinals.getMaxOrd();

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -60,7 +60,7 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -68,7 +68,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         postCollectLastCollector();
         collector = createCollector(reader);
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -74,7 +74,7 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         this.values = this.valuesSource.geoPointValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -58,7 +58,7 @@ public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -58,7 +58,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -68,7 +68,7 @@ public class PercentilesAggregator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -68,7 +68,7 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -70,7 +70,7 @@ public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -57,7 +57,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.doubleValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -62,7 +62,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public void setNextReader(AtomicReaderContext reader) {
+    public void doSetNextReader(AtomicReaderContext reader) {
         values = valuesSource.bytesValues();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -19,15 +19,9 @@
 package org.elasticsearch.search.aggregations.support;
 
 import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
-import org.apache.lucene.index.AtomicReaderContext;
-import org.apache.lucene.index.IndexReaderContext;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.lucene.ReaderContextAware;
-import org.elasticsearch.common.lucene.ScorerAware;
-import org.elasticsearch.common.lucene.TopReaderContextAware;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
@@ -35,25 +29,18 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.internal.SearchContext;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 /**
  *
  */
 @SuppressWarnings({"unchecked", "ForLoopReplaceableByForEach"})
-public class AggregationContext implements ReaderContextAware, ScorerAware {
+public class AggregationContext {
 
     private final SearchContext searchContext;
 
     private ObjectObjectOpenHashMap<ConfigCacheKey, ValuesSource>[] perDepthFieldDataSources = new ObjectObjectOpenHashMap[4];
-    private List<ReaderContextAware> readerAwares = new ArrayList<>();
-    private List<TopReaderContextAware> topReaderAwares = new ArrayList<TopReaderContextAware>();
-    private List<ScorerAware> scorerAwares = new ArrayList<>();
 
-    private AtomicReaderContext reader;
-    private Scorer scorer;
     private boolean scoreDocsInOrder = false;
 
     public AggregationContext(SearchContext searchContext) {
@@ -70,34 +57,6 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
 
     public BigArrays bigArrays() {
         return searchContext.bigArrays();
-    }
-
-    public AtomicReaderContext currentReader() {
-        return reader;
-    }
-
-    public Scorer currentScorer() {
-        return scorer;
-    }
-
-    public void setNextReader(IndexReaderContext reader) {
-        for (TopReaderContextAware topReaderAware : topReaderAwares) {
-            topReaderAware.setNextReader(reader);
-        }
-    }
-
-    public void setNextReader(AtomicReaderContext reader) {
-        this.reader = reader;
-        for (ReaderContextAware aware : readerAwares) {
-            aware.setNextReader(reader);
-        }
-    }
-
-    public void setScorer(Scorer scorer) {
-        this.scorer = scorer;
-        for (ScorerAware scorerAware : scorerAwares) {
-            scorerAware.setScorer(scorer);
-        }
     }
 
     public boolean scoreDocsInOrder() {
@@ -142,14 +101,9 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
     }
 
     private ValuesSource.Numeric numericScript(ValuesSourceConfig<?> config) {
-        setScorerIfNeeded(config.script);
-        setReaderIfNeeded(config.script);
-        scorerAwares.add(config.script);
-        readerAwares.add(config.script);
         ValuesSource.Numeric source = new ValuesSource.Numeric.Script(config.script, config.scriptValueType);
         if (config.ensureUnique || config.ensureSorted) {
             source = new ValuesSource.Numeric.SortedAndUnique(source);
-            readerAwares.add((ReaderContextAware) source);
         }
         return source;
     }
@@ -160,20 +114,13 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
         if (dataSource == null) {
             ValuesSource.MetaData metaData = ValuesSource.MetaData.load(config.fieldContext.indexFieldData(), searchContext);
             dataSource = new ValuesSource.Numeric.FieldData((IndexNumericFieldData<?>) config.fieldContext.indexFieldData(), metaData);
-            setReaderIfNeeded((ReaderContextAware) dataSource);
-            readerAwares.add((ReaderContextAware) dataSource);
             fieldDataSources.put(cacheKey, dataSource);
         }
         if (config.script != null) {
-            setScorerIfNeeded(config.script);
-            setReaderIfNeeded(config.script);
-            scorerAwares.add(config.script);
-            readerAwares.add(config.script);
             dataSource = new ValuesSource.Numeric.WithScript(dataSource, config.script);
 
             if (config.ensureUnique || config.ensureSorted) {
                 dataSource = new ValuesSource.Numeric.SortedAndUnique(dataSource);
-                readerAwares.add((ReaderContextAware) dataSource);
             }
         }
         if (config.needsHashes) {
@@ -193,18 +140,9 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
             } else {
                 dataSource = new ValuesSource.Bytes.FieldData(indexFieldData, metaData);
             }
-            setReaderIfNeeded((ReaderContextAware) dataSource);
-            readerAwares.add((ReaderContextAware) dataSource);
-            if (dataSource instanceof TopReaderContextAware) {
-                topReaderAwares.add((TopReaderContextAware) dataSource);
-            }
             fieldDataSources.put(cacheKey, dataSource);
         }
         if (config.script != null) {
-            setScorerIfNeeded(config.script);
-            setReaderIfNeeded(config.script);
-            scorerAwares.add(config.script);
-            readerAwares.add(config.script);
             dataSource = new ValuesSource.WithScript(dataSource, config.script);
         }
         // Even in case we wrap field data, we might still need to wrap for sorting, because the wrapped field data might be
@@ -212,7 +150,6 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
         // need to wrap for uniqueness
         if ((config.ensureUnique && !dataSource.metaData().uniqueness().unique()) || config.ensureSorted) {
             dataSource = new ValuesSource.Bytes.SortedAndUnique(dataSource);
-            readerAwares.add((ReaderContextAware) dataSource);
         }
 
         if (config.needsHashes) { // the data source needs hash if at least one consumer needs hashes
@@ -222,14 +159,9 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
     }
 
     private ValuesSource.Bytes bytesScript(ValuesSourceConfig<?> config) {
-        setScorerIfNeeded(config.script);
-        setReaderIfNeeded(config.script);
-        scorerAwares.add(config.script);
-        readerAwares.add(config.script);
         ValuesSource.Bytes source = new ValuesSource.Bytes.Script(config.script);
         if (config.ensureUnique || config.ensureSorted) {
             source = new ValuesSource.Bytes.SortedAndUnique(source);
-            readerAwares.add((ReaderContextAware) source);
         }
         return source;
     }
@@ -240,36 +172,12 @@ public class AggregationContext implements ReaderContextAware, ScorerAware {
         if (dataSource == null) {
             ValuesSource.MetaData metaData = ValuesSource.MetaData.load(config.fieldContext.indexFieldData(), searchContext);
             dataSource = new ValuesSource.GeoPoint((IndexGeoPointFieldData<?>) config.fieldContext.indexFieldData(), metaData);
-            setReaderIfNeeded(dataSource);
-            readerAwares.add(dataSource);
             fieldDataSources.put(cacheKey, dataSource);
         }
         if (config.needsHashes) {
             dataSource.setNeedsHashes(true);
         }
         return dataSource;
-    }
-
-    public void registerReaderContextAware(ReaderContextAware readerContextAware) {
-        setReaderIfNeeded(readerContextAware);
-        readerAwares.add(readerContextAware);
-    }
-
-    public void registerScorerAware(ScorerAware scorerAware) {
-        setScorerIfNeeded(scorerAware);
-        scorerAwares.add(scorerAware);
-    }
-
-    private void setReaderIfNeeded(ReaderContextAware readerAware) {
-        if (reader != null) {
-            readerAware.setNextReader(reader);
-        }
-    }
-
-    private void setScorerIfNeeded(ScorerAware scorerAware) {
-        if (scorer != null) {
-            scorerAware.setScorer(scorer);
-        }
     }
 
     private static class ConfigCacheKey {

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
@@ -51,7 +51,11 @@ public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource> ext
             return createUnmapped(context, parent);
         }
         VS vs = context.valuesSource(config, parent == null ? 0 : 1 + parent.depth());
-        return create(vs, expectedBucketsCount, context, parent);
+        Aggregator aggregator = create(vs, expectedBucketsCount, context, parent);
+        aggregator.registerReaderAware(vs);
+        aggregator.registerTopReaderAware(vs);
+        aggregator.registerScorerAware(vs);
+        return aggregator;
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/support/FieldDataSourceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/support/FieldDataSourceTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.support;
 
 import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.BytesValues;
@@ -136,6 +137,18 @@ public class FieldDataSourceTests extends ElasticsearchTestCase {
             @Override
             public MetaData metaData() {
                 throw new UnsupportedOperationException();
+            }
+            
+            @Override
+            public void setNextReader(AtomicReaderContext reader) {
+            }
+            
+            @Override
+            public void setNextReader(IndexReaderContext reader) {
+            }
+            
+            @Override
+            public void setScorer(Scorer scorer) {
             }
 
         };


### PR DESCRIPTION
Currently aggregations subscribe to setNextReader calls in AggregationContext.  When a new reader is used all reader aware objects are notified of the new reader.  With deferred aggregations children aggregations of a breath-first aggregation do not require to be notified of reader changes until the replay stage. Also, at the replay stage only the child aggregations of the breath-first aggregation need to be notified, we should not be notifying all the other aggregations of the new reader.

To solve this the calls for setNextReader are now handled by each aggregation so it can notify its child aggregations and any other ReaderContextAware objects (e.g. ValueSources) of the new reader at the relevant time.

The same idea has also been applied to the setScorer and setTopReader calls for Aggregators and ValueSources.
