### PR TITLE
Fetch text from all possible fields if none are specified

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -72,15 +72,15 @@ The `more_like_this` top level parameters include:
 |=======================================================================
 |Parameter |Description
 |`fields` |A list of the fields to run the more like this query against.
-Defaults to the `_all` field.
+Defaults to the `_all` field for `like_text` and to all the fields of each
+the document when `ids` or `docs` are specified.
 
 |`like_text` |The text to find documents like it, *required* if `ids` or `docs` are
 not specified.
 
 |`ids` or `docs` |A list of documents following the same syntax as the 
-<<docs-multi-get,Multi GET API>>. This parameter is *required* if
-`like_text` is not specified. The texts are fetched from `fields` unless
-specified in each `doc`, and cannot be set to `_all`.
+<<docs-multi-get,Multi GET API>>. The texts are fetched from `fields`
+unless specified in each `doc`.
 
 |`include` |When using `ids` or `docs`, specifies whether the documents should be
 included from the search. Defaults to `false`.

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -169,8 +169,9 @@ public class MoreLikeThisQueryParser implements QueryParser {
         }
         mltQuery.setAnalyzer(analyzer);
 
+        ArrayList<String> allField = Lists.newArrayList(parseContext.defaultField());
         if (moreLikeFields == null) {
-            moreLikeFields = Lists.newArrayList(parseContext.defaultField());
+            moreLikeFields = allField;
         } else if (moreLikeFields.isEmpty()) {
             throw new QueryParsingException(parseContext.index(), "more_like_this requires 'fields' to be non-empty");
         }
@@ -199,11 +200,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                         item.type(parseContext.queryTypes().iterator().next());
                     }
                 }
-                if (item.fields() == null && item.fetchSourceContext() == null) {
+                if (item.fields() == null && item.fetchSourceContext() == null && !moreLikeFields.equals(allField)) {
                     item.fields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
-                } else {
-                    // TODO how about fields content fetched from _source?
-                    removeUnsupportedFields(item, analyzer, failOnUnsupportedField);
                 }
             }
             // fetching the items with multi-get

--- a/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
+++ b/src/main/java/org/elasticsearch/index/search/morelikethis/MoreLikeThisFetchService.java
@@ -19,23 +19,30 @@
 
 package org.elasticsearch.index.search.morelikethis;
 
+import org.apache.lucene.document.Field;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.get.MultiGetRequest.Item;
 import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.get.GetField;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.InternalMapper;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
+import org.elasticsearch.indices.IndicesService;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- *
- */
 public class MoreLikeThisFetchService extends AbstractComponent {
 
     public static final class LikeText {
@@ -55,36 +62,96 @@ public class MoreLikeThisFetchService extends AbstractComponent {
 
     private final Client client;
 
+    private final IndicesService indicesService;
+
     @Inject
-    public MoreLikeThisFetchService(Client client, Settings settings) {
+    public MoreLikeThisFetchService(Client client, Settings settings, IndicesService indicesService) {
         super(settings);
         this.client = client;
+        this.indicesService = indicesService;
     }
 
-    public List<LikeText> fetch(List<MultiGetRequest.Item> items) throws IOException {
+    public List<LikeText> fetch(List<Item> items) throws IOException {
+        // create multi-get request
         MultiGetRequest request = new MultiGetRequest();
-        for (MultiGetRequest.Item item : items) {
-            request.add(item);
+        for (Item item : items) {
+            Item requestItem = new Item(item.index(), item.type(), item.id())
+                    .routing(item.routing())
+                    .fetchSourceContext(item.fetchSourceContext())
+                    .fields(item.fields());
+            // no field specified, so add the source to parse
+            if (item.fields() == null) {
+                requestItem.fields(SourceFieldMapper.NAME);
+            }
+            request.add(requestItem);
         }
+
+        // perform the query
         MultiGetResponse responses = client.multiGet(request).actionGet();
-        List<LikeText> likeTexts = new ArrayList<>();
+
+        // get text from the response
+        final List<LikeText> likeTexts = new ArrayList<>();
+        int idx = 0;
         for (MultiGetItemResponse response : responses) {
+            Item item = items.get(idx++);
+
+            // check the response
             if (response.isFailed()) {
                 continue;
             }
             GetResponse getResponse = response.getResponse();
             if (!getResponse.isExists()) {
-                continue;
+                throw new DocumentMissingException(null, getResponse.getType(), getResponse.getId());
             }
 
-            for (GetField getField : getResponse.getFields().values()) {
-                String[] text = new String[getField.getValues().size()];
-                for (int i = 0; i < text.length; i++) {
-                    text[i] = getField.getValues().get(i).toString();
+            // we didn't specify any field, get them from the source
+            if (item.fields() == null) {
+                parseSource(getResponse, likeTexts);
+            } else {  // or from the ones provided
+                for (GetField getField : getResponse.getFields().values()) {
+                    addToLikeTexts(likeTexts, getField.getName(), getField.getValues());
                 }
-                likeTexts.add(new LikeText(getField.getName(), text));
             }
         }
         return likeTexts;
+    }
+
+    private void addToLikeTexts(List<LikeText> likeTexts, String fieldName, List<Object> values) {
+        String[] text = new String[values.size()];
+        for (int i = 0; i < text.length; i++) {
+            text[i] = values.get(i).toString();
+        }
+        likeTexts.add(new LikeText(fieldName, text));
+    }
+
+    private void parseSource(GetResponse getResponse, final List<LikeText> likeTexts) {
+        final DocumentMapper docMapper = indicesService.indexServiceSafe(getResponse.getIndex())
+                .mapperService().documentMapper(getResponse.getType());
+        if (docMapper == null) {
+            throw new ElasticsearchException("No DocumentMapper found for type [" + getResponse.getType() + "]");
+        }
+        if (getResponse.isSourceEmpty()) {
+            return;
+        }
+        SourceToParse sourceToParse = SourceToParse.source(getResponse.getSourceAsBytesRef())
+                .type(getResponse.getType())
+                .id(getResponse.getId());
+        docMapper.parse(sourceToParse, new DocumentMapper.ParseListenerAdapter() {
+            @Override
+            public boolean beforeFieldAdded(FieldMapper fieldMapper, Field field, Object parseContext) {
+                if (!field.fieldType().indexed()) {
+                    return false;
+                }
+                if (fieldMapper instanceof InternalMapper) {
+                    return false;
+                }
+                String value = field.stringValue();
+                if (value == null) {
+                    return false;
+                }
+                likeTexts.add(new LikeText(field.name(), value));
+                return true;
+            }
+        });
     }
 }

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1718,7 +1718,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchTestCase {
     private static class MockMoreLikeThisFetchService extends MoreLikeThisFetchService {
 
         public MockMoreLikeThisFetchService() {
-            super(null, ImmutableSettings.Builder.EMPTY_SETTINGS);
+            super(null, ImmutableSettings.Builder.EMPTY_SETTINGS, null);
         }
 
         public List<LikeText> fetch(List<MultiGetRequest.Item> items) throws IOException {


### PR DESCRIPTION
Items with no specified field now defaults to all the possible fields from the
document source. Previously, we had required 'fields' to be specified either
as a top level parameter or for each item. The default behavior is now similar
to the MLT API for each item.
