### PR TITLE
Fix return of wrong request type on failed updates

### DIFF
--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -315,7 +315,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
                                         } else {
                                             logger.debug("[{}][{}] failed to execute bulk item (index) {}", t, shardRequest.request.index(), shardRequest.shardId, indexRequest);
                                         }
-                                        responses[requestIndex] = new BulkItemResponse(item.id(), indexRequest.opType().lowercase(),
+                                        responses[requestIndex] = new BulkItemResponse(item.id(), "update",
                                                 new BulkItemResponse.Failure(indexRequest.index(), indexRequest.type(), indexRequest.id(), t));
                                         break;
                                     case DELETE:

--- a/src/test/java/org/elasticsearch/document/BulkTests.java
+++ b/src/test/java/org/elasticsearch/document/BulkTests.java
@@ -23,9 +23,12 @@ import com.google.common.base.Charsets;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -595,6 +598,36 @@ public class BulkTests extends ElasticsearchIntegrationTest {
         for (int i = 0; i < bulkEntryCount; i++) {
             assertThat(bulkResponse.getItems()[i].isFailed(), is(expectedFailures[i]));
         }
+    }
+
+    @Test // issue 6630
+    public void testThatFailedUpdateRequestReturnsCorrectType() throws Exception {
+        BulkResponse indexBulkItemResponse = client().prepareBulk()
+                .add(new IndexRequest("test", "type", "3").source("{ \"title\" : \"Great Title of doc 3\" }"))
+                .add(new IndexRequest("test", "type", "4").source("{ \"title\" : \"Great Title of doc 4\" }"))
+                .add(new IndexRequest("test", "type", "5").source("{ \"title\" : \"Great Title of doc 5\" }"))
+                .add(new IndexRequest("test", "type", "6").source("{ \"title\" : \"Great Title of doc 6\" }"))
+                .setRefresh(true)
+                .get();
+        assertNoFailures(indexBulkItemResponse);
+
+        BulkResponse bulkItemResponse = client().prepareBulk()
+                .add(new IndexRequest("test", "type", "1").source("{ \"title\" : \"Great Title of doc 1\" }"))
+                .add(new IndexRequest("test", "type", "2").source("{ \"title\" : \"Great Title of doc 2\" }"))
+                .add(new UpdateRequest("test", "type", "3").doc("{ \"date\" : \"2014-01-30T23:59:57\"}"))
+                .add(new UpdateRequest("test", "type", "4").doc("{ \"date\" : \"2014-13-30T23:59:57\"}"))
+                .add(new DeleteRequest("test", "type", "5"))
+                .add(new DeleteRequest("test", "type", "6"))
+        .get();
+
+        assertNoFailures(indexBulkItemResponse);
+        assertThat(bulkItemResponse.getItems().length, is(6));
+        assertThat(bulkItemResponse.getItems()[0].getOpType(), is("index"));
+        assertThat(bulkItemResponse.getItems()[1].getOpType(), is("index"));
+        assertThat(bulkItemResponse.getItems()[2].getOpType(), is("update"));
+        assertThat(bulkItemResponse.getItems()[3].getOpType(), is("update"));
+        assertThat(bulkItemResponse.getItems()[4].getOpType(), is("delete"));
+        assertThat(bulkItemResponse.getItems()[5].getOpType(), is("delete"));
     }
 }
 


### PR DESCRIPTION
In case an update request failed (for example when updating with a
wrongly formatted date), the returned index operation type was index
instead of update.

Closes #6630
