### PR TITLE
During relocation, process pending mapping update in phase 2

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -48,9 +48,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -107,30 +109,6 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
 
     public void updateMappingOnMaster(String index, DocumentMapper documentMapper, String indexUUID, MappingUpdateListener listener) {
         masterMappingUpdater.add(new MappingChange(documentMapper, index, indexUUID, listener));
-    }
-
-    /**
-     * Immediately send any pending mapping update to master and wait until they are processed.
-     * <i>Note:</i> any mapping updates which are already "in-flight" are ignored by this method
-     *
-     * @return false if waiting timed out, true other wise
-     */
-    public boolean processPendingUpdatesAndWait(TimeValue timeOut) {
-        final CountDownLatch latch = new CountDownLatch(1);
-        PendingMappingProcessedListener listener = new PendingMappingProcessedListener() {
-            @Override
-            public void allPendingMappingProcessed() {
-                latch.countDown();
-            }
-        };
-        masterMappingUpdater.addPendingMappingProcessedListener(listener);
-        masterMappingUpdater.forceProcessingPendingChanges();
-        try {
-            return latch.await(timeOut.millis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new ElasticsearchException("interrupted while waiting for pending mapping updates");
-        }
     }
 
     @Override
@@ -266,11 +244,7 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
         }
     }
 
