### PR TITLE
Improve performance for many new fields introduction in mapping

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -182,7 +182,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
 
     private ImmutableMap<String, FieldMappingMetaData> findFieldMappingsByType(DocumentMapper documentMapper, GetFieldMappingsIndexRequest request) throws ElasticsearchException {
         MapBuilder<String, FieldMappingMetaData> fieldMappings = new MapBuilder<>();
-        List<FieldMapper> allFieldMappers = documentMapper.mappers().mappers();
+        final List<FieldMapper> allFieldMappers = documentMapper.mappers().mappers();
         for (String field : request.fields()) {
             if (Regex.isMatchAllPattern(field)) {
                 for (FieldMapper fieldMapper : allFieldMappers) {

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -50,6 +50,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 /**
  */
@@ -181,7 +182,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
 
     private ImmutableMap<String, FieldMappingMetaData> findFieldMappingsByType(DocumentMapper documentMapper, GetFieldMappingsIndexRequest request) throws ElasticsearchException {
         MapBuilder<String, FieldMappingMetaData> fieldMappings = new MapBuilder<>();
-        ImmutableList<FieldMapper> allFieldMappers = documentMapper.mappers().mappers();
+        List<FieldMapper> allFieldMappers = documentMapper.mappers().mappers();
         for (String field : request.fields()) {
             if (Regex.isMatchAllPattern(field)) {
                 for (FieldMapper fieldMapper : allFieldMappers) {

--- a/src/main/java/org/elasticsearch/common/collect/UpdateInPlaceMap.java
+++ b/src/main/java/org/elasticsearch/common/collect/UpdateInPlaceMap.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.collect;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.collect.Iterables;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A map that exposes only read only methods, and can be mutated using a {@link #mutator()}. It
+ * allows for a cutoff switch between {@link ImmutableOpenMap} and {@link ConcurrentMap}, based on size, since as
+ * the size grows bigger, cloning the immutable map cost gets bigger and bigger, and might as well move to CHM.
+ * <p/>
+ * Note, its important to understand the semantics of the class and its mutator, its not an update in place, when
+ * CHM is used, changes to the mutator will be reflected in the existing maps!. This class should be used as if
+ * its a regular, mutable concurrent map.
+ * <p/>
+ * This class only allows for a single concurrent mutator to execute at the same time.
+ */
+public class UpdateInPlaceMap<K, V> {
+
+    final int switchSize;
+    final AtomicBoolean mutating = new AtomicBoolean();
+    volatile ImmutableOpenMap<K, V> immutableMap;
+    volatile ConcurrentMap<K, V> concurrentMap;
+
+    UpdateInPlaceMap(int switchSize) {
+        this.switchSize = switchSize;
+        if (switchSize == 0) {
+            this.concurrentMap = ConcurrentCollections.newConcurrentMap();
+            this.immutableMap = null;
+        } else {
+            this.concurrentMap = null;
+            this.immutableMap = ImmutableOpenMap.of();
+        }
+    }
+
+    public boolean isEmpty() {
+        final ImmutableOpenMap<K, V> immutableMap = this.immutableMap;
+        final ConcurrentMap<K, V> concurrentMap = this.concurrentMap;
+        return immutableMap != null ? immutableMap.isEmpty() : concurrentMap.isEmpty();
+    }
+
+    public V get(K key) {
+        final ImmutableOpenMap<K, V> immutableMap = this.immutableMap;
+        final ConcurrentMap<K, V> concurrentMap = this.concurrentMap;
+        return immutableMap != null ? immutableMap.get(key) : concurrentMap.get(key);
+    }
+
+    public Iterable<V> values() {
+        return new Iterable<V>() {
+            @Override
+            public Iterator<V> iterator() {
+                final ImmutableOpenMap<K, V> immutableMap = UpdateInPlaceMap.this.immutableMap;
+                final ConcurrentMap<K, V> concurrentMap = UpdateInPlaceMap.this.concurrentMap;
+                if (immutableMap != null) {
+                    return immutableMap.valuesIt();
+                } else {
+                    return Iterables.unmodifiableIterable(concurrentMap.values()).iterator();
+                }
+            }
+        };
+    }
+
+    public Mutator mutator() {
+        if (!mutating.compareAndSet(false, true)) {
+            throw new ElasticsearchIllegalStateException("map is already mutating, can't have another mutator on it");
+        }
+        return new Mutator();
+    }
+
+    public static <K, V> UpdateInPlaceMap<K, V> of(int switchSize) {
+        return new UpdateInPlaceMap<>(switchSize);
+    }
+
+    public class Mutator implements Releasable {
+
+        private ImmutableOpenMap.Builder<K, V> immutableB;
+
+        private Mutator() {
+            if (immutableMap != null) {
+                immutableB = ImmutableOpenMap.builder(immutableMap);
+            } else {
+                immutableB = null;
+            }
+        }
+
+        public V get(K key) {
+            if (immutableB != null) {
+                return immutableB.get(key);
+            }
+            return concurrentMap.get(key);
+        }
+
+        public V put(K key, V value) {
+            if (immutableB != null) {
+                V v = immutableB.put(key, value);
+                switchIfNeeded();
+                return v;
+            } else {
+                return concurrentMap.put(key, value);
+            }
+        }
+
+        public Mutator putAll(Map<K, V> map) {
+            for (Map.Entry<K, V> entry : map.entrySet()) {
+                put(entry.getKey(), entry.getValue());
+            }
+            return this;
+        }
+
+        public V remove(K key) {
+            return immutableB != null ? immutableB.remove(key) : concurrentMap.remove(key);
+        }
+
+        private void switchIfNeeded() {
+            if (concurrentMap != null) {
+                return;
+            }
+            if (immutableB.size() < switchSize) {
+                return;
+            }
+            concurrentMap = ConcurrentCollections.newConcurrentMap();
+            for (ObjectObjectCursor<K, V> cursor : immutableB) {
+                concurrentMap.put(cursor.key, cursor.value);
+            }
+            immutableB = null;
+            immutableMap = null;
+        }
+
+        public void close() {
+            if (immutableB != null) {
+                immutableMap = immutableB.build();
+            }
+            mutating.set(false);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/FieldNameAnalyzer.java
@@ -21,23 +21,22 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.SimpleAnalyzerWrapper;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.UpdateInPlaceMap;
 
 /**
  *
  */
 public final class FieldNameAnalyzer extends SimpleAnalyzerWrapper {
 
-    private final ImmutableOpenMap<String, Analyzer> analyzers;
-
+    private final UpdateInPlaceMap<String, Analyzer> analyzers;
     private final Analyzer defaultAnalyzer;
 
-    public FieldNameAnalyzer(ImmutableOpenMap<String, Analyzer> analyzers, Analyzer defaultAnalyzer) {
+    public FieldNameAnalyzer(UpdateInPlaceMap<String, Analyzer> analyzers, Analyzer defaultAnalyzer) {
         this.analyzers = analyzers;
         this.defaultAnalyzer = defaultAnalyzer;
     }
 
-    public ImmutableOpenMap<String, Analyzer> analyzers() {
+    public UpdateInPlaceMap<String, Analyzer> analyzers() {
         return analyzers;
     }
 

--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -329,7 +329,7 @@ public class DocumentMapper implements ToXContent {
         // now traverse and get all the statically defined ones
         rootObjectMapper.traverse(fieldMappersAgg);
 
-        this.fieldMappers = new DocumentFieldMappers(this);
+        this.fieldMappers = new DocumentFieldMappers(indexSettings, this);
         this.fieldMappers.addNewMappers(fieldMappersAgg.mappers);
 
         final Map<String, ObjectMapper> objectMappers = Maps.newHashMap();
@@ -566,7 +566,7 @@ public class DocumentMapper implements ToXContent {
         return doc;
     }
 
-    public void addFieldMappers(Iterable<FieldMapper> fieldMappers) {
+    public void addFieldMappers(List<FieldMapper> fieldMappers) {
         synchronized (mappersMutex) {
             this.fieldMappers.addNewMappers(fieldMappers);
         }

--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapperListener.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapperListener.java
@@ -38,7 +38,7 @@ public abstract class FieldMapperListener {
 
     public abstract void fieldMapper(FieldMapper fieldMapper);
 
-    public void fieldMappers(Iterable<FieldMapper>  fieldMappers) {
+    public void fieldMappers(List<FieldMapper>  fieldMappers) {
         for (FieldMapper mapper : fieldMappers) {
             fieldMapper(mapper);
         }

--- a/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AnalyzerMapper.java
@@ -106,7 +106,7 @@ public class AnalyzerMapper implements Mapper, InternalMapper, RootMapper {
             List<IndexableField> fields = context.doc().getFields();
             for (int i = 0, fieldsSize = fields.size(); i < fieldsSize; i++) {
                 IndexableField field = fields.get(i);
-                if (field.name() == path) {
+                if (field.name().equals(path)) {
                     value = field.stringValue();
                     break;
                 }

--- a/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/RootObjectMapper.java
@@ -21,13 +21,16 @@ package org.elasticsearch.index.mapper.object;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
 import java.util.*;
@@ -96,7 +99,7 @@ public class RootObjectMapper extends ObjectMapper {
 
 
         @Override
-        protected ObjectMapper createMapper(String name, String fullPath, boolean enabled, Nested nested, Dynamic dynamic, ContentPath.Type pathType, Map<String, Mapper> mappers) {
+        protected ObjectMapper createMapper(String name, String fullPath, boolean enabled, Nested nested, Dynamic dynamic, ContentPath.Type pathType, Map<String, Mapper> mappers, @Nullable @IndexSettings Settings settings) {
             assert !nested.isNested();
             FormatDateTimeFormatter[] dates = null;
             if (dynamicDateTimeFormatters == null) {
@@ -110,7 +113,7 @@ public class RootObjectMapper extends ObjectMapper {
             return new RootObjectMapper(name, enabled, dynamic, pathType, mappers,
                     dates,
                     dynamicTemplates.toArray(new DynamicTemplate[dynamicTemplates.size()]),
-                    dateDetection, numericDetection);
+                    dateDetection, numericDetection, settings);
         }
     }
 
@@ -195,8 +198,9 @@ public class RootObjectMapper extends ObjectMapper {
     private volatile DynamicTemplate dynamicTemplates[];
 
     RootObjectMapper(String name, boolean enabled, Dynamic dynamic, ContentPath.Type pathType, Map<String, Mapper> mappers,
-                     FormatDateTimeFormatter[] dynamicDateTimeFormatters, DynamicTemplate dynamicTemplates[], boolean dateDetection, boolean numericDetection) {
-        super(name, name, enabled, Nested.NO, dynamic, pathType, mappers);
+                     FormatDateTimeFormatter[] dynamicDateTimeFormatters, DynamicTemplate dynamicTemplates[], boolean dateDetection, boolean numericDetection,
+                     @Nullable @IndexSettings Settings settings) {
+        super(name, name, enabled, Nested.NO, dynamic, pathType, mappers, settings);
         this.dynamicTemplates = dynamicTemplates;
         this.dynamicDateTimeFormatters = dynamicDateTimeFormatters;
         this.dateDetection = dateDetection;

--- a/src/test/java/org/elasticsearch/benchmark/mapping/ManyMappingsBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/mapping/ManyMappingsBenchmark.java
@@ -1,0 +1,132 @@
+package org.elasticsearch.benchmark.mapping;
+
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.jna.Natives;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.transport.TransportModule;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+/**
+ */
+public class ManyMappingsBenchmark {
+
+    private static final String MAPPING = "{\n" +
+            "        \"dynamic_templates\": [\n" +
+            "          {\n" +
+            "            \"t1\": {\n" +
+            "              \"mapping\": {\n" +
+            "                \"store\": false,\n" +
+            "                \"norms\": {\n" +
+            "                  \"enabled\": false\n" +
+            "                },\n" +
+            "                \"type\": \"string\"\n" +
+            "              },\n" +
+            "              \"match\": \"*_ss\"\n" +
+            "            }\n" +
+            "          },\n" +
+            "          {\n" +
+            "            \"t2\": {\n" +
+            "              \"mapping\": {\n" +
+            "                \"store\": false,\n" +
+            "                \"type\": \"date\"\n" +
+            "              },\n" +
+            "              \"match\": \"*_dt\"\n" +
+            "            }\n" +
+            "          },\n" +
+            "          {\n" +
+            "            \"t3\": {\n" +
+            "              \"mapping\": {\n" +
+            "                \"store\": false,\n" +
+            "                \"type\": \"integer\"\n" +
+            "              },\n" +
+            "              \"match\": \"*_i\"\n" +
+            "            }\n" +
+            "          }\n" +
+            "        ],\n" +
+            "        \"_source\": {\n" +
+            "          \"enabled\": false\n" +
+            "        },\n" +
+            "        \"properties\": {}\n" +
+            "      }";
+
+    private static final String INDEX_NAME = "index";
+    private static final String TYPE_NAME = "type";
+    private static final int FIELD_COUNT = 100000;
+    private static final int DOC_COUNT = 10000000;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("es.logger.prefix", "");
+        Natives.tryMlockall();
+        Settings settings = settingsBuilder()
+                .put("index.refresh_interval", "-1")
+                .put("gateway.type", "local")
+                .put(SETTING_NUMBER_OF_SHARDS, 5)
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(TransportModule.TRANSPORT_TYPE_KEY, "local")
+                .build();
+
+        String clusterName = ManyMappingsBenchmark.class.getSimpleName();
+        Node node = nodeBuilder().clusterName(clusterName)
+                .settings(settingsBuilder().put(settings))
+                .node();
+
+        Client client = node.client();
+
+        client.admin().indices().prepareDelete(INDEX_NAME)
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .get();
+        client.admin().indices().prepareCreate(INDEX_NAME)
+                .addMapping(TYPE_NAME, MAPPING)
+                .get();
+
+        BulkRequestBuilder builder = client.prepareBulk();
+        int fieldCount = 0;
+        long time = System.currentTimeMillis();
+        final int PRINT = 1000;
+        for (int i = 0; i < DOC_COUNT; i++) {
+            XContentBuilder sourceBuilder = jsonBuilder().startObject();
+            sourceBuilder.field(++fieldCount + "_ss", "xyz");
+            sourceBuilder.field(++fieldCount + "_dt", System.currentTimeMillis());
+            sourceBuilder.field(++fieldCount + "_i", i % 100);
+            sourceBuilder.endObject();
+
+            if (fieldCount >= FIELD_COUNT) {
+                fieldCount = 0;
+                System.out.println("dynamic fields rolled up");
+            }
+
+            builder.add(
+                    client.prepareIndex(INDEX_NAME, TYPE_NAME, String.valueOf(i))
+                            .setSource(sourceBuilder)
+            );
+
+            if (builder.numberOfActions() >= 1000) {
+                builder.get();
+                builder = client.prepareBulk();
+            }
+
+            if (i % PRINT == 0) {
+                long took = System.currentTimeMillis() - time;
+                time = System.currentTimeMillis();
+                System.out.println("Indexed " + i +  " docs, in " + TimeValue.timeValueMillis(took));
+            }
+        }
+        if (builder.numberOfActions() > 0) {
+            builder.get();
+        }
+
+
+
+    }
+
+}

--- a/src/test/java/org/elasticsearch/common/collect/UpdateInPlaceMapTests.java
+++ b/src/test/java/org/elasticsearch/common/collect/UpdateInPlaceMapTests.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.collect;
+
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ */
+public class UpdateInPlaceMapTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testConcurrentMutator() {
+        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(100);
+        UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+        try {
+            map.mutator();
+            fail("should fail on concurrent mutator");
+        } catch (ElasticsearchIllegalStateException e) {
+            // all is well!
+        }
+        mutator.close();
+        // now this should work well!
+        map.mutator();
+    }
+
+    @Test
+    public void testImmutableMapState() {
+        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(100);
+        UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+        mutator.put("key1", "value1");
+        assertThat(mutator.get("key1"), equalTo("value1"));
+        assertThat(map.get("key1"), nullValue());
+        mutator.close();
+        assertThat(map.get("key1"), equalTo("value1"));
+
+        mutator = map.mutator();
+        mutator.remove("key1");
+        assertThat(mutator.get("key1"), nullValue());
+        assertThat(map.get("key1"), equalTo("value1"));
+        mutator.close();
+        assertThat(map.get("key1"), nullValue());
+    }
+
+    @Test
+    public void testSwitchToCHM() {
+        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(1);
+        UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+        mutator.put("key1", "value1");
+        assertThat(mutator.get("key1"), equalTo("value1"));
+        mutator.put("key2", "value2");
+        assertThat(mutator.get("key2"), equalTo("value2"));
+        // now that we changed to CHM, things are visible on the map as well!
+        assertThat(map.get("key1"), equalTo("value1"));
+        assertThat(map.get("key2"), equalTo("value2"));
+        mutator.close();
+        assertThat(map.get("key1"), equalTo("value1"));
+        assertThat(map.get("key2"), equalTo("value2"));
+
+        mutator = map.mutator();
+        mutator.remove("key1");
+        assertThat(mutator.get("key1"), nullValue());
+        assertThat(map.get("key1"), nullValue());
+        mutator.close();
+        assertThat(map.get("key1"), nullValue());
+    }
+
+    @Test
+    public void testInitializeWithCHM() {
+        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(0);
+        UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+        mutator.put("key1", "value1");
+        assertThat(mutator.get("key1"), equalTo("value1"));
+        mutator.put("key2", "value2");
+        assertThat(mutator.get("key2"), equalTo("value2"));
+    }
+}

--- a/src/test/java/org/elasticsearch/common/collect/UpdateInPlaceMapTests.java
+++ b/src/test/java/org/elasticsearch/common/collect/UpdateInPlaceMapTests.java
@@ -19,12 +19,17 @@
 
 package org.elasticsearch.common.collect;
 
+import com.google.common.collect.Iterables;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.Matchers.*;
 
 /**
  */
@@ -32,7 +37,7 @@ public class UpdateInPlaceMapTests extends ElasticsearchTestCase {
 
     @Test
     public void testConcurrentMutator() {
-        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(100);
+        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(randomIntBetween(0, 500));
         UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
         try {
             map.mutator();
@@ -46,44 +51,31 @@ public class UpdateInPlaceMapTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testImmutableMapState() {
-        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(100);
-        UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
-        mutator.put("key1", "value1");
-        assertThat(mutator.get("key1"), equalTo("value1"));
-        assertThat(map.get("key1"), nullValue());
-        mutator.close();
-        assertThat(map.get("key1"), equalTo("value1"));
-
-        mutator = map.mutator();
-        mutator.remove("key1");
-        assertThat(mutator.get("key1"), nullValue());
-        assertThat(map.get("key1"), equalTo("value1"));
-        mutator.close();
-        assertThat(map.get("key1"), nullValue());
-    }
-
-    @Test
-    public void testSwitchToCHM() {
-        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(1);
-        UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
-        mutator.put("key1", "value1");
-        assertThat(mutator.get("key1"), equalTo("value1"));
-        mutator.put("key2", "value2");
-        assertThat(mutator.get("key2"), equalTo("value2"));
-        // now that we changed to CHM, things are visible on the map as well!
-        assertThat(map.get("key1"), equalTo("value1"));
-        assertThat(map.get("key2"), equalTo("value2"));
-        mutator.close();
-        assertThat(map.get("key1"), equalTo("value1"));
-        assertThat(map.get("key2"), equalTo("value2"));
-
-        mutator = map.mutator();
-        mutator.remove("key1");
-        assertThat(mutator.get("key1"), nullValue());
-        assertThat(map.get("key1"), nullValue());
-        mutator.close();
-        assertThat(map.get("key1"), nullValue());
+    public void testImmutableMapSwitchToCHM() {
+        int switchSize = randomIntBetween(1, 500);
+        UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(switchSize);
+        int i;
+        for (i = 0; i < switchSize; i++) {
+            UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+            String key = "key" + i;
+            String value = "value" + i;
+            mutator.put(key, value);
+            assertThat(mutator.get(key), equalTo(value));
+            assertThat(map.get(key), nullValue());
+            mutator.close();
+            assertThat(map.get(key), equalTo(value));
+        }
+        int countAfter = switchSize + randomIntBetween(0, 100);
+        for (; i < countAfter; i++) {
+            UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+            String key = "key" + i;
+            String value = "value" + i;
+            mutator.put(key, value);
+            assertThat(mutator.get(key), equalTo(value));
+            assertThat(map.get(key), equalTo(value));
+            mutator.close();
+            assertThat(map.get(key), equalTo(value));
+        }
     }
 
     @Test
@@ -94,5 +86,46 @@ public class UpdateInPlaceMapTests extends ElasticsearchTestCase {
         assertThat(mutator.get("key1"), equalTo("value1"));
         mutator.put("key2", "value2");
         assertThat(mutator.get("key2"), equalTo("value2"));
+    }
+
+    @Test
+    public void testConcurrentAccess() throws Exception {
+        final int numberOfThreads = scaledRandomIntBetween(1, 10);
+        final int switchSize = randomIntBetween(1, 500);
+        final CountDownLatch numberOfMutations = new CountDownLatch(scaledRandomIntBetween(300, 1000));
+
+        final UpdateInPlaceMap<String, String> map = UpdateInPlaceMap.of(switchSize);
+        final ConcurrentMap<String, String> verifier = ConcurrentCollections.newConcurrentMap();
+
+        Thread[] threads = new Thread[numberOfThreads];
+        for (int i = 0; i < numberOfThreads; i++) {
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    while (numberOfMutations.getCount() > 0) {
+                        try {
+                            UpdateInPlaceMap<String, String>.Mutator mutator = map.mutator();
+                            String str = Strings.randomBase64UUID();
+                            mutator.put(str, str);
+                            verifier.put(str, str);
+                            mutator.close();
+                            numberOfMutations.countDown();
+                        } catch (ElasticsearchIllegalStateException e) {
+                            // ok, double mutating, continue
+                        }
+                    }
+                }
+            }, getClass().getName() + "concurrent_access_i");
+            threads[i].setDaemon(true);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        numberOfMutations.await();
+
+        // verify the 2 maps are the same
+        assertThat(Iterables.toArray(map.values(), String.class), arrayContainingInAnyOrder(Iterables.toArray(verifier.values(), String.class)));
     }
 }

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -65,6 +65,7 @@ import org.elasticsearch.index.cache.filter.FilterCacheModule;
 import org.elasticsearch.index.cache.filter.none.NoneFilterCache;
 import org.elasticsearch.index.cache.filter.weighted.WeightedFilterCache;
 import org.elasticsearch.index.engine.IndexEngineModule;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalNode;
 import org.elasticsearch.plugins.PluginsService;
@@ -373,6 +374,9 @@ public final class InternalTestCluster extends TestCluster {
 
         if (random.nextBoolean()) {
             builder.put(MappingUpdatedAction.INDICES_MAPPING_ADDITIONAL_MAPPING_CHANGE_TIME, RandomInts.randomIntBetween(random, 0, 500) /*milliseconds*/);
+        }
+        if (random.nextBoolean()) {
+            builder.put(MapperService.DEFAULT_FIELD_MAPPERS_COLLECTION_SWITCH, RandomInts.randomIntBetween(random, 0, 5));
         }
 
         return builder.build();


### PR DESCRIPTION
When we have many new fields keep being introduced, the immutable open map we used becomes more and more expensive because of its clone characteristics, and we use it in several places.

The usage semantics of it allows us to also use a CHM if we want to, but it would be nice to still maintain the concurrency aspects of volatile immutable map when the number of fields is sane.

Introduce a new map like data structure, that can switch internally to CHM when a certain threshold is met.

Also add a benchmark class to exploit the many new field mappings use case, which shows significant gains by using this change, to a level where mapping introduction is no longer a significant bottleneck.
