### PR TITLE
Fix JSON response for significant terms

### DIFF
--- a/rest-api-spec/test/search/test_sig_terms.yaml
+++ b/rest-api-spec/test/search/test_sig_terms.yaml
@@ -1,0 +1,74 @@
+---
+"Default index":
+  - do:
+      indices.create:
+          index:  goodbad
+          body:
+            settings:
+                number_of_shards: "1"
+
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     1
+          body:   { text: "good", class: "good" }
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     2
+          body:   { text: "good", class: "good" }
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     3
+          body:   { text: "bad", class: "bad" }
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     4
+          body:   { text: "bad", class: "bad" }
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     5
+          body:   { text: "good bad", class: "good" }
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     6
+          body:   { text: "good bad", class: "bad" }
+  - do:
+      index:
+          index:  goodbad
+          type:   doc
+          id:     7
+          body:   { text: "bad", class: "bad" }
+
+
+
+  - do:
+      indices.refresh:
+        index: [goodbad]
+
+  - do:
+      search:
+        index: goodbad
+        type:  doc
+
+  - match: {hits.total: 7}
+  
+  - do:
+      search:
+        index: goodbad
+        type:  doc
+        body: {"aggs": {"class": {"terms": {"field": "class"},"aggs": {"sig_terms": {"significant_terms": {"field": "text"}}}}}}
+
+  - match: {aggregations.class.buckets.0.sig_terms.buckets.0.key: "bad"}
+  - match: {aggregations.class.buckets.0.sig_terms.buckets.0.key: "good"}
+  

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -109,7 +109,7 @@ public class SignificantLongTerms extends InternalSignificantTerms {
     @Override
     InternalSignificantTerms newAggregation(long subsetSize, long supersetSize,
             List<InternalSignificantTerms.Bucket> buckets) {
-        return new SignificantLongTerms(subsetSize, supersetSize, getName(), formatter, requiredSize, supersetSize, buckets);
+        return new SignificantLongTerms(subsetSize, supersetSize, getName(), formatter, requiredSize, minDocCount, buckets);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -106,7 +106,7 @@ public class SignificantStringTerms extends InternalSignificantTerms {
     @Override
     InternalSignificantTerms newAggregation(long subsetSize, long supersetSize,
             List<InternalSignificantTerms.Bucket> buckets) {
-        return new SignificantStringTerms(subsetSize, supersetSize, getName(), requiredSize, supersetSize, buckets);
+        return new SignificantStringTerms(subsetSize, supersetSize, getName(), requiredSize, minDocCount, buckets);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
@@ -309,6 +309,7 @@ public class SignificantTermsTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testXContentResponse() throws Exception {
+        cluster().wipeIndices("goodbad");
         String type = randomBoolean() ? "string" : "long";
         prepareGoodBad(type);
         SearchResponse response = client().prepareSearch("goodbad").setTypes("doc")
@@ -342,7 +343,6 @@ public class SignificantTermsTests extends ElasticsearchIntegrationTest {
 
     private void prepareGoodBad(String type) {
         String mappings = "{\"doc\": {\"properties\":{\"text\": {\"type\":\"" + type + "\"}}}}";
-        logger.info(mappings);
         assertAcked(prepareCreate("goodbad").setSettings(SETTING_NUMBER_OF_SHARDS, 1, SETTING_NUMBER_OF_REPLICAS, 0).addMapping("doc", mappings));
         String[] gb = {"0", "1"};
         client().prepareIndex("goodbad", "doc", "1")


### PR DESCRIPTION
Commit fbd7c9aa5d6c1c introduced a regression that caused
the min_doc_count to be equal to the number of documents in the
background set. As a result no buckets were built when the
response for significant terms was created.
This only affected the final XContent response.
