### PR TITLE
Scripting: Wrap groovy script exceptions in a serializable Exception object

### DIFF
--- a/src/main/java/org/elasticsearch/script/groovy/GroovyScriptCompilationException.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovyScriptCompilationException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script.groovy;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ * Exception used to wrap groovy script compilation exceptions so they are
+ * correctly serialized between nodes.
+ */
+public class GroovyScriptCompilationException extends ElasticsearchException {
+    public GroovyScriptCompilationException(String message) {
+        super(message);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/org/elasticsearch/script/groovy/GroovyScriptExecutionException.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovyScriptExecutionException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script.groovy;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ * Exception used to wrap groovy script execution exceptions so they are
+ * correctly serialized between nodes.
+ */
+public class GroovyScriptExecutionException extends ElasticsearchException {
+    public GroovyScriptExecutionException(String message) {
+        super(message);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+}

--- a/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
+++ b/src/test/java/org/elasticsearch/script/GroovyScriptTests.java
@@ -19,11 +19,20 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.elasticsearch.index.query.FilterBuilders.scriptFilter;
+import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Various tests for Groovy scripting
@@ -46,5 +55,51 @@ public class GroovyScriptTests extends ElasticsearchIntegrationTest {
                         "\"sort\":{\"_script\": {\"script\": \""+ script +
                         "; 1\", \"type\": \"number\", \"lang\": \"groovy\"}}}").get();
         assertNoFailures(resp);
+    }
+
+    @Test
+    public void testGroovyExceptionSerialization() throws Exception {
+        List<IndexRequestBuilder> reqs = newArrayList();
+        for (int i = 0; i < randomIntBetween(50, 500); i++) {
+            reqs.add(client().prepareIndex("test", "doc", "" + i).setSource("foo", "bar"));
+        }
+        indexRandom(true, false, reqs);
+        try {
+            client().prepareSearch("test").setQuery(constantScoreQuery(scriptFilter("1 == not_found").lang("groovy"))).get();
+            fail("should have thrown an exception");
+        } catch (SearchPhaseExecutionException e) {
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should not contained NotSerializableTransportException",
+                    ExceptionsHelper.detailedMessage(e).contains("NotSerializableTransportException"), equalTo(false));
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should have contained GroovyScriptExecutionException",
+                    ExceptionsHelper.detailedMessage(e).contains("GroovyScriptExecutionException"), equalTo(true));
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should have contained not_found",
+                    ExceptionsHelper.detailedMessage(e).contains("No such property: not_found"), equalTo(true));
+        }
+
+        try {
+            client().prepareSearch("test").setQuery(constantScoreQuery(
+                    scriptFilter("pr = Runtime.getRuntime().exec(\"touch /tmp/gotcha\"); pr.waitFor()").lang("groovy"))).get();
+            fail("should have thrown an exception");
+        } catch (SearchPhaseExecutionException e) {
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should not contained NotSerializableTransportException",
+                    ExceptionsHelper.detailedMessage(e).contains("NotSerializableTransportException"), equalTo(false));
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should have contained GroovyScriptCompilationException",
+                    ExceptionsHelper.detailedMessage(e).contains("GroovyScriptCompilationException"), equalTo(true));
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should have contained Method calls not allowed on [java.lang.Runtime]",
+                    ExceptionsHelper.detailedMessage(e).contains("Method calls not allowed on [java.lang.Runtime]"), equalTo(true));
+        }
+
+        try {
+            client().prepareSearch("test").setQuery(constantScoreQuery(
+                    scriptFilter("assert false").lang("groovy"))).get();
+            fail("should have thrown an exception");
+        } catch (SearchPhaseExecutionException e) {
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should not contained NotSerializableTransportException",
+                    ExceptionsHelper.detailedMessage(e).contains("NotSerializableTransportException"), equalTo(false));
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should have contained GroovyScriptExecutionException",
+                    ExceptionsHelper.detailedMessage(e).contains("GroovyScriptExecutionException"), equalTo(true));
+            assertThat(ExceptionsHelper.detailedMessage(e) + "should have contained an assert error",
+                    ExceptionsHelper.detailedMessage(e).contains("PowerAssertionError[assert false"), equalTo(true));
+        }
     }
 }


### PR DESCRIPTION
Fixes #6598

It prevents ES from trying to serialize the default Groovy exceptions, which want to carry over a lot of state that doesn't  serialize properly.
