### PR TITLE
Removing plugin does not fail when plugin dir is read only

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -241,19 +241,28 @@ public class PluginManager {
         File pluginToDelete = pluginHandle.extractedDir(environment);
         if (pluginToDelete.exists()) {
             debug("Removing: " + pluginToDelete.getPath());
-            FileSystemUtils.deleteRecursively(pluginToDelete, true);
+            if (!FileSystemUtils.deleteRecursively(pluginToDelete, true)) {
+                throw new IOException("Unable to remove " + pluginHandle.name + ". Check file permissions on " +
+                        pluginToDelete.toString());
+            }
             removed = true;
         }
         pluginToDelete = pluginHandle.distroFile(environment);
         if (pluginToDelete.exists()) {
             debug("Removing: " + pluginToDelete.getPath());
-            pluginToDelete.delete();
+            if (!pluginToDelete.delete()) {
+                throw new IOException("Unable to remove " + pluginHandle.name + ". Check file permissions on " +
+                        pluginToDelete.toString());
+            }
             removed = true;
         }
         File binLocation = pluginHandle.binDir(environment);
         if (binLocation.exists()) {
             debug("Removing: " + binLocation.getPath());
-            FileSystemUtils.deleteRecursively(binLocation);
+            if (!FileSystemUtils.deleteRecursively(binLocation)) {
+                throw new IOException("Unable to remove " + pluginHandle.name + ". Check file permissions on " +
+                        binLocation.toString());
+            }
             removed = true;
         }
         if (removed) {


### PR DESCRIPTION
If you try to remove a plugin in read only dir, you get a successful result:

```
$ bin/plugin --remove marvel
-> Removing marvel
Removed marvel
```

But actually the plugin has not been removed.

When installing, if fails properly:

```
$ bin/plugin -i elasticsearch/marvel/latest
-> Installing elasticsearch/marvel/latest...

Failed to install elasticsearch/marvel/latest, reason: plugin directory /usr/local/elasticsearch/plugins is read only
```

This change throw an exception when we don't succeed removing the plugin.

Closes #6546.
