### PR TITLE
Remove intern calls on FieldMapper#Names for better performance

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -66,11 +66,11 @@ public interface FieldMapper<T> extends Mapper {
         }
 
         public Names(String name, String indexName, String indexNameClean, String fullName, @Nullable String sourcePath) {
-            this.name = name.intern();
-            this.indexName = indexName.intern();
-            this.indexNameClean = indexNameClean.intern();
-            this.fullName = fullName.intern();
-            this.sourcePath = sourcePath == null ? this.fullName : sourcePath.intern();
+            this.name = name;
+            this.indexName = indexName;
+            this.indexNameClean = indexNameClean;
+            this.fullName = fullName;
+            this.sourcePath = sourcePath == null ? this.fullName : sourcePath;
         }
 
         /**


### PR DESCRIPTION
remove internal callas on FieldMappers#Names, we properly reuse FieldMapper, so there is no need to try and call intern in order to reuse the names. This can be heavy with many fields and continuous mapping parsing.
