### PR TITLE
Allow _version to use `disk` as a doc values format.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -103,11 +103,6 @@ public class VersionFieldMapper extends AbstractFieldMapper<Long> implements Int
     }
 
     @Override
-    protected String defaultDocValuesFormat() {
-        return "disk";
-    }
-
-    @Override
     public void preParse(ParseContext context) throws IOException {
         super.parse(context);
     }


### PR DESCRIPTION
VersionFieldMapper.defaultDocValuesFormat claims that the default is `disk`
(which is wrong, it's using Lucene's defaults).
This is not used to choose the DV format in the index but for mappings
serialization in order to know when the _version doc values format is
different from the default format. This made it impossible to use the `disk`
doc values format since mappings would never retain that information at
serialization time.
