### PR TITLE
Fix reducing of range aggregations.

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -61,12 +61,6 @@ public class InternalAggregations implements Aggregations, ToXContent, Streamabl
         this.aggregations = aggregations;
     }
 
-    /** Resets the internal addAggregation */
-    void reset(List<InternalAggregation> aggregations) {
-        this.aggregations = aggregations;
-        this.aggregationsAsMap = null;
-    }
-
     /**
      * Iterates over the {@link Aggregation}s.
      */
@@ -145,20 +139,7 @@ public class InternalAggregations implements Aggregations, ToXContent, Streamabl
             InternalAggregation first = aggregations.get(0); // the list can't be empty as it's created on demand
             reducedAggregations.add(first.reduce(new InternalAggregation.ReduceContext(aggregations, bigArrays)));
         }
-        InternalAggregations result = aggregationsList.get(0);
-        result.reset(reducedAggregations);
-        return result;
-    }
-
-    /**
-     * Reduces this aggregations, effectively propagates the reduce to all the sub aggregations
-     * @param cacheRecycler
-     */
-    public void reduce(BigArrays bigArrays) {
-        for (int i = 0; i < aggregations.size(); i++) {
-            InternalAggregation aggregation = aggregations.get(i);
-            aggregations.set(i, aggregation.reduce(new InternalAggregation.ReduceContext(ImmutableList.of(aggregation), bigArrays)));
-        }
+        return new InternalAggregations(reducedAggregations);
     }
 
     /** The fields required to write this addAggregation to xcontent */

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
@@ -56,4 +56,8 @@ public class InternalFilter extends InternalSingleBucketAggregation implements F
         return TYPE;
     }
 
+    @Override
+    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+        return new InternalFilter(name, docCount, subAggregations);
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobal.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobal.java
@@ -56,4 +56,9 @@ public class InternalGlobal extends InternalSingleBucketAggregation implements G
     public Type type() {
         return TYPE;
     }
+
+    @Override
+    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+        return new InternalGlobal(name, docCount, subAggregations);
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -58,6 +58,11 @@ public class InternalDateHistogram extends InternalHistogram<InternalDateHistogr
         }
 
         @Override
+        protected InternalHistogram.Factory<Bucket> getFactory() {
+            return FACTORY;
+        }
+
+        @Override
         public String getKey() {
             return formatter != null ? formatter.format(key) : ValueFormatter.DateTime.DEFAULT.format(key);
         }
@@ -107,6 +112,11 @@ public class InternalDateHistogram extends InternalHistogram<InternalDateHistogr
     @Override
     public Type type() {
         return TYPE;
+    }
+
+    @Override
+    protected InternalHistogram.Factory<Bucket> getFactory() {
+        return FACTORY;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
@@ -58,4 +58,8 @@ public class InternalMissing extends InternalSingleBucketAggregation implements 
         return TYPE;
     }
 
+    @Override
+    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+        return new InternalMissing(name, docCount, subAggregations);
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNested.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNested.java
@@ -57,4 +57,8 @@ public class InternalNested extends InternalSingleBucketAggregation implements N
         return TYPE;
     }
 
+    @Override
+    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+        return new InternalNested(name, docCount, subAggregations);
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNested.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNested.java
@@ -57,4 +57,8 @@ public class InternalReverseNested extends InternalSingleBucketAggregation imple
         return TYPE;
     }
 
+    @Override
+    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+        return new InternalReverseNested(name, docCount, subAggregations);
+    }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -203,7 +203,7 @@ public class RangeAggregator extends BucketsAggregator {
             buckets.add(bucket);
         }
         // value source can be null in the case of unmapped fields
-        return rangeFactory.create(name, buckets, formatter, keyed, false);
+        return rangeFactory.create(name, buckets, formatter, keyed);
     }
 
     @Override
@@ -217,7 +217,7 @@ public class RangeAggregator extends BucketsAggregator {
             buckets.add(bucket);
         }
         // value source can be null in the case of unmapped fields
