### PR TITLE
Improve Settings#get lookup for camel case support

### DIFF
--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -57,11 +57,12 @@ public class ImmutableSettings implements Settings {
     public static final Settings EMPTY = new Builder().build();
 
     private ImmutableMap<String, String> settings;
-    private Map<String, String> forcedUnderscoreSettings;
+    private final ImmutableMap<String, String> forcedUnderscoreSettings;
     private transient ClassLoader classLoader;
 
     ImmutableSettings(Map<String, String> settings, ClassLoader classLoader) {
         this.settings = ImmutableMap.copyOf(settings);
+        Map<String, String> forcedUnderscoreSettings = null;
         for (Map.Entry<String, String> entry : settings.entrySet()) {
             String toUnderscoreCase = Strings.toUnderscoreCase(entry.getKey());
             if (!toUnderscoreCase.equals(entry.getKey())) {
@@ -71,6 +72,7 @@ public class ImmutableSettings implements Settings {
                 forcedUnderscoreSettings.put(toUnderscoreCase, entry.getValue());
             }
         }
+        this.forcedUnderscoreSettings = forcedUnderscoreSettings == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(forcedUnderscoreSettings);
         this.classLoader = classLoader;
     }
 
@@ -222,11 +224,7 @@ public class ImmutableSettings implements Settings {
         if (retVal != null) {
             return retVal;
         }
-        // try the forced underscore setting
-        if (forcedUnderscoreSettings != null) {
-            return forcedUnderscoreSettings.get(setting);
-        }
-        return null;
+        return forcedUnderscoreSettings.get(setting);
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/common/settings/ImmutableSettingsTests.java
+++ b/src/test/java/org/elasticsearch/common/settings/ImmutableSettingsTests.java
@@ -36,6 +36,15 @@ import static org.hamcrest.Matchers.*;
 public class ImmutableSettingsTests extends ElasticsearchTestCase {
 
     @Test
+    public void testCamelCaseSupport() {
+        Settings settings = settingsBuilder()
+                .put("test.camelCase", "bar")
+                .build();
+        assertThat(settings.get("test.camelCase"), equalTo("bar"));
+        assertThat(settings.get("test.camel_case"), equalTo("bar"));
+    }
+
+    @Test
     public void testGetAsClass() {
         Settings settings = settingsBuilder()
                 .put("test.class", "bar")


### PR DESCRIPTION
Today, if we miss on a get on setting, we try its camel case version. The assumption is that in our code, we never use camel case to lookup a setting, but we want to support camel case if the user provided one.
This can be expensive (#toCamelCase) when the get on the setting is done in a tight call, which is evident when running the allocation deciders as part of the reroute logic.
Instead of doing the camel case check on get, prepare an additional map that includes all the settings that are provided as came case, and try and lookup from it if needed.
