### PR TITLE
bin/plugin removes itself

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -123,6 +123,8 @@ public class PluginManager {
         }
 
         PluginHandle pluginHandle = PluginHandle.parse(name);
+        checkForForbiddenName(pluginHandle.name);
+
         File pluginFile = pluginHandle.distroFile(environment);
         // extract the plugin
         File extractLocation = pluginHandle.extractedDir(environment);
@@ -241,10 +243,7 @@ public class PluginManager {
         PluginHandle pluginHandle = PluginHandle.parse(name);
         boolean removed = false;
 
-        if (Strings.isNullOrEmpty(pluginHandle.name)) {
-            throw new ElasticsearchIllegalArgumentException("plugin name is incorrect");
-        }
-
+        checkForForbiddenName(pluginHandle.name);
         File pluginToDelete = pluginHandle.extractedDir(environment);
         if (pluginToDelete.exists()) {
             debug("Removing: " + pluginToDelete.getPath());
@@ -276,6 +275,21 @@ public class PluginManager {
             log("Removed " + name);
         } else {
             log("Plugin " + name + " not found. Run plugin --list to get list of installed plugins.");
+        }
+    }
+
+    private static void checkForForbiddenName(String name) {
+        if (Strings.isNullOrEmpty(name) ||
+                "elasticsearch.in.sh".equalsIgnoreCase(name) ||
+                "elasticsearch".equalsIgnoreCase(name) ||
+                "plugin".equalsIgnoreCase(name) ||
+                "elasticsearch.bat".equalsIgnoreCase(name) ||
+                "plugin.bat".equalsIgnoreCase(name) ||
+                "service.bat".equalsIgnoreCase(name) ||
+                "elasticsearch-service-x86.exe".equalsIgnoreCase(name) ||
+                "elasticsearch-service-x64.exe".equalsIgnoreCase(name) ||
+                "elasticsearch-service-mgr.exe".equalsIgnoreCase(name)) {
+            throw new ElasticsearchIllegalArgumentException("this plugin name is not allowed.");
         }
     }
 

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -279,17 +279,26 @@ public class PluginManager {
     }
 
     private static void checkForForbiddenName(String name) {
-        if (Strings.isNullOrEmpty(name) ||
-                "elasticsearch.in.sh".equalsIgnoreCase(name) ||
-                "elasticsearch".equalsIgnoreCase(name) ||
-                "plugin".equalsIgnoreCase(name) ||
-                "elasticsearch.bat".equalsIgnoreCase(name) ||
-                "plugin.bat".equalsIgnoreCase(name) ||
-                "service.bat".equalsIgnoreCase(name) ||
-                "elasticsearch-service-x86.exe".equalsIgnoreCase(name) ||
-                "elasticsearch-service-x64.exe".equalsIgnoreCase(name) ||
-                "elasticsearch-service-mgr.exe".equalsIgnoreCase(name)) {
-            throw new ElasticsearchIllegalArgumentException("this plugin name is not allowed.");
+        boolean forbidden = Strings.isNullOrEmpty(name);
+
+        String[] forbiddenNames = {
+                "elasticsearch",
+                "elasticsearch.bat",
+                "elasticsearch.in.sh",
+                "plugin",
+                "plugin.bat",
+                "service.bat"
+        };
+
+        for (String forbiddenName : forbiddenNames) {
+            if (forbiddenName.equalsIgnoreCase(name)) {
+                forbidden = true;
+                break;
+            }
+        }
+
+        if (forbidden) {
+            throw new ElasticsearchIllegalArgumentException("This plugin name is not allowed");
         }
     }
 

--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.plugins;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.ElasticsearchTimeoutException;
@@ -46,6 +47,7 @@ import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import static org.elasticsearch.common.Strings.hasLength;
 import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_SETTINGS;
 
 /**
@@ -65,6 +67,14 @@ public class PluginManager {
 
     // By default timeout is 0 which means no timeout
     public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueMillis(0);
+
+    private static final ImmutableSet<Object> BLACKLIST = ImmutableSet.builder()
+            .add("elasticsearch",
+                    "elasticsearch.bat",
+                    "elasticsearch.in.sh",
+                    "plugin",
+                    "plugin.bat",
+                    "service.bat").build();
 
     private final Environment environment;
 
@@ -279,26 +289,8 @@ public class PluginManager {
     }
 
     private static void checkForForbiddenName(String name) {
-        boolean forbidden = Strings.isNullOrEmpty(name);
-
-        String[] forbiddenNames = {
-                "elasticsearch",
-                "elasticsearch.bat",
-                "elasticsearch.in.sh",
-                "plugin",
-                "plugin.bat",
-                "service.bat"
-        };
-
-        for (String forbiddenName : forbiddenNames) {
-            if (forbiddenName.equalsIgnoreCase(name)) {
-                forbidden = true;
-                break;
-            }
-        }
-
-        if (forbidden) {
-            throw new ElasticsearchIllegalArgumentException("This plugin name is not allowed");
+        if (!hasLength(name) || BLACKLIST.contains(name.toLowerCase(Locale.ROOT))) {
+            throw new ElasticsearchIllegalArgumentException("Illegal plugin name: " + name);
         }
     }
 

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -210,7 +210,7 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
     public void testInstallPlugin() throws IOException {
         PluginManager pluginManager = pluginManager(getPluginUrlForResource("plugin_with_classfile.zip"));
 
-        pluginManager.downloadAndExtract("plugin");
+        pluginManager.downloadAndExtract("plugin-classfile");
         File[] plugins = pluginManager.getListInstalledPlugins();
         assertThat(plugins, notNullValue());
         assertThat(plugins.length, is(1));

--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -332,6 +332,31 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
         pluginManager.removePlugin("file://whatever");
     }
 
+    @Test
+    public void testForbiddenPluginName_ThrowsException() throws IOException {
+        runTestWithForbiddenName(null);
+        runTestWithForbiddenName("");
+        runTestWithForbiddenName("elasticsearch");
+        runTestWithForbiddenName("elasticsearch.bat");
+        runTestWithForbiddenName("elasticsearch.in.sh");
+        runTestWithForbiddenName("plugin");
+        runTestWithForbiddenName("plugin.bat");
+        runTestWithForbiddenName("service.bat");
+        runTestWithForbiddenName("ELASTICSEARCH");
+        runTestWithForbiddenName("ELASTICSEARCH.IN.SH");
+    }
+
+    private void runTestWithForbiddenName(String name) throws IOException {
+        try {
+            pluginManager(null).removePlugin(name);
+            fail("this plugin name [" + name +
+                    "] should not be allowed");
+        } catch (ElasticsearchIllegalArgumentException e) {
+            // We expect that error
+        }
+    }
+
+
     /**
      * Retrieve a URL string that represents the resource with the given {@code resourceName}.
      * @param resourceName The resource name relative to {@link PluginManagerTests}.


### PR DESCRIPTION
If you call `bin/plugin --remove es-plugin` the plugin got removed but the file `bin/plugin` itself was also deleted.

We now don't allow the following plugin names:
- elasticsearch
- elasticsearch-service-x86.exe
- plugin
- elasticsearch-service-mgr.exe
- elasticsearch.bat
- plugin.bat
- elasticsearch-service-x64.exe
- elasticsearch.in.sh
- service.bat

Closes #6745
