### PR TITLE
Fix 'top-tags' and 'terms' ordering in example

### DIFF
--- a/docs/reference/search/aggregations/metrics/tophits-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/metrics/tophits-aggregation.asciidoc
@@ -36,8 +36,8 @@ only the title field is being included in the source.
 --------------------------------------------------
 {
     "aggs": {
-        "terms": {
-            "top-tags": {
+        "top-tags": {
+            "terms": {
                 "field": "tags",
                 "size": 3
             },


### PR DESCRIPTION
aggregation_name is switched with aggregation_type.
