### PR TITLE
Match query with operator and, cutoff_frequency and stacked tokens

### DIFF
--- a/docs/reference/query-dsl/queries/match-query.asciidoc
+++ b/docs/reference/query-dsl/queries/match-query.asciidoc
@@ -98,13 +98,6 @@ The `cutoff_frequency` can either be relative to the number of documents
 in the index if in the range `[0..1)` or absolute if greater or equal to
 `1.0`.
 
-Note: If the `cutoff_frequency` is used and the operator is `and`
-_stacked tokens_ (tokens that are on the same position like `synonym` filter emits)
-are not handled gracefully as they are in a pure `and` query. For instance the query
-`fast fox` is analyzed into 3 terms `[fast, quick, fox]` where `quick` is a synonym
-for `fast` on the same token positions the query might require `fast` and `quick` to
-match if the operator is `and`.
-
 Here is an example showing a query composed of stopwords exclusivly:
 
 [source,js]

--- a/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -279,7 +279,7 @@ public class MatchQuery {
         }
 
         public Query createCommonTermsQuery(String field, String queryText, Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency, FieldMapper<?> mapper) {
-            Query booleanQuery = createBooleanQuery(field, queryText, Occur.SHOULD);
+            Query booleanQuery = createBooleanQuery(field, queryText, lowFreqOccur);
             if (booleanQuery != null && booleanQuery instanceof BooleanQuery) {
                 BooleanQuery bq = (BooleanQuery) booleanQuery;
                 ExtendedCommonTermsQuery query = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, maxTermFrequency, ((BooleanQuery)booleanQuery).isCoordDisabled(), mapper);


### PR DESCRIPTION
If the match query with cutoff_frequency encounters stacked tokens,
like synonyms in the same position, it returns a boolean query instead
of a common terms query.  However, if the original operator was set
to "and", it was ignoring that and resetting the operator to "or".

In fact, if operator is "and" then there is little benefit in using
a common terms query as a must query is already
executed efficiently.

Fixed by https://github.com/elasticsearch/elasticsearch/commit/30c80319c05362fae49fdfe5d6422c59f942f0db
