### PR TITLE
Update plugins.asciidoc to fix typo

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -229,7 +229,7 @@ You can disable that check using `plugins.check_lucene: false`.
 * https://github.com/kzwang/elasticsearch-river-dynamodb[DynamoDB River Plugin] (by Kevin Wang)
 * https://github.com/salyh/elasticsearch-river-imap[IMAP/POP3 Email River Plugin] (by Hendrik Saly)
 * https://github.com/codelibs/elasticsearch-river-web[Web River Plugin] (by CodeLibs Project)
-* https://github.com/eea/eea.elasticsearch.river.rdf[EEA ElasticSearch RDF River Plugin] (by the European Environmental Agency)
+* https://github.com/eea/eea.elasticsearch.river.rdf[EEA ElasticSearch RDF River Plugin] (by the European Environment Agency)
 
 [float]
 [[transport]]


### PR DESCRIPTION
Changed the name of the European Environment Agency (from European Environmental Agency)
