### PR TITLE
Add a transformer to translate constant BigDecimal to double

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -391,16 +391,6 @@ or underflow.
 |=======================================================================
 
 [float]
-=== Floating point numbers in Groovy
-
-When using floating-point literals in Groovy scripts, Groovy will automatically
-use BigDecimal instead of a floating point equivalent to support the
-'least-surprising' approach to literal math operations. To use a floating-point
-number instead, use the specific suffix on the number (ie, instead of 1.2, use
-1.2f). See the http://groovy.codehaus.org/Groovy+Math[Groovy Math] page for more
-information.
-
-[float]
 === Arithmetic precision in MVEL
 
 When dividing two numbers using MVEL based scripts, the engine tries to

--- a/src/main/java/org/elasticsearch/script/groovy/GroovySandboxExpressionChecker.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovySandboxExpressionChecker.java
@@ -81,6 +81,7 @@ public class GroovySandboxExpressionChecker implements SecureASTCustomizer.Expre
             java.util.HashMap.class.getName(),
             java.util.HashSet.class.getName(),
             java.util.UUID.class.getName(),
+            java.math.BigDecimal.class.getName(),
             org.joda.time.DateTime.class.getName(),
             org.joda.time.DateTimeZone.class.getName()
     };

--- a/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+
+/**
+ * Various tests for Groovy scripting
+ */
+public class GroovyScriptTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testGroovyBigDecimalTransformation() {
+        client().prepareIndex("test", "doc", "1").setSource("foo", 5).setRefresh(true).get();
+
+        // Test that something that would usually be a BigDecimal is transformed into a Double
+        assertScript("def n = 1.23; assert n instanceof Double;");
+        assertScript("def n = 1.23G; assert n instanceof Double;");
+        assertScript("def n = BigDecimal.ONE; assert n instanceof BigDecimal;");
+    }
+
+    public void assertScript(String script) {
+        SearchResponse resp = client().prepareSearch("test")
+                .setSource("{\"query\": {\"match_all\": {}}," +
+                        "\"sort\":{\"_script\": {\"script\": \""+ script +
+                        "; 1\", \"type\": \"number\", \"lang\": \"groovy\"}}}").get();
+        assertNoFailures(resp);
+    }
+}


### PR DESCRIPTION
This means the constant `1.42` will be compiled using a double instead of Groovy's default BigDecimal without having to add a `f` suffix.
