### PR TITLE
Improve pending api to include current executing class

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -89,10 +89,11 @@ public class PendingClusterTasksResponse extends ActionResponse implements Itera
         builder.startArray(Fields.TASKS);
         for (PendingClusterTask pendingClusterTask : this) {
             builder.startObject();
-            builder.field(Fields.INSERT_ORDER, pendingClusterTask.insertOrder());
-            builder.field(Fields.PRIORITY, pendingClusterTask.priority());
-            builder.field(Fields.SOURCE, pendingClusterTask.source());
-            builder.field(Fields.TIME_IN_QUEUE_MILLIS, pendingClusterTask.timeInQueueInMillis());
+            builder.field(Fields.INSERT_ORDER, pendingClusterTask.getInsertOrder());
+            builder.field(Fields.PRIORITY, pendingClusterTask.getPriority());
+            builder.field(Fields.SOURCE, pendingClusterTask.getSource());
+            builder.field(Fields.EXECUTING, pendingClusterTask.isExecuting());
+            builder.field(Fields.TIME_IN_QUEUE_MILLIS, pendingClusterTask.getTimeInQueueInMillis());
             builder.field(Fields.TIME_IN_QUEUE, pendingClusterTask.getTimeInQueue());
             builder.endObject();
         }
@@ -103,6 +104,7 @@ public class PendingClusterTasksResponse extends ActionResponse implements Itera
     static final class Fields {
 
         static final XContentBuilderString TASKS = new XContentBuilderString("tasks");
+        static final XContentBuilderString EXECUTING = new XContentBuilderString("executing");
         static final XContentBuilderString INSERT_ORDER = new XContentBuilderString("insert_order");
         static final XContentBuilderString PRIORITY = new XContentBuilderString("priority");
         static final XContentBuilderString SOURCE = new XContentBuilderString("source");

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -279,7 +279,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 timeInQueue = -1;
             }
 
-            pendingClusterTasks.add(new PendingClusterTask(pending.insertionOrder, pending.priority, new StringText(source), timeInQueue));
+            pendingClusterTasks.add(new PendingClusterTask(pending.insertionOrder, pending.priority, new StringText(source), timeInQueue, pending.executing));
         }
         return pendingClusterTasks;
     }

--- a/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
+++ b/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.service;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,51 +37,41 @@ public class PendingClusterTask implements Streamable {
     private Priority priority;
     private Text source;
     private long timeInQueue;
+    private boolean executing;
 
     public PendingClusterTask() {
     }
 
-    public PendingClusterTask(long insertOrder, Priority priority, Text source, long timeInQueue) {
+    public PendingClusterTask(long insertOrder, Priority priority, Text source, long timeInQueue, boolean executing) {
         this.insertOrder = insertOrder;
         this.priority = priority;
         this.source = source;
         this.timeInQueue = timeInQueue;
-    }
-
-    public long insertOrder() {
-        return insertOrder;
+        this.executing = executing;
     }
 
     public long getInsertOrder() {
-        return insertOrder();
-    }
-
-    public Priority priority() {
-        return priority;
+        return insertOrder;
     }
 
     public Priority getPriority() {
-        return priority();
-    }
-
-    public Text source() {
-        return source;
+        return priority;
     }
 
     public Text getSource() {
-        return source();
-    }
-
-    public long timeInQueueInMillis() {
-        return timeInQueue;
+        return source;
     }
 
     public long getTimeInQueueInMillis() {
-        return timeInQueueInMillis();
+        return timeInQueue;
     }
 
     public TimeValue getTimeInQueue() {
         return new TimeValue(getTimeInQueueInMillis());
+    }
+
+    public boolean isExecuting() {
+        return executing;
     }
 
     @Override
@@ -89,6 +80,9 @@ public class PendingClusterTask implements Streamable {
         priority = Priority.readFrom(in);
         source = in.readText();
         timeInQueue = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            executing = in.readBoolean();
+        }
     }
 
     @Override
@@ -97,5 +91,8 @@ public class PendingClusterTask implements Streamable {
         Priority.writeTo(priority, out);
         out.writeText(source);
         out.writeVLong(timeInQueue);
+        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            out.writeBoolean(executing);
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -450,19 +450,23 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         }
 
         // The tasks can be re-ordered, so we need to check out-of-order
-        Set<String> controlSources = new HashSet<>(Arrays.asList("2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        Set<String> controlSources = new HashSet<>(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
         List<PendingClusterTask> pendingClusterTasks = clusterService.pendingTasks();
-        assertThat(pendingClusterTasks.size(), equalTo(9));
+        assertThat(pendingClusterTasks.size(), equalTo(10));
+        assertThat(pendingClusterTasks.get(0).getSource().string(), equalTo("1"));
+        assertThat(pendingClusterTasks.get(0).isExecuting(), equalTo(true));
         for (PendingClusterTask task : pendingClusterTasks) {
-            assertTrue(controlSources.remove(task.source().string()));
+            assertTrue(controlSources.remove(task.getSource().string()));
         }
         assertTrue(controlSources.isEmpty());
 
-        controlSources = new HashSet<>(Arrays.asList("2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        controlSources = new HashSet<>(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
         PendingClusterTasksResponse response = internalCluster().clientNodeClient().admin().cluster().preparePendingClusterTasks().execute().actionGet();
-        assertThat(response.pendingTasks().size(), equalTo(9));
+        assertThat(response.pendingTasks().size(), equalTo(10));
+        assertThat(response.pendingTasks().get(0).getSource().string(), equalTo("1"));
+        assertThat(response.pendingTasks().get(0).isExecuting(), equalTo(true));
         for (PendingClusterTask task : response) {
-            assertTrue(controlSources.remove(task.source().string()));
+            assertTrue(controlSources.remove(task.getSource().string()));
         }
         assertTrue(controlSources.isEmpty());
         block1.countDown();
@@ -511,18 +515,18 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         Thread.sleep(100);
 
         pendingClusterTasks = clusterService.pendingTasks();
-        assertThat(pendingClusterTasks.size(), equalTo(4));
-        controlSources = new HashSet<>(Arrays.asList("2", "3", "4", "5"));
+        assertThat(pendingClusterTasks.size(), equalTo(5));
+        controlSources = new HashSet<>(Arrays.asList("1", "2", "3", "4", "5"));
         for (PendingClusterTask task : pendingClusterTasks) {
-            assertTrue(controlSources.remove(task.source().string()));
+            assertTrue(controlSources.remove(task.getSource().string()));
         }
         assertTrue(controlSources.isEmpty());
 
         response = internalCluster().clientNodeClient().admin().cluster().preparePendingClusterTasks().execute().actionGet();
-        assertThat(response.pendingTasks().size(), equalTo(4));
-        controlSources = new HashSet<>(Arrays.asList("2", "3", "4", "5"));
+        assertThat(response.pendingTasks().size(), equalTo(5));
+        controlSources = new HashSet<>(Arrays.asList("1", "2", "3", "4", "5"));
         for (PendingClusterTask task : response) {
-            assertTrue(controlSources.remove(task.source().string()));
+            assertTrue(controlSources.remove(task.getSource().string()));
             assertThat(task.getTimeInQueueInMillis(), greaterThan(0l));
         }
         assertTrue(controlSources.isEmpty());


### PR DESCRIPTION
the pending tasks api will now include the current executing tasks (with a proper marker boolean flag)
this will also help in tests that wait for no pending tasks, to also wait till the current executing task is done
