### PR TITLE
Fixed query in the example for the histogram aggs page

### DIFF
--- a/docs/reference/search/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/histogram-aggregation.asciidoc
@@ -142,7 +142,7 @@ Example:
 --------------------------------------------------
 {
     "query" : {
-        "filtered" : { "range" : { "price" : { "to" : "500" } } }
+        "filtered" : { "filter": { "range" : { "price" : { "to" : "500" } } } }
     },
     "aggs" : {
         "prices" : {


### PR DESCRIPTION
In the query example added missing "filter" key around the actual filter. Closes #6737
