### PR TITLE
Improve handling of failed primary replica handling

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -310,6 +310,12 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         for (RoutingNode routingNode : this) {
             shards.addAll(routingNode.shardsWithState(state));
         }
+        for (ShardRoutingState s : state) {
+            if (s == ShardRoutingState.UNASSIGNED) {
+                Iterables.addAll(shards, unassigned());
+                break;
+            }
+        }
         return shards;
     }
 
@@ -318,6 +324,16 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         List<MutableShardRouting> shards = newArrayList();
         for (RoutingNode routingNode : this) {
             shards.addAll(routingNode.shardsWithState(index, state));
+        }
+        for (ShardRoutingState s : state) {
+            if (s == ShardRoutingState.UNASSIGNED) {
+                for (MutableShardRouting unassignedShard : unassignedShards) {
+                    if (unassignedShard.index().equals(index)) {
+                        shards.add(unassignedShard);
+                    }
+                }
+                break;
+            }
         }
         return shards;
     }

--- a/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -278,23 +278,18 @@ public class AllocationService extends AbstractComponent {
         }
 
         // go over and remove dangling replicas that are initializing for primary shards
-        List<ShardRouting> shardsToFail = null;
+        List<ShardRouting> shardsToFail = Lists.newArrayList();
         for (MutableShardRouting shardEntry : routingNodes.unassigned()) {
             if (shardEntry.primary()) {
                 for (MutableShardRouting routing : routingNodes.assignedShards(shardEntry)) {
                     if (!routing.primary() && routing.initializing()) {
-                        if (shardsToFail == null) {
-                            shardsToFail = new ArrayList<>();
-                        }
                         shardsToFail.add(routing);
                     }
                 }
             }
         }
-        if (shardsToFail != null) {
-            for (ShardRouting shardToFail : shardsToFail) {
-               changed |= applyFailedShard(allocation, shardToFail, false);
-            }
+        for (ShardRouting shardToFail : shardsToFail) {
+           changed |= applyFailedShard(allocation, shardToFail, false);
         }
 
         // now, go over and elect a new primary if possible, not, from this code block on, if one is elected,


### PR DESCRIPTION
Out of #6808, we improved the handling of a primary failing to make sure replicas that are initializing are properly failed as well. After double checking it, it has 2 problems, the first, if the same shard routing is failed again, there is no protection that we don't apply the failure (which we do in failed shard cases), and the other was that we already tried to handle it (wrongly) in the elect primary method.
This change fixes the handling to work correctly in the elect primary method, and adds unit tests to verify the behavior
