### PR TITLE
Copy the headers from REST requests to the corresponding TransportRequest(s)

### DIFF
--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -49,10 +49,14 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
     static final class HeadersCopyClient extends FilterClient {
 
         private final RestRequest restRequest;
+        private final IndicesAdmin indicesAdmin;
+        private final ClusterAdmin clusterAdmin;
 
         HeadersCopyClient(Client in, RestRequest restRequest) {
             super(in);
             this.restRequest = restRequest;
+            this.indicesAdmin = new IndicesAdmin(in.admin().indices());
+            this.clusterAdmin = new ClusterAdmin(in.admin().cluster());
         }
 
         @Override
@@ -69,36 +73,48 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
         @Override
         public ClusterAdminClient cluster() {
-            return new ClusterAdmin(in().admin().cluster()) {
-                @Override
-                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
-                    request.putHeaders(restRequest.headers());
-                    return super.execute(action, request);
-                }
-
-                @Override
-                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
-                    request.putHeaders(restRequest.headers());
-                    super.execute(action, request, listener);
-                }
-            };
+            return clusterAdmin;
         }
 
         @Override
         public IndicesAdminClient indices() {
-            return new IndicesAdmin(in().admin().indices()) {
-                @Override
-                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
-                    request.putHeaders(restRequest.headers());
-                    return super.execute(action, request);
-                }
+            return indicesAdmin;
+        }
 
-                @Override
-                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
-                    request.putHeaders(restRequest.headers());
-                    super.execute(action, request, listener);
-                }
-            };
+        private final class ClusterAdmin extends FilterClient.ClusterAdmin {
+            private ClusterAdmin(ClusterAdminClient in) {
+                super(in);
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
+                request.putHeaders(restRequest.headers());
+                return super.execute(action, request);
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
+                request.putHeaders(restRequest.headers());
+                super.execute(action, request, listener);
+            }
+        }
+
+        private final class IndicesAdmin extends FilterClient.IndicesAdmin {
+            private IndicesAdmin(IndicesAdminClient in) {
+                super(in);
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
+                request.putHeaders(restRequest.headers());
+                return super.execute(action, request);
+            }
+
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
+                request.putHeaders(restRequest.headers());
+                super.execute(action, request, listener);
+            }
         }
     }
 }

--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -27,10 +27,27 @@ import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Base handler for REST requests
  */
 public abstract class BaseRestHandler extends AbstractComponent implements RestHandler {
+
+    private static final Set<String> usefulHeaders = new HashSet<>();
+
+    /**
+     * Controls which REST headers get copied over from a {@link org.elasticsearch.rest.RestRequest} to
+     * its corresponding {@link org.elasticsearch.transport.TransportRequest}(s).
+     *
+     * By default no headers get copied but it is possible to extend this behaviour via plugins by calling this method.
+     */
+    public static synchronized void addUsefulHeaders(String... headers) {
+        usefulHeaders.addAll(Arrays.asList(headers));
+    }
 
     private final Client client;
 
@@ -41,7 +58,7 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
     @Override
     public final void handleRequest(RestRequest request, RestChannel channel) throws Exception {
-        handleRequest(request, channel, new HeadersCopyClient(client, request));
+        handleRequest(request, channel, usefulHeaders.isEmpty() ? client : new HeadersCopyClient(client, request, usefulHeaders));
     }
 
     protected abstract void handleRequest(RestRequest request, RestChannel channel, Client client) throws Exception;
@@ -49,25 +66,35 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
     static final class HeadersCopyClient extends FilterClient {
 
         private final RestRequest restRequest;
+        private final Set<String> usefulHeaders;
         private final IndicesAdmin indicesAdmin;
         private final ClusterAdmin clusterAdmin;
 
-        HeadersCopyClient(Client in, RestRequest restRequest) {
+        HeadersCopyClient(Client in, RestRequest restRequest, Set<String> usefulHeaders) {
             super(in);
             this.restRequest = restRequest;
+            this.usefulHeaders = usefulHeaders;
             this.indicesAdmin = new IndicesAdmin(in.admin().indices());
             this.clusterAdmin = new ClusterAdmin(in.admin().cluster());
         }
 
+        private void copyHeaders(ActionRequest request) {
+            for (Map.Entry<String, String> header : restRequest.headers()) {
+                if (usefulHeaders.contains(header.getKey())) {
+                    request.putHeader(header.getKey(), header.getValue());
+                }
+            }
+        }
+
         @Override
         public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
-            request.putHeaders(restRequest.headers());
+            copyHeaders(request);
             return super.execute(action, request);
         }
 
         @Override
         public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> void execute(Action<Request, Response, RequestBuilder, Client> action, Request request, ActionListener<Response> listener) {
-            request.putHeaders(restRequest.headers());
+            copyHeaders(request);
             super.execute(action, request, listener);
         }
 
@@ -88,13 +115,13 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
-                request.putHeaders(restRequest.headers());
+                copyHeaders(request);
                 return super.execute(action, request);
             }
 
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
-                request.putHeaders(restRequest.headers());
+                copyHeaders(request);
                 super.execute(action, request, listener);
             }
         }
@@ -106,13 +133,13 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
 
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
-                request.putHeaders(restRequest.headers());
+                copyHeaders(request);
                 return super.execute(action, request);
             }
 
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
-                request.putHeaders(restRequest.headers());
+                copyHeaders(request);
                 super.execute(action, request, listener);
             }
         }

--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -48,11 +48,7 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
         usefulHeaders = copy;
     }
 
