### PR TITLE
Raise proper failure if not fully reading translog entry

### DIFF
--- a/src/main/java/org/elasticsearch/index/translog/fs/BufferingFsTranslogFile.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/BufferingFsTranslogFile.java
@@ -123,7 +123,10 @@ public class BufferingFsTranslogFile implements FsTranslogFile {
             rwl.readLock().unlock();
         }
         ByteBuffer buffer = ByteBuffer.allocate(location.size);
-        raf.channel().read(buffer, location.translogLocation);
+        int read = raf.channel().read(buffer, location.translogLocation);
+        if (read != location.size) {
+            throw new TranslogReadException(shardId, "not enough data read from translog, position=" + location.translogLocation + ", expected=" + location.size + ", read=" + read);
+        }
         return buffer.array();
     }
 

--- a/src/main/java/org/elasticsearch/index/translog/fs/SimpleFsTranslogFile.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/SimpleFsTranslogFile.java
@@ -73,7 +73,10 @@ public class SimpleFsTranslogFile implements FsTranslogFile {
 
     public byte[] read(Translog.Location location) throws IOException {
         ByteBuffer buffer = ByteBuffer.allocate(location.size);
-        raf.channel().read(buffer, location.translogLocation);
+        int read = raf.channel().read(buffer, location.translogLocation);
+        if (read != location.size) {
+            throw new TranslogReadException(shardId, "not enough data read from translog, position=" + location.translogLocation + ", expected=" + location.size + ", read=" + read);
+        }
         return buffer.array();
     }
 

--- a/src/main/java/org/elasticsearch/index/translog/fs/TranslogReadException.java
+++ b/src/main/java/org/elasticsearch/index/translog/fs/TranslogReadException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.translog.fs;
+
+import org.elasticsearch.index.shard.IndexShardException;
+import org.elasticsearch.index.shard.ShardId;
+
+/**
+ */
+public class TranslogReadException extends IndexShardException {
+
+    public TranslogReadException(ShardId shardId, String msg) {
+        super(shardId, msg);
+    }
+}


### PR DESCRIPTION
When reading a translog entry, raise a proper error when not reading it fully.
