### PR TITLE
Test: Prevent usage of System Properties in the InternalTestCluster

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -184,14 +184,14 @@ To run backwards compatibiilty tests untar or unzip a release and run the tests
 with the following command:
 
 ---------------------------------------------------------------------------
-mvn test -Dtests.bwc=true -Dtests.bwc.version=x.y.z -Dtests.bwc.path=/path/to/elasticsearch -Des.node.mode=network
+mvn test -Dtests.bwc=true -Dtests.bwc.version=x.y.z -Dtests.bwc.path=/path/to/elasticsearch 
 ---------------------------------------------------------------------------
 
 If the elasticsearch release is placed under `./backwards/elasticsearch-x.y.z` the path
 can be omitted:
  
 ---------------------------------------------------------------------------
-mvn test -Dtests.bwc=true -Dtests.bwc.version=x.y.z -Des.node.mode=network
+mvn test -Dtests.bwc=true -Dtests.bwc.version=x.y.z 
 ---------------------------------------------------------------------------
 
 To setup the bwc test environment execute the following steps (provided you are

--- a/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
+++ b/src/test/java/org/apache/lucene/util/AbstractRandomizedTest.java
@@ -403,14 +403,4 @@ public abstract class AbstractRandomizedTest extends RandomizedTest {
     public String getTestName() {
         return threadAndTestNameRule.testMethodName;
     }
-
-    static {
-        String nodeLocal = System.getProperty("es.node.mode", System.getProperty("es.node.local", ""));
-        if (Strings.isEmpty(nodeLocal)) {
-            // we default to local mode to speed up tests running in IDEs etc.
-            // compared to a mvn default value this will also work if executed from an IDE.
-            System.setProperty("es.node.mode", "local");
-        }
-    }
-
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
@@ -110,6 +110,7 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
         return ImmutableSettings.builder()
                 .put(TransportModule.TRANSPORT_TYPE_KEY, NettyTransportModule.class) // run same transport  / disco as external
                 .put(DiscoveryModule.DISCOVERY_TYPE_KEY, ZenDiscoveryModule.class)
+                .put("node.mode", "network") // we need network mode for this
                 .put("gateway.type", "local") // we require local gateway to mimic upgrades of nodes
                 .put("discovery.type", "zen") // zen is needed since we start external nodes
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, TransportService.class.getName())

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -90,6 +90,7 @@ final class ExternalNode implements Closeable {
                 case "path.home":
                 case "node.mode":
                 case "gateway.type":
+                case "config.ignore_system_properties":
                     continue;
                 default:
                     params.add("-Des." + entry.getKey() + "=" + entry.getValue());

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -51,7 +51,9 @@ public final class ExternalTestCluster extends TestCluster {
     private final int numBenchNodes;
 
     public ExternalTestCluster(TransportAddress... transportAddresses) {
-        this.client = new TransportClient(ImmutableSettings.settingsBuilder().put("client.transport.ignore_cluster_name", true))
+        this.client = new TransportClient(ImmutableSettings.settingsBuilder()
+                .put("client.transport.ignore_cluster_name", true)
+                .put("node.mode", "network")) // we require network here!
                 .addTransportAddresses(transportAddresses);
 
         NodesInfoResponse nodeInfos = this.client.admin().cluster().prepareNodesInfo().clear().setSettings(true).setHttp(true).get();

--- a/src/test/java/org/elasticsearch/tribe/TribeTests.java
+++ b/src/test/java/org/elasticsearch/tribe/TribeTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.tribe;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -40,6 +41,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -92,12 +94,22 @@ public class TribeTests extends ElasticsearchIntegrationTest {
     }
 
     private void setupTribeNode(Settings settings) {
+        ImmutableMap<String,String> asMap = internalCluster().getDefaultSettings().getAsMap();
+        ImmutableSettings.Builder tribe1Defaults = ImmutableSettings.builder();
+        ImmutableSettings.Builder tribe2Defaults = ImmutableSettings.builder();
+        for (Map.Entry<String, String> entry : asMap.entrySet()) {
+            tribe1Defaults.put("tribe.t1." + entry.getKey(), entry.getValue());
+            tribe2Defaults.put("tribe.t2." + entry.getKey(), entry.getValue());
+        }
         Settings merged = ImmutableSettings.builder()
                 .put("tribe.t1.cluster.name", internalCluster().getClusterName())
                 .put("tribe.t2.cluster.name", cluster2.getClusterName())
                 .put("tribe.blocks.write", false)
                 .put("tribe.blocks.read", false)
                 .put(settings)
+                .put(tribe1Defaults.build())
+                .put(tribe2Defaults.build())
+                .put(internalCluster().getDefaultSettings())
                 .build();
 
         tribeNode = NodeBuilder.nodeBuilder()


### PR DESCRIPTION
All settings should be passes as settings and the enviroment should not
influence the test cluster settings. The settings we care about ie.
`es.node.mode` and `es.logger.level` should be passed via settings.
This allows tests to override these settings if they for instance need
`network` transport to operate at all.