-        return rangeFactory.create(name, buckets, formatter, keyed, false);
+        return rangeFactory.create(name, buckets, formatter, keyed);
     }
 
     private static final void sortRanges(final Range[] ranges) {
@@ -274,7 +274,7 @@ public class RangeAggregator extends BucketsAggregator {
             for (RangeAggregator.Range range : ranges) {
                 buckets.add(factory.createBucket(range.key, range.from, range.to, 0, subAggs, formatter));
             }
-            return factory.create(name, buckets, formatter, keyed, true);
+            return factory.create(name, buckets, formatter, keyed);
         }
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
@@ -72,6 +72,11 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket> i
         public DateTime getToAsDate() {
             return Double.isInfinite(getTo().doubleValue()) ? null : new DateTime(getTo().longValue(), DateTimeZone.UTC);
         }
+
+        @Override
+        protected InternalRange.Factory<Bucket, ?> getFactory() {
+            return FACTORY;
+        }
     }
 
     private static class Factory extends InternalRange.Factory<InternalDateRange.Bucket, InternalDateRange> {
@@ -82,8 +87,8 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket> i
         }
 
         @Override
-        public InternalDateRange create(String name, List<InternalDateRange.Bucket> ranges, ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return new InternalDateRange(name, ranges, formatter, keyed, unmapped);
+        public InternalDateRange create(String name, List<InternalDateRange.Bucket> ranges, ValueFormatter formatter, boolean keyed) {
+            return new InternalDateRange(name, ranges, formatter, keyed);
         }
 
         @Override
@@ -94,8 +99,8 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket> i
 
     InternalDateRange() {} // for serialization
 
-    InternalDateRange(String name, List<InternalDateRange.Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-        super(name, ranges, formatter, keyed, unmapped);
+    InternalDateRange(String name, List<InternalDateRange.Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed) {
+        super(name, ranges, formatter, keyed);
     }
 
     @Override
@@ -104,7 +109,7 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket> i
     }
 
     @Override
-    protected Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, ValueFormatter formatter) {
-        return new Bucket(key, from, to, docCount, aggregations, formatter);
+    protected InternalRange.Factory<Bucket, ?> getFactory() {
+        return FACTORY;
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistance.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistance.java
@@ -61,6 +61,10 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
             super(key, from, to, docCount, aggregations, formatter);
         }
 
+        @Override
+        protected InternalRange.Factory<Bucket, ?> getFactory() {
+            return FACTORY;
+        }
     }
 
     private static class Factory extends InternalRange.Factory<InternalGeoDistance.Bucket, InternalGeoDistance> {
@@ -71,8 +75,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
         }
 
         @Override
-        public InternalGeoDistance create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return new InternalGeoDistance(name, ranges, formatter, keyed, unmapped);
+        public InternalGeoDistance create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed) {
+            return new InternalGeoDistance(name, ranges, formatter, keyed);
         }
 
         @Override
@@ -83,8 +87,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     InternalGeoDistance() {} // for serialization
 
-    public InternalGeoDistance(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-        super(name, ranges, formatter, keyed, unmapped);
+    public InternalGeoDistance(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed) {
+        super(name, ranges, formatter, keyed);
     }
 
     @Override
@@ -93,7 +97,7 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
     }
 
     @Override
-    protected Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, ValueFormatter formatter) {
-        return new Bucket(key, from, to, docCount, aggregations, formatter);
+    protected InternalRange.Factory<Bucket, ?> getFactory() {
+        return FACTORY;
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
@@ -74,6 +74,11 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket> i
             double to = getTo().doubleValue();
             return Double.isInfinite(to) ? null : MAX_IP == to ? null : ValueFormatter.IPv4.format(to);
         }
+
+        @Override
+        protected InternalRange.Factory<Bucket, ?> getFactory() {
+            return FACTORY;
+        }
     }
 
     private static class Factory extends InternalRange.Factory<InternalIPv4Range.Bucket, InternalIPv4Range> {
@@ -84,8 +89,8 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket> i
         }
 
         @Override
-        public InternalIPv4Range create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, boolean unmapped) {
-            return new InternalIPv4Range(name, ranges, keyed, unmapped);
+        public InternalIPv4Range create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed) {
+            return new InternalIPv4Range(name, ranges, keyed);
         }
 
         @Override
@@ -96,8 +101,8 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket> i
 
     public InternalIPv4Range() {} // for serialization
 
