### PR TITLE
significant_terms agg new sampling option.

### DIFF
--- a/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -204,8 +204,15 @@ The significant_terms aggregation can be used effectively on tokenized free-text
 * keywords for refining end-user searches
 * keywords for use in percolator queries
 
-WARNING: Picking a free-text field as the subject of a significant terms analysis can be expensive! It will attempt
-to load every unique word into RAM. It is recommended to only use this on smaller indices.
+WARNING: Picking a free-text field as the subject of a significant terms analysis can be expensive in memory costs and 
+make poor suggestions if there is a lot of duplicate content or low-relevance matches. However there is a solution to
+these problems in version 1.3.0 in the form of `sampling`.
+
+added[1.3.0]
+The new `sampling` parameters allow significant terms to be discovered from analyzing a sample of the top-matching documents, 
+removing the need to load text values for all documents into FieldData in advance and also providing the opportunity to remove
+duplicate sections of text that are typically found in things like copyright notices, retweets or email replies.  
+
 
 .Use the _"like this but not this"_ pattern
 **********************************
@@ -402,6 +409,62 @@ WARNING: Setting `min_doc_count` to `1` is generally not advised as it tends to 
          default value of 3 is used to provide a minimum weight-of-evidence.
          Setting `shard_min_doc_count` too high will cause significant candidate terms to be filtered out on a shard level. This value should be set much lower than `min_doc_count/#shards`.
 
