### PR TITLE
Set a default of 5m to `recover_after_time` when any of the `expected*Nodes` is set

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -42,14 +42,14 @@ once all `gateway.recover_after...nodes` conditions are met.
 
 The `gateway.expected_nodes` allows to set how many data and master
 eligible nodes are expected to be in the cluster, and once met, the
-`recover_after_time` is ignored and recovery starts. The
-`gateway.expected_data_nodes` and `gateway.expected_master_nodes`
+`gateway.recover_after_time` is ignored and recovery starts.
+Setting `gateway.expected_nodes` also defaults `gateway.recovery_after_time` to `5m` coming[1.3.0, before `expected_nodes`
+required `recovery_after_time` to be set]. The `gateway.expected_data_nodes` and `gateway.expected_master_nodes`
 settings are also supported. For example setting:
 
 [source,js]
 --------------------------------------------------
 gateway:
-    recover_after_nodes: 1
     recover_after_time: 5m
     expected_nodes: 2
 --------------------------------------------------

--- a/docs/reference/modules/gateway/local.asciidoc
+++ b/docs/reference/modules/gateway/local.asciidoc
@@ -18,9 +18,8 @@ For example:
 [source,js]
 --------------------------------------------------
 gateway:
-    recover_after_nodes: 1
-    recover_after_time: 5m
-    expected_nodes: 2
+    recover_after_nodes: 3
+    expected_nodes: 5
 --------------------------------------------------
 
 [float]

--- a/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gateway;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.cluster.NoopClusterService;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+
+
+public class GatewayServiceTests extends ElasticsearchTestCase {
+
+
+    private GatewayService createService(ImmutableSettings.Builder settings) {
+        return new GatewayService(ImmutableSettings.builder()
+                .put("http.enabled", "false")
+                .put("discovery.type", "local")
+                .put(settings.build()).build(), null, null, new NoopClusterService(), null, null);
+
+    }
+
+    @Test
+    public void testDefaultRecoverAfterTime() throws IOException {
+
+        // check that the default is not set
+        GatewayService service = createService(ImmutableSettings.builder());
+        assertNull(service.recoverAfterTime());
+
+        // ensure default is set when setting expected_nodes
+        service = createService(ImmutableSettings.builder().put("gateway.expected_nodes", 1));
+        assertThat(service.recoverAfterTime(), Matchers.equalTo(GatewayService.DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET));
+
+        // ensure default is set when setting expected_data_nodes
+        service = createService(ImmutableSettings.builder().put("gateway.expected_data_nodes", 1));
+        assertThat(service.recoverAfterTime(), Matchers.equalTo(GatewayService.DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET));
+
+        // ensure default is set when setting expected_master_nodes
+        service = createService(ImmutableSettings.builder().put("gateway.expected_master_nodes", 1));
+        assertThat(service.recoverAfterTime(), Matchers.equalTo(GatewayService.DEFAULT_RECOVER_AFTER_TIME_IF_EXPECTED_NODES_IS_SET));
+
+        // ensure settings override default
+        TimeValue timeValue = TimeValue.timeValueHours(3);
+        // ensure default is set when setting expected_nodes
+        service = createService(ImmutableSettings.builder().put("gateway.expected_nodes", 1).put("gateway.recover_after_time", timeValue.toString()));
+        assertThat(service.recoverAfterTime().millis(), Matchers.equalTo(timeValue.millis()));
+    }
+}

--- a/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
+++ b/src/test/java/org/elasticsearch/test/cluster/NoopClusterService.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.cluster;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.cluster.*;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.operation.OperationRouting;
+import org.elasticsearch.cluster.service.PendingClusterTask;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.List;
+
+public class NoopClusterService implements ClusterService {
+
+    @Override
+    public DiscoveryNode localNode() {
+        return null;
+    }
+
+    @Override
+    public ClusterState state() {
+        return null;
+    }
+
+    @Override
+    public void addInitialStateBlock(ClusterBlock block) throws ElasticsearchIllegalStateException {
+
+    }
+
+    @Override
+    public void removeInitialStateBlock(ClusterBlock block) throws ElasticsearchIllegalStateException {
+
+    }
+
+    @Override
+    public OperationRouting operationRouting() {
+        return null;
+    }
+
+    @Override
+    public void addFirst(ClusterStateListener listener) {
+
+    }
+
+    @Override
+    public void addLast(ClusterStateListener listener) {
+
+    }
+
+    @Override
+    public void add(ClusterStateListener listener) {
+
+    }
+
+    @Override
+    public void remove(ClusterStateListener listener) {
+
+    }
+
+    @Override
+    public void add(LocalNodeMasterListener listener) {
+
+    }
+
+    @Override
+    public void remove(LocalNodeMasterListener listener) {
+
+    }
+
+    @Override
+    public void add(TimeValue timeout, TimeoutClusterStateListener listener) {
+
+    }
+
+    @Override
+    public void submitStateUpdateTask(String source, Priority priority, ClusterStateUpdateTask updateTask) {
+
+    }
+
+    @Override
+    public void submitStateUpdateTask(String source, ClusterStateUpdateTask updateTask) {
+
+    }
+
+    @Override
+    public List<PendingClusterTask> pendingTasks() {
+        return null;
+    }
+
+    @Override
+    public Lifecycle.State lifecycleState() {
+        return null;
+    }
+
+    @Override
+    public void addLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public void removeLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public ClusterService start() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public ClusterService stop() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+
+    }
+}


### PR DESCRIPTION
The `recovery_after_time` tells the gateway to wait before starting recovery from disk. The goal here is to allow for more nodes to join the cluster and thus not start potentially unneeded replications. The `expectedNodes` setting (and friends) tells the gateway when it can start recovering even if the `recover_after_time` has not yet elapsed. However, `expectedNodes` is useless if one doesn't set `recovery_after_time`. This commit changes that by setting a sensible default of 5m for `recover_after_time` _if_ a `expectedNodes` setting is present.
