### PR TITLE
Test: Change es.node.mode default for tests to `local`

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -20,13 +20,13 @@ mvn clean package -DskipTests
 
 To disable and enable network transport, set the `Des.node.mode`.
 
-Use network transport (default):
+Use network transport:
 
 ------------------------------------
 -Des.node.mode=network
 ------------------------------------
 
-Use local transport:
+Use local transport (default since 1.3):
 
 -------------------------------------
 -Des.node.mode=local

--- a/src/main/java/org/elasticsearch/common/Strings.java
+++ b/src/main/java/org/elasticsearch/common/Strings.java
@@ -219,6 +219,25 @@ public class Strings {
         return hasLength((CharSequence) str);
     }
 
+
+    /**
+     * Check that the given CharSequence is either <code>null</code> or of length 0.
+     * Note: Will return <code>false</code> for a CharSequence that purely consists of whitespace.
+     * <p><pre>
+     * StringUtils.isEmpty(null) = true
+     * StringUtils.isEmpty("") = true
+     * StringUtils.isEmpty(" ") = false
+     * StringUtils.isEmpty("Hello") = false
+     * </pre>
+     *
+     * @param str the CharSequence to check (may be <code>null</code>)
+     * @return <code>true</code> if the CharSequence is either null or has a zero length
+     */
+    public static boolean isEmpty(CharSequence str) {
+        return !hasLength(str);
+    }
+
+
     /**
      * Check whether the given CharSequence has actual text.
      * More specifically, returns <code>true</code> if the string not <code>null</code>,

--- a/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
+++ b/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
@@ -31,6 +31,7 @@ import com.carrotsearch.randomizedtesting.rules.NoInstanceHooksOverridesRule;
 import com.carrotsearch.randomizedtesting.rules.StaticFieldsInvariantRule;
 import com.carrotsearch.randomizedtesting.rules.SystemPropertiesInvariantRule;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -401,6 +402,15 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
      */
     public String getTestName() {
         return threadAndTestNameRule.testMethodName;
+    }
+
+    static {
+        String nodeLocal = System.getProperty("es.node.mode", System.getProperty("es.node.local", ""));
+        if (Strings.isEmpty(nodeLocal)) {
+            // we default to local mode to speed up tests running in IDEs etc.
+            // compared to a mvn default value this will also work if executed from an IDE.
+            System.setProperty("es.node.mode", "local");
+        }
     }
 
 }


### PR DESCRIPTION
In order to speed up test execution we should run in local mode by
default. CI builds will still use network builds all the time.
