### PR TITLE
Add basic authentication authentication for plugin manager

### DIFF
--- a/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -24,7 +24,6 @@ import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.plugins.AuthCredentials;
-import org.elasticsearch.plugins.BasicAuthCredentials;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -263,9 +262,7 @@ public class HttpDownloadHelper {
                 ((HttpURLConnection) connection).setUseCaches(true);
                 ((HttpURLConnection) connection).setConnectTimeout(5000);
 
-                if (authCredentials != null && authCredentials instanceof BasicAuthCredentials) {
-                    connection.setRequestProperty("Authorization", "Basic " + authCredentials.encodedAuthorization());
-                }
+                authCredentials.applyAuthorization(connection);
             }
             // connect to the remote site (may take some time)
             connection.connect();

--- a/src/main/java/org/elasticsearch/plugins/AuthCredentials.java
+++ b/src/main/java/org/elasticsearch/plugins/AuthCredentials.java
@@ -19,24 +19,8 @@
 
 package org.elasticsearch.plugins;
 
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.common.Base64;
+public abstract class AuthCredentials {
 
-public class BasicAuthCredentials extends AuthCredentials {
+    public abstract String encodedAuthorization();
 
-    private final String username;
-    private final String password;
-
-    public BasicAuthCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
-    }
-
-    public String encodedAuthorization() {
-        if (username == null || password == null) {
-            throw new ElasticsearchIllegalArgumentException("username and password are empty");
-        }
-
-        return Base64.encodeBytes( (username + ":" + password).getBytes() );
-    }
 }

--- a/src/main/java/org/elasticsearch/plugins/AuthCredentials.java
+++ b/src/main/java/org/elasticsearch/plugins/AuthCredentials.java
@@ -19,8 +19,13 @@
 
 package org.elasticsearch.plugins;
 
