### PR TITLE
Catch the NumberFormatException and handle it in GET

### DIFF
--- a/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -254,7 +254,12 @@ public class ShardGetService extends AbstractIndexShardComponent {
                                 List<Object> values = searchLookup.source().extractRawValues(field);
                                 if (!values.isEmpty()) {
                                     for (int i = 0; i < values.size(); i++) {
-                                        values.set(i, x.valueForSearch(values.get(i)));
+                                        try {
+                                            values.set(i, x.valueForSearch(values.get(i)));
+                                        } catch (NumberFormatException e) {
+                                            values = null;
+                                            break;
+                                        }
                                     }
                                     value = values;
                                 }


### PR DESCRIPTION
If a field is a multi field and requested with a GET request then
this will return the value of the parent field in case the document
is retrieved from the transaction log.
If the type is numeric but the value a string, the numeric value will
be parsed. This caused the NumberFprmatException in case the field
is of type `token_count`.

closes #6676
