### PR TITLE
[DOC] Regexp term clarification

### DIFF
--- a/docs/reference/query-dsl/queries/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/queries/regexp-query.asciidoc
@@ -3,6 +3,9 @@
 
 The `regexp` query allows you to use regular expression term queries.
 See <<regexp-syntax>> for details of the supported regular expression language.
+The "term queries" in that first sentence means that Elasticsearch will apply
+the regexp to the terms produced by the tokenizer for that field, and not
+to the original text of the field.
 
 *Note*: The performance of a `regexp` query heavily depends on the
 regular expression chosen. Matching everything like `.*` is very slow as

--- a/docs/reference/query-dsl/queries/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/queries/regexp-query.asciidoc
@@ -52,7 +52,7 @@ You can also use special flags
 
 Possible flags are `ALL`, `ANYSTRING`, `AUTOMATON`, `COMPLEMENT`,
 `EMPTY`, `INTERSECTION`, `INTERVAL`, or `NONE`. Please check the
-http://lucene.apache.org/core/4_3_0/core/index.html?org%2Fapache%2Flucene%2Futil%2Fautomaton%2FRegExp.html[Lucene
+http://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html[Lucene
 documentation] for their meaning
 
 


### PR DESCRIPTION
The `RegExp` query didn't behave like I expected, and only after some trial-and-error and searching StackOverflow did I finally realize that "term queries" was a very important part of the first sentence in the `RegExp` documentation.

This attempts to clarify that so that others do not suffer the same fate.

It also, incidentally, updates the Lucene javadoc link, which I just fixed while I was editing this file.
