### PR TITLE
Fix possible race condition in checksum name generator

### DIFF
--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -224,8 +224,9 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
     public void writeChecksums() throws IOException {
         ensureOpen();
         ImmutableMap<String, StoreFileMetaData> files = list();
-        String checksumName = CHECKSUMS_PREFIX + System.currentTimeMillis();
+        String checksumName;
         synchronized (mutex) {
+            checksumName = CHECKSUMS_PREFIX + System.currentTimeMillis();
             Map<String, String> checksums = new HashMap<>();
             for (StoreFileMetaData metaData : files.values()) {
                 if (metaData.checksum() != null) {


### PR DESCRIPTION
When three threads are trying to write checksums at the same time, it's possible for all three threads to obtain the same checksum file name A. Then the first thread enters the synchronized section, creates the file with name A and exits. The second thread enters the synchronized section, checks that A exists, creates file A+1 and exits the critical section. Then it proceeds to clean up  and deletes all checksum files including A. If it happens before the third thread enters the synchronized section, it's possible for the third thread to check for A and since it no longer exists create the checksum file A the second time, which triggers "file _checksums-XXXXXXXXXXXXX was already written to" exception in MockDirectoryWrapper and fails recovery.
