### PR TITLE
[Engine] checkVersionMapRefresh shouldn't use indexWriter.getConfig()

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.engine.internal;
 
 import com.google.common.collect.Lists;
-
 import org.apache.lucene.index.*;
 import org.apache.lucene.index.IndexWriter.IndexReaderWarmer;
 import org.apache.lucene.search.IndexSearcher;
@@ -80,7 +79,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -389,21 +387,18 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     public void create(Create create) throws EngineException {
         final IndexWriter writer;
         try (InternalLock _ = readLock.acquire()) {
-            writer = this.indexWriter;
-            if (writer == null) {
-                throw new EngineClosedException(shardId, failedEngine);
-            }
+            writer = currentIndexWriter();
             try (Releasable r = throttle.acquireThrottle()) {
                 innerCreate(create, writer);
             }
             dirty = true;
             possibleMergeNeeded = true;
             flushNeeded = true;
+            checkVersionMapRefresh(writer);
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine(t);
             throw new CreateFailedEngineException(shardId, create, t);
         }
-        checkVersionMapRefresh(writer);
     }
 
     private void maybeFailEngine(Throwable t) {
@@ -485,43 +480,39 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
     public void index(Index index) throws EngineException {
         final IndexWriter writer;
         try (InternalLock _ = readLock.acquire()) {
-            writer = this.indexWriter;
-            if (writer == null) {
-                throw new EngineClosedException(shardId, failedEngine);
-            }
+            writer = currentIndexWriter();
             try (Releasable r = throttle.acquireThrottle()) {
                 innerIndex(index, writer);
             }
             dirty = true;
             possibleMergeNeeded = true;
             flushNeeded = true;
+            checkVersionMapRefresh(writer);
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine(t);
             throw new IndexFailedEngineException(shardId, index, t);
         }
-        checkVersionMapRefresh(writer);
     }
 
-    /** Forces a refresh if the versionMap is using too much RAM (currently > 25% of IndexWriter's RAM buffer).
-     * */
+    /**
+     * Forces a refresh if the versionMap is using too much RAM (currently > 25% of IndexWriter's RAM buffer).
+     */
     private void checkVersionMapRefresh(final IndexWriter indexWriter) {
         // TODO: we force refresh when versionMap is using > 25% of IW's RAM buffer; should we make this separately configurable?
-        if (versionMap.ramBytesUsedForRefresh()/1024/1024. > 0.25 * indexWriter.getConfig().getRAMBufferSizeMB() && versionMapRefreshPending.getAndSet(true) == false) {
-            if (!closed) {
-                try {
-                    // Now refresh to clear versionMap:
-                    threadPool.executor(ThreadPool.Names.REFRESH).execute(new Runnable() {
-                            public void run() {
-                                try {
-                                    refresh(new Refresh("version_table_full"));
-                                } catch (EngineClosedException ex) {
-                                    // ignore
-                                }
-                            }
-                        });
-                } catch (EsRejectedExecutionException ex) {
-                    // that is fine too.. we might be shutting down
-                }
+        if (versionMap.ramBytesUsedForRefresh() / 1024 / 1024. > 0.25 * indexWriter.getConfig().getRAMBufferSizeMB() && versionMapRefreshPending.getAndSet(true) == false) {
+            try {
+                // Now refresh to clear versionMap:
+                threadPool.executor(ThreadPool.Names.REFRESH).execute(new Runnable() {
+                    public void run() {
+                        try {
+                            refresh(new Refresh("version_table_full"));
+                        } catch (EngineClosedException ex) {
+                            // ignore
+                        }
+                    }
+                });
+            } catch (EsRejectedExecutionException ex) {
+                // that is fine too.. we might be shutting down
             }
         }
     }
@@ -596,11 +587,11 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
 
         maybePruneDeletedTombstones();
     }
-    
+
     private void maybePruneDeletedTombstones() {
         // It's expensive to prune because we walk the deletes map acquiring dirtyLock for each uid so we only do it
         // every 1/4 of gcDeletesInMillis:
-        if (enableGcDeletes && threadPool.estimatedTimeInMillis() - lastDeleteVersionPruneTimeMSec > gcDeletesInMillis*0.25) {
+        if (enableGcDeletes && threadPool.estimatedTimeInMillis() - lastDeleteVersionPruneTimeMSec > gcDeletesInMillis * 0.25) {
             pruneDeletedTombstones();
         }
     }


### PR DESCRIPTION
We run it out of lock, the indexWriter may be closed..

Relates to #6443, #6786