-public abstract class AuthCredentials {
+import java.net.URLConnection;
 
-    public abstract String encodedAuthorization();
+public interface AuthCredentials {
+
+    /**
+     * Modify the URLConnection if needed for your Authorization Scheme
+     */
+    public abstract void applyAuthorization(URLConnection connection);
 
 }

--- a/src/main/java/org/elasticsearch/plugins/BasicAuthCredentials.java
+++ b/src/main/java/org/elasticsearch/plugins/BasicAuthCredentials.java
@@ -1,0 +1,41 @@
+package org.elasticsearch.plugins;
+
+import sun.misc.BASE64Encoder;
+
+public class BasicAuthCredentials {
+
+    public static BasicAuthCredentials NONE = new BasicAuthCredentials();
+
+    private String username;
+    private String password;
+
+    private BasicAuthCredentials() {
+    }
+
+    public BasicAuthCredentials(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String encodedAuthorization() {
+        if(isEmpty()) {
+            return "";
+        }
+
+        BASE64Encoder enc = new sun.misc.BASE64Encoder();
+        String userpassword = username + ":" + password;
+        return enc.encode( userpassword.getBytes() );
+    }
+
+    public boolean isEmpty() {
+        return username==null || password==null;
+    }
+}

--- a/src/main/java/org/elasticsearch/plugins/EmptyAuthCredentials.java
+++ b/src/main/java/org/elasticsearch/plugins/EmptyAuthCredentials.java
@@ -19,24 +19,10 @@
 
 package org.elasticsearch.plugins;
 
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
-import org.elasticsearch.common.Base64;
-
-public class BasicAuthCredentials extends AuthCredentials {
-
-    private final String username;
-    private final String password;
-
-    public BasicAuthCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
-    }
+public class EmptyAuthCredentials extends AuthCredentials {
 
     public String encodedAuthorization() {
-        if (username == null || password == null) {
-            throw new ElasticsearchIllegalArgumentException("username and password are empty");
-        }
-
-        return Base64.encodeBytes( (username + ":" + password).getBytes() );
+        return "";
     }
+
 }

--- a/src/main/java/org/elasticsearch/plugins/NoAuthCredentials.java
+++ b/src/main/java/org/elasticsearch/plugins/NoAuthCredentials.java
@@ -19,10 +19,14 @@
 
 package org.elasticsearch.plugins;
 
-public class EmptyAuthCredentials extends AuthCredentials {
+import java.net.URLConnection;
 
-    public String encodedAuthorization() {
-        return "";
+/**
+ * No Auth needed so we don't modify the URLConnection
+ */
+public class NoAuthCredentials implements AuthCredentials {
+
+    @Override
+    public void applyAuthorization(URLConnection connection) {
     }
-
 }

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -431,10 +431,10 @@ public class PluginManager {
         if (action > ACTION.NONE) {
             int exitCode = EXIT_CODE_ERROR; // we fail unless it's reset
             AuthCredentials credentials;
-            if (username != null && password != null) {
+            if (username != null) {
                 credentials = new BasicAuthCredentials(username, password);
             } else {
-                credentials = new EmptyAuthCredentials();
+                credentials = new NoAuthCredentials();
             }
 
             PluginManager pluginManager = new PluginManager(initialSettings.v2(), url, outputMode, timeout, credentials);

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -71,15 +71,15 @@ public class PluginManager {
     private String url;
     private OutputMode outputMode;
     private TimeValue timeout;
-    private BasicAuthCredentials basicAuthCredentials;
+    private AuthCredentials authCredentials;
 
     public PluginManager(Environment environment, String url, OutputMode outputMode, TimeValue timeout,
-                         BasicAuthCredentials basicAuthCredentials) {
+                         AuthCredentials authCredentials) {
         this.environment = environment;
         this.url = url;
         this.outputMode = outputMode;
         this.timeout = timeout;
-        this.basicAuthCredentials = basicAuthCredentials;
+        this.authCredentials = authCredentials;
 
         TrustManager[] trustAllCerts = new TrustManager[]{
                 new X509TrustManager() {
@@ -138,7 +138,7 @@ public class PluginManager {
             URL pluginUrl = new URL(url);
             log("Trying " + pluginUrl.toExternalForm() + "...");
             try {
-                downloadHelper.download(pluginUrl, pluginFile, progress, this.timeout, basicAuthCredentials);
+                downloadHelper.download(pluginUrl, pluginFile, progress, this.timeout, authCredentials);
                 downloaded = true;
             } catch (ElasticsearchTimeoutException e) {
                 throw e;
@@ -153,7 +153,7 @@ public class PluginManager {
             for (URL url : pluginHandle.urls()) {
                 log("Trying " + url.toExternalForm() + "...");
                 try {
-                    downloadHelper.download(url, pluginFile, progress, this.timeout, basicAuthCredentials);
+                    downloadHelper.download(url, pluginFile, progress, this.timeout, authCredentials);
                     downloaded = true;
                     break;
                 } catch (ElasticsearchTimeoutException e) {
@@ -430,11 +430,11 @@ public class PluginManager {
 
         if (action > ACTION.NONE) {
             int exitCode = EXIT_CODE_ERROR; // we fail unless it's reset
-            BasicAuthCredentials credentials;
+            AuthCredentials credentials;
             if (username != null && password != null) {
                 credentials = new BasicAuthCredentials(username, password);
             } else {
-                credentials = BasicAuthCredentials.NONE;
+                credentials = new EmptyAuthCredentials();
             }
 
             PluginManager pluginManager = new PluginManager(initialSettings.v2(), url, outputMode, timeout, credentials);

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
-import org.elasticsearch.plugins.EmptyAuthCredentials;
+import org.elasticsearch.plugins.NoAuthCredentials;
 import org.elasticsearch.plugins.PluginManager;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.helper.HttpClient;
@@ -143,7 +143,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             FileSystemUtils.mkdirs(initialSettings.v2().pluginsFile());
         }
         return new PluginManager(initialSettings.v2(), pluginUrl, PluginManager.OutputMode.SILENT,
-                TimeValue.timeValueSeconds(30), new EmptyAuthCredentials());
+                TimeValue.timeValueSeconds(30), new NoAuthCredentials());
     }
 
     private static void downloadAndExtract(String pluginName, String pluginUrl) throws IOException {

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
+import org.elasticsearch.plugins.BasicAuthCredentials;
 import org.elasticsearch.plugins.PluginManager;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.helper.HttpClient;
@@ -141,7 +142,8 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
         if (!initialSettings.v2().pluginsFile().exists()) {
             FileSystemUtils.mkdirs(initialSettings.v2().pluginsFile());
         }
-        return new PluginManager(initialSettings.v2(), pluginUrl, PluginManager.OutputMode.SILENT, TimeValue.timeValueSeconds(30));
+        return new PluginManager(initialSettings.v2(), pluginUrl, PluginManager.OutputMode.SILENT,
+                TimeValue.timeValueSeconds(30), BasicAuthCredentials.NONE);
     }
 
     private static void downloadAndExtract(String pluginName, String pluginUrl) throws IOException {

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
-import org.elasticsearch.plugins.BasicAuthCredentials;
+import org.elasticsearch.plugins.EmptyAuthCredentials;
 import org.elasticsearch.plugins.PluginManager;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.helper.HttpClient;
@@ -143,7 +143,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             FileSystemUtils.mkdirs(initialSettings.v2().pluginsFile());
         }
         return new PluginManager(initialSettings.v2(), pluginUrl, PluginManager.OutputMode.SILENT,
-                TimeValue.timeValueSeconds(30), BasicAuthCredentials.NONE);
+                TimeValue.timeValueSeconds(30), new EmptyAuthCredentials());
     }
 
     private static void downloadAndExtract(String pluginName, String pluginUrl) throws IOException {


### PR DESCRIPTION
The plugin downloader which is invoked by the plugin command line does not support downloading the plugin from a URL which is secured using basic auth.
## Use Case

In the continuous integration process if we want to install a plugin where the plugin artifact is available on the CI server which is restricted with basic auth this is not possible.
## Workaround

Download using wget passing auth details and use the elasticsearch plugin command line passing the _file_ url instead of _http_ url
## Good to have

Plugin command line to have options to take in basic auth credentials and pass it on to the downloader.

Thanks to @katta for the original PR!

Closes #2550.
