### PR TITLE
Boostrap: Log startup exception to console if needed and to file as error

### DIFF
--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -243,9 +243,8 @@ public class Bootstrap {
                 logger.error(errorMessage);
             }
             Loggers.disableConsoleLogging();
-            if (logger.isDebugEnabled()) {
-                logger.debug("Exception", e);
-            }
+            logger.error("Exception", e);
+            
             System.exit(3);
         }
     }

--- a/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -239,10 +239,8 @@ public class Bootstrap {
             if (foreground) {
                 System.err.println(errorMessage);
                 System.err.flush();
-            } else {
-                logger.error(errorMessage);
+                Loggers.disableConsoleLogging();
             }
-            Loggers.disableConsoleLogging();
             logger.error("Exception", e);
             
             System.exit(3);


### PR DESCRIPTION
We ran into an issue with one of our data nodes which would quit immediately upon starting the service. Looking at every log there was nothing informative. We turned the log up to DEBUG and an exception came out:

```
[2014-06-20 14:48:00,502][DEBUG][bootstrap                ] Exception
org.elasticsearch.ElasticsearchIllegalStateException: Failed to obtain node lock, is the following location writable?: [/usr/local/var/data/elasticsearch/contacts-search-new]
    at org.elasticsearch.env.NodeEnvironment.<init>(NodeEnvironment.java:114)
    at org.elasticsearch.node.internal.InternalNode.<init>(InternalNode.java:150)
    at org.elasticsearch.node.NodeBuilder.build(NodeBuilder.java:159)
    at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:68)
    at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:201)
    at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:32)
```

It's helpful to have all exceptions printing to `ERROR` level logging or at least `WARN`. But in the case where `Bootstrap.java` is going to quit the JVM, the reason for doing so should be at `ERROR` level so it's clear to the developer what is going wrong.
