### PR TITLE
Query DSL: Improved explanation for match_phrase_prefix

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
@@ -198,15 +198,27 @@ public class MultiPhrasePrefixQuery extends Query {
                 buffer.append("(");
                 for (int j = 0; j < terms.length; j++) {
                     buffer.append(terms[j].text());
-                    if (j < terms.length - 1)
-                        buffer.append(" ");
+                    if (j < terms.length - 1) {
+                        if (i.hasNext()) {
+                            buffer.append(" ");
+                        } else {
+                            buffer.append("* ");
+                        }
+                    }
                 }
-                buffer.append(")");
+                if (i.hasNext()) {
+                    buffer.append(") ");
+                } else {
+                    buffer.append("*)");
+                }
             } else {
                 buffer.append(terms[0].text());
+                if (i.hasNext()) {
+                    buffer.append(" ");
+                } else {
+                    buffer.append("*");
+                }
             }
-            if (i.hasNext())
-                buffer.append(" ");
         }
         buffer.append("\"");
 
@@ -272,7 +284,7 @@ public class MultiPhrasePrefixQuery extends Query {
         }
         return true;
     }
-    
+
     public String getField() {
         return field;
     }

--- a/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
+++ b/src/test/java/org/elasticsearch/validate/SimpleValidateQueryTests.java
@@ -226,7 +226,7 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
             assertThat(response.getQueryExplanation().get(0).getExplanation(), nullValue());
 
         }
-        
+
         for (Client client : internalCluster()) {
                 ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
                     .setQuery(QueryBuilders.queryString("foo"))
@@ -295,6 +295,43 @@ public class SimpleValidateQueryTests extends ElasticsearchIntegrationTest {
         assertThat(validateQueryResponse.getQueryExplanation().size(), equalTo(1));
         assertThat(validateQueryResponse.getQueryExplanation().get(0).getIndex(), equalTo("test"));
         assertThat(validateQueryResponse.getQueryExplanation().get(0).getExplanation(), containsString("field:value1"));
+    }
+
+    @Test
+    public void explainMatchPhrasePrefix() {
+        assertAcked(prepareCreate("test").setSettings(
+                ImmutableSettings.settingsBuilder().put(indexSettings())
+                        .put("index.analysis.filter.syns.type", "synonym")
+                        .putArray("index.analysis.filter.syns.synonyms", "one,two")
+                        .put("index.analysis.analyzer.syns.tokenizer", "standard")
+                        .putArray("index.analysis.analyzer.syns.filter", "syns")
+                    ).addMapping("test", "field","type=string,analyzer=syns"));
+        ensureGreen();
+
+        ValidateQueryResponse validateQueryResponse = client().admin().indices().prepareValidateQuery("test")
+                .setQuery(QueryBuilders.matchPhrasePrefixQuery("field", "foo")).setExplain(true).get();
+        assertThat(validateQueryResponse.isValid(), equalTo(true));
+        assertThat(validateQueryResponse.getQueryExplanation().size(), equalTo(1));
+        assertThat(validateQueryResponse.getQueryExplanation().get(0).getExplanation(), containsString("field:\"foo*\""));
+
+        validateQueryResponse = client().admin().indices().prepareValidateQuery("test")
+                .setQuery(QueryBuilders.matchPhrasePrefixQuery("field", "foo bar")).setExplain(true).get();
+        assertThat(validateQueryResponse.isValid(), equalTo(true));
+        assertThat(validateQueryResponse.getQueryExplanation().size(), equalTo(1));
+        assertThat(validateQueryResponse.getQueryExplanation().get(0).getExplanation(), containsString("field:\"foo bar*\""));
+
+        // Stacked tokens
+        validateQueryResponse = client().admin().indices().prepareValidateQuery("test")
+                .setQuery(QueryBuilders.matchPhrasePrefixQuery("field", "one bar")).setExplain(true).get();
+        assertThat(validateQueryResponse.isValid(), equalTo(true));
+        assertThat(validateQueryResponse.getQueryExplanation().size(), equalTo(1));
+        assertThat(validateQueryResponse.getQueryExplanation().get(0).getExplanation(), containsString("field:\"(one two) bar*\""));
+
+        validateQueryResponse = client().admin().indices().prepareValidateQuery("test")
+                .setQuery(QueryBuilders.matchPhrasePrefixQuery("field", "foo one")).setExplain(true).get();
+        assertThat(validateQueryResponse.isValid(), equalTo(true));
+        assertThat(validateQueryResponse.getQueryExplanation().size(), equalTo(1));
+        assertThat(validateQueryResponse.getQueryExplanation().get(0).getExplanation(), containsString("field:\"foo (one* two*)\""));
     }
 
     @Test


### PR DESCRIPTION
The match_phrase_prefix provided the same explanation as the match_phrase
query. There was no indication that the last term was run as a prefix
query.

This change marks the last term (or terms if there are multiple terms
in the same position) with a *

Closes #2449