-    public InternalIPv4Range(String name, List<InternalIPv4Range.Bucket> ranges, boolean keyed, boolean unmapped) {
-        super(name, ranges, ValueFormatter.IPv4, keyed, unmapped);
+    public InternalIPv4Range(String name, List<InternalIPv4Range.Bucket> ranges, boolean keyed) {
+        super(name, ranges, ValueFormatter.IPv4, keyed);
     }
 
     @Override
@@ -106,8 +111,7 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket> i
     }
 
     @Override
-    protected Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, @Nullable ValueFormatter formatter ) {
-        return new Bucket(key, from, to, docCount, aggregations);
+    protected InternalRange.Factory<Bucket, ?> getFactory() {
+        return FACTORY;
     }
-
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -83,6 +83,11 @@ public class SignificantLongTerms extends InternalSignificantTerms {
             return Long.toString(term);
         }
 
+        @Override
+        Bucket newBucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, InternalAggregations aggregations) {
+            return new Bucket(subsetDf, subsetSize, supersetDf, supersetSize, term, aggregations);
+        }
+
     }
 
     private ValueFormatter formatter;
@@ -99,6 +104,12 @@ public class SignificantLongTerms extends InternalSignificantTerms {
     @Override
     public Type type() {
         return TYPE;
+    }
+
+    @Override
+    InternalSignificantTerms newAggregation(long subsetSize, long supersetSize,
+            List<InternalSignificantTerms.Bucket> buckets) {
+        return new SignificantLongTerms(subsetSize, supersetSize, getName(), formatter, requiredSize, supersetSize, buckets);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -85,6 +85,10 @@ public class SignificantStringTerms extends InternalSignificantTerms {
             return termBytes.utf8ToString();
         }
 
+        @Override
+        Bucket newBucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, InternalAggregations aggregations) {
+            return new Bucket(termBytes, subsetDf, subsetSize, supersetDf, supersetSize, aggregations);
+        }
     }
 
     SignificantStringTerms() {} // for serialization
