### PR TITLE
QueryParser can return null from a query

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/support/XContentStructure.java
+++ b/src/main/java/org/elasticsearch/index/query/support/XContentStructure.java
@@ -127,13 +127,14 @@ public abstract class XContentStructure {
      */
     public static class InnerQuery extends XContentStructure {
         private Query query = null;
-
+        private boolean queryParsed = false;
         public InnerQuery(QueryParseContext parseContext1, @Nullable String... types) throws IOException {
             super(parseContext1);
             if (types != null) {
                 String[] origTypes = QueryParseContext.setTypesWithPrevious(types);
                 try {
                     query = parseContext1.parseInnerQuery();
+                    queryParsed = true;
                 } finally {
                     QueryParseContext.setTypes(origTypes);
                 }
@@ -150,7 +151,7 @@ public abstract class XContentStructure {
          */
         @Override
         public Query asQuery(String... types) throws IOException {
-            if (this.query == null) {
+            if (!queryParsed) { // query can be null
                 this.query = super.asQuery(types);
             }
             return this.query;
@@ -164,6 +165,8 @@ public abstract class XContentStructure {
      */
     public static class InnerFilter extends XContentStructure {
         private Query query = null;
+        private boolean queryParsed = false;
+
 
         public InnerFilter(QueryParseContext parseContext1, @Nullable String... types) throws IOException {
             super(parseContext1);
@@ -172,6 +175,7 @@ public abstract class XContentStructure {
                 try {
                     Filter innerFilter = parseContext1.parseInnerFilter();
                     query = new XConstantScoreQuery(innerFilter);
+                    queryParsed = true;
                 } finally {
                     QueryParseContext.setTypes(origTypes);
                 }
@@ -190,7 +194,7 @@ public abstract class XContentStructure {
          */
         @Override
         public Query asFilter(String... types) throws IOException {
-            if (this.query == null) {
+            if (!queryParsed) { // query can be null
                 this.query = super.asFilter(types);
             }
             return this.query;

--- a/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
+++ b/src/test/java/org/elasticsearch/search/child/SimpleChildQuerySearchTests.java
@@ -126,6 +126,24 @@ public class SimpleChildQuerySearchTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    // see #6722
+    public void test6722() throws ElasticsearchException, IOException {
+        assertAcked(prepareCreate("test")
+                .addMapping("foo")
+                .addMapping("test", "_parent", "type=foo"));
+        ensureGreen();
+
+        // index simple data
+        client().prepareIndex("test", "foo", "1").setSource("foo", 1).get();
+        client().prepareIndex("test", "test").setSource("foo", 1).setParent("1").get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch("test").setSource("{\"query\":{\"filtered\":{\"filter\":{\"has_parent\":{\"type\":\"test\",\"query\":{\"bool\":{\"must\":[],\"must_not\":[],\"should\":[]}}},\"query\":[]}}}}").get();
+        assertNoFailures(searchResponse);
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+    }
+
+    @Test
     // see #2744
     public void test2744() throws ElasticsearchException, IOException {
         assertAcked(prepareCreate("test")


### PR DESCRIPTION
This causes a NPE since XContentStructure checks if the query is null
and takes this as the condition to parse from the byte source which is
actually null in that case.

Closes #6722
