### PR TITLE
[DOCS] YAML mappings use colons, not equals sign

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -54,12 +54,12 @@ different clusters by simply setting the `cluster.name` setting, or
 explicitly using the `clusterName` method on the builder.
 
 You can define `cluster.name` in the `/src/main/resources/elasticsearch.yml`
-dir in your project. As long as `elasticsearch.yml` is present in the
+file in your project. As long as `elasticsearch.yml` is present in the
 classpath, it will be used when you start your node.
 
-[source,java]
+[source,yaml]
 --------------------------------------------------
-cluster.name=yourclustername
+cluster.name: yourclustername
 --------------------------------------------------
 
 Or in Java:


### PR DESCRIPTION
YAML  mappings use a colon and space (`:`) to mark each key: value pair, not the equals sign (`=`)

Also,
- `elasticsearch.yml` is a file, not a directory
- modify the AsciiDoc language attribute
