### PR TITLE
The query_string cache should returned cloned Query instances.

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/query/parser/resident/ResidentQueryParserCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/query/parser/resident/ResidentQueryParserCache.java
@@ -63,7 +63,12 @@ public class ResidentQueryParserCache extends AbstractIndexComponent implements 
 
     @Override
     public Query get(QueryParserSettings queryString) {
-        return cache.getIfPresent(queryString);
+        Query value =  cache.getIfPresent(queryString);
+        if (value != null) {
+            return value.clone();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/index/cache/query/parser/resident/ResidentQueryParserCacheTest.java
+++ b/src/test/java/org/elasticsearch/index/cache/query/parser/resident/ResidentQueryParserCacheTest.java
@@ -1,0 +1,35 @@
+package org.elasticsearch.index.cache.query.parser.resident;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.QueryParserSettings;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ */
+public class ResidentQueryParserCacheTest extends ElasticsearchTestCase {
+
+    @Test
+    public void testCaching() throws Exception {
+        ResidentQueryParserCache cache = new ResidentQueryParserCache(new Index("test"), ImmutableSettings.EMPTY);
+        QueryParserSettings key = new QueryParserSettings();
+        key.queryString("abc");
+        key.defaultField("a");
+        key.boost(2.0f);
+
+        Query query = new TermQuery(new Term("a", "abc"));
+        cache.put(key, query);
+
+        assertThat(cache.get(key), not(sameInstance(query)));
+        assertThat(cache.get(key), equalTo(query));
+    }
+
+}


### PR DESCRIPTION
The query string cache can't return the same instance, since Query is mutable changing the query else where in the execution path changes the instance in the cache too.

Fixes #2542
