### PR TITLE
Build: Add all netty classes during shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -713,6 +713,12 @@
                                 <exclude>build.properties</exclude>
                             </excludes>
                         </filter>
+                        <filter>
+                            <artifact>io.netty:netty</artifact>
+                            <includes>
+                                <include>org/jboss/netty/**</include>
+                            </includes>
+                        </filter>
                     </filters>
                 </configuration>
             </plugin>


### PR DESCRIPTION
In order to have access to all codecs and handlers by netty, they
need to be exposed during shading, otherwise only the classes, which
are used by the built are exposed.
