### PR TITLE
Refactored AckedClusterStateUpdateTask & co. to remove code repetitions in subclasses

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.common.inject.Inject;
@@ -76,10 +77,9 @@ public class TransportDeleteRepositoryAction extends TransportMasterNodeOperatio
         repositoriesService.unregisterRepository(
                 new RepositoriesService.UnregisterRepositoryRequest("delete_repository [" + request.name() + "]", request.name())
                         .masterNodeTimeout(request.masterNodeTimeout()).ackTimeout(request.timeout()),
-                new ActionListener<RepositoriesService.UnregisterRepositoryResponse>() {
-
+                new ActionListener<ClusterStateUpdateResponse>() {
                     @Override
-                    public void onResponse(RepositoriesService.UnregisterRepositoryResponse unregisterRepositoryResponse) {
+                    public void onResponse(ClusterStateUpdateResponse unregisterRepositoryResponse) {
                         listener.onResponse(new DeleteRepositoryResponse(unregisterRepositoryResponse.isAcknowledged()));
                     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.common.inject.Inject;
@@ -77,10 +78,10 @@ public class TransportPutRepositoryAction extends TransportMasterNodeOperationAc
         repositoriesService.registerRepository(new RepositoriesService.RegisterRepositoryRequest("put_repository [" + request.name() + "]", request.name(), request.type())
                 .settings(request.settings())
                 .masterNodeTimeout(request.masterNodeTimeout())
-                .ackTimeout(request.timeout()), new ActionListener<RepositoriesService.RegisterRepositoryResponse>() {
+                .ackTimeout(request.timeout()), new ActionListener<ClusterStateUpdateResponse>() {
 
             @Override
-            public void onResponse(RepositoriesService.RegisterRepositoryResponse response) {
+            public void onResponse(ClusterStateUpdateResponse response) {
                 listener.onResponse(new PutRepositoryResponse(response.isAcknowledged()));
             }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -87,13 +86,13 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
         final ImmutableSettings.Builder transientUpdates = ImmutableSettings.settingsBuilder();
         final ImmutableSettings.Builder persistentUpdates = ImmutableSettings.settingsBuilder();
 
-        clusterService.submitStateUpdateTask("cluster_update_settings", Priority.IMMEDIATE, new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("cluster_update_settings", Priority.IMMEDIATE, new AckedClusterStateUpdateTask<ClusterUpdateSettingsResponse>(request, listener) {
 
             private volatile boolean changed = false;
 
             @Override
-            public boolean mustAck(DiscoveryNode discoveryNode) {
-                return true;
+            protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
+                return new ClusterUpdateSettingsResponse(acknowledged, transientUpdates.build(), persistentUpdates.build());
             }
 
             @Override
@@ -101,9 +100,8 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                 if (changed) {
                     reroute(true);
                 } else {
-                    listener.onResponse(new ClusterUpdateSettingsResponse(true, transientUpdates.build(), persistentUpdates.build()));
+                    super.onAllNodesAcked(t);
                 }
-
             }
 
             @Override
@@ -111,7 +109,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                 if (changed) {
                     reroute(false);
                 } else {
-                    listener.onResponse(new ClusterUpdateSettingsResponse(false, transientUpdates.build(), persistentUpdates.build()));
+                    super.onAckTimeout();
                 }
             }
 
@@ -129,7 +127,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                 // in the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible
                 // to the components until the ClusterStateListener instances have been invoked, but are visible after
                 // the first update task has been completed.
-                clusterService.submitStateUpdateTask("reroute_after_cluster_update_settings", Priority.URGENT, new AckedClusterStateUpdateTask() {
+                clusterService.submitStateUpdateTask("reroute_after_cluster_update_settings", Priority.URGENT, new AckedClusterStateUpdateTask<ClusterUpdateSettingsResponse>(request, listener) {
 
                     @Override
                     public boolean mustAck(DiscoveryNode discoveryNode) {
@@ -138,25 +136,9 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                     }
 
                     @Override
-                    public void onAllNodesAcked(@Nullable Throwable t) {
-                        //we return when the cluster reroute is acked (the acknowledged flag depends on whether the update settings was acknowledged)
-                        listener.onResponse(new ClusterUpdateSettingsResponse(updateSettingsAcked, transientUpdates.build(), persistentUpdates.build()));
-                    }
-
-                    @Override
-                    public void onAckTimeout() {
-                        //we return when the cluster reroute ack times out (acknowledged false)
-                        listener.onResponse(new ClusterUpdateSettingsResponse(false, transientUpdates.build(), persistentUpdates.build()));
-                    }
-
-                    @Override
-                    public TimeValue ackTimeout() {
-                        return request.timeout();
-                    }
-
-                    @Override
-                    public TimeValue timeout() {
-                        return request.masterNodeTimeout();
+                    //we return when the cluster reroute is acked or it times out but the acknowledged flag depends on whether the update settings was acknowledged
+                    protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
+                        return new ClusterUpdateSettingsResponse(updateSettingsAcked && acknowledged, transientUpdates.build(), persistentUpdates.build());
                     }
 
                     @Override
@@ -175,27 +157,13 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                         }
                         return ClusterState.builder(currentState).routingResult(routingResult).build();
                     }
-
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    }
                 });
-            }
-
-            @Override
-            public TimeValue ackTimeout() {
-                return request.timeout();
-            }
-
-            @Override
-            public TimeValue timeout() {
-                return request.masterNodeTimeout();
             }
 
             @Override
             public void onFailure(String source, Throwable t) {
                 logger.debug("failed to perform [{}]", t, source);
-                listener.onFailure(t);
+                super.onFailure(source, t);
             }
 
             @Override
@@ -251,11 +219,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                 }
 
                 return builder(currentState).metaData(metaData).blocks(blocks).build();
-            }
-
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-
             }
         });
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasA
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -123,7 +122,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .actions(finalActions.toArray(new AliasAction[finalActions.size()]));
 
-        indexAliasesService.indicesAliases(updateRequest, new ClusterStateUpdateListener() {
+        indexAliasesService.indicesAliases(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {
                 listener.onResponse(new IndicesAliasesResponse(response.isAcknowledged()));

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -91,7 +90,7 @@ public class TransportCloseIndexAction extends TransportMasterNodeOperationActio
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(request.indices());
 
-        indexStateService.closeIndex(updateRequest, new ClusterStateUpdateListener() {
+        indexStateService.closeIndex(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
 
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -87,7 +86,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeOperationActi
                 .settings(request.settings()).mappings(request.mappings())
                 .aliases(request.aliases()).customs(request.customs());
 
-        createIndexService.createIndex(updateRequest, new ClusterStateUpdateListener() {
+        createIndexService.createIndex(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
 
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
@@ -37,7 +37,6 @@ import org.elasticsearch.action.support.master.TransportMasterNodeOperationActio
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -179,7 +178,7 @@ public class TransportDeleteMappingAction extends TransportMasterNodeOperationAc
                                         .ackTimeout(request.timeout())
                                         .masterNodeTimeout(request.masterNodeTimeout());
 
-                                metaDataMappingService.removeMapping(clusterStateUpdateRequest, new ClusterStateUpdateListener() {
+                                metaDataMappingService.removeMapping(clusterStateUpdateRequest, new ActionListener<ClusterStateUpdateResponse>() {
                                     @Override
                                     public void onResponse(ClusterStateUpdateResponse response) {
                                         listener.onResponse(new DeleteMappingResponse(response.isAcknowledged()));

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -87,7 +86,7 @@ public class TransportPutMappingAction extends TransportMasterNodeOperationActio
                 .indices(request.indices()).type(request.type())
                 .source(request.source()).ignoreConflicts(request.ignoreConflicts());
 
-        metaDataMappingService.putMapping(updateRequest, new ClusterStateUpdateListener() {
+        metaDataMappingService.putMapping(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
 
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -91,7 +90,7 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(request.indices());
 
-        indexStateService.openIndex(updateRequest, new ClusterStateUpdateListener() {
+        indexStateService.openIndex(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {
 
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.metadata.MetaDataUpdateSettingsService;
 import org.elasticsearch.common.inject.Inject;
@@ -81,7 +80,7 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeOperationA
                 .ackTimeout(request.timeout())
                 .masterNodeTimeout(request.masterNodeTimeout());
 
-        updateSettingsService.updateSettings(clusterStateUpdateRequest, new ClusterStateUpdateListener() {
+        updateSettingsService.updateSettings(clusterStateUpdateRequest, new ActionListener<ClusterStateUpdateResponse>() {
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {
                 listener.onResponse(new UpdateSettingsResponse(response.isAcknowledged()));

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -31,12 +31,9 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
@@ -98,37 +95,17 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
                     return;
                 }
 
-                clusterService.submitStateUpdateTask("put_warmer [" + request.name() + "]", new AckedClusterStateUpdateTask() {
+                clusterService.submitStateUpdateTask("put_warmer [" + request.name() + "]", new AckedClusterStateUpdateTask<PutWarmerResponse>(request, listener) {
 
                     @Override
-                    public boolean mustAck(DiscoveryNode discoveryNode) {
-                        return true;
-                    }
-
-                    @Override
-                    public void onAllNodesAcked(@Nullable Throwable t) {
-                        listener.onResponse(new PutWarmerResponse(true));
-                    }
-
-                    @Override
-                    public void onAckTimeout() {
-                        listener.onResponse(new PutWarmerResponse(false));
-                    }
-
-                    @Override
-                    public TimeValue ackTimeout() {
-                        return request.timeout();
-                    }
-
-                    @Override
-                    public TimeValue timeout() {
-                        return request.masterNodeTimeout();
+                    protected PutWarmerResponse newResponse(boolean acknowledged) {
+                        return new PutWarmerResponse(acknowledged);
                     }
 
                     @Override
                     public void onFailure(String source, Throwable t) {
                         logger.debug("failed to put warmer [{}] on indices [{}]", t, request.name(), request.searchRequest().indices());
-                        listener.onFailure(t);
+                        super.onFailure(source, t);
                     }
 
                     @Override
@@ -179,11 +156,6 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
                         }
 
                         return ClusterState.builder(currentState).metaData(mdBuilder).build();
-                    }
-
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-
                     }
                 });
             }

--- a/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.action.support.master;
 
+import org.elasticsearch.cluster.ack.AckedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -31,7 +32,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * Abstract class that allows to mark action requests that support acknowledgements.
  * Facilitates consistency across different api.
  */
-public abstract class AcknowledgedRequest<T extends MasterNodeOperationRequest> extends MasterNodeOperationRequest<T> {
+public abstract class AcknowledgedRequest<T extends MasterNodeOperationRequest> extends MasterNodeOperationRequest<T> implements AckedRequest {
 
     public static final TimeValue DEFAULT_ACK_TIMEOUT = timeValueSeconds(30);
 
@@ -82,5 +83,10 @@ public abstract class AcknowledgedRequest<T extends MasterNodeOperationRequest> 
      */
     protected void writeTimeout(StreamOutput out) throws IOException {
         timeout.writeTo(out);
+    }
+
+    @Override
+    public TimeValue ackTimeout() {
+        return timeout;
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ack.AckedRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
@@ -26,30 +28,63 @@ import org.elasticsearch.common.unit.TimeValue;
  * An extension interface to {@link ClusterStateUpdateTask} that allows to be notified when
  * all the nodes have acknowledged a cluster state update request
  */
-public interface AckedClusterStateUpdateTask extends TimeoutClusterStateUpdateTask {
+public abstract class AckedClusterStateUpdateTask<Response> implements TimeoutClusterStateUpdateTask {
+
+    private final ActionListener<Response> listener;
+    private final AckedRequest request;
+
+    protected AckedClusterStateUpdateTask(AckedRequest request, ActionListener<Response> listener) {
+        this.listener = listener;
+        this.request = request;
+    }
 
     /**
      * Called to determine which nodes the acknowledgement is expected from
      * @param discoveryNode a node
      * @return true if the node is expected to send ack back, false otherwise
      */
-    boolean mustAck(DiscoveryNode discoveryNode);
+    public boolean mustAck(DiscoveryNode discoveryNode) {
+        return true;
+    }
 
     /**
      * Called once all the nodes have acknowledged the cluster state update request. Must be
      * very lightweight execution, since it gets executed on the cluster service thread.
      * @param t optional error that might have been thrown
      */
-    void onAllNodesAcked(@Nullable Throwable t);
+    public void onAllNodesAcked(@Nullable Throwable t) {
+        listener.onResponse(newResponse(true));
+    }
+
+    protected abstract Response newResponse(boolean acknowledged);
 
     /**
      * Called once the acknowledgement timeout defined by
      * {@link AckedClusterStateUpdateTask#ackTimeout()} has expired
      */
-    void onAckTimeout();
+    public void onAckTimeout() {
+        listener.onResponse(newResponse(false));
+    }
+
+    @Override
+    public void onFailure(String source, Throwable t) {
+        listener.onFailure(t);
+    }
+
+    @Override
+    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+
+    }
 
     /**
      * Acknowledgement timeout, maximum time interval to wait for acknowledgements
      */
-    TimeValue ackTimeout();
+    public TimeValue ackTimeout() {
+        return request.ackTimeout();
+    }
+
+    @Override
+    public TimeValue timeout() {
+        return request.masterNodeTimeout();
+    }
 }

--- a/src/main/java/org/elasticsearch/cluster/ack/AckedRequest.java
+++ b/src/main/java/org/elasticsearch/cluster/ack/AckedRequest.java
@@ -19,19 +19,20 @@
 
 package org.elasticsearch.cluster.ack;
 
+import org.elasticsearch.common.unit.TimeValue;
+
 /**
- * Listener used for cluster state updates processing
- * Supports acknowledgement logic
+ * Identifies a cluster state update request with acknowledgement support
  */
-public interface ClusterStateUpdateListener {
+public interface AckedRequest {
 
     /**
-     * Called when the cluster state update is acknowledged
+     * Returns the acknowledgement timeout
      */
-    void onResponse(ClusterStateUpdateResponse response);
+    TimeValue ackTimeout();
 
     /**
-     * Called when any error is thrown during the cluster state update processing
+     * Returns the timeout for the request to be completed on the master node
      */
-    void onFailure(Throwable t);
+    TimeValue masterNodeTimeout();
 }

--- a/src/main/java/org/elasticsearch/cluster/ack/ClusterStateUpdateRequest.java
+++ b/src/main/java/org/elasticsearch/cluster/ack/ClusterStateUpdateRequest.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.unit.TimeValue;
  * Base class to be used when needing to update the cluster state
  * Contains the basic fields that are always needed
  */
-public abstract class ClusterStateUpdateRequest<T extends ClusterStateUpdateRequest<T>> {
+public abstract class ClusterStateUpdateRequest<T extends ClusterStateUpdateRequest<T>> implements AckedRequest {
 
     private TimeValue ackTimeout;
     private TimeValue masterNodeTimeout;

--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaDataMappingService;
@@ -148,7 +147,7 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
 
     @Override
     protected void masterOperation(final MappingUpdatedRequest request, final ClusterState state, final ActionListener<MappingUpdatedResponse> listener) throws ElasticsearchException {
-        metaDataMappingService.updateMapping(request.index(), request.indexUUID(), request.type(), request.mappingSource(), request.order, request.nodeId, new ClusterStateUpdateListener() {
+        metaDataMappingService.updateMapping(request.index(), request.indexUUID(), request.type(), request.mappingSource(), request.order, request.nodeId, new ActionListener<ClusterStateUpdateResponse>() {
             @Override
             public void onResponse(ClusterStateUpdateResponse response) {
                 listener.onResponse(new MappingUpdatedResponse());

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -22,20 +22,17 @@ package org.elasticsearch.cluster.metadata;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesClusterStateUpdateRequest;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.service.IndexService;
@@ -64,37 +61,11 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
         this.aliasValidator = aliasValidator;
     }
 
-    public void indicesAliases(final IndicesAliasesClusterStateUpdateRequest request, final ClusterStateUpdateListener listener) {
-        clusterService.submitStateUpdateTask("index-aliases", Priority.URGENT, new AckedClusterStateUpdateTask() {
-
+    public void indicesAliases(final IndicesAliasesClusterStateUpdateRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
+        clusterService.submitStateUpdateTask("index-aliases", Priority.URGENT, new AckedClusterStateUpdateTask<ClusterStateUpdateResponse>(request, listener) {
             @Override
-            public boolean mustAck(DiscoveryNode discoveryNode) {
-                return true;
-            }
-
-            @Override
-            public void onAllNodesAcked(@Nullable Throwable t) {
-                listener.onResponse(new ClusterStateUpdateResponse(true));
-            }
-
-            @Override
-            public void onAckTimeout() {
-                listener.onResponse(new ClusterStateUpdateResponse(false));
-            }
-
-            @Override
-            public TimeValue ackTimeout() {
-                return request.ackTimeout();
-            }
-
-            @Override
-            public TimeValue timeout() {
-                return request.masterNodeTimeout();
-            }
-
-            @Override
-            public void onFailure(String source, Throwable t) {
-                listener.onFailure(t);
+            protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                return new ClusterStateUpdateResponse(acknowledged);
             }
 
             @Override
@@ -185,11 +156,6 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                         indicesService.removeIndex(index, "created for alias processing");
                     }
                 }
-            }
-
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-
             }
         });
     }

--- a/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Injector;
@@ -37,7 +36,6 @@ import org.elasticsearch.common.inject.Injectors;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.snapshots.IndexShardRepository;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.SnapshotsService;
@@ -84,10 +82,15 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
      * @param request  register repository request
      * @param listener register repository listener
      */
-    public void registerRepository(final RegisterRepositoryRequest request, final ActionListener<RegisterRepositoryResponse> listener) {
+    public void registerRepository(final RegisterRepositoryRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
         final RepositoryMetaData newRepositoryMetaData = new RepositoryMetaData(request.name, request.type, request.settings);
 
-        clusterService.submitStateUpdateTask(request.cause, new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask(request.cause, new AckedClusterStateUpdateTask<ClusterStateUpdateResponse>(request, listener) {
+            @Override
+            protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                return new ClusterStateUpdateResponse(acknowledged);
+            }
+
             @Override
             public ClusterState execute(ClusterState currentState) {
                 ensureRepositoryNotInUse(currentState, request.name);
@@ -129,37 +132,12 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
             @Override
             public void onFailure(String source, Throwable t) {
                 logger.warn("failed to create repository [{}]", t, request.name);
-                listener.onFailure(t);
-            }
-
-            @Override
-            public TimeValue timeout() {
-                return request.masterNodeTimeout();
-            }
-
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-
+                super.onFailure(source, t);
             }
 
             @Override
             public boolean mustAck(DiscoveryNode discoveryNode) {
                 return discoveryNode.masterNode();
-            }
-
-            @Override
-            public void onAllNodesAcked(@Nullable Throwable t) {
-                listener.onResponse(new RegisterRepositoryResponse(true));
-            }
-
-            @Override
-            public void onAckTimeout() {
-                listener.onResponse(new RegisterRepositoryResponse(false));
-            }
-
-            @Override
-            public TimeValue ackTimeout() {
-                return request.ackTimeout();
             }
         });
     }
@@ -172,8 +150,13 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
      * @param request  unregister repository request
      * @param listener unregister repository listener
      */
-    public void unregisterRepository(final UnregisterRepositoryRequest request, final ActionListener<UnregisterRepositoryResponse> listener) {
-        clusterService.submitStateUpdateTask(request.cause, new AckedClusterStateUpdateTask() {
+    public void unregisterRepository(final UnregisterRepositoryRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
+        clusterService.submitStateUpdateTask(request.cause, new AckedClusterStateUpdateTask<ClusterStateUpdateResponse>(request, listener) {
+            @Override
+            protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                return new ClusterStateUpdateResponse(acknowledged);
+            }
+
             @Override
             public ClusterState execute(ClusterState currentState) {
                 ensureRepositoryNotInUse(currentState, request.name);
@@ -201,38 +184,9 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
             }
 
             @Override
-            public void onFailure(String source, Throwable t) {
-                listener.onFailure(t);
-            }
-
-            @Override
-            public TimeValue timeout() {
-                return request.masterNodeTimeout();
-            }
-
-            @Override
-            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-            }
-
-            @Override
             public boolean mustAck(DiscoveryNode discoveryNode) {
                 // Since operation occurs only on masters, it's enough that only master-eligible nodes acked
                 return discoveryNode.masterNode();
-            }
-
-            @Override
-            public void onAllNodesAcked(@Nullable Throwable t) {
-                listener.onResponse(new UnregisterRepositoryResponse(true));
-            }
-
-            @Override
-            public void onAckTimeout() {
-                listener.onResponse(new UnregisterRepositoryResponse(false));
-            }
-
-            @Override
-            public TimeValue ackTimeout() {
-                return request.ackTimeout();
             }
         });
     }
@@ -465,17 +419,6 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
     }
 
     /**
-     * Register repository response
-     */
-    public static class RegisterRepositoryResponse extends ClusterStateUpdateResponse {
-
-        RegisterRepositoryResponse(boolean acknowledged) {
-            super(acknowledged);
-        }
-
-    }
-
-    /**
      * Unregister repository request
      */
     public static class UnregisterRepositoryRequest extends ClusterStateUpdateRequest<UnregisterRepositoryRequest> {
@@ -495,14 +438,5 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
             this.name = name;
         }
 
-    }
-
-    /**
-     * Unregister repository response
-     */
-    public static class UnregisterRepositoryResponse extends ClusterStateUpdateResponse {
-        UnregisterRepositoryResponse(boolean acknowledged) {
-            super(acknowledged);
-        }
     }
 }

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -122,7 +122,12 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch processedLatch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask<Void>(null, null) {
+            @Override
+            protected Void newResponse(boolean acknowledged) {
+                return null;
+            }
+
             @Override
             public boolean mustAck(DiscoveryNode discoveryNode) {
                 return true;
@@ -193,10 +198,10 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch processedLatch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask<Void>(null, null) {
             @Override
-            public boolean mustAck(DiscoveryNode discoveryNode) {
-                return true;
+            protected Void newResponse(boolean acknowledged) {
+                return null;
             }
 
             @Override
@@ -263,7 +268,12 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         final AtomicBoolean onFailure = new AtomicBoolean(false);
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask<Void>(null, null) {
+            @Override
+            protected Void newResponse(boolean acknowledged) {
+                return null;
+            }
+
             @Override
             public boolean mustAck(DiscoveryNode discoveryNode) {
                 return false;
@@ -331,7 +341,12 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch processedLatch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("test", new AckedClusterStateUpdateTask<Void>(null, null) {
+            @Override
+            protected Void newResponse(boolean acknowledged) {
+                return null;
+            }
+
             @Override
             public boolean mustAck(DiscoveryNode discoveryNode) {
                 return false;


### PR DESCRIPTION
Made `AckedClusterStateUpdateTask` an abstract class instead of an interface, which contains the common methods.
Also introduced the `AckedRequest` interface to mark both `AcknowledgedRequest` & `ClusterStateUpdateRequest` so that the different ways of updating the cluster state (with or without a `MetaData*Service`) can share the same code.
Removed `ClusterStateUpdateListener` as we can just use its base class `ActionListener` instead.
