### PR TITLE
Windows: Modify command window title (windows)

### DIFF
--- a/bin/elasticsearch.bat
+++ b/bin/elasticsearch.bat
@@ -68,6 +68,8 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 set ES_CLASSPATH=%ES_CLASSPATH%;%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*;%ES_HOME%/lib/sigar/*
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"
 
+TITLE Elasticsearch ${project.version}
+
 "%JAVA_HOME%\bin\java" %JAVA_OPTS% %ES_JAVA_OPTS% %ES_PARAMS% %* -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch"
 goto finally
 


### PR DESCRIPTION
When launching multiple nodes in MS Windows env, batch command window does not come by default with any title.

This patch add `Elasticsearch VERSION` as a title, where VERSION is the current elasticsearch version.

Closes #6336
