### PR TITLE
Test: Take compatibility version into account for XContentType randomization

### DIFF
--- a/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -40,7 +41,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
-@ElasticsearchIntegrationTest.CompatibilityVersion(version = Version.V_1_2_0_ID) // we throw an exception if we create an index with _field_names that is 1.3
+@ElasticsearchTestCase.CompatibilityVersion(version = Version.V_1_2_0_ID) // we throw an exception if we create an index with _field_names that is 1.3
 public class PreBuiltAnalyzerIntegrationTests extends ElasticsearchIntegrationTest {
 
     @Override

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -189,13 +189,6 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     public static final String SETTING_INDEX_SEED = "index.tests.seed";
 
     /**
-     * Property that allows to adapt the tests behaviour to older features/bugs based on the input version
-     */
-    public static final String TESTS_COMPATIBILITY = "tests.compatibility";
-
-    private static final Version COMPATIBILITY_VERSION = Version.fromString(compatibilityVersionProperty());
-
-    /**
      * Threshold at which indexing switches from frequently async to frequently bulk.
      */
     private static final int FREQUENT_BULK_THRESHOLD = 300;
@@ -267,7 +260,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
             } else {
                 long masterSeed = SeedUtils.parseSeed(RandomizedContext.current().getRunnerSeedAsString());
                 int numClientNodes;
-                if (COMPATIBILITY_VERSION.before(Version.V_1_2_0)) {
+                if (globalCompatibilityVersion().before(Version.V_1_2_0)) {
                     numClientNodes = 0;
                 } else {
                     numClientNodes = InternalTestCluster.DEFAULT_NUM_CLIENT_NODES;
@@ -1651,44 +1644,4 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     @Ignore
     public @interface SuiteScopeTest {
     }
-
-
-    /**
-     * If a test is annotated with {@link org.elasticsearch.test.ElasticsearchIntegrationTest.CompatibilityVersion}
-     * all randomized settings will only contain settings or mappings which are compatible with the specified version ID.
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.TYPE})
-    @Ignore
-    public @interface CompatibilityVersion {
-        int version();
-    }
-
-    /**
-     * Retruns the tests compatibility version.
-     */
-    public Version compatibilityVersion() {
-        return compatibiltyVersion(getClass());
-    }
-
-    private Version compatibiltyVersion(Class<?> clazz) {
-        if (clazz == Object.class || clazz == ElasticsearchIntegrationTest.class) {
-            return COMPATIBILITY_VERSION;
-        }
-        CompatibilityVersion annotation = clazz.getAnnotation(CompatibilityVersion.class);
-        if (annotation != null) {
-            return  Version.smallest(Version.fromId(annotation.version()), COMPATIBILITY_VERSION);
-        }
-        return compatibiltyVersion(clazz.getSuperclass());
-    }
-
-    private static String compatibilityVersionProperty() {
-        final String version = System.getProperty(TESTS_COMPATIBILITY);
-        if (Strings.hasLength(version)) {
-            return version;
-        }
-        return System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_VERSION);
-    }
-
-
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchTestCase.java
@@ -42,10 +42,15 @@ import org.elasticsearch.test.store.MockDirectoryHelper;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.URI;
@@ -73,6 +78,13 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     public static final String TESTS_SECURITY_MANAGER = System.getProperty("tests.security.manager");
 
     public static final String JAVA_SECURTY_POLICY = System.getProperty("java.security.policy");
+
+    /**
+     * Property that allows to adapt the tests behaviour to older features/bugs based on the input version
+     */
+    private static final String TESTS_COMPATIBILITY = "tests.compatibility";
+
+    private static final Version GLOABL_COMPATIBILITY_VERSION = Version.fromString(compatibilityVersionProperty());
 
     public static final boolean ASSERTIONS_ENABLED;
     static {
@@ -165,7 +177,16 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     }
 
     private static XContentType randomXContentType() {
-        return randomFrom(XContentType.values());
+        if (globalCompatibilityVersion().onOrAfter(Version.V_1_2_0)) {
+            return randomFrom(XContentType.values());
+        } else {
+            // CBOR was added in 1.2.0 earlier version can't derive the format
+            XContentType type = randomFrom(XContentType.values());
+            while(type == XContentType.CBOR) {
+                type = randomFrom(XContentType.values());
+            }
+            return type;
+        }
     }
 
     @AfterClass
@@ -309,4 +330,54 @@ public abstract class ElasticsearchTestCase extends AbstractRandomizedTest {
     public static String[] generateRandomStringArray(int maxArraySize, int maxStringSize) {
         return generateRandomStringArray(maxArraySize, maxStringSize, false);
     }
+
+
+    /**
+     * If a test is annotated with {@link org.elasticsearch.test.ElasticsearchTestCase.CompatibilityVersion}
+     * all randomized settings will only contain settings or mappings which are compatible with the specified version ID.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    @Ignore
+    public @interface CompatibilityVersion {
+        int version();
+    }
+
+    /**
+     * Returns a global compatibility version that is set via the
+     * {@value #TESTS_COMPATIBILITY} or {@value #TESTS_BACKWARDS_COMPATIBILITY_VERSION} system property.
+     * If both are unset the current version is used as the global compatibility version. This
+     * compatibility version is used for static randomization. For per-suite compatibility version see
+     * {@link #compatibilityVersion()}
+     */
+    public static Version globalCompatibilityVersion() {
+        return GLOABL_COMPATIBILITY_VERSION;
+    }
+
+    /**
+     * Retruns the tests compatibility version.
+     */
+    public Version compatibilityVersion() {
+        return compatibiltyVersion(getClass());
+    }
+
+    private Version compatibiltyVersion(Class<?> clazz) {
+        if (clazz == Object.class || clazz == ElasticsearchIntegrationTest.class) {
+            return globalCompatibilityVersion();
+        }
+        CompatibilityVersion annotation = clazz.getAnnotation(CompatibilityVersion.class);
+        if (annotation != null) {
+            return  Version.smallest(Version.fromId(annotation.version()), compatibiltyVersion(clazz.getSuperclass()));
+        }
+        return compatibiltyVersion(clazz.getSuperclass());
+    }
+
+    private static String compatibilityVersionProperty() {
+        final String version = System.getProperty(TESTS_COMPATIBILITY);
+        if (Strings.hasLength(version)) {
+            return version;
+        }
+        return System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_VERSION);
+    }
+
 }


### PR DESCRIPTION
We randomize the XContentType to test deriving the content type on all
APIs. Yet, BWC tests run against versions where CBOR wasn't around
this commit ensures we don't use CBOR when compatibility version is
less than `1.2.0`
