### PR TITLE
Changing ES_MAX_MEM default from '1gb' to '1g'

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -18,7 +18,7 @@ The `ES_HEAP_SIZE` environment variable allows to set the heap memory
 that will be allocated to elasticsearch java process. It will allocate
 the same value to both min and max values, though those can be set
 explicitly (not recommended) by setting `ES_MIN_MEM` (defaults to
-`256m`), and `ES_MAX_MEM` (defaults to `1gb`).
+`256m`), and `ES_MAX_MEM` (defaults to `1g`).
 
 It is recommended to set the min and max memory to the same value, and
 enable <<setup-configuration-memory,`mlockall`>>.


### PR DESCRIPTION
If you set ES_HEAP_SIZE to '1gb' as suggested, Java will yield an "Invalid initial heap size".
