### PR TITLE
New entry/front-end

### DIFF
--- a/docs/community/frontends.asciidoc
+++ b/docs/community/frontends.asciidoc
@@ -15,3 +15,6 @@
 
 * http://elastichammer.exploringelasticsearch.com/[Hammer]: 
   Web front-end for elasticsearch
+
+* https://github.com/romansanchez/Calaca[Calaca]: 
+  Simple search client for ElasticSearch


### PR DESCRIPTION
Adding, Calaca, a simple search client for ElasticSearch.
