### PR TITLE
New entry/front-end

### DIFF
--- a/docs/community/frontends.asciidoc
+++ b/docs/community/frontends.asciidoc
@@ -12,3 +12,6 @@
 
 * http://elastichammer.exploringelasticsearch.com/[Hammer]: 
   Web front-end for elasticsearch
+
+* https://github.com/romansanchez/Calaca[Calaca]: 
+  Simple search client for Elasticsearch


### PR DESCRIPTION
Adding, Calaca, a simple search client for Elasticsearch.
