### PR TITLE
Handle ConnectionTransportException during a Master/Node fault detection ping during Discovery

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -228,15 +228,17 @@ public class NodesFaultDetection extends AbstractComponent {
                             if (!running) {
                                 return;
                             }
-                            if (exp instanceof ConnectTransportException) {
-                                // ignore this one, we already handle it by registering a connection listener
-                                return;
-                            }
                             NodeFD nodeFD = nodesFD.get(node);
                             if (nodeFD != null) {
                                 if (!nodeFD.running) {
                                     return;
                                 }
+                                if (exp instanceof ConnectTransportException) {
+                                    // ignore this one, we already handle it by registering a connection listener
+                                    handleTransportDisconnect(node);
+                                    return;
+                                }
+
                                 int retryCount = ++nodeFD.retryCount;
                                 logger.trace("[node  ] failed to ping [{}], retry [{}] out of [{}]", exp, node, retryCount, pingRetryCount);
                                 if (retryCount >= pingRetryCount) {


### PR DESCRIPTION
Both the Master and Node fault detection register themselves to be notified when a node disconnects to be able to respond to it accordingly. As such, when a ConnectionTransportException was raised on a ping request, it was not handled as it is already handled somewhere else. However, this does introduce a racing condition, if the disconnect  happen during a period where there is no current master (minimum_master_node breach) at which time the fault detection is not active. In this case, we will only discover the disconnect error during the ping request, so we have to respond accordingly.
