### PR TITLE
Thread pool rejection status code should be 429

### DIFF
--- a/src/main/java/org/elasticsearch/common/util/concurrent/EsRejectedExecutionException.java
+++ b/src/main/java/org/elasticsearch/common/util/concurrent/EsRejectedExecutionException.java
@@ -40,6 +40,6 @@ public class EsRejectedExecutionException extends ElasticsearchException {
 
     @Override
     public RestStatus status() {
-        return RestStatus.SERVICE_UNAVAILABLE;
+        return RestStatus.TOO_MANY_REQUESTS;
     }
 }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -185,6 +185,8 @@ public class NettyHttpChannel extends HttpChannel {
         }
     }
 
+    private static final HttpResponseStatus TOO_MANY_REQUESTS = new HttpResponseStatus(429, "Too Many Requests");
+
     private HttpResponseStatus getStatus(RestStatus status) {
         switch (status) {
             case CONTINUE:
@@ -264,6 +266,8 @@ public class NettyHttpChannel extends HttpChannel {
                 return HttpResponseStatus.BAD_REQUEST;
             case FAILED_DEPENDENCY:
                 return HttpResponseStatus.BAD_REQUEST;
+            case TOO_MANY_REQUESTS:
+                return TOO_MANY_REQUESTS;
             case INTERNAL_SERVER_ERROR:
                 return HttpResponseStatus.INTERNAL_SERVER_ERROR;
             case NOT_IMPLEMENTED:

--- a/src/main/java/org/elasticsearch/rest/RestStatus.java
+++ b/src/main/java/org/elasticsearch/rest/RestStatus.java
@@ -429,6 +429,10 @@ public enum RestStatus {
      */
     FAILED_DEPENDENCY(424),
     /**
+     * 429 Too Many Requests (RFC6585)
+     */
+    TOO_MANY_REQUESTS(429),
+    /**
      * The server encountered an unexpected condition which prevented it from fulfilling the request.
      */
     INTERNAL_SERVER_ERROR(500),


### PR DESCRIPTION
Thread rejection should return too many requests status code, and not 503, which is used to also show that the cluster is not available
 relates to #6627, but only for rejections for now
