### PR TITLE
IndexingMemoryController should only update buffer settings of fully recovered shards

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -19,19 +19,7 @@
 
 package org.elasticsearch.index.engine.internal;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
+import com.google.common.collect.Lists;
 import org.apache.lucene.index.*;
 import org.apache.lucene.index.IndexWriter.IndexReaderWarmer;
 import org.apache.lucene.search.IndexSearcher;
@@ -40,7 +28,6 @@ import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.LockObtainFailedException;
-import org.apache.lucene.store.NoLockFactory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
@@ -53,7 +40,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.LoggerInfoStream;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.SegmentReaderUtils;
@@ -64,7 +50,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.codec.CodecService;
@@ -89,7 +74,18 @@ import org.elasticsearch.index.translog.TranslogStreams;
 import org.elasticsearch.indices.warmer.IndicesWarmer;
 import org.elasticsearch.indices.warmer.InternalIndicesWarmer;
 import org.elasticsearch.threadpool.ThreadPool;
-import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  *
@@ -312,6 +308,11 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     @Override
     public TimeValue defaultRefreshInterval() {
         return new TimeValue(1, TimeUnit.SECONDS);
+    }
+
+
+    public ByteSizeValue indexingBufferSize() {
+        return indexingBufferSize;
     }
 
     @Override
@@ -1566,11 +1567,11 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
         @Override
         public void beforeMerge(OnGoingMerge merge) {
-          if (numMergesInFlight.incrementAndGet() > maxNumMerges) {
-              if (isThrottling.getAndSet(true) == false) {
-                  logger.info("now throttling indexing: numMergesInFlight={}, maxNumMerges={}", numMergesInFlight, maxNumMerges);
-              }
-              lock = lockReference;
+            if (numMergesInFlight.incrementAndGet() > maxNumMerges) {
+                if (isThrottling.getAndSet(true) == false) {
+                    logger.info("now throttling indexing: numMergesInFlight={}, maxNumMerges={}", numMergesInFlight, maxNumMerges);
+                }
+                lock = lockReference;
             }
         }
 
@@ -1588,7 +1589,8 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     private static final class NoOpLock implements Lock {
 
         @Override
-        public void lock() {}
+        public void lock() {
+        }
 
         @Override
         public void lockInterruptibly() throws InterruptedException {

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -310,7 +310,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
         return new TimeValue(1, TimeUnit.SECONDS);
     }
 
-
+    /** return the current indexing buffer size setting * */
     public ByteSizeValue indexingBufferSize() {
         return indexingBufferSize;
     }

--- a/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -152,6 +152,10 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
     protected void doClose() throws ElasticsearchException {
     }
 
+    /**
+     * returns the current budget for the total amount of indexing buffers of
+     * active shards on this node
+     */
     public ByteSizeValue indexingBufferSize() {
         return indexingBuffer;
     }

--- a/src/test/java/org/elasticsearch/indices/memory/IndexMemoryControllerTests.java
+++ b/src/test/java/org/elasticsearch/indices/memory/IndexMemoryControllerTests.java
@@ -35,7 +35,6 @@ public class IndexMemoryControllerTests extends ElasticsearchIntegrationTest {
     public void testIndexBufferSizeUpdateAfterShardCreation() throws InterruptedException {
 
         internalCluster().startNode(ImmutableSettings.builder()
-                        .put("gateway.type", "local")
                         .put("http.enabled", "false")
                         .put("discovery.type", "local")
                         .put("indices.memory.interval", "1s")

--- a/src/test/java/org/elasticsearch/indices/memory/IndexMemoryControllerTests.java
+++ b/src/test/java/org/elasticsearch/indices/memory/IndexMemoryControllerTests.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.memory;
+
+import com.google.common.base.Predicate;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.index.engine.internal.InternalEngine;
+import org.elasticsearch.index.shard.service.InternalIndexShard;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 0)
+public class IndexMemoryControllerTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testIndexBufferSizeUpdateAfterShardCreation() throws InterruptedException {
+
+        internalCluster().startNode(ImmutableSettings.builder()
+                        .put("gateway.type", "local")
+                        .put("http.enabled", "false")
+                        .put("discovery.type", "local")
+                        .put("indices.memory.interval", "1s")
+        );
+
+        client().admin().indices().prepareCreate("test1")
+                .setSettings(ImmutableSettings.builder()
+                                .put("number_of_shards", 1)
+                                .put("number_of_replicas", 0)
+                ).get();
+
+        ensureGreen();
+
+        final InternalIndexShard shard1 = (InternalIndexShard) internalCluster().getInstance(IndicesService.class).indexService("test1").shard(0);
+
+        client().admin().indices().prepareCreate("test2")
+                .setSettings(ImmutableSettings.builder()
+                                .put("number_of_shards", 1)
+                                .put("number_of_replicas", 0)
+                ).get();
+
+        ensureGreen();
+
+        final InternalIndexShard shard2 = (InternalIndexShard) internalCluster().getInstance(IndicesService.class).indexService("test2").shard(0);
+        final long expectedShardSize = internalCluster().getInstance(IndexingMemoryController.class).indexingBufferSize().bytes() / 2;
+
+        boolean success = awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                return ((InternalEngine) shard1.engine()).indexingBufferSize().bytes() <= expectedShardSize &&
+                        ((InternalEngine) shard2.engine()).indexingBufferSize().bytes() <= expectedShardSize;
+            }
+        });
+
+        if (!success) {
+            fail("failed to update shard indexing buffer size. expected [" + expectedShardSize + "] shard1 [" +
+                            ((InternalEngine) shard1.engine()).indexingBufferSize().bytes() + "] shard2  [" +
+                            ((InternalEngine) shard1.engine()).indexingBufferSize().bytes() + "]"
+            );
+        }
+
+    }
+}


### PR DESCRIPTION
At the moment the IndexingMemoryController can try to update the index buffer memory of shards at any give moment. This update involves a flush, which may cause a FlushNotAllowedEngineException to be thrown in a concurrently finalizing recovery.

Closes #6642
