### PR TITLE
Add a best effort waiting for ongoing recoveries to cancel on close

### DIFF
--- a/src/main/java/org/elasticsearch/index/service/InternalIndexService.java
+++ b/src/main/java/org/elasticsearch/index/service/InternalIndexService.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.IndexCache;
 import org.elasticsearch.index.cache.filter.ShardFilterCacheModule;
 import org.elasticsearch.index.deletionpolicy.DeletionPolicyModule;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineModule;
 import org.elasticsearch.index.engine.IndexEngine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
@@ -397,12 +396,6 @@ public class InternalIndexService extends AbstractIndexComponent implements Inde
                 logger.debug("failed to close index shard", e);
                 // ignore
             }
-        }
-        try {
-            shardInjector.getInstance(Engine.class).close();
-        } catch (Throwable e) {
-            logger.debug("failed to close engine", e);
-            // ignore
         }
         try {
             shardInjector.getInstance(MergeSchedulerProvider.class).close();

--- a/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
+++ b/src/main/java/org/elasticsearch/index/shard/service/InternalIndexShard.java
@@ -664,6 +664,7 @@ public class InternalIndexShard extends AbstractIndexShardComponent implements I
             }
             changeState(IndexShardState.CLOSED, reason);
         }
+        engine.close();
     }
 
     public long checkIndexTook() {


### PR DESCRIPTION
Currently one can close the engine while there are still on going recoveries. This is not a problem because the engine is close in tandem with the shard it belongs to, which in turn cancels the recoveries. This does cause some issues in our tests as we check the no resources were left behind after an index was deleted, which trips if the recoveries are not canceled.