+===== Sampling foreground content
+added[1.3.0] `sampling` parameter
+
+For free-text fields it is typically beneficial to perform significant_terms analysis on a sample of the matching documents
+because: 
+
+. It avoids having to load large numbers of unique terms for all documents into FieldData caches up-front
+. It allows only the top-matching documents to be considered, potentially giving more focused suggestions
+. As part of the sampling it is possible to remove duplicate sections of content that otherwise artificially inflate the statistics of word uses. 
+
+[source,js]
+--------------------------------------------------
+{
+    "query" : {
+        "match" : "bird flu"
+    },
+    "aggs" : {
+        "tags" : {
+            "significant_terms" : { 
+                "field" : "description",
+                "sampling": {
+                	"docs_per_shard":100
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+In the above example the "sampling" section holds the settings that relate to performing significant_terms analysis 
+on a subset of the results for the given query. The fields that are relevant in the "sampling" section are as follows:
+
+
+[horizontal]
+docs_per_shard::         Optional. The number of top-matching documents to be sampled on each shard. Defaults to 50.
+						  The more documents sampled, the slower the response and this also does not always lead to higher 
+						  quality suggestions as the sample will typically start to include less relevant documents in 
+						  the sample.
+
+duplicate_para_length::     Optional but recommended. The minimum number of tokens seen in sequence before they are a candidate
+							for de-duplication and may be removed from the sampling process. The default setting is zero
+							meaning no duplicate-detection is performed.
+							For typical text useful settings are perhaps 6 tokens or more. Settings that are too large
+							e.g. 100 are probably being too picky and typically unlikely to discover duplicate sequences of 
+							that scale.							 
+							Lower settings like 2 may have some false-positives
+							due to the way sequences are encoded internally but are generally not advisable anyway as
+							many useful text phrases consist of small numbers of words and we want to identify these
+							repetitions rather than eliminate them as duplicate sections of content. 
+							
+max_tokens_parsed_per_doc:: Optional. The maximum number of tokens sampled from each document.
+							This is principally a performance optimization to avoid the costs of re-tokenizing 
+							very large documents in their entirety. The default is 1,000.
+
+num_recorded_tokens::    Optional. If duplicate_para_length is set to >1 this setting controls the size in 
+						bytes of the sliding window used to identify duplicate content. The default setting is 50,000 and 
+						each token is recorded in hashed form as a single byte to minimize RAM.
 
 
 ===== Custom background context

--- a/src/main/java/org/elasticsearch/index/analysis/ByteStreamDuplicateSequenceSpotter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ByteStreamDuplicateSequenceSpotter.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import java.util.Arrays;
+
+
+/**
+ * Records a potentially endless stream of bytes and for each byte added
+ * reports how many of the immediate predecessors were seen in that sequence
+ * previously (the maximum chain length seen in a buffer of controllable size) 
+ */
+public final class ByteStreamDuplicateSequenceSpotter {
+    
+    private final int ringLength;
+    private final byte[] byteBuffer;
+    private final byte[] chainLengths;
+    private int nextFreePos = 0;
+    private int numAdditions;
+    private byte lastBestChainLength = 0;    
+    
+    final int priorIndex(int i){
+        if(i>0){
+            return i-1;
+        }
+        return ringLength-1;
+    }
+    
+    /**
+     * Adds the next byte in a stream, returning the cumulative length of duplicate
+     * bytes seen in succession. The definition of "duplicate" is dependent on the 
+     * earlier sightings remaining in our sliding window of content.
+     * 
+     * Given an infinite window of content, the result will have no false negatives 
+     * (i.e. failures to spot duplicate byte sequences) but may contain false positives 
+     * (i.e. reports a sequence as duplicate due to hash collisions). The longer the 
+     * sequence of tokens, the less likely a false positive will occur.
+     * Given a larger window (and we typically use a large one) the number of false 
+     * negatives will decrease but the time to check for duplicates will increase. 
+     * 
+     * TODO add option of a user-defined "slop factor" into chains e.g. allow one or 
+     * more non-contiguous tokens in a chain - could somehow encode (using reserved bits?) 
+     * how many slops have been encountered in a chain as we propagate counts along the 
+     * chainLengths array. 
+     * 
+     * 
+     * @param newByte The next token being processed in a stream
+     * @return The longest recorded sequence of tokens seen in the current stream (max recorded value is 127)
+     * 
+     * TODO could still use a byte array internally for chainLength but once we are into >127 we could use
+     * a single int held in instance data to keep incrementing when we can no longer count above constraints 
+     * of a byte. This has the potential to misreport lengths but would be unlikely. 
+     */
+    byte addByte(byte newByte) {
+        byte bestLength = 0;
+        // Walk the entire ring backwards - if we do it forwards it messes up
+        // counts being carried forward
+        int i = priorIndex(nextFreePos);
+        int numToCheck = Math.min(numAdditions-1, ringLength-1);
+        while (numToCheck >= 0) {
+            int prior = priorIndex(i);
+            byte priorCount = chainLengths[prior];
+            if (byteBuffer[i] == newByte) {
+                byte newCount = 1;
+                if (priorCount == lastBestChainLength) {
+                    // Carry forward the best chain header adding one to its
+                    // count (as far as a byte will let us count)
+                    // A low-probability of false positives here - we don't
+                    // check that newToken and its preceeding tokens are
+                    // the ones that gave rise to the recorded chain end here
+                    // but this is mitigated by the fact that contiguous
+                    // waves of such low-probability false-positives would 
+                    // need to occur at the same spot before the
+                    // final min duplicate chain length (typically 8 or so
+                    // tokens) is filtered. A very low risk.
+                    newCount = priorCount == Byte.MAX_VALUE ? Byte.MAX_VALUE : (byte) (priorCount + 1);
+                    chainLengths[i] = newCount;
+                    chainLengths[prior] = 0; // clean out the count to reflect
+                                             // the new head position
+                } else {
+                    // The newByte is not a continuation of the prior
+                    // chain - establish a new chain with a count of 1 and terminate the old one
+                    chainLengths[i] = newCount;
+                    chainLengths[prior] = 0; // clean out the cold trail
+                }
+                bestLength = (byte) Math.max(bestLength, newCount);
+            } else {
+                if (priorCount > 0) {
+                    // Our newByte is not the hoped-for continuation of a prior
+                    // chain - reset the chain to mark its end and avoid further growth.
+                    chainLengths[prior] = 0;
+                    chainLengths[i] = 0;
+                }
+            }
+            numToCheck--;
+            i = priorIndex(i);
+        }
+        lastBestChainLength = bestLength;
+        
+        // Now add the new token to the buffer
+        // trash the chain counts as we have changed the data that is being
+        // counted here
+        if (numAdditions >= ringLength) {
+            chainLengths[nextFreePos] = 0;
+        }
+
+        if(numAdditions<Integer.MAX_VALUE){
+            numAdditions++;
+        }
+        byteBuffer[nextFreePos] = newByte;
+
+        nextFreePos++;
+        if (nextFreePos >= ringLength) {
+            nextFreePos = 0;
+        }
+        return bestLength;
+    }
+
+    public ByteStreamDuplicateSequenceSpotter(int numRecordedBytes) {
+        ringLength=numRecordedBytes;
+        byteBuffer = new byte[ringLength];
+        chainLengths = new byte[ringLength];
+    }
+
+    public void reset() {
+        Arrays.fill(chainLengths, 0, ringLength, (byte) 0);
+        // TODO need to reserve a special byte to indicate end of doc? 
+        // Would prevent matches over doc boundaries but I'm reluctant 
+        // to give up one of my 256 bytes for this rare scenario 
+        lastBestChainLength = 0;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/DeDuplicatingTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/DeDuplicatingTokenFilter.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import org.apache.lucene.analysis.util.FilteringTokenFilter;
+import org.apache.lucene.codecs.bloom.MurmurHash2;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Version;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class DeDuplicatingTokenFilter extends FilteringTokenFilter {
+    private final DuplicateSequenceLengthAttribute seqAtt = addAttribute(DuplicateSequenceLengthAttribute.class);
+    private int minDupChainLength;
+
+    public DeDuplicatingTokenFilter(Version version, TokenStream in, ByteStreamDuplicateSequenceSpotter byteStreamDuplicateSpotter,
+            int minDupChainLength) {
+        // Need to compute the chain-length to both left and right of each
+        // token so need a dedup window size double that of the minDupChainLength        
+        super(version, new DuplicateTaggingFilter(byteStreamDuplicateSpotter, minDupChainLength * 2, in));
+        this.minDupChainLength = minDupChainLength;
+    }
+    
+    @Override
+    protected boolean accept() throws IOException {
+        return seqAtt.getSequenceLength() < minDupChainLength;
+    }
+    
+    private static class DuplicateTaggingFilter extends TokenFilter{
+        private final DuplicateSequenceLengthAttribute seqAtt = addAttribute(DuplicateSequenceLengthAttribute.class);
+        TermToBytesRefAttribute termBytesAtt=addAttribute(TermToBytesRefAttribute.class);
+        private ByteStreamDuplicateSequenceSpotter byteStreamDuplicateSpotter;
+
+    protected DuplicateTaggingFilter(ByteStreamDuplicateSequenceSpotter byteStreamDuplicateSpotter, int windowSize, TokenStream input) {
+            super(input);
+            this.byteStreamDuplicateSpotter=byteStreamDuplicateSpotter;
+            this.windowSize=windowSize;
+        }
+        private ArrayList<State> tokens;
+        private ArrayList<Boolean> valids;
+        int pos=0;
+        private int windowSize;
+
+
+
+    @Override
+    public final boolean incrementToken() throws IOException {
+        if (tokens == null) {
+            loadTokensBuffer();
+        }
+        clearAttributes();
+        if (pos < tokens.size()) {
+            State earlierToken = tokens.get(pos);
+            pos++;
+            restoreState(earlierToken);
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+       
+
+        public void loadTokensBuffer() throws IOException {
+            tokens = new ArrayList<State>();
+            valids = new ArrayList<Boolean>();
+            pos = 0;
+            boolean isWrapped = false;
+            // int windowSize = 256;
+            State tokenStates[] = new State[windowSize];
+            int maxLens[] = new int[windowSize];
+            int cursor = 0;
+            BytesRef bytesRef=termBytesAtt.getBytesRef();
+            while (input.incrementToken()) {
+                termBytesAtt.fillBytesRef();
+                int tokenHash = MurmurHash2.hash32(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+                byte tokenByte = (byte) (tokenHash % 256);
+                tokenStates[cursor] = captureState();
+                int len = byteStreamDuplicateSpotter.addByte(tokenByte);
+
+                // Mark prior tokens with the longest chain length of any
+                // significance
+                int pos = cursor;
+                int numLengthsToRecord = len;
+                // while (len >= container.minDupChainLength) {
+                while (numLengthsToRecord > 0) {
+                    if (pos < 0) {
+                        pos = windowSize - 1;
+                    }
+                    maxLens[pos] = Math.max(maxLens[pos], len);
+                    numLengthsToRecord--;
+                    pos--;
+                }
+                // Reposition cursor to next free slot
+                cursor++;
+                if (cursor >= windowSize) {
+                    // wrap around the buffer
+                    cursor = 0;
+                    isWrapped = true;
+                }
+                // clean out the end of the tail that we may overwrite if the
+                // next iteration adds a new head
+                if (isWrapped) {
+                    // tokenPos is now positioned on tail - emit any valid
+                    // tokens we may about to overwrite in the next iteration
+                    if (tokenStates[cursor] != null) {
+                        recordLengthInfoState(maxLens, tokenStates, cursor);
+                    }
+                }
+            } // end loop reading all tokens from stream
+
+            // Flush the buffered tokens
+            int pos = isWrapped?nextAfter(cursor):0;
+            while (pos != cursor) {
+                recordLengthInfoState(maxLens, tokenStates, pos);
+                pos=nextAfter(pos);
+            } 
+        }
+        
+
+        int nextAfter(int pos){
+            pos++;
+            if (pos >= windowSize) {
+                pos = 0;
+            }
+            return pos;
+        }
+        
+        private final void recordLengthInfoState(int[] maxLens, State[] tokenStates, int cursor) {
+            if (maxLens[cursor] > 0) {
+                // We need to patch in the max sequence length we recorded at
+                // this position
+                // into the token state
+                restoreState(tokenStates[cursor]);
+                seqAtt.setSequenceLength(maxLens[cursor]);
+                maxLens[cursor] = 0;
+                // record the patched state
+                tokenStates[cursor] = captureState();
+            }
+            tokens.add(tokenStates[cursor]);
+        }
+
+        @Override
+        public final void reset() throws IOException {
+            super.reset();
+            byteStreamDuplicateSpotter.reset();
+            if (tokens != null) {
+                tokens.clear();
+                tokens = null;
+            }
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/DuplicateSequenceLengthAttribute.java
+++ b/src/main/java/org/elasticsearch/index/analysis/DuplicateSequenceLengthAttribute.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.util.Attribute;
+
+public interface DuplicateSequenceLengthAttribute extends Attribute {
+    /**
+     * Gets the number of tokens before and after this one that form a sequence seen previously  
+     * @return The number of tokens.
+     */
+    public int getSequenceLength();
+
+    public void setSequenceLength(int len);
+}

--- a/src/main/java/org/elasticsearch/index/analysis/DuplicateSequenceLengthAttributeImpl.java
+++ b/src/main/java/org/elasticsearch/index/analysis/DuplicateSequenceLengthAttributeImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.util.AttributeImpl;
+
+public class DuplicateSequenceLengthAttributeImpl extends AttributeImpl implements DuplicateSequenceLengthAttribute {
+    protected int sequenceLength = 0;
+    @Override
+    public void clear() {
+        sequenceLength = 0;
+    }
+
+    @Override
+    public void copyTo(AttributeImpl target) {
+        DuplicateSequenceLengthAttributeImpl t = (DuplicateSequenceLengthAttributeImpl) target;
+        t.sequenceLength = sequenceLength;
+    }
+
+    @Override
+    public int getSequenceLength() {
+        return sequenceLength;
+    }
+
+    @Override
+    public void setSequenceLength(int len) {
+        sequenceLength = len;
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SampleSettings.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SampleSettings.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.significant;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class SampleSettings implements ToXContent {
+    public static final int DEFAULT_NUM_DOCS_PER_SHARD = 50;
+    private int numDocsPerShard = DEFAULT_NUM_DOCS_PER_SHARD;
+    
+    public static final int DEFAULT_MAX_TOKENS_PER_DOC = 1000;
+    private int maxTokensParsedPerDocument = DEFAULT_MAX_TOKENS_PER_DOC;
+    
+
+    public static final int NO_DUPLICATE_DETECTION = 0;
+     private int duplicateParagraphLengthInWords = NO_DUPLICATE_DETECTION;
+     
+    public static final int DEFAULT_NUM_RECORDED_TOKENS = 50000;    
+    int numRecordedTokens = DEFAULT_NUM_RECORDED_TOKENS;
+    
+    // Note: I experimented with extrapolating stats from the sample
+    // e.g. multiplying all foreground freq counts by (totalMatchesOnShard/numDocsPerShard)
+    // This was intended to compensate for the fact we were only using a sample
+    // but some insignificant rare terms ended up being artificially over-inflated and so 
+    // became significant. The net take-away is it doesn't make sense to extrapolate from
+    // a sample when we are often looking for the rarer elements in a set.
+    //boolean extrapolateStats = false;
+    
+    // TODO Big documents e.g. Wikipedia articles could potentially be split
+    // and considered as multiple documents for the purposes of analyzing
+    // frequencies of terms in documents. A setting like the one below could control
+    // the boundaries of how TokenStreams are split into multiple docs after
+    // N tokens have been produced
+    //int wordsPerSplitDoc = -1;
+    
+    
+    public int getNumDocsPerShard() {
+        return numDocsPerShard;
+    }
+    /**
+     * Max number of docs to sample on each shard. 
+     * The more documents sampled, the slower the query and 
+     * also does not always lead to higher quality suggestions 
+     * as the sample will typically start to include less 
+     * relevant documents in the sample.  
+     * 
+     * @param numDocsPerShard The maximum number of documents sampled on each shard
+     */
+    public void setNumDocsPerShard(int numDocsPerShard) {
+        //TODO do we want to mandate an upper limit on this setting?
+        this.numDocsPerShard = numDocsPerShard;
+    }
+    
+
+    public int getMaxTokensParsedPerDocument() {
+        return maxTokensParsedPerDocument;
+    }
+    /**
+     * The maximum number of tokens sampled from each document.
+     * This is principally a performance optimization to avoid 
+     * the costs of re-tokenizing very large documents in their 
+     * entirety.
+     * 
+     * @param maxTokensParsedPerDocument The maximum number of terms tokenized from each document.
+     */
+    public void setMaxTokensParsedPerDocument(int maxTokensParsedPerDocument) {
+        this.maxTokensParsedPerDocument = maxTokensParsedPerDocument;
+    }
+    
+    
+    public int getDuplicateParagraphLengthInWords() {
+        return duplicateParagraphLengthInWords;
+    }
+    /**
+     * Set this value to > 1 to enable removal of duplicate token sequences
+     * from sampled documents. For useful, significant term suggestions the content
+     * samples should generally be cleansed of repeated sections which can be introduced 
+     * by boiler-plate copyright footers, retweets or email replies that automatically 
+     * copy the bodies of the mail they reply to.
+     * This setting uses a window of historical tokens hashes to identify duplicate token
+     * sequences. The window holds hashes of tokens not the original strings so will produce
+     * some false positives if duplicateParagraphLengthInWords is set to a low number e.g. 2
+     * but should be accurate on longer sequences e.g. 8 tokens 
+     * 
+     * @param duplicateParagraphLengthInWords The minimum number of tokens seen in the same sequence
+     * as previously which are required before the sequence is marked as duplicate content and
+     * removed from our analysis sample
+     */
+    public void setDuplicateParagraphLengthInWords(int duplicateParagraphLengthInWords) {
+        //TODO mandate a sensible lower-bound on this? e.g. <=2 not generally useful
+        this.duplicateParagraphLengthInWords = duplicateParagraphLengthInWords;
+    }
+    public int getNumRecordedTokens() {
+        return numRecordedTokens;
+    }
+    
+    /**
+     * If duplicateParagraphLengthInWords is set to >1 this setting controls the size in bytes of the
+     * sliding window used to identify duplicate content. The default setting is 50000 and each token
+     * is recorded in hashed form as a single byte.
+     * 
+     * @param numRecordedTokens size in bytes of the sliding window used to find duplicate content
+     */
+    public void setNumRecordedTokens(int numRecordedTokens) {
+        //TODO do we want to mandate an upper limit on this setting?
+        this.numRecordedTokens = numRecordedTokens;
+    }
+    
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(SignificantTermsParametersParser.SAMPLING_SETTINGS.getPreferredName());
+        if (numDocsPerShard != DEFAULT_NUM_DOCS_PER_SHARD) {
+            builder.field(SignificantTermsParametersParser.DOCS_PER_SHARD.getPreferredName(), numDocsPerShard);
+        }
+        if (numRecordedTokens != DEFAULT_NUM_RECORDED_TOKENS) {
+            builder.field(SignificantTermsParametersParser.NUM_RECORDED_TOKENS.getPreferredName(), numRecordedTokens);
+        }
+        if (duplicateParagraphLengthInWords != NO_DUPLICATE_DETECTION) {
+            builder.field(SignificantTermsParametersParser.DUPLICATE_PARA_WORD_LENGTH.getPreferredName(), duplicateParagraphLengthInWords);
+        }
+        if (maxTokensParsedPerDocument != DEFAULT_MAX_TOKENS_PER_DOC) {
+            builder.field(SignificantTermsParametersParser.MAX_TOKENS_PARSED_PER_DOC.getPreferredName(), maxTokensParsedPerDocument);
+        }
+
+        builder.endObject();
+        return builder;
+    }
+    
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsSamplingAggregator.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsSamplingAggregator.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.significant;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.miscellaneous.LimitTokenCountFilter;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.*;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Version;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.FastStringReader;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lucene.ScorerAware;
+import org.elasticsearch.index.analysis.AnalysisService;
+import org.elasticsearch.index.analysis.ByteStreamDuplicateSequenceSpotter;
+import org.elasticsearch.index.analysis.DeDuplicatingTokenFilter;
+import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.UidAndSourceFieldsVisitor;
+import org.elasticsearch.index.mapper.FieldMappers;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.bucket.significant.SignificantStringTerms.Bucket;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator;
+import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.FieldContext;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.query.QueryPhaseExecutionException;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * An aggregator of significant string values based on samples of top-matching documents.
+ * Sample docs can be cleansed of duplicate content for better results e.g. when the content
+ * might be many emails with copies of prior content or many tweets which include retweets.
+ * 
+ * TODO - what to do about any potential child aggs? Use the deferring mechanism in the base class
+ * until collection completed here or simply throw an exception saying child aggs are not permitted?
+ * 
+ */
+public class SignificantStringTermsSamplingAggregator extends TermsAggregator implements ScorerAware {
+
+    protected final SignificantTermsAggregatorFactory termsAggFactory;
+    private TopDocsCollector topDocsCollector;
+    private Scorer currentScorer;
+    private AtomicReaderContext currentContext;
+    private String fieldName;
+    private IncludeExclude includeExclude;
+    private SampleSettings samplerSettings;
+    private SignificanceHeuristic significantHeuristic;
+
+    public SignificantStringTermsSamplingAggregator(String name, AggregatorFactories factories, FieldContext fieldContext,
+            long estimatedBucketCount, BucketCountThresholds bucketCountThresholds, IncludeExclude includeExclude,
+            AggregationContext aggregationContext, Aggregator parent, SignificantTermsAggregatorFactory termsAggFactory,
+            SignificanceHeuristic significanceHeuristic, SampleSettings samplerSettings) {
+        super(name, BucketAggregationMode.PER_BUCKET, factories, estimatedBucketCount, aggregationContext, parent, bucketCountThresholds,
+                null, SubAggCollectionMode.DEPTH_FIRST);
+        this.termsAggFactory = termsAggFactory;
+        this.includeExclude = includeExclude;
+        this.samplerSettings = samplerSettings;
+        this.significantHeuristic = significanceHeuristic;
+        this.fieldName = fieldContext.field();
+        context.registerScorerAware(this);
+    }
+
+    @Override
+    public void collect(int doc, long owningBucketOrdinal) throws IOException {
+        if (topDocsCollector == null) {
+            topDocsCollector = TopScoreDocCollector.create(samplerSettings.getNumDocsPerShard(), false);
+            topDocsCollector.setNextReader(currentContext);
+            topDocsCollector.setScorer(currentScorer);
+        }
+        topDocsCollector.collect(doc);
+    }
+    
+    @Override
+    public void setNextReader(AtomicReaderContext reader) {
+        currentContext = reader;
+        if (topDocsCollector != null) {
+            try {
+                topDocsCollector.setNextReader(currentContext);
+            } catch (IOException e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }   
+
+    @Override
+    public SignificantStringTerms buildAggregation(long owningBucketOrdinal) {
+        assert owningBucketOrdinal == 0;
+        if (topDocsCollector == null) {
+            return buildEmptyAggregation();
+        }
+        final int maxNumTermsToReturn = (int) bucketCountThresholds.getShardSize();
+        TopDocs topDocs = topDocsCollector.topDocs();
+        ScoreDoc[] sd = topDocs.scoreDocs;
+
+        List<Bucket> sampleTokenStats = getTermStatsFromForegroundSample(sd);
+        
+        //Complete each term's stats using background frequency and calc score
+        long supersetSize = termsAggFactory.prepareBackground(context);
+        long subsetSize = sd.length;
+        BucketSignificancePriorityQueue ordered = new BucketSignificancePriorityQueue(maxNumTermsToReturn);
+        int bucketNum = 0;
+        long shardMinDocCount = bucketCountThresholds.getShardMinDocCount();
+        for (Bucket bucket : sampleTokenStats) {
+            if (bucket.subsetDf >= shardMinDocCount) {
+                if (includeExclude != null && !includeExclude.accept(bucket.termBytes)) {
+                    continue;
+                }
+                bucket.subsetSize = subsetSize;
+                bucket.supersetDf = termsAggFactory.getBackgroundFrequency(bucket.termBytes);
+                bucket.supersetSize = supersetSize;
+                bucket.updateScore(significantHeuristic);
+                bucketNum++;
+                bucket.bucketOrd = bucketNum;
+                ordered.insertWithOverflow(bucket);
+            }
+        }
+        final InternalSignificantTerms.Bucket[] list = new InternalSignificantTerms.Bucket[ordered.size()];
+        for (int i = ordered.size() - 1; i >= 0; i--) {
+            final SignificantStringTerms.Bucket bucket = (SignificantStringTerms.Bucket) ordered.pop();
+            bucket.aggregations = bucketAggregations(bucket.bucketOrd);
+            list[i] = bucket;
+        }
+        return new SignificantStringTerms(subsetSize, supersetSize, name, bucketCountThresholds.getRequiredSize(),
+                bucketCountThresholds.getMinDocCount(), significantHeuristic, Arrays.asList(list));
+      }
+
+    /**
+     * Loads a sample of top-matching content, applying any required truncation/de-duping
+     * and provides "foreground" or "subset" stats for resulting Buckets
+     * @param sd The top-scoring documents
+     * @return The top terms' stats, sorted by term
+     */
+    private List<Bucket> getTermStatsFromForegroundSample(ScoreDoc[] sd) {
+        // Uses TreeMap to maintain sorted sequence of terms for faster
+        // subsequent lookup of background frequencies
+        Map<String, SignificantStringTerms.Bucket> result = new HashMap<>();
+        SearchContext searchContext = SearchContext.current();
+        ByteStreamDuplicateSequenceSpotter byteStreamDuplicateSequenceSpotter = null;
+        if (samplerSettings.getDuplicateParagraphLengthInWords() > SampleSettings.NO_DUPLICATE_DETECTION) {
+            int bufferSizeInBytes = Math.min(samplerSettings.numRecordedTokens,
+                    (samplerSettings.getNumDocsPerShard() * samplerSettings.getMaxTokensParsedPerDocument()));
+            // TODO move ByteStreamDuplicateSequenceSpotter to using BigArrays
+            // for circuit-breaker/recycling benefits over raw byte[] impl?
+            // A generic byte array impl seems useful to maintain more broadly
+            // but once we've ironed out all
+            // the potential issues in this maybe port it to using
+            // BigArrays-backed arrays.
+            byteStreamDuplicateSequenceSpotter = new ByteStreamDuplicateSequenceSpotter(bufferSizeInBytes);
+        }
+        FieldTokenStreamProvider provider = new FieldTokenStreamProvider(fieldName, searchContext);
+        Set<String> thisDocsUniqueTokens = new HashSet<>();
+        for (int i = 0; i < sd.length; i++) {
+            int docId = sd[i].doc;
+            thisDocsUniqueTokens.clear();
+            TokenStream stream = null;
+            try {
+                stream = provider.getTokenStream(docId);
+                if (stream == null) {
+                    continue;
+                }
+                if (samplerSettings.getMaxTokensParsedPerDocument() > 0) {
+                    stream = new LimitTokenCountFilter(stream, samplerSettings.getMaxTokensParsedPerDocument());
+                }
+                if (byteStreamDuplicateSequenceSpotter != null) {
+                    // Add a filter to remove duplicate content using the
+                    // byteStreamDuplicateSequenceSpotter
+                    stream = new DeDuplicatingTokenFilter(Version.LUCENE_4_9, stream, byteStreamDuplicateSequenceSpotter,
+                            samplerSettings.getDuplicateParagraphLengthInWords());
+                }
+                stream.reset();
+                CharTermAttribute term = stream.addAttribute(CharTermAttribute.class);
+                // TODO - how to get ByteRefs rather than strings?
+                while (stream.incrementToken()) {
+                    thisDocsUniqueTokens.add(term.toString());
+                }
+                stream.end();
+            } catch (IOException e) {
+                throw new ElasticsearchException("failed to analyze field " + fieldName, e);
+            } finally {
+                if (stream != null) {
+                    try {
+                        stream.close();
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                }
+            }
+            // Now we have a de-duped and unique set of tokens, add to our
+            // sample's stats
+            for (String t : thisDocsUniqueTokens) {
+                Bucket stats = result.get(t);
+                if (stats == null) {
+                    stats = new Bucket(new BytesRef(t), 0, sd.length, 0, 0, null);
+                    result.put(t, stats);
+                }
+                stats.subsetDf++;
+            }
+        }
+        // Sort the buckets for faster lookup of background term frequencies
+        ArrayList<Bucket> sortedResults = new ArrayList<>(result.values());
+        Collections.sort(sortedResults, new Comparator<Bucket>() {
+            @Override
+            public int compare(Bucket o1, Bucket o2) {
+                return o1.compareTerm(o2);
+            }
+        });
+        return sortedResults;
+    }
+    
+    // TODO break this out as a utility class (poss usable by MLT) and add
+    // support for TermVectors if present (although I have heard they are not always faster 
+    // than re-analysis)
+    static class FieldTokenStreamProvider {
+        private SearchContext searchContext;
+        private String fieldName;
+        private FieldsVisitor fieldsVisitor;
+        private boolean sourceRequested = false;
+        Analyzer analyzer;
+
+        public FieldTokenStreamProvider(String fieldName, SearchContext searchContext) {
+            this.searchContext = searchContext;
+            this.fieldName = fieldName;
+
+            AnalysisService analysisService = searchContext.analysisService();
+            analyzer = analysisService.analyzer(fieldName);
+            if (analyzer == null) {
+                analyzer = analysisService.defaultIndexAnalyzer();
+            }
+
+            Set<String> fieldNames = null;
+            List<String> extractFieldNames = null;
+            FieldMappers x = searchContext.smartNameFieldMappers(fieldName);
+            if ((x != null) && x.mapper().fieldType().stored()) {
+                if (fieldNames == null) {
+                    fieldNames = new HashSet<String>();
+                }
+                fieldNames.add(x.mapper().names().indexName());
+            } else {
+                if (extractFieldNames == null) {
+                    extractFieldNames = new ArrayList<String>();
+                }
+                extractFieldNames.add(fieldName);
+            }
+            fieldsVisitor = null;
+            if (fieldNames != null) {
+                boolean loadSource = extractFieldNames != null;
+                fieldsVisitor = new CustomFieldsVisitor(fieldNames, loadSource);
+            } else if (extractFieldNames != null) {
+                fieldsVisitor = new UidAndSourceFieldsVisitor();
+                sourceRequested = true;
+            }
+        }
+
+        TokenStream getTokenStream(int docId) throws IOException {
+            // load stored fields
+            fieldsVisitor.reset();
+            try {
+                searchContext.searcher().doc(docId, fieldsVisitor);
+            } catch (IOException e) {
+                throw new QueryPhaseExecutionException(searchContext, "Failed to load doc id [" + docId + "]", e);
+            }
+            fieldsVisitor.postProcess(searchContext.mapperService());
+            String value = null;
+            // Either the field is specially held as a stored field or is
+            // squirrelled away in a JSON structure as part of a "source"
+            // field
+            if (sourceRequested) {
+                BytesReference src = fieldsVisitor.source();
+                if (src != null) {
+                    // Load data vals from source (mostly copied from
+                    // FetchPhase.java)
+                    searchContext.lookup().source().setNextDocId(docId);
+                    searchContext.lookup().source().setNextSource(src);
+                    List<Object> values = searchContext.lookup().source().extractRawValues(fieldName);
+                    if (!values.isEmpty()) {
+                        StringBuilder sb = new StringBuilder();
+                        for (Object val : values) {
+                            if (val != null) {
+                                sb.append(val);
+                                sb.append(" ");
+                            }
+                        }
+                        value = sb.toString();
+                    }
+                }
+            } else {
+                if (fieldsVisitor.fields() != null) {
+                    for (Map.Entry<String, List<Object>> entry : fieldsVisitor.fields().entrySet()) {
+                        StringBuilder sb = new StringBuilder();
+                        for (Object val : entry.getValue()) {
+                            sb.append(val);
+                            sb.append(" ");
+                        }
+                        value = sb.toString();
+                    }
+                }
+            }
+            if (value != null) {
+                return analyzer.tokenStream(fieldName, new FastStringReader(value));
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public SignificantStringTerms buildEmptyAggregation() {
+        // We need to account for the significance of a miss in our global stats
+        // - provide corpus size as context
+        ContextIndexSearcher searcher = context.searchContext().searcher();
+        IndexReader topReader = searcher.getIndexReader();
+        int supersetSize = topReader.numDocs();
+        return new SignificantStringTerms(0, supersetSize, name, bucketCountThresholds.getRequiredSize(),
+                bucketCountThresholds.getMinDocCount(), significantHeuristic, Collections.<InternalSignificantTerms.Bucket> emptyList());
+    }
+    
+    @Override
+    public void setScorer(Scorer scorer) {
+        this.currentScorer = scorer;
+        if (topDocsCollector != null) {
+            try {
+                topDocsCollector.setScorer(scorer);
+            } catch (IOException e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }
+
+    @Override
+    public void doClose() {
+        Releasables.close(termsAggFactory);
+    }
+
+    @Override
+    public boolean shouldCollect() {
+        return true;
+    }
+
+}
+

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsBuilder.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsBuilder.java
@@ -50,6 +50,7 @@ public class SignificantTermsBuilder extends AggregationBuilder<SignificantTerms
     private String[] excludeTerms = null;
     private FilterBuilder filterBuilder;
     private SignificanceHeuristicBuilder significanceHeuristicBuilder;
+    private SampleSettings sampleSettings;
 
     /**
      * Sole constructor.
@@ -114,6 +115,11 @@ public class SignificantTermsBuilder extends AggregationBuilder<SignificantTerms
         this.executionHint = executionHint;
         return this;
     }
+    
+    public SignificantTermsBuilder sampleSettings(SampleSettings sampleSettings) {
+        this.sampleSettings = sampleSettings;
+        return this;
+    }    
 
     /**
      * Define a regular expression that will determine what terms should be aggregated. The regular expression is based
@@ -264,7 +270,9 @@ public class SignificantTermsBuilder extends AggregationBuilder<SignificantTerms
         if (significanceHeuristicBuilder != null) {
             significanceHeuristicBuilder.toXContent(builder);
         }
-
+        if (sampleSettings != null) {
+            sampleSettings.toXContent(builder, params); 
+        }        
         return builder.endObject();
     }
 

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
@@ -77,8 +77,13 @@ public class SignificantTermsParser implements Aggregator.Parser {
         if (significanceHeuristic == null) {
             significanceHeuristic = JLHScore.INSTANCE;
         }
+        if (aggParser.getSamplingSettings() != null) {
+            // TODO - may need to throw exception if user has supplied any sort of script - not supported with the sampling approach
+            return new SignificantTermsSamplingAggregatorFactory(context, aggregationName, vsParser.getInputFieldName(), //FIXME need to discover field name
+                    bucketCountThresholds, aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic, aggParser.getSamplingSettings());
+        }
+        
         return new SignificantTermsAggregatorFactory(aggregationName, vsParser.config(), bucketCountThresholds,
-                aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic,
-                aggParser.getSamplingSettings());
+                aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic);
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
@@ -77,6 +77,8 @@ public class SignificantTermsParser implements Aggregator.Parser {
         if (significanceHeuristic == null) {
             significanceHeuristic = JLHScore.INSTANCE;
         }
-        return new SignificantTermsAggregatorFactory(aggregationName, vsParser.config(), bucketCountThresholds, aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic);
+        return new SignificantTermsAggregatorFactory(aggregationName, vsParser.config(), bucketCountThresholds,
+                aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic,
+                aggParser.getSamplingSettings());
     }
 }

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsSamplingAggregatorFactory.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsSamplingAggregatorFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.significant;
+
+import org.apache.lucene.search.Filter;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator;
+import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.internal.SearchContext;
+
+/**
+ *
+ */
+public class SignificantTermsSamplingAggregatorFactory extends AggregatorFactory implements Releasable {
+
+    private final IncludeExclude includeExclude;
+    private String indexedFieldName;
+    private int numberOfAggregatorsCreated = 0;
+    private final TermsAggregator.BucketCountThresholds bucketCountThresholds;
+    private final SampleSettings samplerSettings;
+    private TermFrequencyProvider termFrequencyProvider;
+    private SignificanceHeuristic significanceHeuristic;
+
+    public SignificantTermsSamplingAggregatorFactory(SearchContext context,String name, String indexedFieldName, TermsAggregator.BucketCountThresholds bucketCountThresholds, IncludeExclude includeExclude,
+                                             String executionHint, Filter filter, SignificanceHeuristic significanceHeuristic, SampleSettings samplerSettings) {
+
+        super(name, SignificantStringTerms.TYPE.name());
+        this.bucketCountThresholds = bucketCountThresholds;        
+        this.includeExclude = includeExclude;
+        this.indexedFieldName = indexedFieldName;
+        this.samplerSettings = samplerSettings;
+        this.significanceHeuristic = significanceHeuristic;
+        FieldMapper mapper = context.smartNameFieldMapper(indexedFieldName);
+        termFrequencyProvider=new TermFrequencyProvider(indexedFieldName,filter,mapper);
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+        Releasables.close(termFrequencyProvider);
+    }
+
+    @Override
+    public Aggregator create(AggregationContext context, Aggregator parent, long expectedBucketsCount) {
+        numberOfAggregatorsCreated++;
+        if (numberOfAggregatorsCreated > 1) {
+            termFrequencyProvider.setUseCaching(true);
+        }
+        long estimatedBucketCount = 1000;// TODO not sure how best to estimate?
+        return new SignificantStringTermsSamplingAggregator(name, factories, indexedFieldName, estimatedBucketCount, bucketCountThresholds,
+                includeExclude, context, parent, termFrequencyProvider, significanceHeuristic, samplerSettings);
+    }
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/TermFrequencyProvider.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/TermFrequencyProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.significant;
+
+import org.apache.lucene.index.DocsEnum;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lucene.index.FilterableTermsEnum;
+import org.elasticsearch.common.lucene.index.FreqTermsEnum;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+
+public class TermFrequencyProvider implements Releasable {
+
+    
+    private FilterableTermsEnum termsEnum;
+    private String indexedFieldName;
+    private Filter filter;
+    private FieldMapper mapper;
+    private boolean useCaching = false;
+
+    public TermFrequencyProvider(String indexedFieldName, Filter filter, FieldMapper mapper) {
+        this.indexedFieldName = indexedFieldName;
+        this.filter = filter;
+        this.mapper = mapper;
+    }
+
+    protected boolean isUseCaching() {
+        return useCaching;
+    }
+
+    protected void setUseCaching(boolean useCaching) {
+        this.useCaching = useCaching;
+    }
+
+    /**
+     * Creates the TermsEnum (if not already created) and must be called before any calls to getBackgroundFrequency
+     * @param context The aggregation context 
+     * @return The number of documents in the index (after an optional filter might have been applied)
+     */
+    public long prepareBackground(AggregationContext context) {
+        if (termsEnum != null) {
+            // already prepared - return 
+            return termsEnum.getNumDocs();
+        }
+        SearchContext searchContext = context.searchContext();
+        IndexReader reader = searchContext.searcher().getIndexReader();
+        try {
+            if (!useCaching) {
+                // Setup a termsEnum for sole use by one aggregator
+                termsEnum = new FilterableTermsEnum(reader, indexedFieldName, DocsEnum.FLAG_NONE, filter);
+            } else {
+                // When we have > 1 agg we have possibility of duplicate term frequency lookups 
+                // and so use a TermsEnum that caches results of all term lookups
+                termsEnum = new FreqTermsEnum(reader, indexedFieldName, true, false, filter, searchContext.bigArrays());
+            }
+        } catch (IOException e) {
+            throw new ElasticsearchException("failed to build terms enumeration", e);
+        }
+        return termsEnum.getNumDocs();
+    }
+
+    public long getBackgroundFrequency(BytesRef termBytes) {
+        assert termsEnum != null; // having failed to find a field in the index we don't expect any calls for frequencies
+        long result = 0;
+        try {
+            if (termsEnum.seekExact(termBytes)) {
+                result = termsEnum.docFreq();
+            }
+        } catch (IOException e) {
+            throw new ElasticsearchException("IOException loading background document frequency info", e);
+        }
+        return result;
+    }
+
+
+    public long getBackgroundFrequency(long term) {
+        BytesRef indexedVal = mapper.indexedValueForSearch(term);
+        return getBackgroundFrequency(indexedVal);
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+        try {
+            if (termsEnum instanceof Releasable) {
+                ((Releasable) termsEnum).close();
+            }
+        } finally {
+            termsEnum = null;
+        }
+    }    
+}

--- a/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -125,6 +125,10 @@ public class ValuesSourceParser<VS extends ValuesSource> {
 
         return false;
     }
+    
+    public String getInputFieldName(){
+        return input.field;
+    }
 
     public ValuesSourceConfig<VS> config() {
         

--- a/src/test/java/org/elasticsearch/index/analysis/ByteStreamDuplicateSequenceSpotterTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/ByteStreamDuplicateSequenceSpotterTests.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+public class ByteStreamDuplicateSequenceSpotterTests extends ElasticsearchTestCase {
+    
+    @Test
+    public void testSimpleStreamNoDups()  {
+        int bufferSize=10000;
+        ByteStreamDuplicateSequenceSpotter spotter=new ByteStreamDuplicateSequenceSpotter(bufferSize);        
+        for (byte b = Byte.MIN_VALUE; b < Byte.MAX_VALUE; b++) {
+            int len=spotter.addByte(b);
+            assertEquals(0, len);
+        }
+    } 
+    
+    @Test
+    public void testSimpleWrappingStreamNoDups()  {
+        //buffer smaller than the set of bytes added
+        int bufferSize=100;
+        ByteStreamDuplicateSequenceSpotter spotter=new ByteStreamDuplicateSequenceSpotter(bufferSize);        
+        for (byte b = Byte.MIN_VALUE; b < Byte.MAX_VALUE; b++) {
+            int len=spotter.addByte(b);
+            assertEquals(0, len);
+        }
+    }   
+    
+    
+    @Test
+    public void testSimpleStreamWithDups()  {
+        int bufferSize=10000;
+        ByteStreamDuplicateSequenceSpotter spotter=new ByteStreamDuplicateSequenceSpotter(bufferSize);        
+        for (int loopNum = 0; loopNum < 3; loopNum++) {
+            byte expectedChainLength=loopNum==0?(byte)0:(byte)1; 
+            spotter.reset();
+            for (byte b = Byte.MIN_VALUE; b < Byte.MAX_VALUE; b++) {
+                byte len=spotter.addByte(b);
+                if(loopNum==0){
+                    assertEquals(0, len);                    
+                }else{
+                    assertEquals(expectedChainLength, len);                                        
+                }
+                if(expectedChainLength<Byte.MAX_VALUE){
+                    expectedChainLength++;
+                }
+            }            
+        }
+    }       
+
+    @Test
+    public void testWrappedStreamWithDups()  {
+        int bufferSize=500;
+        ByteStreamDuplicateSequenceSpotter spotter=new ByteStreamDuplicateSequenceSpotter(bufferSize);        
+        for (int loopNum = 0; loopNum < 3; loopNum++) {
+            byte expectedChainLength=loopNum==0?(byte)0:(byte)1; 
+            spotter.reset();
+            for (byte b = Byte.MIN_VALUE; b < Byte.MAX_VALUE; b++) {
+                byte len=spotter.addByte(b);
+                if(loopNum==0){
+                    assertEquals(0, len);                    
+                }else{
+                    assertEquals(expectedChainLength, len);                                        
+                }
+                if(expectedChainLength<Byte.MAX_VALUE){
+                    expectedChainLength++;
+                }
+            }            
+        }
+    }       
+    
+    @Test
+    public void testStreamWithNovelAndDups()  {
+        int bufferSize=10000;        
+        ByteStreamDuplicateSequenceSpotter spotter=new ByteStreamDuplicateSequenceSpotter(bufferSize);
+        testByteAdditions(spotter, new byte[]{1, 2,3},new byte[]{0,0,0});        
+        testByteAdditions(spotter, new byte[]{3, 5, 2},new byte[]{1,0,1});        
+        testByteAdditions(spotter, new byte[]{3, 4, 5},new byte[]{2,0,1});
+        testByteAdditions(spotter, new byte[]{1, 2},new byte[]{1,2});
+        spotter.reset();
+        testByteAdditions(spotter, new byte[]{3, 4},new byte[]{1,2});
+    }     
+
+    private void testByteAdditions(ByteStreamDuplicateSequenceSpotter spotter, byte[] additions, byte[] expectedLengths) {
+        for (int i = 0; i < additions.length; i++) {
+            byte reportedChainLength=spotter.addByte(additions[i]);
+            assertEquals(expectedLengths[i], reportedChainLength);                                        
+        }
+    }
+    
+}

--- a/src/test/java/org/elasticsearch/index/analysis/DeDuplicatingTokenFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/DeDuplicatingTokenFilterTests.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.util.Version;
+import org.elasticsearch.common.io.FastStringReader;
+import org.elasticsearch.test.ElasticsearchTokenStreamTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class DeDuplicatingTokenFilterTests extends ElasticsearchTokenStreamTestCase {
+
+    @Test
+    public void testSimpleWrappingStreamNoDups() throws IOException {
+        int bufferSize = 10000;
+        ByteStreamDuplicateSequenceSpotter spotter = new ByteStreamDuplicateSequenceSpotter(bufferSize);
+
+        testAdditions(spotter, 3, "this is a test", new String[] { "this", "is", "a", "test" });
+        testAdditions(spotter, 3, "and this is a test too", new String[] { "and", "too" });
+        testAdditions(spotter, 3, "this is ok", new String[] { "this", "is", "ok" });
+        testAdditions(spotter, 5, "this is a test", new String[] { "this", "is", "a", "test" });
+        testAdditions(spotter, 4, "this is a test", new String[] {});
+        // This call checks that the prior doc "this is a test" is seen as distinct from the new doc that starts with "too"
+        testAdditions(spotter, 3, "too new", new String[] { "too", "new" });
+
+    }
+
+    private void testAdditions(ByteStreamDuplicateSequenceSpotter spotter, int dupLength, String input, String[] expectedOutputs)
+            throws IOException {
+        WhitespaceAnalyzer ws = new WhitespaceAnalyzer(Version.LUCENE_4_9);
+        TokenStream stream = ws.tokenStream("default", new FastStringReader(input));
+        stream = new DeDuplicatingTokenFilter(Version.LUCENE_4_9, stream, spotter, dupLength);
+        assertTokenStreamContents(stream, expectedOutputs);
+    }
+
+}


### PR DESCRIPTION
Avoids the use of FieldData in high-cardinality free-text fields by re-tokenizing samples of the top matching documents.
Also provides a de-duplication option to remove duplicated sections of text commonly found in free-text document fields in order to avoid skewing word usage stats and making bad keyword suggestions as a result.
