### PR TITLE
Security: Disable JSONP by default

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -241,17 +241,19 @@ document indexed.
 [float]
 === JSONP
 
-By default JSONP resposes are enabled. All REST APIs accept a `callback` parameter
-resulting in a http://en.wikipedia.org/wiki/JSONP[JSONP] result. You can disable
+By default JSONP resposes are disabled.
+
+When enabled, all REST APIs accept a `callback` parameter
+resulting in a http://en.wikipedia.org/wiki/JSONP[JSONP] result. You can enable
 this behavior by adding the following to `config.yaml`:
 
-    http.jsonp.enable: false
+    http.jsonp.enable: true
 
-Please note, due to the architecture of Elasticsearch, this may pose a security
-risk. Under some circumstances, an attacker may be able to exfiltrate data in your
-Elasticsearch server if they're able to force your browser to make a JSONP request
-on your behalf (e.g. by including a <script> tag on an untrusted site with a
-legitimate query against a local Elasticsearch server).
+Please note, when enabled, due to the architecture of Elasticsearch, this may pose
+a security risk. Under some circumstances, an attacker may be able to exfiltrate
+data in your Elasticsearch server if they're able to force your browser to make a
+JSONP request on your behalf (e.g. by including a <script> tag on an untrusted site
+with a legitimate query against a local Elasticsearch server).
 
 [float]
 === Request body in query string

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -241,7 +241,7 @@ document indexed.
 [float]
 === JSONP
 
-By default JSONP resposes are disabled.
+By default JSONP responses are disabled by default. coming[1.3,Previously JSONP was enabled by default]
 
 When enabled, all REST APIs accept a `callback` parameter
 resulting in a http://en.wikipedia.org/wiki/JSONP[JSONP] result. You can enable

--- a/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/src/main/java/org/elasticsearch/rest/RestController.java
@@ -43,6 +43,8 @@ import static org.elasticsearch.rest.RestStatus.FORBIDDEN;
  */
 public class RestController extends AbstractLifecycleComponent<RestController> {
 
+    public static final String HTTP_JSON_ENABLE = "http.jsonp.enable";
+
     private final PathTrie<RestHandler> getHandlers = new PathTrie<>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> postHandlers = new PathTrie<>(RestUtils.REST_DECODER);
     private final PathTrie<RestHandler> putHandlers = new PathTrie<>(RestUtils.REST_DECODER);
@@ -140,7 +142,7 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
 
     public void dispatchRequest(final RestRequest request, final RestChannel channel) {
         // If JSONP is disabled and someone sends a callback parameter we should bail out before querying
-        if (!settings.getAsBoolean("http.jsonp.enable", false) && request.hasParam("callback")){
+        if (!settings.getAsBoolean(HTTP_JSON_ENABLE, false) && request.hasParam("callback")){
             try {
                 XContentBuilder builder = channel.newBuilder();
                 builder.startObject().field("error","JSONP is disabled.").endObject().string();

--- a/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/src/main/java/org/elasticsearch/rest/RestController.java
@@ -140,7 +140,7 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
 
     public void dispatchRequest(final RestRequest request, final RestChannel channel) {
         // If JSONP is disabled and someone sends a callback parameter we should bail out before querying
-        if (!settings.getAsBoolean("http.jsonp.enable", true) && request.hasParam("callback")){
+        if (!settings.getAsBoolean("http.jsonp.enable", false) && request.hasParam("callback")){
             try {
                 XContentBuilder builder = channel.newBuilder();
                 builder.startObject().field("error","JSONP is disabled.").endObject().string();

--- a/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionDisabledTest.java
+++ b/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionDisabledTest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.options.jsonp;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.helper.HttpClient;
 import org.elasticsearch.rest.helper.HttpClientResponse;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -39,8 +40,13 @@ public class JsonpOptionDisabledTest extends ElasticsearchIntegrationTest {
     // Build our cluster settings
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
+        // false is the default!
+        if (randomBoolean()) {
+            logger.info("using default jsonp settings (should be false)");
+            return super.nodeSettings(nodeOrdinal);
+        }
         return ImmutableSettings.settingsBuilder()
-                .put("http.jsonp.enable", false)
+                .put(RestController.HTTP_JSON_ENABLE, false)
                 .put(super.nodeSettings(nodeOrdinal))
                 .build();
     }

--- a/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionEnabledTest.java
+++ b/src/test/java/org/elasticsearch/options/jsonp/JsonpOptionEnabledTest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.options.jsonp;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.helper.HttpClient;
 import org.elasticsearch.rest.helper.HttpClientResponse;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -40,7 +41,7 @@ public class JsonpOptionEnabledTest extends ElasticsearchIntegrationTest {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.settingsBuilder()
-                .put("http.jsonp.enable", true)
+                .put(RestController.HTTP_JSON_ENABLE, true)
                 .put(super.nodeSettings(nodeOrdinal))
                 .build();
     }


### PR DESCRIPTION
By default, disable the option to use JSONP in our REST layer
