### PR TITLE
Remove Queries#optimizeQuery - already handled in BooleanQuery

### DIFF
--- a/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -43,7 +43,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
-import static org.elasticsearch.common.lucene.search.Queries.optimizeQuery;
 import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
 
 /**
@@ -839,7 +838,7 @@ public class MapperQueryParser extends QueryParser {
         if (q == null) {
             return null;
         }
-        return optimizeQuery(fixNegativeQueryIfNeeded(q));
+        return fixNegativeQueryIfNeeded(q);
     }
 
     private void applyBoost(String field, Query q) {

--- a/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -49,30 +49,6 @@ public class Queries {
         return new MatchNoDocsQuery();
     }
 
-    /**
-     * Optimizes the given query and returns the optimized version of it.
-     */
-    public static Query optimizeQuery(Query q) {
-        if (q instanceof BooleanQuery) {
-            BooleanQuery booleanQuery = (BooleanQuery) q;
-            BooleanClause[] clauses = booleanQuery.getClauses();
-            if (clauses.length == 1) {
-                BooleanClause clause = clauses[0];
-                if (clause.getOccur() == BooleanClause.Occur.MUST) {
-                    Query query = clause.getQuery();
-                    query.setBoost(booleanQuery.getBoost() * query.getBoost());
-                    return optimizeQuery(query);
-                }
-                if (clause.getOccur() == BooleanClause.Occur.SHOULD && booleanQuery.getMinimumNumberShouldMatch() > 0) {
-                    Query query = clause.getQuery();
-                    query.setBoost(booleanQuery.getBoost() * query.getBoost());
-                    return optimizeQuery(query);
-                }
-            }
-        }
-        return q;
-    }
-
     public static boolean isNegativeQuery(Query q) {
         if (!(q instanceof BooleanQuery)) {
             return false;

--- a/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -32,7 +32,6 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
-import static org.elasticsearch.common.lucene.search.Queries.optimizeQuery;
 
 /**
  *
@@ -141,7 +140,7 @@ public class BoolQueryParser implements QueryParser {
         }
         booleanQuery.setBoost(boost);
         Queries.applyMinimumShouldMatch(booleanQuery, minimumShouldMatch);
-        Query query = optimizeQuery(adjustPureNegative ? fixNegativeQueryIfNeeded(booleanQuery) : booleanQuery);
+        Query query = adjustPureNegative ? fixNegativeQueryIfNeeded(booleanQuery) : booleanQuery;
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }

--- a/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.util.Locale;
 
 import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
-import static org.elasticsearch.common.lucene.search.Queries.optimizeQuery;
 
 /**
  *
@@ -228,7 +227,7 @@ public class QueryStringQueryParser implements QueryParser {
             if (qpSettings.boost() != QueryParserSettings.DEFAULT_BOOST) {
                 query.setBoost(query.getBoost() * qpSettings.boost());
             }
-            query = optimizeQuery(fixNegativeQueryIfNeeded(query));
+            query = fixNegativeQueryIfNeeded(query);
             if (query instanceof BooleanQuery) {
                 Queries.applyMinimumShouldMatch((BooleanQuery) query, qpSettings.minimumShouldMatch());
             }

--- a/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -35,7 +35,6 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
-import static org.elasticsearch.common.lucene.search.Queries.optimizeQuery;
 import static org.elasticsearch.index.query.support.QueryParsers.wrapSmartNameQuery;
 
 /**
@@ -128,7 +127,7 @@ public class TermsQueryParser implements QueryParser {
             }
             booleanQuery.setBoost(boost);
             Queries.applyMinimumShouldMatch(booleanQuery, minimumShouldMatch);
-            Query query = wrapSmartNameQuery(optimizeQuery(fixNegativeQueryIfNeeded(booleanQuery)), smartNameFieldMappers, parseContext);
+            Query query = wrapSmartNameQuery(fixNegativeQueryIfNeeded(booleanQuery), smartNameFieldMappers, parseContext);
             if (queryName != null) {
                 parseContext.addNamedQuery(queryName, query);
             }


### PR DESCRIPTION
This method tires to optimize boolean queries if there is only
one clause. Yet BooleanQuery already does that internally This
optimization is unneeded.
