### PR TITLE
Aggregations: Aggregation names can now include dot

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/AggregatorParsers.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  */
 public class AggregatorParsers {
 
-    public static final Pattern VALID_AGG_NAME = Pattern.compile("[a-zA-Z0-9\\-_]+");
+    public static final Pattern VALID_AGG_NAME = Pattern.compile("[^\\[\\]>]+");
     private final ImmutableMap<String, Aggregator.Parser> parsers;
 
 

--- a/src/main/java/org/elasticsearch/search/aggregations/support/OrderPath.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/OrderPath.java
@@ -71,27 +71,36 @@ public class OrderPath {
         String[] tuple = new String[2];
         for (int i = 0; i < elements.length; i++) {
             String element = elements[i];
-            int index = element.lastIndexOf('.');
-            if (index >=  0) {
+            if (i == elements.length - 1) {
+                int index = element.lastIndexOf('[');
+                if (index >= 0) {
+                    if (index == 0 || index > element.length() - 3) {
+                        throw new AggregationExecutionException("Invalid path element [" + element + "] in path [" + path + "]");
+                    }
+                    if (element.charAt(element.length() - 1) != ']') {
+                        throw new AggregationExecutionException("Invalid path element [" + element + "] in path [" + path + "]");
+                    }
+                    tokens[i] = new Token(element, element.substring(0, index), element.substring(index + 1, element.length() - 1));
+                    continue;
+                }
+                index = element.lastIndexOf('.');
+                if (index < 0) {
+                    tokens[i] = new Token(element, element, null);
+                    continue;
+                }
                 if (index == 0 || index > element.length() - 2) {
                     throw new AggregationExecutionException("Invalid path element [" + element + "] in path [" + path + "]");
                 }
                 tuple = split(element, index, tuple);
                 tokens[i] = new Token(element, tuple[0], tuple[1]);
-                continue;
-            }
-            index = element.lastIndexOf('[');
-            if (index < 0) {
+
+            } else {
+                int index = element.lastIndexOf('[');
+                if (index >= 0) {
+                    throw new AggregationExecutionException("Invalid path element [" + element + "] in path [" + path + "]");
+                }
                 tokens[i] = new Token(element, element, null);
-                continue;
             }
-            if (index == 0 || index > element.length() - 3) {
-                throw new AggregationExecutionException("Invalid path element [" + element + "] in path [" + path + "]");
-            }
-            if (element.charAt(element.length() - 1) != ']') {
-                throw new AggregationExecutionException("Invalid path element [" + element + "] in path [" + path + "]");
-            }
-            tokens[i] = new Token(element, element.substring(0, index), element.substring(index + 1, element.length() - 1));
         }
         return new OrderPath(tokens);
     }


### PR DESCRIPTION
Aggregation name are now able to use any character except '[', ']', and '>'. Dot syntax may still be used to reference values (e.g. in the order field) but may only reference the value directly beneath the last aggregation in the list. more complex structures will need to be accessed using the aggname[value] syntax

Closes #6702