@@ -97,6 +101,12 @@ public class SignificantStringTerms extends InternalSignificantTerms {
     @Override
     public Type type() {
         return TYPE;
+    }
+
+    @Override
+    InternalSignificantTerms newAggregation(long subsetSize, long supersetSize,
+            List<InternalSignificantTerms.Bucket> buckets) {
+        return new SignificantStringTerms(subsetSize, supersetSize, getName(), requiredSize, supersetSize, buckets);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/UnmappedSignificantTerms.java
@@ -22,10 +22,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -62,6 +64,21 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms {
     @Override
     public Type type() {
         return TYPE;
+    }
+
+    @Override
+    public InternalAggregation reduce(ReduceContext reduceContext) {
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            if (!(aggregation instanceof UnmappedSignificantTerms)) {
+                return aggregation.reduce(reduceContext);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    InternalSignificantTerms newAggregation(long subsetSize, long supersetSize, List<Bucket> buckets) {
+        throw new UnsupportedOperationException("How did you get there?");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -23,18 +23,14 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.terms.support.BucketPriorityQueue;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -87,6 +83,16 @@ public class LongTerms extends InternalTerms {
         int compareTerm(Terms.Bucket other) {
             return Long.compare(term, other.getKeyAsNumber().longValue());
         }
+
+        @Override
+        Object getKeyAsObject() {
+            return getKeyAsNumber();
+        }
+
+        @Override
+        Bucket newBucket(long docCount, InternalAggregations aggs) {
+            return new Bucket(term, docCount, aggs);
+        }
     }
 
     private @Nullable ValueFormatter formatter;
@@ -104,59 +110,8 @@ public class LongTerms extends InternalTerms {
     }
 
     @Override
-    public InternalTerms reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            InternalTerms terms = (InternalTerms) aggregations.get(0);
-            terms.trimExcessEntries(reduceContext.bigArrays());
-            return terms;
-        }
-        InternalTerms reduced = null;
-
-        LongObjectPagedHashMap<List<Bucket>> buckets = null;
-        for (InternalAggregation aggregation : aggregations) {
-            InternalTerms terms = (InternalTerms) aggregation;
-            if (terms instanceof UnmappedTerms) {
-                continue;
-            }
-            if (reduced == null) {
-                reduced = terms;
-            }
-            if (buckets == null) {
-                buckets = new LongObjectPagedHashMap<>(terms.buckets.size(), reduceContext.bigArrays());
-            }
-            for (Terms.Bucket bucket : terms.buckets) {
-                List<Bucket> existingBuckets = buckets.get(((Bucket) bucket).term);
-                if (existingBuckets == null) {
-                    existingBuckets = new ArrayList<>(aggregations.size());
-                    buckets.put(((Bucket) bucket).term, existingBuckets);
-                }
-                existingBuckets.add((Bucket) bucket);
-            }
-        }
-
-        if (reduced == null) {
-            // there are only unmapped terms, so we just return the first one (no need to reduce)
-            return (UnmappedTerms) aggregations.get(0);
-        }
-
-        // TODO: would it be better to sort the backing array buffer of the hppc map directly instead of using a PQ?
-        final int size = (int) Math.min(requiredSize, buckets.size());
-        BucketPriorityQueue ordered = new BucketPriorityQueue(size, order.comparator(null));
-        for (LongObjectPagedHashMap.Cursor<List<LongTerms.Bucket>> cursor : buckets) {
-            List<LongTerms.Bucket> sameTermBuckets = cursor.value;
-            final InternalTerms.Bucket b = sameTermBuckets.get(0).reduce(sameTermBuckets, reduceContext.bigArrays());
-            if (b.getDocCount() >= minDocCount) {
-                ordered.insertWithOverflow(b);
-            }
-        }
-        buckets.close();
-        InternalTerms.Bucket[] list = new InternalTerms.Bucket[ordered.size()];
-        for (int i = ordered.size() - 1; i >= 0; i--) {
-            list[i] = (Bucket) ordered.pop();
-        }
-        reduced.buckets = Arrays.asList(list);
-        return reduced;
+    protected InternalTerms newAggregation(String name, List<InternalTerms.Bucket> buckets) {
+        return new LongTerms(name, order, formatter, requiredSize, minDocCount, buckets);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -84,6 +84,16 @@ public class StringTerms extends InternalTerms {
         int compareTerm(Terms.Bucket other) {
             return BytesRef.getUTF8SortedAsUnicodeComparator().compare(termBytes, ((Bucket) other).termBytes);
         }
+
+        @Override
+        Object getKeyAsObject() {
+            return getKeyAsText();
+        }
+
+        @Override
+        Bucket newBucket(long docCount, InternalAggregations aggs) {
+            return new Bucket(termBytes, docCount, aggs);
+        }
     }
 
     StringTerms() {} // for serialization
@@ -95,6 +105,11 @@ public class StringTerms extends InternalTerms {
     @Override
     public Type type() {
         return TYPE;
+    }
+
+    @Override
+    protected InternalTerms newAggregation(String name, List<InternalTerms.Bucket> buckets) {
+        return new StringTerms(name, order, requiredSize, minDocCount, buckets);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -22,10 +22,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationStreams;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -78,6 +80,21 @@ public class UnmappedTerms extends InternalTerms {
         InternalOrder.Streams.writeOrder(order, out);
         writeSize(requiredSize, out);
         out.writeVLong(minDocCount);
+    }
+
+    @Override
+    public InternalAggregation reduce(ReduceContext reduceContext) {
+        for (InternalAggregation agg : reduceContext.aggregations()) {
+            if (!(agg instanceof UnmappedTerms)) {
+                return agg.reduce(reduceContext);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    protected InternalTerms newAggregation(String name, List<Bucket> buckets) {
+        throw new UnsupportedOperationException("How did you get there?");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggre
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
 *
@@ -76,20 +75,13 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public InternalAvg reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            return (InternalAvg) aggregations.get(0);
+        long count = 0;
+        double sum = 0;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            count += ((InternalAvg) aggregation).count;
+            sum += ((InternalAvg) aggregation).sum;
         }
-        InternalAvg reduced = null;
-        for (InternalAggregation aggregation : aggregations) {
-            if (reduced == null) {
-                reduced = (InternalAvg) aggregation;
-            } else {
-                reduced.count += ((InternalAvg) aggregation).count;
-                reduced.sum += ((InternalAvg) aggregation).sum;
-            }
-        }
-        return reduced;
+        return new InternalAvg(getName(), sum, count);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
@@ -184,6 +184,10 @@ public final class HyperLogLogPlusPlus implements Releasable {
         alphaMM = alpha * m * m;
     }
 
+    public int precision() {
+        return p;
+    }
+
     public long maxBucket() {
         return runLens.size() >>> p;
     }

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -104,18 +104,17 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
             final InternalCardinality cardinality = (InternalCardinality) aggregation;
             if (cardinality.counts != null) {
                 if (reduced == null) {
-                    reduced = cardinality;
-                } else {
-                    reduced.merge(cardinality);
+                    reduced = new InternalCardinality(name, new HyperLogLogPlusPlus(cardinality.counts.precision(), BigArrays.NON_RECYCLING_INSTANCE, 1));
                 }
+                reduced.merge(cardinality);
             }
         }
 
         if (reduced == null) { // all empty
-            reduced = (InternalCardinality) aggregations.get(0);
+            return aggregations.get(0);
+        } else {
+            return reduced;
         }
-
-        return reduced;
     }
 
     public void merge(InternalCardinality other) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalMetricsAggregation;
 
 import java.io.IOException;
-import java.util.List;
 
 public class InternalGeoBounds extends InternalMetricsAggregation implements GeoBounds {
 
@@ -72,36 +71,36 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
     
     @Override
     public InternalAggregation reduce(ReduceContext reduceContext) {
-        InternalGeoBounds reduced = null;
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        for (InternalAggregation aggregation : aggregations) {
-            InternalGeoBounds bounds = (InternalGeoBounds) aggregation;
-            
-            if (reduced == null) {
-                reduced = bounds;
-                continue;
-            }
+        double top = Double.NEGATIVE_INFINITY;
+        double bottom = Double.POSITIVE_INFINITY;
+        double posLeft = Double.POSITIVE_INFINITY;
+        double posRight = Double.NEGATIVE_INFINITY;
+        double negLeft = Double.POSITIVE_INFINITY;
+        double negRight = Double.NEGATIVE_INFINITY;
 
-            if (bounds.top > reduced.top) {
-                reduced.top = bounds.top;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            InternalGeoBounds bounds = (InternalGeoBounds) aggregation;
+
+            if (bounds.top > top) {
+                top = bounds.top;
             }
-            if (bounds.bottom < reduced.bottom) {
-                reduced.bottom = bounds.bottom;
+            if (bounds.bottom < bottom) {
+                bottom = bounds.bottom;
             }
-            if (bounds.posLeft < reduced.posLeft) {
-                reduced.posLeft = bounds.posLeft;
+            if (bounds.posLeft < posLeft) {
+                posLeft = bounds.posLeft;
             }
-            if (bounds.posRight > reduced.posRight) {
-                reduced.posRight = bounds.posRight;
+            if (bounds.posRight > posRight) {
+                posRight = bounds.posRight;
             }
-            if (bounds.negLeft < reduced.negLeft) {
-                reduced.negLeft = bounds.negLeft;
+            if (bounds.negLeft < negLeft) {
+                negLeft = bounds.negLeft;
             }
-            if (bounds.negRight > reduced.negRight) {
-                reduced.negRight = bounds.negRight;
+            if (bounds.negRight > negRight) {
+                negRight = bounds.negRight;
             }
         }
-        return reduced;
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude);
     }
     
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggre
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
 *
@@ -74,22 +73,11 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public InternalMax reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            return (InternalMax) aggregations.get(0);
+        double max = Double.NEGATIVE_INFINITY;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            max = Math.max(max, ((InternalMax) aggregation).max);
         }
-        InternalMax reduced = null;
-        for (InternalAggregation aggregation : aggregations) {
-            if (reduced == null) {
-                reduced = (InternalMax) aggregation;
-            } else {
-                reduced.max = Math.max(reduced.max, ((InternalMax) aggregation).max);
-            }
-        }
-        if (reduced != null) {
-            return reduced;
-        }
-        return (InternalMax) aggregations.get(0);
+        return new InternalMax(name, max);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggre
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
 *
@@ -75,22 +74,11 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public InternalMin reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            return (InternalMin) aggregations.get(0);
+        double min = Double.POSITIVE_INFINITY;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            min = Math.min(min, ((InternalMin) aggregation).min);
         }
-        InternalMin reduced = null;
-        for (InternalAggregation aggregation : aggregations) {
-            if (reduced == null) {
-                reduced = (InternalMin) aggregation;
-            } else {
-                reduced.min = Math.min(reduced.min, ((InternalMin) aggregation).min);
-            }
-        }
-        if (reduced != null) {
-            return reduced;
-        }
-        return (InternalMin) aggregations.get(0);
+        return new InternalMin(getName(), min);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigestState.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigestState.java
@@ -36,6 +36,10 @@ public class TDigestState extends AVLTreeDigest {
         this.compression = compression;
     }
 
+    public double compression() {
+        return compression;
+    }
+
     public static void write(TDigestState state, StreamOutput out) throws IOException {
         out.writeDouble(state.compression);
         out.writeVInt(state.centroidCount());

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggre
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
 *
@@ -120,33 +119,18 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
 
     @Override
     public InternalStats reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            return (InternalStats) aggregations.get(0);
+        long count = 0;
+        double min = Double.POSITIVE_INFINITY;
+        double max = Double.NEGATIVE_INFINITY;
+        double sum = 0;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            InternalStats stats = (InternalStats) aggregation;
+            count += stats.getCount();
+            min = Math.min(min, stats.getMin());
+            max = Math.max(max, stats.getMax());
+            sum += stats.getSum();
         }
-        InternalStats reduced = null;
-        for (InternalAggregation aggregation : aggregations) {
-            if (reduced == null) {
-                if (((InternalStats) aggregation).count != 0) {
-                    reduced = (InternalStats) aggregation;
-                }
-            } else {
-                if (((InternalStats) aggregation).count != 0) {
-                    reduced.count += ((InternalStats) aggregation).count;
-                    reduced.min = Math.min(reduced.min, ((InternalStats) aggregation).min);
-                    reduced.max = Math.max(reduced.max, ((InternalStats) aggregation).max);
-                    reduced.sum += ((InternalStats) aggregation).sum;
-                    mergeOtherStats(reduced, aggregation);
-                }
-            }
-        }
-        if (reduced != null) {
-            return reduced;
-        }
-        return (InternalStats) aggregations.get(0);
-    }
-
-    protected void mergeOtherStats(InternalStats to, InternalAggregation from) {
+        return new InternalStats(name, count, sum, min, max);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
@@ -101,8 +101,14 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
     }
 
     @Override
-    protected void mergeOtherStats(InternalStats to, InternalAggregation from) {
-        ((InternalExtendedStats) to).sumOfSqrs += ((InternalExtendedStats) from).sumOfSqrs;
+    public InternalExtendedStats reduce(ReduceContext reduceContext) {
+        double sumOfSqrs = 0;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            InternalExtendedStats stats = (InternalExtendedStats) aggregation;
+            sumOfSqrs += stats.getSumOfSquares();
+        }
+        final InternalStats stats = super.reduce(reduceContext);
+        return new InternalExtendedStats(name, stats.getCount(), stats.getSum(), stats.getMin(), stats.getMax(), sumOfSqrs);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggre
 import org.elasticsearch.search.aggregations.support.format.ValueFormatterStreams;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
 *
@@ -74,22 +73,11 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
 
     @Override
     public InternalSum reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            return (InternalSum) aggregations.get(0);
+        double sum = 0;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            sum += ((InternalSum) aggregation).sum;
         }
-        InternalSum reduced = null;
-        for (InternalAggregation aggregation : aggregations) {
-            if (reduced == null) {
-                reduced = (InternalSum) aggregation;
-            } else {
-                reduced.sum += ((InternalSum) aggregation).sum;
-            }
-        }
-        if (reduced != null) {
-            return reduced;
-        }
-        return (InternalSum) aggregations.get(0);
+        return new InternalSum(name, sum);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHits.java
@@ -94,10 +94,6 @@ public class InternalTopHits extends InternalMetricsAggregation implements TopHi
     @Override
     public InternalAggregation reduce(ReduceContext reduceContext) {
         List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1 && from == 0) {
-            return aggregations.get(0);
-        }
-
         TopDocs[] shardDocs = new TopDocs[aggregations.size()];
         InternalSearchHits[] shardHits = new InternalSearchHits[aggregations.size()];
         for (int i = 0; i < shardDocs.length; i++) {

--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/InternalValueCount.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * An internal implementation of {@link ValueCount}.
@@ -69,19 +68,11 @@ public class InternalValueCount extends InternalNumericMetricsAggregation implem
 
     @Override
     public InternalAggregation reduce(ReduceContext reduceContext) {
-        List<InternalAggregation> aggregations = reduceContext.aggregations();
-        if (aggregations.size() == 1) {
-            return aggregations.get(0);
+        long valueCount = 0;
+        for (InternalAggregation aggregation : reduceContext.aggregations()) {
+            valueCount += ((InternalValueCount) aggregation).value;
         }
-        InternalValueCount reduced = null;
-        for (InternalAggregation aggregation : aggregations) {
-            if (reduced == null) {
-                reduced = (InternalValueCount) aggregation;
-            } else {
-                reduced.value += ((InternalValueCount) aggregation).value;
-            }
-        }
-        return reduced;
+        return new InternalValueCount(name, valueCount);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/RandomTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.range.RangeBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory;
+import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 
 import java.util.List;
@@ -308,6 +309,51 @@ public class RandomTests extends ElasticsearchIntegrationTest {
         SearchResponse response = client().prepareSearch("idx").addAggregation(terms("terms").field("double_value").collectMode(randomFrom(SubAggCollectionMode.values())).subAggregation(percentiles("pcts").field("double_value"))).execute().actionGet();
         assertAllSuccessful(response);
         assertEquals(numDocs, response.getHits().getTotalHits());
+    }
+
+    // https://github.com/elasticsearch/elasticsearch/issues/6435
+    public void testReduce() throws Exception {
+        createIndex("idx");
+        final int value = randomIntBetween(0, 10);
+        indexRandom(true, client().prepareIndex("idx", "type").setSource("f", value));
+
+        SearchResponse response = client().prepareSearch("idx")
+                .addAggregation(filter("filter").filter(FilterBuilders.matchAllFilter())
+                .subAggregation(range("range")
+                        .field("f")
+                        .addUnboundedTo(6)
+                        .addUnboundedFrom(6)
+                .subAggregation(sum("sum").field("f"))))
+                .execute().actionGet();
+
+        assertSearchResponse(response);System.out.println(response);
+
+        Filter filter = response.getAggregations().get("filter");
+        assertNotNull(filter);
+        assertEquals(1, filter.getDocCount());
+
+        Range range = filter.getAggregations().get("range");
+        assertThat(range, notNullValue());
+        assertThat(range.getName(), equalTo("range"));
+        assertThat(range.getBuckets().size(), equalTo(2));
+
+        Range.Bucket bucket = range.getBucketByKey("*-6.0");
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKey(), equalTo("*-6.0"));
+        assertThat(bucket.getFrom().doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
+        assertThat(bucket.getTo().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getDocCount(), equalTo(value < 6 ? 1L : 0L));
+        Sum sum = bucket.getAggregations().get("sum");
+        assertEquals(value < 6 ? value : 0, sum.getValue(), 0d);
+
+        bucket = range.getBucketByKey("6.0-*");
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.getKey(), equalTo("6.0-*"));
+        assertThat(bucket.getFrom().doubleValue(), equalTo(6.0));
+        assertThat(bucket.getTo().doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+        assertThat(bucket.getDocCount(), equalTo(value >= 6 ? 1L : 0L));
+        sum = bucket.getAggregations().get("sum");
+        assertEquals(value >= 6 ? value : 0, sum.getValue(), 0d);
     }
 
 }


### PR DESCRIPTION
Under some rare circumstances:
- local transport,
- the range aggregation has both a parent and a child aggregation,
- the range aggregation got no documents on one shard or more and several
  documents on one shard or more.

the range aggregation could return incorrect counts and sub aggregations.

The root cause is that since the reduce happens in-place and since the range
aggregation uses the same instance for all sub-aggregation in case of an
empty bucket, sometimes non-empty buckets would have been reduced into this
shared instance.

In order to avoid similar bugs in the future, aggregations have been updated
to return a new instance when reducing instead of doing it in-place.

Close #6435
