### PR TITLE
Improve large bytes request handling by detecting content composite buffer

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -231,8 +231,6 @@ public class MappingMetaData {
             Timestamp timestamp = (Timestamp) o;
 
             if (enabled != timestamp.enabled) return false;
-            if (dateTimeFormatter != null ? !dateTimeFormatter.equals(timestamp.dateTimeFormatter) : timestamp.dateTimeFormatter != null)
-                return false;
             if (format != null ? !format.equals(timestamp.format) : timestamp.format != null) return false;
             if (path != null ? !path.equals(timestamp.path) : timestamp.path != null) return false;
             if (!Arrays.equals(pathElements, timestamp.pathElements)) return false;

--- a/src/main/java/org/elasticsearch/common/netty/NettyUtils.java
+++ b/src/main/java/org/elasticsearch/common/netty/NettyUtils.java
@@ -18,15 +18,21 @@
  */
 package org.elasticsearch.common.netty;
 
+import com.google.common.collect.Lists;
 import org.elasticsearch.transport.netty.NettyInternalESLoggerFactory;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.buffer.CompositeChannelBuffer;
 import org.jboss.netty.logging.InternalLogger;
 import org.jboss.netty.logging.InternalLoggerFactory;
 import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.ThreadRenamingRunnable;
 
+import java.util.List;
+
 /**
  */
-public class NettyStaticSetup {
+public class NettyUtils {
 
     private static EsThreadNameDeterminer ES_THREAD_NAME_DETERMINER = new EsThreadNameDeterminer();
 
@@ -51,5 +57,21 @@ public class NettyStaticSetup {
 
     public static void setup() {
 
+    }
+
+    public static ChannelBuffer buildComposite(boolean useGathering, ChannelBuffer... buffers) {
+        if (buffers == null || buffers.length == 0) {
+            return ChannelBuffers.EMPTY_BUFFER;
+        }
+        List<ChannelBuffer> list = Lists.newArrayList();
+        for (ChannelBuffer buffer : buffers) {
+            if (buffer instanceof CompositeChannelBuffer) {
+                CompositeChannelBuffer compBuffer = (CompositeChannelBuffer) buffer;
+                list.addAll(compBuffer.decompose(0, compBuffer.readableBytes()));
+            } else {
+                list.add(buffer);
+            }
+        }
+        return new CompositeChannelBuffer(buffers[0].order(), list, useGathering);
     }
 }

--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -22,7 +22,7 @@ package org.elasticsearch.http.netty;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.netty.NettyStaticSetup;
+import org.elasticsearch.common.netty.NettyUtils;
 import org.elasticsearch.common.netty.OpenChannelsHandler;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.network.NetworkUtils;
@@ -61,7 +61,7 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
 public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpServerTransport> implements HttpServerTransport {
 
     static {
-        NettyStaticSetup.setup();
+        NettyUtils.setup();
     }
 
     private final NetworkService networkService;

--- a/src/test/java/org/elasticsearch/cluster/SimpleClusterStateTests.java
+++ b/src/test/java/org/elasticsearch/cluster/SimpleClusterStateTests.java
@@ -21,16 +21,20 @@ package org.elasticsearch.cluster;
 
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.hamcrest.CollectionAssertions;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertIndexTemplateExists;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Checking simple filtering capabilites of the cluster state
@@ -119,5 +123,31 @@ public class SimpleClusterStateTests extends ElasticsearchIntegrationTest {
         assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("foo"), is(true));
         assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("fuu"), is(true));
         assertThat(clusterStateResponseFiltered.getState().routingTable().hasIndex("baz"), is(false));
+    }
+
+    @Test
+    public void testLargeClusterStatePublishing() throws Exception {
+        int estimatedBytesSize = scaledRandomIntBetween(ByteSizeValue.parseBytesSizeValue("10k").bytesAsInt(), ByteSizeValue.parseBytesSizeValue("1m").bytesAsInt());
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties");
+        int counter = 0;
+        int numberOfFields = 0;
+        while (true) {
+            mapping.startObject(Strings.randomBase64UUID()).field("type", "string").endObject();
+            counter += 10; // each field is about 10 bytes, assuming compression in place
+            numberOfFields++;
+            if (counter > estimatedBytesSize) {
+                break;
+            }
+        }
+        logger.info("number of fields [{}], estimated bytes [{}]", numberOfFields, estimatedBytesSize);
+        mapping.endObject().endObject().endObject();
+        // if the create index is ack'ed, then all nodes have successfully processed the cluster state
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", mapping).get());
+        MappingMetaData masterMappingMetaData = client().admin().indices().prepareGetMappings("test").setTypes("type").get().getMappings().get("test").get("type");
+        for (Client client : clients()) {
+            MappingMetaData mappingMetadata = client.admin().indices().prepareGetMappings("test").setTypes("type").setLocal(true).get().getMappings().get("test").get("type");
+            assertThat(mappingMetadata.source().string(), equalTo(masterMappingMetaData.source().string()));
+            assertThat(mappingMetadata, equalTo(masterMappingMetaData));
+        }
     }
 }

--- a/src/test/java/org/elasticsearch/cluster/metadata/MappingMetaDataParserTests.java
+++ b/src/test/java/org/elasticsearch/cluster/metadata/MappingMetaDataParserTests.java
@@ -113,6 +113,19 @@ public class MappingMetaDataParserTests extends ElasticsearchTestCase {
     }
 
     @Test
+    public void testParseTimestampEquals() throws Exception {
+        MappingMetaData md1 = new MappingMetaData("type1", new CompressedString(""),
+                new MappingMetaData.Id("id"),
+                new MappingMetaData.Routing(true, "routing"),
+                new MappingMetaData.Timestamp(true, "timestamp", "dateOptionalTime"), false);
+        MappingMetaData md2 = new MappingMetaData("type1", new CompressedString(""),
+                new MappingMetaData.Id("id"),
+                new MappingMetaData.Routing(true, "routing"),
+                new MappingMetaData.Timestamp(true, "timestamp", "dateOptionalTime"), false);
+        assertThat(md1, equalTo(md2));
+    }
+
+    @Test
     public void testParseIdAndRoutingAndTimestamp() throws Exception {
         MappingMetaData md = new MappingMetaData("type1", new CompressedString(""),
                 new MappingMetaData.Id("id"),


### PR DESCRIPTION
There is a special type of request that tries to not allocate another buffer when sending bytes request (used by the public cluster state action). With the new pages bytes reference support, the content can already be a composite channel buffer, take that into account when building the actual composite buffer that will be sent over the network