-    /**
-     * Returns the REST headers that get copied over from a {@link org.elasticsearch.rest.RestRequest} to
-     * its corresponding {@link org.elasticsearch.transport.TransportRequest}(s).
-     */
-    public static String[] usefulHeaders() {
+    static String[] usefulHeaders() {
         String[] copy = new String[usefulHeaders.length];
         System.arraycopy(usefulHeaders, 0, copy, 0 , usefulHeaders.length);
         return copy;

--- a/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -79,9 +78,10 @@ public abstract class BaseRestHandler extends AbstractComponent implements RestH
         }
 
         private void copyHeaders(ActionRequest request) {
-            for (Map.Entry<String, String> header : restRequest.headers()) {
-                if (usefulHeaders.contains(header.getKey())) {
-                    request.putHeader(header.getKey(), header.getValue());
+            for (String usefulHeader : usefulHeaders) {
+                String headerValue = restRequest.header(usefulHeader);
+                if (headerValue != null) {
+                    request.putHeader(usefulHeader, headerValue);
                 }
             }
         }

--- a/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.rest;
 
 /**
- *
+ * Handler for REST requests
  */
 public interface RestHandler {
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/health/RestClusterHealthAction.java
@@ -50,7 +50,7 @@ public class RestClusterHealthAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClusterHealthRequest clusterHealthRequest = clusterHealthRequest(Strings.splitStringByCommaToArray(request.param("index")));
         clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
         clusterHealthRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/hotthreads/RestNodesHotThreadsAction.java
@@ -50,7 +50,7 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(nodesIds);
         nodesHotThreadsRequest.threads(request.paramAsInt("threads", nodesHotThreadsRequest.threads()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/info/RestNodesInfoAction.java
@@ -59,7 +59,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] nodeIds;
         Set<String> metrics;
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/restart/RestNodesRestartAction.java
@@ -43,7 +43,7 @@ public class RestNodesRestartAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesRestartRequest nodesRestartRequest = new NodesRestartRequest(nodesIds);
         nodesRestartRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/shutdown/RestNodesShutdownAction.java
@@ -45,7 +45,7 @@ public class RestNodesShutdownAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         NodesShutdownRequest nodesShutdownRequest = new NodesShutdownRequest(nodesIds);
         nodesShutdownRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -58,7 +58,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         Set<String> metrics = Strings.splitStringByCommaToSet(request.param("metric", "_all"));
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/delete/RestDeleteRepositoryAction.java
@@ -42,7 +42,7 @@ public class RestDeleteRepositoryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteRepositoryRequest deleteRepositoryRequest = deleteRepositoryRequest(request.param("repository"));
         deleteRepositoryRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteRepositoryRequest.masterNodeTimeout()));
         deleteRepositoryRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/get/RestGetRepositoriesAction.java
@@ -31,8 +31,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
-import java.io.IOException;
-
 import static org.elasticsearch.client.Requests.getRepositoryRequest;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestStatus.OK;
@@ -50,7 +48,7 @@ public class RestGetRepositoriesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] repositories = request.paramAsStringArray("repository", Strings.EMPTY_ARRAY);
         GetRepositoriesRequest getRepositoriesRequest = getRepositoryRequest(repositories);
         getRepositoriesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getRepositoriesRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/repositories/put/RestPutRepositoryAction.java
@@ -45,7 +45,7 @@ public class RestPutRepositoryAction extends BaseRestHandler {
 
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PutRepositoryRequest putRepositoryRequest = putRepositoryRequest(request.param("repository"));
         putRepositoryRequest.listenerThreaded(false);
         putRepositoryRequest.source(request.content().toUtf8());

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/reroute/RestClusterRerouteAction.java
@@ -48,7 +48,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         final ClusterRerouteRequest clusterRerouteRequest = Requests.clusterRerouteRequest();
         clusterRerouteRequest.listenerThreaded(false);
         clusterRerouteRequest.dryRun(request.paramAsBoolean("dry_run", clusterRerouteRequest.dryRun()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterGetSettingsAction.java
@@ -29,8 +29,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
-import java.io.IOException;
-
 /**
  */
 public class RestClusterGetSettingsAction extends BaseRestHandler {
@@ -42,7 +40,7 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest()
                 .listenerThreaded(false)
                 .routingTable(false)

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/settings/RestClusterUpdateSettingsAction.java
@@ -44,7 +44,7 @@ public class RestClusterUpdateSettingsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = Requests.clusterUpdateSettingsRequest();
         clusterUpdateSettingsRequest.listenerThreaded(false);
         clusterUpdateSettingsRequest.timeout(request.paramAsTime("timeout", clusterUpdateSettingsRequest.timeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/shards/RestClusterSearchShardsAction.java
@@ -52,7 +52,7 @@ public class RestClusterSearchShardsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final ClusterSearchShardsRequest clusterSearchShardsRequest = Requests.clusterSearchShardsRequest(indices);
         clusterSearchShardsRequest.local(request.paramAsBoolean("local", clusterSearchShardsRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/create/RestCreateSnapshotAction.java
@@ -47,7 +47,7 @@ public class RestCreateSnapshotAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         CreateSnapshotRequest createSnapshotRequest = createSnapshotRequest(request.param("repository"), request.param("snapshot"));
         createSnapshotRequest.listenerThreaded(false);
         createSnapshotRequest.source(request.content().toUtf8());

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java
@@ -42,7 +42,7 @@ public class RestDeleteSnapshotAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteSnapshotRequest deleteSnapshotRequest = deleteSnapshotRequest(request.param("repository"), request.param("snapshot"));
         deleteSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteSnapshotRequest.masterNodeTimeout()));
         client.admin().cluster().deleteSnapshot(deleteSnapshotRequest, new AcknowledgedRestListener<DeleteSnapshotResponse>(channel));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/get/RestGetSnapshotsAction.java
@@ -47,7 +47,7 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
 
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String repository = request.param("repository");
         String[] snapshots = request.paramAsStringArray("snapshot", Strings.EMPTY_ARRAY);
         if (snapshots.length == 1 && "_all".equalsIgnoreCase(snapshots[0])) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/restore/RestRestoreSnapshotAction.java
@@ -45,7 +45,7 @@ public class RestRestoreSnapshotAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         RestoreSnapshotRequest restoreSnapshotRequest = restoreSnapshotRequest(request.param("repository"), request.param("snapshot"));
         restoreSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", restoreSnapshotRequest.masterNodeTimeout()));
         restoreSnapshotRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/status/RestSnapshotsStatusAction.java
@@ -48,7 +48,7 @@ public class RestSnapshotsStatusAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String repository = request.param("repository", "_all");
         String[] snapshots = request.paramAsStringArray("snapshot", Strings.EMPTY_ARRAY);
         if (snapshots.length == 1 && "_all".equalsIgnoreCase(snapshots[0])) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/state/RestClusterStateAction.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
-import java.io.IOException;
 import java.util.Set;
 
 
@@ -55,7 +54,7 @@ public class RestClusterStateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest();
         clusterStateRequest.listenerThreaded(false);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/stats/RestClusterStatsAction.java
@@ -44,7 +44,7 @@ public class RestClusterStatsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
         clusterStatsRequest.listenerThreaded(false);
         client.admin().cluster().clusterStats(clusterStatsRequest, new RestToXContentListener<ClusterStatsResponse>(channel));

--- a/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/cluster/tasks/RestPendingClusterTasksAction.java
@@ -41,7 +41,7 @@ public class RestPendingClusterTasksAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
         pendingClusterTasksRequest.masterNodeTimeout(request.paramAsTime("master_timeout", pendingClusterTasksRequest.masterNodeTimeout()));
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -48,7 +48,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
         indicesAliasesRequest.listenerThreaded(false);
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", indicesAliasesRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/delete/RestIndexDeleteAliasesAction.java
@@ -41,7 +41,7 @@ public class RestIndexDeleteAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] aliases = Strings.splitStringByCommaToArray(request.param("name"));
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetAliasesAction.java
@@ -54,7 +54,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] aliases = request.paramAsStringArrayOrEmptyIfAll("name");
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final GetAliasesRequest getAliasesRequest = new GetAliasesRequest(aliases);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
@@ -54,7 +54,7 @@ public class RestGetIndicesAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] aliases = Strings.splitStringByCommaToArray(request.param("name"));
 

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/head/RestAliasesExistAction.java
@@ -47,7 +47,7 @@ public class RestAliasesExistAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] aliases = request.paramAsStringArray("name", Strings.EMPTY_ARRAY);
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         GetAliasesRequest getAliasesRequest = new GetAliasesRequest(aliases);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/put/RestIndexPutAliasAction.java
@@ -60,7 +60,7 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         String alias = request.param("name");
         Map<String, Object> filter = null;

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/analyze/RestAnalyzeAction.java
@@ -48,7 +48,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String text = request.param("text");
         if (text == null && request.hasContent()) {
             text = request.content().toUtf8();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/cache/clear/RestClearIndicesCacheAction.java
@@ -54,7 +54,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(Strings.splitStringByCommaToArray(request.param("index")));
         clearIndicesCacheRequest.listenerThreaded(false);
         clearIndicesCacheRequest.indicesOptions(IndicesOptions.fromRequest(request, clearIndicesCacheRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/close/RestCloseIndexAction.java
@@ -42,7 +42,7 @@ public class RestCloseIndexAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         closeIndexRequest.listenerThreaded(false);
         closeIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", closeIndexRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/create/RestCreateIndexAction.java
@@ -44,7 +44,7 @@ public class RestCreateIndexAction extends BaseRestHandler {
 
     @SuppressWarnings({"unchecked"})
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest(request.param("index"));
         createIndexRequest.listenerThreaded(false);
         if (request.hasContent()) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/delete/RestDeleteIndexAction.java
@@ -42,7 +42,7 @@ public class RestDeleteIndexAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteIndexRequest.listenerThreaded(false);
         deleteIndexRequest.timeout(request.paramAsTime("timeout", deleteIndexRequest.timeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/indices/RestIndicesExistsAction.java
@@ -51,7 +51,7 @@ public class RestIndicesExistsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         indicesExistsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesExistsRequest.indicesOptions()));
         indicesExistsRequest.local(request.paramAsBoolean("local", indicesExistsRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/exists/types/RestTypesExistsAction.java
@@ -44,7 +44,7 @@ public class RestTypesExistsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         TypesExistsRequest typesExistsRequest = new TypesExistsRequest(
                 Strings.splitStringByCommaToArray(request.param("index")), Strings.splitStringByCommaToArray(request.param("type"))
         );

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/flush/RestFlushAction.java
@@ -51,7 +51,7 @@ public class RestFlushAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         FlushRequest flushRequest = new FlushRequest(Strings.splitStringByCommaToArray(request.param("index")));
         flushRequest.listenerThreaded(false);
         flushRequest.indicesOptions(IndicesOptions.fromRequest(request, flushRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/delete/RestDeleteMappingAction.java
@@ -50,7 +50,7 @@ public class RestDeleteMappingAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteMappingRequest deleteMappingRequest = deleteMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteMappingRequest.listenerThreaded(false);
         deleteMappingRequest.types(Strings.splitStringByCommaToArray(request.param("type")));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
@@ -56,7 +56,7 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] types = request.paramAsStringArrayOrEmptyIfAll("type");
         final String[] fields = Strings.splitStringByCommaToArray(request.param("fields"));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -57,7 +57,7 @@ public class RestGetMappingAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] types = request.paramAsStringArrayOrEmptyIfAll("type");
         GetMappingsRequest getMappingsRequest = new GetMappingsRequest();

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/put/RestPutMappingAction.java
@@ -65,7 +65,7 @@ public class RestPutMappingAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         putMappingRequest.listenerThreaded(false);
         putMappingRequest.type(request.param("type"));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/open/RestOpenIndexAction.java
@@ -42,7 +42,7 @@ public class RestOpenIndexAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         OpenIndexRequest openIndexRequest = new OpenIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         openIndexRequest.listenerThreaded(false);
         openIndexRequest.timeout(request.paramAsTime("timeout", openIndexRequest.timeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/optimize/RestOptimizeAction.java
@@ -51,7 +51,7 @@ public class RestOptimizeAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         OptimizeRequest optimizeRequest = new OptimizeRequest(Strings.splitStringByCommaToArray(request.param("index")));
         optimizeRequest.listenerThreaded(false);
         optimizeRequest.indicesOptions(IndicesOptions.fromRequest(request, optimizeRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/recovery/RestRecoveryAction.java
@@ -46,7 +46,7 @@ public class RestRecoveryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
 
         final RecoveryRequest recoveryRequest = new RecoveryRequest(Strings.splitStringByCommaToArray(request.param("index")));
         recoveryRequest.detailed(request.paramAsBoolean("detailed", false));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/refresh/RestRefreshAction.java
@@ -51,7 +51,7 @@ public class RestRefreshAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         RefreshRequest refreshRequest = new RefreshRequest(Strings.splitStringByCommaToArray(request.param("index")));
         refreshRequest.listenerThreaded(false);
         refreshRequest.force(request.paramAsBoolean("force", refreshRequest.force()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/segments/RestIndicesSegmentsAction.java
@@ -46,7 +46,7 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         indicesSegmentsRequest.listenerThreaded(false);
         indicesSegmentsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesSegmentsRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestGetSettingsAction.java
@@ -48,7 +48,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] names = request.paramAsStringArrayOrEmptyIfAll("name");
         GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
                 .indices(Strings.splitStringByCommaToArray(request.param("index")))
@@ -79,8 +79,6 @@ public class RestGetSettingsAction extends BaseRestHandler {
     }
 
     static class Fields {
-
         static final XContentBuilderString SETTINGS = new XContentBuilderString("settings");
-
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -47,7 +47,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         UpdateSettingsRequest updateSettingsRequest = updateSettingsRequest(Strings.splitStringByCommaToArray(request.param("index")));
         updateSettingsRequest.listenerThreaded(false);
         updateSettingsRequest.timeout(request.paramAsTime("timeout", updateSettingsRequest.timeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -51,7 +51,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
         indicesStatsRequest.listenerThreaded(false);
         indicesStatsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesStatsRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/delete/RestDeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/delete/RestDeleteIndexTemplateAction.java
@@ -38,7 +38,7 @@ public class RestDeleteIndexTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteIndexTemplateRequest deleteIndexTemplateRequest = new DeleteIndexTemplateRequest(request.param("name"));
         deleteIndexTemplateRequest.listenerThreaded(false);
         deleteIndexTemplateRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteIndexTemplateRequest.masterNodeTimeout()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -51,7 +51,7 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] names = Strings.splitStringByCommaToArray(request.param("name"));
 
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(names);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/head/RestHeadIndexTemplateAction.java
@@ -43,7 +43,7 @@ public class RestHeadIndexTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest(request.param("name"));
         getIndexTemplatesRequest.local(request.paramAsBoolean("local", getIndexTemplatesRequest.local()));
         client.admin().indices().getTemplates(getIndexTemplatesRequest, new RestResponseListener<GetIndexTemplatesResponse>(channel) {

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/template/put/RestPutIndexTemplateAction.java
@@ -40,7 +40,7 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
 
     @SuppressWarnings({"unchecked"})
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(request.param("name"));
         putRequest.listenerThreaded(false);
         putRequest.template(request.param("template", putRequest.template()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/query/RestValidateQueryAction.java
@@ -55,7 +55,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest(Strings.splitStringByCommaToArray(request.param("index")));
         validateQueryRequest.listenerThreaded(false);
         validateQueryRequest.indicesOptions(IndicesOptions.fromRequest(request, validateQueryRequest.indicesOptions()));

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/delete/RestDeleteWarmerAction.java
@@ -47,7 +47,7 @@ public class RestDeleteWarmerAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteWarmerRequest deleteWarmerRequest = new DeleteWarmerRequest(Strings.splitStringByCommaToArray(request.param("name")))
                 .indices(Strings.splitStringByCommaToArray(request.param("index")));
         deleteWarmerRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/get/RestGetWarmerAction.java
@@ -52,7 +52,7 @@ public class RestGetWarmerAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final String[] types = Strings.splitStringByCommaToArray(request.param("type"));
         final String[] names = request.paramAsStringArray("name", Strings.EMPTY_ARRAY);

--- a/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -60,7 +60,7 @@ public class RestPutWarmerAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PutWarmerRequest putWarmerRequest = new PutWarmerRequest(request.param("name"));
         putWarmerRequest.listenerThreaded(false);
         SearchRequest searchRequest = new SearchRequest(Strings.splitStringByCommaToArray(request.param("index")))

--- a/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bench/RestBenchAction.java
@@ -70,16 +70,16 @@ public class RestBenchAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         switch (request.method()) {
             case POST:
-                handleAbortRequest(request, channel);
+                handleAbortRequest(request, channel, client);
                 break;
             case PUT:
-                handleSubmitRequest(request, channel);
+                handleSubmitRequest(request, channel, client);
                 break;
             case GET:
-                handleStatusRequest(request, channel);
+                handleStatusRequest(request, channel, client);
                 break;
             default:
                 // Politely ignore methods we don't support
@@ -90,7 +90,7 @@ public class RestBenchAction extends BaseRestHandler {
     /**
      * Reports on the status of all actively running benchmarks
      */
-    private void handleStatusRequest(final RestRequest request, final RestChannel channel) {
+    private void handleStatusRequest(final RestRequest request, final RestChannel channel, final Client client) {
 
         BenchmarkStatusRequest benchmarkStatusRequest = new BenchmarkStatusRequest();
 
@@ -109,7 +109,7 @@ public class RestBenchAction extends BaseRestHandler {
     /**
      * Aborts an actively running benchmark
      */
-    private void handleAbortRequest(final RestRequest request, final RestChannel channel) {
+    private void handleAbortRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] benchmarkNames = Strings.splitStringByCommaToArray(request.param("name"));
         AbortBenchmarkRequest abortBenchmarkRequest = new AbortBenchmarkRequest(benchmarkNames);
 
@@ -119,7 +119,7 @@ public class RestBenchAction extends BaseRestHandler {
     /**
      * Submits a benchmark for execution
      */
-    private void handleSubmitRequest(final RestRequest request, final RestChannel channel) {
+    private void handleSubmitRequest(final RestRequest request, final RestChannel channel, final Client client) {
 
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         String[] types = Strings.splitStringByCommaToArray(request.param("type"));

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -69,7 +69,7 @@ public class RestBulkAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         BulkRequest bulkRequest = Requests.bulkRequest();
         bulkRequest.listenerThreaded(false);
         String defaultIndex = request.param("index");

--- a/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -37,14 +37,14 @@ public abstract class AbstractCatAction extends BaseRestHandler {
         super(settings, client);
     }
 
-    abstract void doRequest(final RestRequest request, final RestChannel channel);
+    abstract void doRequest(final RestRequest request, final RestChannel channel, final Client client);
 
     abstract void documentation(StringBuilder sb);
 
     abstract Table getTableWithHeader(final RestRequest request);
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         boolean helpWanted = request.paramAsBoolean("help", false);
         if (helpWanted) {
             Table table = getTableWithHeader(request);
@@ -63,7 +63,7 @@ public abstract class AbstractCatAction extends BaseRestHandler {
             out.close();
             channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, bytesOutput.bytes(), true));
         } else {
-            doRequest(request, channel);
+            doRequest(request, channel, client);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -52,7 +52,7 @@ public class RestAliasAction extends AbstractCatAction {
 
 
     @Override
-    void doRequest(final RestRequest request, final RestChannel channel) {
+    void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final GetAliasesRequest getAliasesRequest = request.hasParam("alias") ?
                 new GetAliasesRequest(request.param("alias")) :
                 new GetAliasesRequest();

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -59,7 +59,7 @@ public class RestAllocationAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] nodes = Strings.splitStringByCommaToArray(request.param("nodes"));
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().routingTable(true);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCatAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
 
-import java.io.IOException;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -48,7 +47,7 @@ public class RestCatAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         channel.sendResponse(new BytesRestResponse(RestStatus.OK, HELP));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -57,7 +57,7 @@ public class RestCountAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         CountRequest countRequest = new CountRequest(indices);
         String source = request.param("source");

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -56,7 +56,7 @@ public class RestFielddataAction extends AbstractCatAction {
     }
 
     @Override
-    void doRequest(final RestRequest request, final RestChannel channel) {
+    void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
 
         final NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
         nodesStatsRequest.clear();

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -53,7 +53,7 @@ public class RestHealthAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest();
 
         client.admin().cluster().health(clusterHealthRequest, new RestResponseListener<ClusterHealthResponse>(channel) {

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -62,7 +62,7 @@ public class RestIndicesAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().indices(indices).metaData(true);

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -50,7 +50,7 @@ public class RestMasterAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -61,7 +61,7 @@ public class RestNodesAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -48,7 +48,7 @@ public class RestPendingClusterTasksAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
         pendingClusterTasksRequest.masterNodeTimeout(request.paramAsTime("master_timeout", pendingClusterTasksRequest.masterNodeTimeout()));
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -55,7 +55,7 @@ public class RestPluginsAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -64,7 +64,7 @@ public class RestRecoveryAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final RecoveryRequest recoveryRequest = new RecoveryRequest(Strings.splitStringByCommaToArray(request.param("index")));
         recoveryRequest.detailed(request.paramAsBoolean("detailed", false));
         recoveryRequest.activeOnly(request.paramAsBoolean("active_only", false));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.segments.*;
@@ -35,7 +34,6 @@ import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +49,7 @@ public class RestSegmentsAction extends AbstractCatAction {
     }
 
     @Override
-    void doRequest(final RestRequest request, final RestChannel channel) {
+    void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -56,7 +56,7 @@ public class RestShardsAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -120,7 +120,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
     }
 
     @Override
-    public void doRequest(final RestRequest request, final RestChannel channel) {
+    public void doRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));

--- a/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/count/RestCountAction.java
@@ -54,7 +54,7 @@ public class RestCountAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         CountRequest countRequest = new CountRequest(Strings.splitStringByCommaToArray(request.param("index")));
         countRequest.indicesOptions(IndicesOptions.fromRequest(request, countRequest.indicesOptions()));
         countRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -49,7 +49,7 @@ public class RestDeleteAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteRequest deleteRequest = new DeleteRequest(request.param("index"), request.param("type"), request.param("id"));
 
         deleteRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -53,7 +53,7 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteByQueryRequest.listenerThreaded(false);
         if (request.hasContent()) {

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -58,7 +58,7 @@ public class RestExplainAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final ExplainRequest explainRequest = new ExplainRequest(request.param("index"), request.param("type"), request.param("id"));
         explainRequest.parent(request.param("parent"));
         explainRequest.routing(request.param("routing"));

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetAction.java
@@ -48,7 +48,7 @@ public class RestGetAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);

--- a/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestGetSourceAction.java
@@ -49,7 +49,7 @@ public class RestGetSourceAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);

--- a/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestHeadAction.java
@@ -45,7 +45,7 @@ public class RestHeadAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
         getRequest.listenerThreaded(false);
         getRequest.operationThreaded(true);

--- a/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/get/RestMultiGetAction.java
@@ -19,25 +19,19 @@
 
 package org.elasticsearch.rest.action.get;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
-import java.io.IOException;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestMultiGetAction extends BaseRestHandler {
 
@@ -57,7 +51,7 @@ public class RestMultiGetAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         multiGetRequest.listenerThreaded(false);
         multiGetRequest.refresh(request.paramAsBoolean("refresh", multiGetRequest.refresh()));

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -50,20 +50,25 @@ public class RestIndexAction extends BaseRestHandler {
         controller.registerHandler(POST, "/{index}/{type}", this); // auto id creation
         controller.registerHandler(PUT, "/{index}/{type}/{id}", this);
         controller.registerHandler(POST, "/{index}/{type}/{id}", this);
-        controller.registerHandler(PUT, "/{index}/{type}/{id}/_create", new CreateHandler());
-        controller.registerHandler(POST, "/{index}/{type}/{id}/_create", new CreateHandler());
+        CreateHandler createHandler = new CreateHandler(settings, client);
+        controller.registerHandler(PUT, "/{index}/{type}/{id}/_create", createHandler);
+        controller.registerHandler(POST, "/{index}/{type}/{id}/_create", createHandler);
     }
 
-    final class CreateHandler implements RestHandler {
+    final class CreateHandler extends BaseRestHandler {
+        protected CreateHandler(Settings settings, final Client client) {
+            super(settings, client);
+        }
+
         @Override
-        public void handleRequest(RestRequest request, RestChannel channel) {
+        public void handleRequest(RestRequest request, RestChannel channel, final Client client) {
             request.params().put("op_type", "create");
-            RestIndexAction.this.handleRequest(request, channel);
+            RestIndexAction.this.handleRequest(request, channel, client);
         }
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         IndexRequest indexRequest = new IndexRequest(request.param("index"), request.param("type"), request.param("id"));
         indexRequest.listenerThreaded(false);
         indexRequest.operationThreaded(true);

--- a/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.rest.action.main;
 
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Build;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -52,7 +51,7 @@ public class RestMainAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.listenerThreaded(false);
         clusterStateRequest.masterNodeTimeout(TimeValue.timeValueMillis(0));

--- a/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mlt/RestMoreLikeThisAction.java
@@ -19,25 +19,20 @@
 
 package org.elasticsearch.rest.action.mlt;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.mlt.MoreLikeThisRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.Scroll;
-
-import java.io.IOException;
 
 import static org.elasticsearch.client.Requests.moreLikeThisRequest;
 import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  *
@@ -52,7 +47,7 @@ public class RestMoreLikeThisAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         MoreLikeThisRequest mltRequest = moreLikeThisRequest(request.param("index")).type(request.param("type")).id(request.param("id"));
         mltRequest.routing(request.param("routing"));
 

--- a/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/percolate/RestMultiPercolateAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.rest.action.percolate;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.percolate.MultiPercolateRequest;
 import org.elasticsearch.action.percolate.MultiPercolateResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -26,16 +25,12 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
-import java.io.IOException;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  *
@@ -59,7 +54,7 @@ public class RestMultiPercolateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest restRequest, final RestChannel restChannel) throws Exception {
+    public void handleRequest(final RestRequest restRequest, final RestChannel restChannel, final Client client) throws Exception {
         MultiPercolateRequest multiPercolateRequest = new MultiPercolateRequest();
         multiPercolateRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, multiPercolateRequest.indicesOptions()));
         multiPercolateRequest.indices(Strings.splitStringByCommaToArray(restRequest.param("index")));

--- a/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -49,7 +49,7 @@ public class RestClearScrollAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String scrollIds = request.param("scroll_id");
         if (scrollIds == null) {
             scrollIds = RestActions.getRestContent(request).toUtf8();

--- a/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.search;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,17 +26,12 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
-import java.io.IOException;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  */
@@ -60,7 +54,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         multiSearchRequest.listenerThreaded(false);
 

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -34,7 +34,6 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
-import org.elasticsearch.rest.action.support.RestToXContentListener;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -68,7 +67,7 @@ public class RestSearchAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         SearchRequest searchRequest;
         searchRequest = RestSearchAction.parseSearchRequest(request);
         searchRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.rest.action.search;
 
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
@@ -51,7 +52,7 @@ public class RestSearchScrollAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String scrollId = request.param("scroll_id");
         if (scrollId == null) {
             scrollId = RestActions.getRestContent(request).toUtf8();
@@ -63,6 +64,6 @@ public class RestSearchScrollAction extends BaseRestHandler {
             searchScrollRequest.scroll(new Scroll(parseTimeValue(scroll, null)));
         }
 
-        client.searchScroll(searchScrollRequest, new RestStatusToXContentListener(channel));
+        client.searchScroll(searchScrollRequest, new RestStatusToXContentListener<SearchResponse>(channel));
     }
 }

--- a/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/suggest/RestSuggestAction.java
@@ -52,7 +52,7 @@ public class RestSuggestAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         SuggestRequest suggestRequest = new SuggestRequest(Strings.splitStringByCommaToArray(request.param("index")));
         suggestRequest.indicesOptions(IndicesOptions.fromRequest(request, suggestRequest.indicesOptions()));
         suggestRequest.listenerThreaded(false);

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestMultiTermVectorsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.termvector;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.termvector.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvector.MultiTermVectorsResponse;
 import org.elasticsearch.action.termvector.TermVectorRequest;
@@ -27,14 +26,12 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestMultiTermVectorsAction extends BaseRestHandler {
 
@@ -50,7 +47,7 @@ public class RestMultiTermVectorsAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         MultiTermVectorsRequest multiTermVectorsRequest = new MultiTermVectorsRequest();
         multiTermVectorsRequest.listenerThreaded(false);
         TermVectorRequest template = new TermVectorRequest();

--- a/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/termvector/RestTermVectorAction.java
@@ -53,7 +53,7 @@ public class RestTermVectorAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         TermVectorRequest termVectorRequest = new TermVectorRequest(request.param("index"), request.param("type"), request.param("id"));
         XContentParser parser = null;
         if (request.hasContent()) {

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -52,7 +52,7 @@ public class RestUpdateAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(final RestRequest request, final RestChannel channel) throws Exception {
+    public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) throws Exception {
         UpdateRequest updateRequest = new UpdateRequest(request.param("index"), request.param("type"), request.param("id"));
         updateRequest.listenerThreaded(false);
         updateRequest.routing(request.param("routing"));

--- a/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -68,16 +68,6 @@ public abstract class TransportRequest implements Streamable {
         return this;
     }
 
-    public final TransportRequest putHeaders(Iterable<Map.Entry<String, String>> stringHeaders) {
-        if (headers == null) {
-            headers = Maps.newHashMap();
-        }
-        for (Map.Entry<String, String> stringHeader : stringHeaders) {
-            headers.put(stringHeader.getKey(), stringHeader.getValue());
-        }
-        return this;
-    }
-
     @SuppressWarnings("unchecked")
     public final <V> V getHeader(String key) {
         if (headers == null) {

--- a/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -68,6 +68,16 @@ public abstract class TransportRequest implements Streamable {
         return this;
     }
 
+    public final TransportRequest putHeaders(Iterable<Map.Entry<String, String>> stringHeaders) {
+        if (headers == null) {
+            headers = Maps.newHashMap();
+        }
+        for (Map.Entry<String, String> stringHeader : stringHeaders) {
+            headers.put(stringHeader.getKey(), stringHeader.getValue());
+        }
+        return this;
+    }
+
     @SuppressWarnings("unchecked")
     public final <V> V getHeader(String key) {
         if (headers == null) {

--- a/src/test/java/org/elasticsearch/plugin/responseheader/TestResponseHeaderRestAction.java
+++ b/src/test/java/org/elasticsearch/plugin/responseheader/TestResponseHeaderRestAction.java
@@ -32,7 +32,7 @@ public class TestResponseHeaderRestAction extends BaseRestHandler {
     }
 
     @Override
-    public void handleRequest(RestRequest request, RestChannel channel) {
+    public void handleRequest(RestRequest request, RestChannel channel, Client client) {
         if ("password".equals(request.header("Secret"))) {
             RestResponse response = new BytesRestResponse(RestStatus.OK, "Access granted");
             response.addHeader("Secret", "granted");

--- a/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
+++ b/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.*;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.*;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.client.support.AbstractClusterAdminClient;
+import org.elasticsearch.client.support.AbstractIndicesAdminClient;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.rest.BaseRestHandler.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+public class HeadersCopyClientTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testCopyHeadersRequest() {
+        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+
+        HashMap<String, String> resultingHeaders = new HashMap<>();
+        resultingHeaders.putAll(existingHeaders);
+        resultingHeaders.putAll(newHeaders);
+
+        RestRequest restRequest = new FakeRestRequest(newHeaders);
+        NoOpClient noOpClient = new NoOpClient();
+        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+
+        SearchRequest searchRequest = Requests.searchRequest();
+        searchRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(searchRequest, existingHeaders);
+        headersCopyClient.search(searchRequest);
+        assertHeaders(searchRequest, resultingHeaders);
+
+        GetRequest getRequest = Requests.getRequest("index");
+        getRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(getRequest, existingHeaders);
+        headersCopyClient.get(getRequest);
+        assertHeaders(getRequest, resultingHeaders);
+
+        IndexRequest indexRequest = Requests.indexRequest();
+        indexRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(indexRequest, existingHeaders);
+        headersCopyClient.index(indexRequest);
+        assertHeaders(indexRequest, resultingHeaders);
+    }
+
+    @Test
+    public void testCopyHeadersClusterAdminRequest() {
+        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+
+        HashMap<String, String> resultingHeaders = new HashMap<>();
+        resultingHeaders.putAll(existingHeaders);
+        resultingHeaders.putAll(newHeaders);
+
+        RestRequest restRequest = new FakeRestRequest(newHeaders);
+        NoOpClient noOpClient = new NoOpClient();
+        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+
+        ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest();
+        clusterHealthRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(clusterHealthRequest, existingHeaders);
+        headersCopyClient.admin().cluster().health(clusterHealthRequest);
+        assertHeaders(clusterHealthRequest, resultingHeaders);
+
+        ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest();
+        clusterStateRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(clusterStateRequest, existingHeaders);
+        headersCopyClient.admin().cluster().state(clusterStateRequest);
+        assertHeaders(clusterStateRequest, resultingHeaders);
+
+        ClusterStatsRequest clusterStatsRequest = Requests.clusterStatsRequest();
+        clusterStatsRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(clusterStatsRequest, existingHeaders);
+        headersCopyClient.admin().cluster().clusterStats(clusterStatsRequest);
+        assertHeaders(clusterStatsRequest, resultingHeaders);
+    }
+
+    @Test
+    public void testCopyHeadersIndicesAdminRequest() {
+        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+
+        HashMap<String, String> resultingHeaders = new HashMap<>();
+        resultingHeaders.putAll(existingHeaders);
+        resultingHeaders.putAll(newHeaders);
+
+        RestRequest restRequest = new FakeRestRequest(newHeaders);
+        NoOpClient noOpClient = new NoOpClient();
+        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+
+        CreateIndexRequest createIndexRequest = Requests.createIndexRequest("test");
+        createIndexRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(createIndexRequest, existingHeaders);
+        headersCopyClient.admin().indices().create(createIndexRequest);
+        assertHeaders(createIndexRequest, resultingHeaders);
+
+        CloseIndexRequest closeIndexRequest = Requests.closeIndexRequest("test");
+        closeIndexRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(closeIndexRequest, existingHeaders);
+        headersCopyClient.admin().indices().close(closeIndexRequest);
+        assertHeaders(closeIndexRequest, resultingHeaders);
+
+        FlushRequest flushRequest = Requests.flushRequest();
+        flushRequest.putHeaders(existingHeaders.entrySet());
+        assertHeaders(flushRequest, existingHeaders);
+        headersCopyClient.admin().indices().flush(flushRequest);
+        assertHeaders(flushRequest, resultingHeaders);
+    }
+
+    @Test
+    public void testCopyHeadersRequestBuilder() {
+        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+
+        HashMap<String, String> resultingHeaders = new HashMap<>();
+        resultingHeaders.putAll(existingHeaders);
+        resultingHeaders.putAll(newHeaders);
+
+        RestRequest restRequest = new FakeRestRequest(newHeaders);
+
+        NoOpClient noOpClient = new NoOpClient();
+        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+
+        ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
+                headersCopyClient.prepareIndex("index", "type"),
+                headersCopyClient.prepareGet("index", "type", "id"),
+                headersCopyClient.prepareBulk(),
+                headersCopyClient.prepareDelete(),
+                headersCopyClient.prepareIndex(),
+                headersCopyClient.prepareClearScroll(),
+                headersCopyClient.prepareMultiGet(),
+                headersCopyClient.prepareBenchStatus()
+        };
+
+        for (ActionRequestBuilder requestBuilder : requestBuilders) {
+            requestBuilder.request().putHeaders(existingHeaders.entrySet());
+            assertHeaders(requestBuilder.request(), existingHeaders);
+            requestBuilder.get();
+            assertHeaders(requestBuilder.request(), resultingHeaders);
+        }
+    }
+
+    @Test
+    public void testCopyHeadersClusterAdminRequestBuilder() {
+        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+
+        HashMap<String, String> resultingHeaders = new HashMap<>();
+        resultingHeaders.putAll(existingHeaders);
+        resultingHeaders.putAll(newHeaders);
+
+        RestRequest restRequest = new FakeRestRequest(newHeaders);
+
+        NoOpClient noOpClient = new NoOpClient();
+        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+
+        ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
+                headersCopyClient.admin().cluster().prepareNodesInfo(),
+                headersCopyClient.admin().cluster().prepareClusterStats(),
+                headersCopyClient.admin().cluster().prepareState(),
+                headersCopyClient.admin().cluster().prepareCreateSnapshot("repo", "name"),
+                headersCopyClient.admin().cluster().prepareHealth(),
+                headersCopyClient.admin().cluster().prepareReroute()
+        };
+
+        for (ActionRequestBuilder requestBuilder : requestBuilders) {
+            requestBuilder.request().putHeaders(existingHeaders.entrySet());
+            assertHeaders(requestBuilder.request(), existingHeaders);
+            requestBuilder.get();
+            assertHeaders(requestBuilder.request(), resultingHeaders);
+        }
+    }
+
+    @Test
+    public void testCopyHeadersIndicesAdminRequestBuilder() {
+        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+
+        HashMap<String, String> resultingHeaders = new HashMap<>();
+        resultingHeaders.putAll(existingHeaders);
+        resultingHeaders.putAll(newHeaders);
+
+        RestRequest restRequest = new FakeRestRequest(newHeaders);
+
+        NoOpClient noOpClient = new NoOpClient();
+        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+
+        ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
+                headersCopyClient.admin().indices().prepareValidateQuery(),
+                headersCopyClient.admin().indices().prepareCreate("test"),
+                headersCopyClient.admin().indices().prepareAliases(),
+                headersCopyClient.admin().indices().prepareAnalyze("text"),
+                headersCopyClient.admin().indices().prepareDeleteWarmer(),
+                headersCopyClient.admin().indices().prepareTypesExists("type"),
+                headersCopyClient.admin().indices().prepareClose()
+        };
+
+        for (ActionRequestBuilder requestBuilder : requestBuilders) {
+            requestBuilder.request().putHeaders(existingHeaders.entrySet());
+            assertHeaders(requestBuilder.request(), existingHeaders);
+            requestBuilder.get();
+            assertHeaders(requestBuilder.request(), resultingHeaders);
+        }
+    }
+
+    private static Map<String, String> randomHeaders(int count) {
+        Map<String, String> headers = new HashMap<>();
+        for (int i = 0; i < count; i++) {
+            headers.put("header-" + randomInt(30), randomRealisticUnicodeOfLengthBetween(1, 20));
+        }
+        return headers;
+    }
+
+    private static void assertHeaders(ActionRequest<?> request, Map<String, String> headers) {
+        if (headers.size() == 0) {
+            assertThat(request.getHeaders() == null || request.getHeaders().size() == 0, equalTo(true));
+        } else {
+            assertThat(request.getHeaders(), notNullValue());
+            assertThat(request.getHeaders().size(), equalTo(headers.size()));
+            for (Map.Entry<String, Object> entry : request.getHeaders().entrySet()) {
+                assertThat(headers.get(entry.getKey()), equalTo(entry.getValue()));
+            }
+        }
+    }
+
+    private static class FakeRestRequest extends RestRequest {
+
+        private final Map<String, String> headers;
+
+        private FakeRestRequest(Map<String, String> headers) {
+            this.headers = headers;
+        }
+
+        @Override
+        public Method method() {
+            return null;
+        }
+
+        @Override
+        public String uri() {
+            return null;
+        }
+
+        @Override
+        public String rawPath() {
+            return null;
+        }
+
+        @Override
+        public boolean hasContent() {
+            return false;
+        }
+
+        @Override
+        public boolean contentUnsafe() {
+            return false;
+        }
+
+        @Override
+        public BytesReference content() {
+            return null;
+        }
+
+        @Override
+        public String header(String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public Iterable<Map.Entry<String, String>> headers() {
+            return headers.entrySet();
+        }
+
+        @Override
+        public boolean hasParam(String key) {
+            return false;
+        }
+
+        @Override
+        public String param(String key) {
+            return null;
+        }
+
+        @Override
+        public String param(String key, String defaultValue) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> params() {
+            return null;
+        }
+    }
+
+    private static class NoOpClient extends AbstractClient implements AdminClient {
+
+        @Override
+        public AdminClient admin() {
+            return this;
+        }
+
+        @Override
+        public Settings settings() {
+            return null;
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
+            return null;
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> void execute(Action<Request, Response, RequestBuilder, Client> action, Request request, ActionListener<Response> listener) {
+            listener.onResponse(null);
+        }
+
+        @Override
+        public ThreadPool threadPool() {
+            return null;
+        }
+
+        @Override
+        public void close() throws ElasticsearchException {
+
+        }
+
+        @Override
+        public ClusterAdminClient cluster() {
+            return new AbstractClusterAdminClient() {
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
+                    return null;
+                }
+
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
+                    listener.onResponse(null);
+                }
+
+                @Override
+                public ThreadPool threadPool() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public IndicesAdminClient indices() {
+            return new AbstractIndicesAdminClient() {
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
+                    return null;
+                }
+
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
+                    listener.onResponse(null);
+                }
+
+                @Override
+                public ThreadPool threadPool() {
+                    return null;
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
+++ b/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
@@ -71,13 +71,10 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
             executorService.submit(new Runnable() {
                 @Override
                 public void run() {
-                    logger.info("adding new {} headers", newHeaders.length);
                     BaseRestHandler.addUsefulHeaders(newHeaders);
                 }
             });
         }
-
-        logger.info("headers size {}", headers.size());
 
         executorService.shutdown();
         assertThat(executorService.awaitTermination(1, TimeUnit.SECONDS), equalTo(true));

--- a/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
+++ b/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,13 +55,15 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     public void testCopyHeadersRequest() {
         Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
         Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
+        Map<String, String> leftRestHeaders = randomHeadersFrom(restHeaders);
+        Set<String> usefulRestHeaders = new HashSet<>(leftRestHeaders.keySet());
+        usefulRestHeaders.addAll(randomHeaders(randomIntBetween(0, 10), "useful-").keySet());
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(existingTransportHeaders);
-        expectedHeaders.putAll(usefulRestHeaders);
+        expectedHeaders.putAll(leftRestHeaders);
 
-        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders);
 
         SearchRequest searchRequest = Requests.searchRequest();
         putHeaders(searchRequest, existingTransportHeaders);
@@ -85,13 +88,15 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     public void testCopyHeadersClusterAdminRequest() {
         Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
         Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
+        Map<String, String> leftRestHeaders = randomHeadersFrom(restHeaders);
+        Set<String> usefulRestHeaders = new HashSet<>(leftRestHeaders.keySet());
+        usefulRestHeaders.addAll(randomHeaders(randomIntBetween(0, 10), "useful-").keySet());
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(existingTransportHeaders);
-        expectedHeaders.putAll(usefulRestHeaders);
+        expectedHeaders.putAll(leftRestHeaders);
 
-        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders);
 
         ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest();
         putHeaders(clusterHealthRequest, existingTransportHeaders);
@@ -116,13 +121,15 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     public void testCopyHeadersIndicesAdminRequest() {
         Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
         Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
+        Map<String, String> leftRestHeaders = randomHeadersFrom(restHeaders);
+        Set<String> usefulRestHeaders = new HashSet<>(leftRestHeaders.keySet());
+        usefulRestHeaders.addAll(randomHeaders(randomIntBetween(0, 10), "useful-").keySet());
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(existingTransportHeaders);
-        expectedHeaders.putAll(usefulRestHeaders);
+        expectedHeaders.putAll(leftRestHeaders);
 
-        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders);
 
         CreateIndexRequest createIndexRequest = Requests.createIndexRequest("test");
         putHeaders(createIndexRequest, existingTransportHeaders);
@@ -147,13 +154,15 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     public void testCopyHeadersRequestBuilder() {
         Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
         Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
+        Map<String, String> leftRestHeaders = randomHeadersFrom(restHeaders);
+        Set<String> usefulRestHeaders = new HashSet<>(leftRestHeaders.keySet());
+        usefulRestHeaders.addAll(randomHeaders(randomIntBetween(0, 10), "useful-").keySet());
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(existingTransportHeaders);
-        expectedHeaders.putAll(usefulRestHeaders);
+        expectedHeaders.putAll(leftRestHeaders);
 
-        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders);
 
         ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
                 client.prepareIndex("index", "type"),
@@ -178,13 +187,15 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     public void testCopyHeadersClusterAdminRequestBuilder() {
         Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
         Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
+        Map<String, String> leftRestHeaders = randomHeadersFrom(restHeaders);
+        Set<String> usefulRestHeaders = new HashSet<>(leftRestHeaders.keySet());
+        usefulRestHeaders.addAll(randomHeaders(randomIntBetween(0, 10), "useful-").keySet());
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(existingTransportHeaders);
-        expectedHeaders.putAll(usefulRestHeaders);
+        expectedHeaders.putAll(leftRestHeaders);
 
-        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders);
 
         ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
                 client.admin().cluster().prepareNodesInfo(),
@@ -207,13 +218,15 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     public void testCopyHeadersIndicesAdminRequestBuilder() {
         Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
         Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
+        Map<String, String> leftRestHeaders = randomHeadersFrom(restHeaders);
+        Set<String> usefulRestHeaders = new HashSet<>(leftRestHeaders.keySet());
+        usefulRestHeaders.addAll(randomHeaders(randomIntBetween(0, 10), "useful-").keySet());
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(existingTransportHeaders);
-        expectedHeaders.putAll(usefulRestHeaders);
+        expectedHeaders.putAll(leftRestHeaders);
 
-        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders);
 
         ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
                 client.admin().indices().prepareValidateQuery(),
@@ -234,9 +247,13 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
     }
 
     private static Map<String, String> randomHeaders(int count) {
+        return randomHeaders(count, "header-");
+    }
+
+    private static Map<String, String> randomHeaders(int count, String prefix) {
         Map<String, String> headers = new HashMap<>();
         for (int i = 0; i < count; i++) {
-            headers.put("header-" + randomInt(30), randomRealisticUnicodeOfLengthBetween(1, 20));
+            headers.put(prefix + randomInt(30), randomRealisticUnicodeOfLengthBetween(1, 20));
         }
         return headers;
     }

--- a/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
+++ b/src/test/java/org/elasticsearch/rest/HeadersCopyClientTests.java
@@ -42,8 +42,9 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
-import static org.elasticsearch.rest.BaseRestHandler.*;
+import static org.elasticsearch.rest.BaseRestHandler.HeadersCopyClient;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
@@ -51,193 +52,184 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
 
     @Test
     public void testCopyHeadersRequest() {
-        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
 
-        HashMap<String, String> resultingHeaders = new HashMap<>();
-        resultingHeaders.putAll(existingHeaders);
-        resultingHeaders.putAll(newHeaders);
+        HashMap<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.putAll(existingTransportHeaders);
+        expectedHeaders.putAll(usefulRestHeaders);
 
-        RestRequest restRequest = new FakeRestRequest(newHeaders);
-        NoOpClient noOpClient = new NoOpClient();
-        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
 
         SearchRequest searchRequest = Requests.searchRequest();
-        searchRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(searchRequest, existingHeaders);
-        headersCopyClient.search(searchRequest);
-        assertHeaders(searchRequest, resultingHeaders);
+        putHeaders(searchRequest, existingTransportHeaders);
+        assertHeaders(searchRequest, existingTransportHeaders);
+        client.search(searchRequest);
+        assertHeaders(searchRequest, expectedHeaders);
 
         GetRequest getRequest = Requests.getRequest("index");
-        getRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(getRequest, existingHeaders);
-        headersCopyClient.get(getRequest);
-        assertHeaders(getRequest, resultingHeaders);
+        putHeaders(getRequest, existingTransportHeaders);
+        assertHeaders(getRequest, existingTransportHeaders);
+        client.get(getRequest);
+        assertHeaders(getRequest, expectedHeaders);
 
         IndexRequest indexRequest = Requests.indexRequest();
-        indexRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(indexRequest, existingHeaders);
-        headersCopyClient.index(indexRequest);
-        assertHeaders(indexRequest, resultingHeaders);
+        putHeaders(indexRequest, existingTransportHeaders);
+        assertHeaders(indexRequest, existingTransportHeaders);
+        client.index(indexRequest);
+        assertHeaders(indexRequest, expectedHeaders);
     }
 
     @Test
     public void testCopyHeadersClusterAdminRequest() {
-        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
 
-        HashMap<String, String> resultingHeaders = new HashMap<>();
-        resultingHeaders.putAll(existingHeaders);
-        resultingHeaders.putAll(newHeaders);
+        HashMap<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.putAll(existingTransportHeaders);
+        expectedHeaders.putAll(usefulRestHeaders);
 
-        RestRequest restRequest = new FakeRestRequest(newHeaders);
-        NoOpClient noOpClient = new NoOpClient();
-        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
 
         ClusterHealthRequest clusterHealthRequest = Requests.clusterHealthRequest();
-        clusterHealthRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(clusterHealthRequest, existingHeaders);
-        headersCopyClient.admin().cluster().health(clusterHealthRequest);
-        assertHeaders(clusterHealthRequest, resultingHeaders);
+        putHeaders(clusterHealthRequest, existingTransportHeaders);
+        assertHeaders(clusterHealthRequest, existingTransportHeaders);
+        client.admin().cluster().health(clusterHealthRequest);
+        assertHeaders(clusterHealthRequest, expectedHeaders);
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest();
-        clusterStateRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(clusterStateRequest, existingHeaders);
-        headersCopyClient.admin().cluster().state(clusterStateRequest);
-        assertHeaders(clusterStateRequest, resultingHeaders);
+        putHeaders(clusterStateRequest, existingTransportHeaders);
+        assertHeaders(clusterStateRequest, existingTransportHeaders);
+        client.admin().cluster().state(clusterStateRequest);
+        assertHeaders(clusterStateRequest, expectedHeaders);
 
         ClusterStatsRequest clusterStatsRequest = Requests.clusterStatsRequest();
-        clusterStatsRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(clusterStatsRequest, existingHeaders);
-        headersCopyClient.admin().cluster().clusterStats(clusterStatsRequest);
-        assertHeaders(clusterStatsRequest, resultingHeaders);
+        putHeaders(clusterStatsRequest, existingTransportHeaders);
+        assertHeaders(clusterStatsRequest, existingTransportHeaders);
+        client.admin().cluster().clusterStats(clusterStatsRequest);
+        assertHeaders(clusterStatsRequest, expectedHeaders);
     }
 
     @Test
     public void testCopyHeadersIndicesAdminRequest() {
-        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
 
-        HashMap<String, String> resultingHeaders = new HashMap<>();
-        resultingHeaders.putAll(existingHeaders);
-        resultingHeaders.putAll(newHeaders);
+        HashMap<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.putAll(existingTransportHeaders);
+        expectedHeaders.putAll(usefulRestHeaders);
 
-        RestRequest restRequest = new FakeRestRequest(newHeaders);
-        NoOpClient noOpClient = new NoOpClient();
-        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
 
         CreateIndexRequest createIndexRequest = Requests.createIndexRequest("test");
-        createIndexRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(createIndexRequest, existingHeaders);
-        headersCopyClient.admin().indices().create(createIndexRequest);
-        assertHeaders(createIndexRequest, resultingHeaders);
+        putHeaders(createIndexRequest, existingTransportHeaders);
+        assertHeaders(createIndexRequest, existingTransportHeaders);
+        client.admin().indices().create(createIndexRequest);
+        assertHeaders(createIndexRequest, expectedHeaders);
 
         CloseIndexRequest closeIndexRequest = Requests.closeIndexRequest("test");
-        closeIndexRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(closeIndexRequest, existingHeaders);
-        headersCopyClient.admin().indices().close(closeIndexRequest);
-        assertHeaders(closeIndexRequest, resultingHeaders);
+        putHeaders(closeIndexRequest, existingTransportHeaders);
+        assertHeaders(closeIndexRequest, existingTransportHeaders);
+        client.admin().indices().close(closeIndexRequest);
+        assertHeaders(closeIndexRequest, expectedHeaders);
 
         FlushRequest flushRequest = Requests.flushRequest();
-        flushRequest.putHeaders(existingHeaders.entrySet());
-        assertHeaders(flushRequest, existingHeaders);
-        headersCopyClient.admin().indices().flush(flushRequest);
-        assertHeaders(flushRequest, resultingHeaders);
+        putHeaders(flushRequest, existingTransportHeaders);
+        assertHeaders(flushRequest, existingTransportHeaders);
+        client.admin().indices().flush(flushRequest);
+        assertHeaders(flushRequest, expectedHeaders);
     }
 
     @Test
     public void testCopyHeadersRequestBuilder() {
-        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
 
-        HashMap<String, String> resultingHeaders = new HashMap<>();
-        resultingHeaders.putAll(existingHeaders);
-        resultingHeaders.putAll(newHeaders);
+        HashMap<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.putAll(existingTransportHeaders);
+        expectedHeaders.putAll(usefulRestHeaders);
 
-        RestRequest restRequest = new FakeRestRequest(newHeaders);
-
-        NoOpClient noOpClient = new NoOpClient();
-        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
 
         ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
-                headersCopyClient.prepareIndex("index", "type"),
-                headersCopyClient.prepareGet("index", "type", "id"),
-                headersCopyClient.prepareBulk(),
-                headersCopyClient.prepareDelete(),
-                headersCopyClient.prepareIndex(),
-                headersCopyClient.prepareClearScroll(),
-                headersCopyClient.prepareMultiGet(),
-                headersCopyClient.prepareBenchStatus()
+                client.prepareIndex("index", "type"),
+                client.prepareGet("index", "type", "id"),
+                client.prepareBulk(),
+                client.prepareDelete(),
+                client.prepareIndex(),
+                client.prepareClearScroll(),
+                client.prepareMultiGet(),
+                client.prepareBenchStatus()
         };
 
         for (ActionRequestBuilder requestBuilder : requestBuilders) {
-            requestBuilder.request().putHeaders(existingHeaders.entrySet());
-            assertHeaders(requestBuilder.request(), existingHeaders);
+            putHeaders(requestBuilder.request(), existingTransportHeaders);
+            assertHeaders(requestBuilder.request(), existingTransportHeaders);
             requestBuilder.get();
-            assertHeaders(requestBuilder.request(), resultingHeaders);
+            assertHeaders(requestBuilder.request(), expectedHeaders);
         }
     }
 
     @Test
     public void testCopyHeadersClusterAdminRequestBuilder() {
-        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
 
-        HashMap<String, String> resultingHeaders = new HashMap<>();
-        resultingHeaders.putAll(existingHeaders);
-        resultingHeaders.putAll(newHeaders);
+        HashMap<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.putAll(existingTransportHeaders);
+        expectedHeaders.putAll(usefulRestHeaders);
 
-        RestRequest restRequest = new FakeRestRequest(newHeaders);
-
-        NoOpClient noOpClient = new NoOpClient();
-        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
 
         ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
-                headersCopyClient.admin().cluster().prepareNodesInfo(),
-                headersCopyClient.admin().cluster().prepareClusterStats(),
-                headersCopyClient.admin().cluster().prepareState(),
-                headersCopyClient.admin().cluster().prepareCreateSnapshot("repo", "name"),
-                headersCopyClient.admin().cluster().prepareHealth(),
-                headersCopyClient.admin().cluster().prepareReroute()
+                client.admin().cluster().prepareNodesInfo(),
+                client.admin().cluster().prepareClusterStats(),
+                client.admin().cluster().prepareState(),
+                client.admin().cluster().prepareCreateSnapshot("repo", "name"),
+                client.admin().cluster().prepareHealth(),
+                client.admin().cluster().prepareReroute()
         };
 
         for (ActionRequestBuilder requestBuilder : requestBuilders) {
-            requestBuilder.request().putHeaders(existingHeaders.entrySet());
-            assertHeaders(requestBuilder.request(), existingHeaders);
+            putHeaders(requestBuilder.request(), existingTransportHeaders);
+            assertHeaders(requestBuilder.request(), existingTransportHeaders);
             requestBuilder.get();
-            assertHeaders(requestBuilder.request(), resultingHeaders);
+            assertHeaders(requestBuilder.request(), expectedHeaders);
         }
     }
 
     @Test
     public void testCopyHeadersIndicesAdminRequestBuilder() {
-        Map<String, String> existingHeaders = randomHeaders(randomIntBetween(0, 10));
-        Map<String, String> newHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> existingTransportHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> restHeaders = randomHeaders(randomIntBetween(0, 10));
+        Map<String, String> usefulRestHeaders = randomHeadersFrom(restHeaders);
 
-        HashMap<String, String> resultingHeaders = new HashMap<>();
-        resultingHeaders.putAll(existingHeaders);
-        resultingHeaders.putAll(newHeaders);
+        HashMap<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.putAll(existingTransportHeaders);
+        expectedHeaders.putAll(usefulRestHeaders);
 
-        RestRequest restRequest = new FakeRestRequest(newHeaders);
-
-        NoOpClient noOpClient = new NoOpClient();
-        HeadersCopyClient headersCopyClient = new HeadersCopyClient(noOpClient, restRequest);
+        Client client = client(new NoOpClient(), new FakeRestRequest(restHeaders), usefulRestHeaders.keySet());
 
         ActionRequestBuilder requestBuilders [] = new ActionRequestBuilder[] {
-                headersCopyClient.admin().indices().prepareValidateQuery(),
-                headersCopyClient.admin().indices().prepareCreate("test"),
-                headersCopyClient.admin().indices().prepareAliases(),
-                headersCopyClient.admin().indices().prepareAnalyze("text"),
-                headersCopyClient.admin().indices().prepareDeleteWarmer(),
-                headersCopyClient.admin().indices().prepareTypesExists("type"),
-                headersCopyClient.admin().indices().prepareClose()
+                client.admin().indices().prepareValidateQuery(),
+                client.admin().indices().prepareCreate("test"),
+                client.admin().indices().prepareAliases(),
+                client.admin().indices().prepareAnalyze("text"),
+                client.admin().indices().prepareDeleteWarmer(),
+                client.admin().indices().prepareTypesExists("type"),
+                client.admin().indices().prepareClose()
         };
 
         for (ActionRequestBuilder requestBuilder : requestBuilders) {
-            requestBuilder.request().putHeaders(existingHeaders.entrySet());
-            assertHeaders(requestBuilder.request(), existingHeaders);
+            putHeaders(requestBuilder.request(), existingTransportHeaders);
+            assertHeaders(requestBuilder.request(), existingTransportHeaders);
             requestBuilder.get();
-            assertHeaders(requestBuilder.request(), resultingHeaders);
+            assertHeaders(requestBuilder.request(), expectedHeaders);
         }
     }
 
@@ -247,6 +239,33 @@ public class HeadersCopyClientTests extends ElasticsearchTestCase {
             headers.put("header-" + randomInt(30), randomRealisticUnicodeOfLengthBetween(1, 20));
         }
         return headers;
+    }
+
+    private static Map<String, String> randomHeadersFrom(Map<String, String> headers) {
+        Map<String, String> newHeaders = new HashMap<>();
+        if (headers.isEmpty()) {
+            return newHeaders;
+        }
+        int i = randomInt(headers.size() - 1);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (randomInt(i) == 0) {
+                newHeaders.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return newHeaders;
+    }
+
+    private static Client client(Client noOpClient, RestRequest restRequest, Set<String> usefulRestHeaders) {
+        if (usefulRestHeaders.isEmpty() && randomBoolean()) {
+            return noOpClient;
+        }
+        return new HeadersCopyClient(noOpClient, restRequest, usefulRestHeaders);
+    }
+
+    private static void putHeaders(ActionRequest<?> request, Map<String, String> headers) {
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            request.putHeader(header.getKey(), header.getValue());
+        }
     }
 
     private static void assertHeaders(ActionRequest<?> request, Map<String, String> headers) {


### PR DESCRIPTION
Introduced the use of the `FilterClient` in all of the REST actions, which delegates all of the operations to the internal `Client`, but makes sure that the headers are properly copied if needed from REST requests to `TransportRequest`(s) when it comes to executing them.  Added new abstract handleRequest method to `BaseRestHandler` with additional `Client` argument and made private the client instance member (was protected before) to force the use of the client received as argument.  The list of headers to be copied over is by default empty but can be extended via plugins.

Replaces #6464 as it provides a better and safer way to copy headers from REST layer to transport layer.
