### PR TITLE
Separate parsing implementation from setter in SearchParseElement

### DIFF
--- a/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceParseElement.java
+++ b/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceParseElement.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.internal.SearchContext;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,17 +44,19 @@ public class FetchSourceParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
+        context.fetchSourceContext(parse(parser));
+    }
+
+    public FetchSourceContext parse(XContentParser parser) throws IOException {
         XContentParser.Token token;
 
         List<String> includes = null, excludes = null;
         String currentFieldName = null;
         token = parser.currentToken(); // we get it on the value
         if (parser.isBooleanValue()) {
-            context.fetchSourceContext(new FetchSourceContext(parser.booleanValue()));
-            return;
+            return new FetchSourceContext(parser.booleanValue());
         } else if (token == XContentParser.Token.VALUE_STRING) {
-            context.fetchSourceContext(new FetchSourceContext(new String[]{parser.text()}));
-            return;
+            return new FetchSourceContext(new String[]{parser.text()});
         } else if (token == XContentParser.Token.START_ARRAY) {
             includes = new ArrayList<>();
             while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
@@ -87,10 +90,8 @@ public class FetchSourceParseElement implements SearchParseElement {
             throw new ElasticsearchParseException("source element value can be of type " + token.name());
         }
 
-
-        context.fetchSourceContext(new FetchSourceContext(
+        return new FetchSourceContext(
                 includes == null ? Strings.EMPTY_ARRAY : includes.toArray(new String[includes.size()]),
-                excludes == null ? Strings.EMPTY_ARRAY : excludes.toArray(new String[excludes.size()])));
-
+                excludes == null ? Strings.EMPTY_ARRAY : excludes.toArray(new String[excludes.size()]));
     }
 }

--- a/src/main/java/org/elasticsearch/search/rescore/RescoreParseElement.java
+++ b/src/main/java/org/elasticsearch/search/rescore/RescoreParseElement.java
@@ -41,7 +41,7 @@ public class RescoreParseElement implements SearchParseElement {
         }
     }
 
-    private void parseSingleRescoreContext(XContentParser parser, SearchContext context) throws Exception {
+    public void parseSingleRescoreContext(XContentParser parser, SearchContext context) throws Exception {
         String fieldName = null;
         RescoreSearchContext rescoreContext = null;
         Integer windowSize = null;


### PR DESCRIPTION
This, in order to allow reuse of parsing logic by plugins or other internal parts.

Closes #3602
