### PR TITLE
Client intermediate interfaces removal follow-up

### DIFF
--- a/src/main/java/org/elasticsearch/action/Action.java
+++ b/src/main/java/org/elasticsearch/action/Action.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action;
 import org.elasticsearch.client.ElasticsearchClient;
 
 /**
- * Main action (used with {@link Client} API.
+ * Base action. Supports building the <code>Request</code> through a <code>RequestBuilder</code>.
  */
 public abstract class Action<Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>, Client extends ElasticsearchClient>
         extends GenericAction<Request, Response> {
@@ -31,5 +31,8 @@ public abstract class Action<Request extends ActionRequest, Response extends Act
         super(name);
     }
 
+    /**
+     * Creates a new request builder given the client provided as argument
+     */
     public abstract RequestBuilder newRequestBuilder(Client client);
 }

--- a/src/main/java/org/elasticsearch/action/ClientAction.java
+++ b/src/main/java/org/elasticsearch/action/ClientAction.java
@@ -20,10 +20,9 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 
 /**
- * Indices action (used with {@link IndicesAdminClient} API.
+ * Action (used with {@link Client} API).
  */
 public abstract class ClientAction<Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>>
         extends Action<Request, Response, RequestBuilder, Client> {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/ClusterAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/ClusterAction.java
@@ -19,12 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster;
 
-import org.elasticsearch.action.*;
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.ClusterAdminClient;
-import org.elasticsearch.client.ElasticsearchClient;
 
 /**
- * Cluster action (used with {@link ClusterAdminClient} API.
+ * Cluster action (used with {@link ClusterAdminClient} API).
  */
 public abstract class ClusterAction<Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>>
         extends Action<Request, Response, RequestBuilder, ClusterAdminClient> {

--- a/src/main/java/org/elasticsearch/action/admin/indices/IndicesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/IndicesAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.action.*;
 import org.elasticsearch.client.IndicesAdminClient;
 
 /**
- * Indices action (used with {@link IndicesAdminClient} API.
+ * Indices action (used with {@link IndicesAdminClient} API).
  */
 public abstract class IndicesAction<Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>>
         extends Action<Request, Response, RequestBuilder, IndicesAdminClient> {

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.bench;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.bench;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;

--- a/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.bulk;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;

--- a/src/main/java/org/elasticsearch/action/count/CountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/CountAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.count;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/delete/DeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/DeleteAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.delete;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.deletebyquery;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/explain/ExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.explain;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/get/GetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/GetAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.get;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/get/MultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.get;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/index/IndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.index;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.mlt;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;

--- a/src/main/java/org/elasticsearch/action/percolate/MultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/MultiPercolateAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.percolate;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.percolate;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/search/ClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/ClearScrollAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/search/SearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/search/SearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchScrollAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/suggest/SuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.suggest;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.suggest.Suggest;

--- a/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.termvector;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/action/update/UpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.update;
 
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ClientAction;
 import org.elasticsearch.client.Client;
 

--- a/src/main/java/org/elasticsearch/client/node/NodeClient.java
+++ b/src/main/java/org/elasticsearch/client/node/NodeClient.java
@@ -42,17 +42,17 @@ public class NodeClient extends AbstractClient {
 
     private final NodeAdminClient admin;
 
-    private final ImmutableMap<Action, TransportAction> actions;
+    private final ImmutableMap<ClientAction, TransportAction> actions;
 
     @Inject
     public NodeClient(Settings settings, ThreadPool threadPool, NodeAdminClient admin, Map<GenericAction, TransportAction> actions) {
         this.settings = settings;
         this.threadPool = threadPool;
         this.admin = admin;
-        MapBuilder<Action, TransportAction> actionsBuilder = new MapBuilder<>();
+        MapBuilder<ClientAction, TransportAction> actionsBuilder = new MapBuilder<>();
         for (Map.Entry<GenericAction, TransportAction> entry : actions.entrySet()) {
-            if (entry.getKey() instanceof Action) {
-                actionsBuilder.put((Action) entry.getKey(), entry.getValue());
+            if (entry.getKey() instanceof ClientAction) {
+                actionsBuilder.put((ClientAction) entry.getKey(), entry.getValue());
             }
         }
         this.actions = actionsBuilder.immutableMap();
@@ -81,14 +81,14 @@ public class NodeClient extends AbstractClient {
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
-        TransportAction<Request, Response> transportAction = actions.get(action);
+        TransportAction<Request, Response> transportAction = actions.get((ClientAction)action);
         return transportAction.execute(request);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> void execute(Action<Request, Response, RequestBuilder, Client> action, Request request, ActionListener<Response> listener) {
-        TransportAction<Request, Response> transportAction = actions.get(action);
+        TransportAction<Request, Response> transportAction = actions.get((ClientAction)action);
         transportAction.execute(request, listener);
     }
 }

--- a/src/main/java/org/elasticsearch/client/node/NodeClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/node/NodeClusterAdminClient.java
@@ -27,7 +27,6 @@ import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.support.AbstractClusterAdminClient;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Map;
@@ -42,7 +41,7 @@ public class NodeClusterAdminClient extends AbstractClusterAdminClient implement
     private final ImmutableMap<ClusterAction, TransportAction> actions;
 
     @Inject
-    public NodeClusterAdminClient(Settings settings, ThreadPool threadPool, Map<GenericAction, TransportAction> actions) {
+    public NodeClusterAdminClient(ThreadPool threadPool, Map<GenericAction, TransportAction> actions) {
         this.threadPool = threadPool;
         MapBuilder<ClusterAction, TransportAction> actionsBuilder = new MapBuilder<>();
         for (Map.Entry<GenericAction, TransportAction> entry : actions.entrySet()) {
@@ -61,14 +60,14 @@ public class NodeClusterAdminClient extends AbstractClusterAdminClient implement
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
-        TransportAction<Request, Response> transportAction = actions.get(action);
+        TransportAction<Request, Response> transportAction = actions.get((ClusterAction)action);
         return transportAction.execute(request);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> void execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request, ActionListener<Response> listener) {
-        TransportAction<Request, Response> transportAction = actions.get(action);
+        TransportAction<Request, Response> transportAction = actions.get((ClusterAction)action);
         transportAction.execute(request, listener);
     }
 }

--- a/src/main/java/org/elasticsearch/client/node/NodeIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/node/NodeIndicesAdminClient.java
@@ -27,7 +27,6 @@ import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.support.AbstractIndicesAdminClient;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Map;
@@ -39,15 +38,15 @@ public class NodeIndicesAdminClient extends AbstractIndicesAdminClient implement
 
     private final ThreadPool threadPool;
 
-    private final ImmutableMap<Action, TransportAction> actions;
+    private final ImmutableMap<IndicesAction, TransportAction> actions;
 
     @Inject
-    public NodeIndicesAdminClient(Settings settings, ThreadPool threadPool, Map<GenericAction, TransportAction> actions) {
+    public NodeIndicesAdminClient(ThreadPool threadPool, Map<GenericAction, TransportAction> actions) {
         this.threadPool = threadPool;
-        MapBuilder<Action, TransportAction> actionsBuilder = new MapBuilder<>();
+        MapBuilder<IndicesAction, TransportAction> actionsBuilder = new MapBuilder<>();
         for (Map.Entry<GenericAction, TransportAction> entry : actions.entrySet()) {
             if (entry.getKey() instanceof IndicesAction) {
-                actionsBuilder.put((Action) entry.getKey(), entry.getValue());
+                actionsBuilder.put((IndicesAction) entry.getKey(), entry.getValue());
             }
         }
         this.actions = actionsBuilder.immutableMap();
@@ -61,14 +60,14 @@ public class NodeIndicesAdminClient extends AbstractIndicesAdminClient implement
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
-        TransportAction<Request, Response> transportAction = actions.get(action);
+        TransportAction<Request, Response> transportAction = actions.get((IndicesAction)action);
         return transportAction.execute(request);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> void execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request, ActionListener<Response> listener) {
-        TransportAction<Request, Response> transportAction = actions.get(action);
+        TransportAction<Request, Response> transportAction = actions.get((IndicesAction)action);
         transportAction.execute(request, listener);
     }
 }


### PR DESCRIPTION
After #6517 we ended up registering all of the actions (included admin ones) to the NodeClient. 
Made sure that only the proper type of `Action` instances are registered to each client type.
Also fixed some compiler warnings: unused members, imports and non matching generic types.
