### PR TITLE
Docs: Added field data circuit breaker settings

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -220,3 +220,13 @@ All the disable allocation settings have been deprecated in favour for
 
 Logger values can also be updated by setting `logger.` prefix. More
 settings will be allowed to be updated.
+
+[float]
+=== Field data circuit breaker
+
+`indices.fielddata.breaker.limit`::
+     See <<index-modules-fielddata>>
+
+`indices.fielddata.breaker.overhead`::
+     See <<index-modules-fielddata>>
+


### PR DESCRIPTION
Added field data circuit breaker settings to list of update-able properties by the cluster update api.