-    private static interface QueueItem {
-
-    }
-
-    private static class MappingChange implements QueueItem {
+    private static class MappingChange {
         public final DocumentMapper documentMapper;
         public final String index;
         public final String indexUUID;
@@ -294,11 +268,6 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
         void onFailure(Throwable t);
     }
 
-    private interface PendingMappingProcessedListener extends QueueItem {
-        void allPendingMappingProcessed();
-    }
-
-
     /**
      * The master mapping updater removes the overhead of refreshing the mapping (refreshSource) on the
      * indexing thread.
@@ -311,7 +280,7 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
     private class MasterMappingUpdater extends Thread {
 
         private volatile boolean running = true;
-        private final BlockingQueue<QueueItem> queue = ConcurrentCollections.newBlockingQueue();
+        private final BlockingQueue<MappingChange> queue = ConcurrentCollections.newBlockingQueue();
 
         public MasterMappingUpdater(String name) {
             super(name);
@@ -319,14 +288,6 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
 
         public void add(MappingChange change) {
             queue.add(change);
-        }
-
-        public void addPendingMappingProcessedListener(PendingMappingProcessedListener listener) {
-            queue.add(listener);
-        }
-
-        public void forceProcessingPendingChanges() {
-            this.interrupt();
         }
 
         public void close() {
@@ -400,45 +361,28 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
             Map<UpdateKey, UpdateValue> pendingUpdates = Maps.newHashMap();
             while (running) {
                 try {
-                    QueueItem polledItem = null;
-                    try {
-                        polledItem = queue.poll(10, TimeUnit.MINUTES);
-                        if (polledItem != null && polledItem instanceof MappingChange && additionalMappingChangeTime.millis() > 0) {
-                            Thread.sleep(additionalMappingChangeTime.millis());
-                        }
-                    } catch (InterruptedException e) {
-                        // meh
-                    }
-                    if (polledItem == null) {
+                    MappingChange polledChange = queue.poll(10, TimeUnit.MINUTES);
+                    if (polledChange == null) {
                         continue;
                     }
-
-                    final List<PendingMappingProcessedListener> processingListeners = Collections.synchronizedList(new ArrayList<PendingMappingProcessedListener>());
-                    List<QueueItem> items = Lists.newArrayList(polledItem);
-                    queue.drainTo(items);
-
-                    Collections.reverse(items); // process then in newest one to oldest
+                    List<MappingChange> changes = Lists.newArrayList(polledChange);
+                    if (additionalMappingChangeTime.millis() > 0) {
+                        Thread.sleep(additionalMappingChangeTime.millis());
+                    }
+                    queue.drainTo(changes);
+                    Collections.reverse(changes); // process then in newest one to oldest
                     // go over and add to pending updates map
-                    for (QueueItem item : items) {
-                        if (item instanceof PendingMappingProcessedListener) {
-                            processingListeners.add((PendingMappingProcessedListener) item);
-                        } else if (item instanceof MappingChange) {
-                            MappingChange change = (MappingChange) item;
-                            UpdateKey key = new UpdateKey(change.indexUUID, change.documentMapper.type());
-                            UpdateValue updateValue = pendingUpdates.get(key);
-                            if (updateValue == null) {
-                                updateValue = new UpdateValue(change);
-                                pendingUpdates.put(key, updateValue);
-                            }
-                            if (change.listener != null) {
-                                updateValue.listeners.add(change.listener);
-                            }
-                        } else {
-                            assert false : "unknown QueueItem type: " + item.getClass();
+                    for (MappingChange change : changes) {
+                        UpdateKey key = new UpdateKey(change.indexUUID, change.documentMapper.type());
+                        UpdateValue updateValue = pendingUpdates.get(key);
+                        if (updateValue == null) {
+                            updateValue = new UpdateValue(change);
+                            pendingUpdates.put(key, updateValue);
+                        }
+                        if (change.listener != null) {
+                            updateValue.listeners.add(change.listener);
                         }
                     }
-
-                    final AtomicLong pendingRequests = new AtomicLong(pendingUpdates.size());
 
                     for (Iterator<UpdateValue> iterator = pendingUpdates.values().iterator(); iterator.hasNext(); ) {
                         final UpdateValue updateValue = iterator.next();
@@ -465,28 +409,23 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
                             @Override
                             public void onResponse(MappingUpdatedAction.MappingUpdatedResponse mappingUpdatedResponse) {
                                 logger.debug("successfully updated master with mapping update: {}", mappingRequest);
-                                if (pendingRequests.decrementAndGet() == 0) {
-                                    notifyPendingMappingProcessedListeners(processingListeners);
-                                }
                                 updateValue.notifyListeners(null);
                             }
 
                             @Override
                             public void onFailure(Throwable e) {
                                 logger.warn("failed to update master on updated mapping for {}", e, mappingRequest);
-                                if (pendingRequests.decrementAndGet() == 0) {
-                                    notifyPendingMappingProcessedListeners(processingListeners);
-                                }
                                 updateValue.notifyListeners(e);
                             }
                         });
 
                     }
-                    if (pendingRequests.get() == 0) {
-                        notifyPendingMappingProcessedListeners(processingListeners);
-                    }
                 } catch (Throwable t) {
-                    logger.warn("failed to process mapping updates", t);
+                    if (t instanceof InterruptedException && !running) {
+                        // all is well, we are shutting down
+                    } else {
+                        logger.warn("failed to process mapping updates", t);
+                    }
                     // cleanup all pending update callbacks that were not processed due to a global failure...
                     for (Iterator<Map.Entry<UpdateKey, UpdateValue>> iterator = pendingUpdates.entrySet().iterator(); iterator.hasNext(); ) {
                         Map.Entry<UpdateKey, UpdateValue> entry = iterator.next();
@@ -494,12 +433,6 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
                         entry.getValue().notifyListeners(t);
                     }
                 }
-            }
-        }
-
-        void notifyPendingMappingProcessedListeners(List<PendingMappingProcessedListener> listeners) {
-            for (PendingMappingProcessedListener listener : listeners) {
-                listener.allPendingMappingProcessed();
             }
         }
     }

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -39,6 +39,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.IndexShardState;
@@ -54,6 +56,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -94,7 +97,8 @@ public class RecoverySource extends AbstractComponent {
     }
 
     private RecoveryResponse recover(final StartRecoveryRequest request) {
-        final InternalIndexShard shard = (InternalIndexShard) indicesService.indexServiceSafe(request.shardId().index().name()).shardSafe(request.shardId().id());
+        final IndexService indexService = indicesService.indexServiceSafe(request.shardId().index().name());
+        final InternalIndexShard shard = (InternalIndexShard) indexService.shardSafe(request.shardId().id());
 
         // verify that our (the source) shard state is marking the shard to be in recovery mode as well, otherwise
         // the index operations will not be routed to it properly
@@ -261,18 +265,46 @@ public class RecoverySource extends AbstractComponent {
                 response.startTime = stopWatch.totalTime().millis();
                 logger.trace("{} recovery [phase2] to {}: start took [{}]", request.shardId(), request.targetNode(), request.targetNode(), stopWatch.totalTime());
 
-                logger.trace("{} recovery [phase2] to {}: waiting on pending mapping update", request.shardId(), request.targetNode());
-                if (!mappingUpdatedAction.processPendingUpdatesAndWait(internalActionTimeout)) {
-                    logger.debug("{} recovery [phase2] to {}: waiting on pending mapping update timed out. waited [{}]", request.shardId(), request.targetNode(), internalActionTimeout);
-                }
 
-                logger.trace("{} recovery [phase2] to {}: sending transaction log operations", request.shardId(), request.targetNode(), request.targetNode());
+                logger.trace("{} recovery [phase2] to {}: updating current mapping to master", request.shardId(), request.targetNode());
+                updateMappingOnMaster();
+
+                logger.trace("{} recovery [phase2] to {}: sending transaction log operations", request.shardId(), request.targetNode());
                 stopWatch = new StopWatch().start();
                 int totalOperations = sendSnapshot(snapshot);
                 stopWatch.stop();
                 logger.trace("{} recovery [phase2] to {}: took [{}]", request.shardId(), request.targetNode(), stopWatch.totalTime());
                 response.phase2Time = stopWatch.totalTime().millis();
                 response.phase2Operations = totalOperations;
+            }
+
+            private void updateMappingOnMaster() {
+                List<DocumentMapper> documentMappersToUpdate = Lists.newArrayList(indexService.mapperService());
+                final CountDownLatch countDownLatch = new CountDownLatch(documentMappersToUpdate.size());
+                MappingUpdatedAction.MappingUpdateListener listener = new MappingUpdatedAction.MappingUpdateListener() {
+                    @Override
+                    public void onMappingUpdate() {
+                        countDownLatch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        logger.debug("{} recovery to {}: failed to update mapping on master", request.shardId(), request.targetNode(), t);
+                        countDownLatch.countDown();
+                    }
+                };
+                for (DocumentMapper documentMapper : documentMappersToUpdate) {
+                    mappingUpdatedAction.updateMappingOnMaster(indexService.index().getName(), documentMapper, indexService.indexUUID(), listener);
+                }
+                try {
+                    if (!countDownLatch.await(internalActionTimeout.millis(), TimeUnit.MILLISECONDS)) {
+                        logger.debug("{} recovery [phase2] to {}: waiting on pending mapping update timed out. waited [{}]", request.shardId(), request.targetNode(), internalActionTimeout);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.debug("interrupted while waiting for mapping to update on master");
+                }
+
             }
 
             @Override

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -258,7 +258,7 @@ public class RecoverySource extends AbstractComponent {
                 if (shard.state() == IndexShardState.CLOSED) {
                     throw new IndexShardClosedException(request.shardId());
                 }
-                logger.trace("{} recovery [phase2] to {}: start", request.shardId().index().name(), request.shardId().id(), request.targetNode());
+                logger.trace("{} recovery [phase2] to {}: start", request.shardId(), request.targetNode());
                 StopWatch stopWatch = new StopWatch().start();
                 transportService.submitRequest(request.targetNode(), RecoveryTarget.Actions.PREPARE_TRANSLOG, new RecoveryPrepareForTranslogOperationsRequest(request.recoveryId(), request.shardId()), TransportRequestOptions.options().withTimeout(internalActionTimeout), EmptyTransportResponseHandler.INSTANCE_SAME).txGet();
                 stopWatch.stop();
@@ -280,6 +280,9 @@ public class RecoverySource extends AbstractComponent {
 
             private void updateMappingOnMaster() {
                 List<DocumentMapper> documentMappersToUpdate = Lists.newArrayList(indexService.mapperService());
+                if (documentMappersToUpdate.size() == 0) {
+                    return;
+                }
                 final CountDownLatch countDownLatch = new CountDownLatch(documentMappersToUpdate.size());
                 MappingUpdatedAction.MappingUpdateListener listener = new MappingUpdatedAction.MappingUpdateListener() {
                     @Override


### PR DESCRIPTION
During phase1 we copy over all lucene segments. These make refer to mapping updates that are still queued up to be sent to master. We must make sure those pending updates are sent before completing the relocation.

Relates to #6648
