### PR TITLE
Fixed the node retry mechanism which could fail without trying all the connected nodes

### DIFF
--- a/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
+++ b/src/main/java/org/elasticsearch/action/TransportActionNodeProxy.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -30,8 +28,6 @@ import org.elasticsearch.transport.BaseTransportResponseHandler;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
-
-import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
 
 /**
  * A generic proxy that will execute the given action against a specific node.
@@ -50,13 +46,6 @@ public class TransportActionNodeProxy<Request extends ActionRequest, Response ex
         this.action = action;
         this.transportService = transportService;
         this.transportOptions = action.transportOptions(settings);
-    }
-
-    public ActionFuture<Response> execute(DiscoveryNode node, Request request) throws ElasticsearchException {
-        PlainActionFuture<Response> future = newFuture();
-        request.listenerThreaded(false);
-        execute(node, request, future);
-        return future;
     }
 
     public void execute(DiscoveryNode node, final Request request, final ActionListener<Response> listener) {

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -474,13 +474,8 @@ public class TransportClientNodesService extends AbstractComponent {
         }
     }
 
-    public static interface NodeCallback<T> {
-
-        T doWithNode(DiscoveryNode node) throws ElasticsearchException;
-    }
-
     public static interface NodeListenerCallback<Response> {
 
-        void doWithNode(DiscoveryNode node, ActionListener<Response> listener) throws ElasticsearchException;
+        void doWithNode(DiscoveryNode node, ActionListener<Response> listener);
     }
 }

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -218,6 +218,9 @@ public class TransportClientNodesService extends AbstractComponent {
         try {
             callback.doWithNode(node, retryListener);
         } catch (ElasticsearchException e) {
+            //ConnectTransportException gets thrown as well by TransportService due to throwConnectException option,
+            //which is needed for the correct operation of execute(...).
+            //We can ignore it here because it will be passed to the listener interface anyway through the request holder.
             if (!(e.unwrapCause() instanceof ConnectTransportException)) {
                 throw e;
             }
@@ -254,10 +257,9 @@ public class TransportClientNodesService extends AbstractComponent {
                     try {
                         callback.doWithNode(nodes.get((index + i) % nodes.size()), this);
                     } catch (Throwable e1) {
-                        //no need to retry here, the transport service will notify this same listener
-                        //of the failure through the request holder, which will retry
-                        //ConnectTransportException gets thrown as well by TransportService due to throwConnectException option
-                        //fail though in case an exception gets thrown before that
+                        //ConnectTransportException gets thrown as well by TransportService due to throwConnectException option,
+                        //which is needed for the correct operation of execute(...).
+                        //We can ignore it here because it will be passed to the listener interface anyway through the request holder.
                         if (!(ExceptionsHelper.unwrapCause(e1) instanceof ConnectTransportException)) {
                             listener.onFailure(e1);
                         }

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -255,7 +255,12 @@ public class TransportClientNodesService extends AbstractComponent {
                         callback.doWithNode(nodes.get((index + i) % nodes.size()), this);
                     } catch (Throwable e1) {
                         //no need to retry here, the transport service will notify this same listener
-                        //of the failure through the request holder
+                        //of the failure through the request holder, which will retry
+                        //ConnectTransportException gets thrown as well by TransportService due to throwConnectException option
+                        //fail though in case an exception gets thrown before that
+                        if (!(ExceptionsHelper.unwrapCause(e1) instanceof ConnectTransportException)) {
+                            listener.onFailure(e1);
+                        }
                     }
                 }
             } else {

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -218,9 +218,7 @@ public class TransportClientNodesService extends AbstractComponent {
         try {
             callback.doWithNode(node, retryListener);
         } catch (ElasticsearchException e) {
-            if (e.unwrapCause() instanceof ConnectTransportException) {
-                retryListener.onFailure(e);
-            } else {
+            if (!(e.unwrapCause() instanceof ConnectTransportException)) {
                 throw e;
             }
         }
@@ -256,8 +254,8 @@ public class TransportClientNodesService extends AbstractComponent {
                     try {
                         callback.doWithNode(nodes.get((index + i) % nodes.size()), this);
                     } catch (Throwable e1) {
-                        // retry the next one...
-                        onFailure(e1);
+                        //no need to retry here, the transport service will notify this same listener
+                        //of the failure through the request holder
                     }
                 }
             } else {

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -217,7 +217,7 @@ public class TransportClientNodesService extends AbstractComponent {
             //ConnectTransportException gets thrown as well by TransportService due to throwConnectException option,
             //which is needed for the correct operation of execute(...).
             //We can ignore it here because it will be passed to the listener interface anyway through the request holder.
-        } catch(Throwable t) {
+        } catch (Throwable t) {
             //this exception can't come from the TransportService as it throws only ConnectTransportException,
             //the listener hasn't been notified then. no need to go ahead with retries though
             listener.onFailure(t);

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportAdminClient.java
@@ -22,7 +22,6 @@ package org.elasticsearch.client.transport.support;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.IndicesAdminClient;
-import org.elasticsearch.client.transport.TransportClientNodesService;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -32,17 +31,13 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class InternalTransportAdminClient extends AbstractComponent implements AdminClient {
 
-    private final TransportClientNodesService nodesService;
-
     private final InternalTransportIndicesAdminClient indicesAdminClient;
 
     private final InternalTransportClusterAdminClient clusterAdminClient;
 
     @Inject
-    public InternalTransportAdminClient(Settings settings, TransportClientNodesService nodesService,
-                                        InternalTransportIndicesAdminClient indicesAdminClient, InternalTransportClusterAdminClient clusterAdminClient) {
+    public InternalTransportAdminClient(Settings settings, InternalTransportIndicesAdminClient indicesAdminClient, InternalTransportClusterAdminClient clusterAdminClient) {
         super(settings);
-        this.nodesService = nodesService;
         this.indicesAdminClient = indicesAdminClient;
         this.clusterAdminClient = clusterAdminClient;
     }

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClient.java
@@ -22,6 +22,7 @@ package org.elasticsearch.client.transport.support;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.*;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.support.AbstractClient;
@@ -89,13 +90,9 @@ public class InternalTransportClient extends AbstractClient {
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(final Action<Request, Response, RequestBuilder, Client> action, final Request request) {
-        final TransportActionNodeProxy<Request, Response> proxy = actions.get(action);
-        return nodesService.execute(new TransportClientNodesService.NodeCallback<ActionFuture<Response>>() {
-            @Override
-            public ActionFuture<Response> doWithNode(DiscoveryNode node) throws ElasticsearchException {
-                return proxy.execute(node, request);
-            }
-        });
+        PlainActionFuture<Response> actionFuture = PlainActionFuture.newFuture();
+        execute(action, request, actionFuture);
+        return actionFuture;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClient.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.client.transport.support;
 
 import com.google.common.collect.ImmutableMap;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.AdminClient;
@@ -101,7 +100,7 @@ public class InternalTransportClient extends AbstractClient {
         final TransportActionNodeProxy<Request, Response> proxy = actions.get(action);
         nodesService.execute(new TransportClientNodesService.NodeListenerCallback<Response>() {
             @Override
-            public void doWithNode(DiscoveryNode node, ActionListener<Response> listener) throws ElasticsearchException {
+            public void doWithNode(DiscoveryNode node, ActionListener<Response> listener) {
                 proxy.execute(node, request, listener);
             }
         }, listener);

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClusterAdminClient.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.client.transport.support;
 
 import com.google.common.collect.ImmutableMap;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.cluster.ClusterAction;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -81,7 +80,7 @@ public class InternalTransportClusterAdminClient extends AbstractClusterAdminCli
         final TransportActionNodeProxy<Request, Response> proxy = actions.get(action);
         nodesService.execute(new TransportClientNodesService.NodeListenerCallback<Response>() {
             @Override
-            public void doWithNode(DiscoveryNode node, ActionListener<Response> listener) throws ElasticsearchException {
+            public void doWithNode(DiscoveryNode node, ActionListener<Response> listener) {
                 proxy.execute(node, request, listener);
             }
         }, listener);

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClusterAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportClusterAdminClient.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.cluster.ClusterAction;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.support.AbstractClusterAdminClient;
 import org.elasticsearch.client.transport.TransportClientNodesService;
@@ -69,13 +70,9 @@ public class InternalTransportClusterAdminClient extends AbstractClusterAdminCli
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(final Action<Request, Response, RequestBuilder, ClusterAdminClient> action, final Request request) {
-        final TransportActionNodeProxy<Request, Response> proxy = actions.get(action);
-        return nodesService.execute(new TransportClientNodesService.NodeCallback<ActionFuture<Response>>() {
-            @Override
-            public ActionFuture<Response> doWithNode(DiscoveryNode node) throws ElasticsearchException {
-                return proxy.execute(node, request);
-            }
-        });
+        PlainActionFuture<Response> actionFuture = PlainActionFuture.newFuture();
+        execute(action, request, actionFuture);
+        return actionFuture;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportIndicesAdminClient.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.indices.IndicesAction;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.support.AbstractIndicesAdminClient;
 import org.elasticsearch.client.transport.TransportClientNodesService;
@@ -69,13 +70,9 @@ public class InternalTransportIndicesAdminClient extends AbstractIndicesAdminCli
     @SuppressWarnings("unchecked")
     @Override
     public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(final Action<Request, Response, RequestBuilder, IndicesAdminClient> action, final Request request) {
-        final TransportActionNodeProxy<Request, Response> proxy = actions.get(action);
-        return nodesService.execute(new TransportClientNodesService.NodeCallback<ActionFuture<Response>>() {
-            @Override
-            public ActionFuture<Response> doWithNode(DiscoveryNode node) throws ElasticsearchException {
-                return proxy.execute(node, request);
-            }
-        });
+        PlainActionFuture<Response> actionFuture = PlainActionFuture.newFuture();
+        execute(action, request, actionFuture);
+        return actionFuture;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/elasticsearch/client/transport/support/InternalTransportIndicesAdminClient.java
+++ b/src/main/java/org/elasticsearch/client/transport/support/InternalTransportIndicesAdminClient.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.client.transport.support;
 
 import com.google.common.collect.ImmutableMap;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.indices.IndicesAction;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -81,7 +80,7 @@ public class InternalTransportIndicesAdminClient extends AbstractIndicesAdminCli
         final TransportActionNodeProxy<Request, Response> proxy = actions.get(action);
         nodesService.execute(new TransportClientNodesService.NodeListenerCallback<Response>() {
             @Override
-            public void doWithNode(DiscoveryNode node, ActionListener<Response> listener) throws ElasticsearchException {
+            public void doWithNode(DiscoveryNode node, ActionListener<Response> listener) {
                 proxy.execute(node, request, listener);
             }
         }, listener);

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -178,12 +178,12 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
     }
 
     public <T extends TransportResponse> void sendRequest(final DiscoveryNode node, final String action, final TransportRequest request,
-                                                          final TransportResponseHandler<T> handler) throws TransportException {
+                                                          final TransportResponseHandler<T> handler) {
         sendRequest(node, action, request, TransportRequestOptions.EMPTY, handler);
     }
 
     public <T extends TransportResponse> void sendRequest(final DiscoveryNode node, final String action, final TransportRequest request,
-                                                          final TransportRequestOptions options, TransportResponseHandler<T> handler) throws TransportException {
+                                                          final TransportRequestOptions options, TransportResponseHandler<T> handler) {
         if (node == null) {
             throw new ElasticsearchIllegalStateException("can't send request to a null node");
         }

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -69,7 +69,6 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         }
     });
 
-    private boolean throwConnectException = false;
     private final TransportService.Adapter adapter = new Adapter();
 
     public TransportService(Transport transport, ThreadPool threadPool) {
@@ -166,17 +165,6 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         connectionListeners.remove(listener);
     }
 
-    /**
-     * Set to <tt>true</tt> to indicate that a {@link ConnectTransportException} should be thrown when
-     * sending a message (otherwise, it will be passed to the response handler). Defaults to <tt>false</tt>.
-     * <p/>
-     * <p>This is useful when logic based on connect failure is needed without having to wrap the handler,
-     * for example, in case of retries across several nodes.
-     */
-    public void throwConnectException(boolean throwConnectException) {
-        this.throwConnectException = throwConnectException;
-    }
-
     public <T extends TransportResponse> TransportFuture<T> submitRequest(DiscoveryNode node, String action, TransportRequest request,
                                                                           TransportResponseHandler<T> handler) throws TransportException {
         return submitRequest(node, action, request, TransportRequestOptions.EMPTY, handler);
@@ -228,12 +216,6 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                         holderToNotify.handler().handleException(sendRequestException);
                     }
                 });
-            }
-
-            if (throwConnectException) {
-                if (e instanceof ConnectTransportException) {
-                    throw (ConnectTransportException) e;
-                }
             }
         }
     }

--- a/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.transport;
+
+import com.carrotsearch.randomizedtesting.generators.RandomInts;
+import org.elasticsearch.Build;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.transport.*;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class FailAndRetryMockTransport<Response extends TransportResponse> implements Transport {
+
+    private final Random random;
+
+    private boolean connectMode = true;
+
+    private TransportServiceAdapter transportServiceAdapter;
+
+    private final AtomicInteger connectTransportExceptions = new AtomicInteger();
+    private final AtomicInteger failures = new AtomicInteger();
+    private final AtomicInteger successes = new AtomicInteger();
+    private final Set<DiscoveryNode> triedNodes = new CopyOnWriteArraySet<>();
+
+    public FailAndRetryMockTransport(Random random) {
+        this.random = new Random(random.nextLong());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void sendRequest(DiscoveryNode node, long requestId, String action, TransportRequest request, TransportRequestOptions options) throws IOException, TransportException {
+
+        //we make sure that nodes get added to the connected ones when calling addTransportAddress, by returning proper nodes info
+        if (connectMode) {
+            TransportResponseHandler transportResponseHandler = transportServiceAdapter.remove(requestId);
+            NodeInfo nodeInfo = new NodeInfo(Version.CURRENT, Build.CURRENT, node, null, null, null, null, null, null, null, null, null, null);
+            NodesInfoResponse nodesInfoResponse = new NodesInfoResponse(ClusterName.DEFAULT, new NodeInfo[]{nodeInfo});
+            transportResponseHandler.handleResponse(nodesInfoResponse);
+            return;
+        }
+
+        //once nodes are connected we'll just return errors for each sendRequest call
+        triedNodes.add(node);
+
+        if (RandomInts.randomInt(random, 100) > 10) {
+            connectTransportExceptions.incrementAndGet();
+            throw new ConnectTransportException(node, "node not available");
+        } else {
+            if (random.nextBoolean()) {
+                failures.incrementAndGet();
+                //throw whatever exception that is not a subclass of ConnectTransportException
+                throw new IllegalStateException();
+            } else {
+                TransportResponseHandler transportResponseHandler = transportServiceAdapter.remove(requestId);
+                if (random.nextBoolean()) {
+                    successes.incrementAndGet();
+                    transportResponseHandler.handleResponse(newResponse());
+                } else {
+                    failures.incrementAndGet();
+                    transportResponseHandler.handleException(new TransportException("transport exception"));
+                }
+            }
+        }
+    }
+
+    protected abstract Response newResponse();
+
+    public void endConnectMode() {
+        this.connectMode = false;
+    }
+
+    public int connectTransportExceptions() {
+        return connectTransportExceptions.get();
+    }
+
+    public int failures() {
+        return failures.get();
+    }
+
+    public int successes() {
+        return successes.get();
+    }
+
+    public Set<DiscoveryNode> triedNodes() {
+        return triedNodes;
+    }
+
+    @Override
+    public void transportServiceAdapter(TransportServiceAdapter transportServiceAdapter) {
+        this.transportServiceAdapter = transportServiceAdapter;
+    }
+
+    @Override
+    public BoundTransportAddress boundAddress() {
+        return null;
+    }
+
+    @Override
+    public TransportAddress[] addressesFromString(String address) throws Exception {
+        return new TransportAddress[0];
+    }
+
+    @Override
+    public boolean addressSupported(Class<? extends TransportAddress> address) {
+        return false;
+    }
+
+    @Override
+    public boolean nodeConnected(DiscoveryNode node) {
+        return false;
+    }
+
+    @Override
+    public void connectToNode(DiscoveryNode node) throws ConnectTransportException {
+
+    }
+
+    @Override
+    public void connectToNodeLight(DiscoveryNode node) throws ConnectTransportException {
+
+    }
+
+    @Override
+    public void disconnectFromNode(DiscoveryNode node) {
+
+    }
+
+    @Override
+    public long serverOpen() {
+        return 0;
+    }
+
+    @Override
+    public Lifecycle.State lifecycleState() {
+        return null;
+    }
+
+    @Override
+    public void addLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public void removeLifecycleListener(LifecycleListener listener) {
+
+    }
+
+    @Override
+    public Transport start() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public Transport stop() throws ElasticsearchException {
+        return null;
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+
+    }
+}

--- a/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -127,12 +127,12 @@ public abstract class FailAndRetryMockTransport<Response extends TransportRespon
 
     @Override
     public TransportAddress[] addressesFromString(String address) throws Exception {
-        return new TransportAddress[0];
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean addressSupported(Class<? extends TransportAddress> address) {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -167,12 +167,12 @@ public abstract class FailAndRetryMockTransport<Response extends TransportRespon
 
     @Override
     public void addLifecycleListener(LifecycleListener listener) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void removeLifecycleListener(LifecycleListener listener) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.transport;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class TransportClientNodesServiceTests extends ElasticsearchTestCase {
+
+    private static class TestIteration implements Closeable {
+        private final ThreadPool threadPool;
+        private final FailAndRetryMockTransport<TestResponse> transport;
+        private final TransportService transportService;
+        private final TransportClientNodesService transportClientNodesService;
+        private final int nodesCount;
+
+        TestIteration() {
+            threadPool = new ThreadPool("transport-client-nodes-service-tests");
+            transport = new FailAndRetryMockTransport<TestResponse>(getRandom()) {
+                @Override
+                protected TestResponse newResponse() {
+                    return  new TestResponse();
+                }
+            };
+            transportService = new TransportService(ImmutableSettings.EMPTY, transport, threadPool);
+            transportService.start();
+            transportClientNodesService = new TransportClientNodesService(ImmutableSettings.EMPTY, ClusterName.DEFAULT, transportService, threadPool, Version.CURRENT);
+
+            nodesCount = randomIntBetween(1, 10);
+            for (int i = 0; i < nodesCount; i++) {
+                transportClientNodesService.addTransportAddresses(new LocalTransportAddress("node" + i));
+            }
+            transport.endConnectMode();
+        }
+
+        public void close() {
+            threadPool.shutdown();
+            try {
+                threadPool.awaitTermination(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().isInterrupted();
+            }
+            transportService.stop();
+            transportClientNodesService.close();
+        }
+    }
+
+    @Test
+    public void testListenerFailures() throws InterruptedException {
+
+        int iters = iterations(10, 100);
+        for (int i = 0; i <iters; i++) {
+            try(final TestIteration iteration = new TestIteration()) {
+                final CountDownLatch latch = new CountDownLatch(1);
+                final AtomicInteger finalFailures = new AtomicInteger();
+                final AtomicReference<Throwable> finalFailure = new AtomicReference<>();
+                final AtomicReference<TestResponse> response = new AtomicReference<>();
+                ActionListener<TestResponse> actionListener = new ActionListener<TestResponse>() {
+                    @Override
+                    public void onResponse(TestResponse testResponse) {
+                        response.set(testResponse);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        finalFailures.incrementAndGet();
+                        finalFailure.set(e);
+                        latch.countDown();
+                    }
+                };
+
+                final AtomicInteger preSendFailures = new AtomicInteger();
+
+                iteration.transportClientNodesService.execute(new TransportClientNodesService.NodeListenerCallback<TestResponse>() {
+                    @Override
+                    public void doWithNode(DiscoveryNode node, final ActionListener<TestResponse> retryListener) throws ElasticsearchException {
+                        if (rarely()) {
+                            preSendFailures.incrementAndGet();
+                            //throw whatever exception that is not a subclass of ConnectTransportException
+                            throw new IllegalArgumentException();
+                        }
+
+                        iteration.transportService.sendRequest(node, "action", new TestRequest(), new TransportRequestOptions().withTimeout(50), new BaseTransportResponseHandler<TestResponse>() {
+                            @Override
+                            public TestResponse newInstance() {
+                                return new TestResponse();
+                            }
+
+                            @Override
+                            public void handleResponse(TestResponse response) {
+                                retryListener.onResponse(response);
+                            }
+
+                            @Override
+                            public void handleException(TransportException exp) {
+                                retryListener.onFailure(exp);
+                            }
+
+                            @Override
+                            public String executor() {
+                                return randomBoolean() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC;
+                            }
+                        });
+                    }
+                }, actionListener);
+
+                assertThat(latch.await(1, TimeUnit.SECONDS), equalTo(true));
+
+                //there can be only either one failure that causes the request to fail straightaway or success
+                assertThat(preSendFailures.get() + iteration.transport.failures() + iteration.transport.successes(), lessThanOrEqualTo(1));
+
+                if (iteration.transport.successes() == 1) {
+                    assertThat(finalFailures.get(), equalTo(0));
+                    assertThat(finalFailure.get(), nullValue());
+                    assertThat(response.get(), notNullValue());
+                } else {
+                    assertThat(finalFailures.get(), equalTo(1));
+                    assertThat(finalFailure.get(), notNullValue());
+                    assertThat(response.get(), nullValue());
+                    if (preSendFailures.get() == 0 && iteration.transport.failures() == 0) {
+                        assertThat(finalFailure.get(), instanceOf(NoNodeAvailableException.class));
+                    }
+                }
+
+                assertThat(iteration.transport.triedNodes().size(), lessThanOrEqualTo(iteration.nodesCount));
+                assertThat(iteration.transport.triedNodes().size(), equalTo(iteration.transport.connectTransportExceptions() + iteration.transport.failures() + iteration.transport.successes()));
+            }
+        }
+    }
+
+    @Test
+    public void testSyncFailures() throws InterruptedException {
+
+        int iters = iterations(10, 100);
+        for (int i = 0; i <iters; i++) {
+            try(final TestIteration iteration = new TestIteration()) {
+                final AtomicInteger preSendFailures = new AtomicInteger();
+                Throwable finalFailure = null;
+                TestResponse testResponse = null;
+
+                try {
+                    ActionFuture<TestResponse> actionFuture = iteration.transportClientNodesService.execute(new TransportClientNodesService.NodeCallback<ActionFuture<TestResponse>>() {
+                        @Override
+                        public ActionFuture<TestResponse> doWithNode(DiscoveryNode node) throws ElasticsearchException {
+
+                            final PlainActionFuture<TestResponse> future = newFuture();
+
+                            if (rarely()) {
+                                preSendFailures.incrementAndGet();
+                                //throw whatever exception that is not a subclass of ConnectTransportException
+                                throw new IllegalArgumentException();
+                            }
+
+                            iteration.transportService.sendRequest(node, "action", new TestRequest(), TransportRequestOptions.EMPTY, new BaseTransportResponseHandler<TestResponse>() {
+                                @Override
+                                public TestResponse newInstance() {
+                                    return new TestResponse();
+                                }
+
+                                @Override
+                                public void handleResponse(TestResponse response) {
+                                    future.onResponse(response);
+                                }
+
+                                @Override
+                                public void handleException(TransportException exp) {
+                                    future.onFailure(exp);
+                                }
+
+                                @Override
+                                public String executor() {
+                                    //listener is never threaded in the blocking case
+                                    return ThreadPool.Names.SAME;
+                                }
+                            });
+
+                            return future;
+                        }
+                    });
+                    testResponse = actionFuture.get();
+                } catch (Throwable t) {
+                    finalFailure = t;
+                }
+
+                //there can be only either one failure that causes the request to fail straightaway or success
+                assertThat(preSendFailures.get() + iteration.transport.failures() + iteration.transport.successes(), lessThanOrEqualTo(1));
+
+                if (iteration.transport.successes() == 1) {
+                    assertThat(finalFailure, nullValue());
+                    assertThat(testResponse, notNullValue());
+                } else {
+                    assertThat(testResponse, nullValue());
+                    assertThat(finalFailure, notNullValue());
+                    if (preSendFailures.get() == 0 && iteration.transport.failures() == 0) {
+                        assertThat(finalFailure, instanceOf(NoNodeAvailableException.class));
+                    }
+                }
+
+                assertThat(iteration.transport.triedNodes().size(), lessThanOrEqualTo(iteration.nodesCount));
+                assertThat(iteration.transport.triedNodes().size(), equalTo(iteration.transport.connectTransportExceptions() + iteration.transport.failures() + iteration.transport.successes()));
+            }
+        }
+    }
+
+    private static class TestRequest extends TransportRequest {
+
+    }
+
+    private static class TestResponse extends TransportResponse {
+
+    }
+}

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.transport;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
@@ -110,7 +109,7 @@ public class TransportClientNodesServiceTests extends ElasticsearchTestCase {
 
                 iteration.transportClientNodesService.execute(new TransportClientNodesService.NodeListenerCallback<TestResponse>() {
                     @Override
-                    public void doWithNode(DiscoveryNode node, final ActionListener<TestResponse> retryListener) throws ElasticsearchException {
+                    public void doWithNode(DiscoveryNode node, final ActionListener<TestResponse> retryListener) {
                         if (rarely()) {
                             preSendFailures.incrementAndGet();
                             //throw whatever exception that is not a subclass of ConnectTransportException

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
@@ -59,7 +59,7 @@ public class TransportClientRetryTests extends ElasticsearchIntegrationTest {
 
         ImmutableSettings.Builder builder = settingsBuilder().put("client.transport.nodes_sampler_interval", "1s")
                 .put("name", "transport_client_retry_test")
-                .put("node.mode", InternalTestCluster.NODE_MODE)
+                .put("node.mode", InternalTestCluster.nodeMode())
                 .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, false)
                 .put(ClusterName.SETTING, internalCluster().getClusterName())
                 .put("config.ignore_system_properties", true);

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.transport;
+
+import com.google.common.base.Predicate;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.TEST;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@ClusterScope(scope = TEST, numClientNodes = 0)
+public class TransportClientRetryTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testRetry() throws IOException {
+
+        Iterable<TransportService> instances = internalCluster().getInstances(TransportService.class);
+        TransportAddress[] addresses = new TransportAddress[internalCluster().size()];
+        int i = 0;
+        for (TransportService instance : instances) {
+            addresses[i++] = instance.boundAddress().publishAddress();
+        }
+
+        ImmutableSettings.Builder builder = settingsBuilder().put("client.transport.nodes_sampler_interval", "1s")
+                .put("name", "transport_client_retry_test")
+                .put("node.mode", InternalTestCluster.NODE_MODE)
+                .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, false)
+                .put(ClusterName.SETTING, internalCluster().getClusterName())
+                .put("config.ignore_system_properties", true);
+
+        try (TransportClient transportClient = new TransportClient(builder.build())) {
+            transportClient.addTransportAddresses(addresses);
+            assertThat(transportClient.connectedNodes().size(), equalTo(internalCluster().size()));
+
+            int size = cluster().size();
+            for (int j = 1; j < size; j++) {
+                internalCluster().stopRandomNode(new Predicate<Settings>() {
+                    @Override
+                    public boolean apply(Settings input) {
+                        return true;
+                    }
+                });
+                ClusterState state = transportClient.admin().cluster().prepareState().setLocal(true).get().getState();
+                assertThat(state.nodes().size(), greaterThanOrEqualTo(1));
+            }
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
@@ -69,6 +69,7 @@ public class TransportClientRetryTests extends ElasticsearchIntegrationTest {
             assertThat(transportClient.connectedNodes().size(), equalTo(internalCluster().size()));
 
             int size = cluster().size();
+            //kill all nodes one by one, leaving a single master/data node at the end of the loop
             for (int j = 1; j < size; j++) {
                 internalCluster().stopRandomNode(new Predicate<Settings>() {
                     @Override

--- a/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/TransportClientRetryTests.java
@@ -40,11 +40,11 @@ import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope.TEST;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-@ClusterScope(scope = TEST, numClientNodes = 0)
+@ClusterScope(scope = Scope.TEST, numClientNodes = 0)
 public class TransportClientRetryTests extends ElasticsearchIntegrationTest {
 
     @Test
@@ -81,13 +81,14 @@ public class TransportClientRetryTests extends ElasticsearchIntegrationTest {
                 ClusterState clusterState;
                 //use both variants of execute method: with and without listener
                 if (randomBoolean()) {
-                  clusterState = transportClient.admin().cluster().state(clusterStateRequest).get().getState();
+                    clusterState = transportClient.admin().cluster().state(clusterStateRequest).get().getState();
                 } else {
                     PlainListenableActionFuture<ClusterStateResponse> future = new PlainListenableActionFuture<>(clusterStateRequest.listenerThreaded(), transportClient.threadPool());
                     transportClient.admin().cluster().state(clusterStateRequest, future);
                     clusterState = future.get().getState();
                 }
-                assertThat(clusterState.nodes().size(), greaterThanOrEqualTo(1));
+                assertThat(clusterState.nodes().size(), greaterThanOrEqualTo(size - j));
+                assertThat(transportClient.connectedNodes().size(), greaterThanOrEqualTo(size - j));
             }
         }
     }

--- a/src/test/java/org/elasticsearch/client/transport/support/InternalTransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/support/InternalTransportClientTests.java
@@ -254,8 +254,7 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
 
         @Override
         public TestRequestBuilder newRequestBuilder(Client client) {
-            //not needed
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -272,7 +271,7 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
 
         @Override
         protected void doExecute(ActionListener<TestResponse> listener) {
-            //not needed
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -286,8 +285,7 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
 
         @Override
         public IndicesAdminTestRequestBuilder newRequestBuilder(IndicesAdminClient client) {
-            //not needed
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -304,7 +302,7 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
 
         @Override
         protected void doExecute(ActionListener<TestResponse> listener) {
-            //not needed
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -318,8 +316,7 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
 
         @Override
         public ClusterAdminTestRequestBuilder newRequestBuilder(ClusterAdminClient client) {
-            //not needed
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -336,7 +333,7 @@ public class InternalTransportClientTests extends ElasticsearchTestCase {
 
         @Override
         protected void doExecute(ActionListener<TestResponse> listener) {
-            //not needed
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/src/test/java/org/elasticsearch/client/transport/support/InternalTransportClientTests.java
+++ b/src/test/java/org/elasticsearch/client/transport/support/InternalTransportClientTests.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.transport.support;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.*;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.FailAndRetryMockTransport;
+import org.elasticsearch.client.transport.NoNodeAvailableException;
+import org.elasticsearch.client.transport.TransportClientNodesService;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class InternalTransportClientTests extends ElasticsearchTestCase {
+
+    private static class TestIteration implements Closeable {
+        private final ThreadPool threadPool;
+        private final FailAndRetryMockTransport<TestResponse> transport;
+        private final TransportService transportService;
+        private final TransportClientNodesService transportClientNodesService;
+        private final InternalTransportClient internalTransportClient;
+        private final int nodesCount;
+
+        TestIteration() {
+            threadPool = new ThreadPool("internal-transport-client-tests");
+            transport = new FailAndRetryMockTransport<TestResponse>(getRandom()) {
+                @Override
+                protected TestResponse newResponse() {
+                    return new TestResponse();
+                }
+            };
+            transportService = new TransportService(ImmutableSettings.EMPTY, transport, threadPool);
+            transportService.start();
+            transportClientNodesService = new TransportClientNodesService(ImmutableSettings.EMPTY, ClusterName.DEFAULT, transportService, threadPool, Version.CURRENT);
+            Map<String, GenericAction> actions = new HashMap<>();
+            actions.put(TestAction.NAME, TestAction.INSTANCE);
+            actions.put(NodesInfoAction.NAME, NodesInfoAction.INSTANCE);
+            internalTransportClient = new InternalTransportClient(ImmutableSettings.EMPTY, threadPool, transportService,
+                    transportClientNodesService, null, actions);
+
+            nodesCount = randomIntBetween(1, 10);
+            for (int i = 0; i < nodesCount; i++) {
+                transportClientNodesService.addTransportAddresses(new LocalTransportAddress("node" + i));
+            }
+            transport.endConnectMode();
+        }
+
+        public void close() {
+            threadPool.shutdown();
+            try {
+                threadPool.awaitTermination(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().isInterrupted();
+            }
+            transportService.stop();
+            transportClientNodesService.close();
+            internalTransportClient.close();
+        }
+    }
+
+    @Test
+    public void testListenerFailures() throws InterruptedException {
+
+        int iters = iterations(10, 100);
+        for (int i = 0; i < iters; i++) {
+            try(final TestIteration iteration = new TestIteration()) {
+                final CountDownLatch latch = new CountDownLatch(1);
+                final AtomicInteger finalFailures = new AtomicInteger();
+                final AtomicReference<Throwable> finalFailure = new AtomicReference<>();
+                final AtomicReference<TestResponse> response = new AtomicReference<>();
+                ActionListener<TestResponse> actionListener = new ActionListener<TestResponse>() {
+                    @Override
+                    public void onResponse(TestResponse testResponse) {
+                        response.set(testResponse);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        finalFailures.incrementAndGet();
+                        finalFailure.set(e);
+                        latch.countDown();
+                    }
+                };
+
+                final AtomicInteger preSendFailures = new AtomicInteger();
+
+                iteration.internalTransportClient.execute(TestAction.INSTANCE, new TestRequest(), actionListener);
+
+                assertThat(latch.await(1, TimeUnit.SECONDS), equalTo(true));
+
+                //there can be only either one failure that causes the request to fail straightaway or success
+                assertThat(preSendFailures.get() + iteration.transport.failures() + iteration.transport.successes(), lessThanOrEqualTo(1));
+
+                if (iteration.transport.successes() == 1) {
+                    assertThat(finalFailures.get(), equalTo(0));
+                    assertThat(finalFailure.get(), nullValue());
+                    assertThat(response.get(), notNullValue());
+                } else {
+                    assertThat(finalFailures.get(), equalTo(1));
+                    assertThat(finalFailure.get(), notNullValue());
+                    assertThat(response.get(), nullValue());
+                    if (preSendFailures.get() == 0 && iteration.transport.failures() == 0) {
+                        assertThat(finalFailure.get(), instanceOf(NoNodeAvailableException.class));
+                    }
+                }
+
+                assertThat(iteration.transport.triedNodes().size(), lessThanOrEqualTo(iteration.nodesCount));
+                assertThat(iteration.transport.triedNodes().size(), equalTo(iteration.transport.connectTransportExceptions() + iteration.transport.failures() + iteration.transport.successes()));
+            }
+        }
+    }
+
+    @Test
+    public void testSyncFailures() throws InterruptedException {
+
+        int iters = iterations(10, 100);
+        for (int i = 0; i < iters; i++) {
+            try(final TestIteration iteration = new TestIteration()) {
+                TestResponse testResponse = null;
+                Throwable finalFailure = null;
+
+                try {
+                    ActionFuture<TestResponse> future = iteration.internalTransportClient.execute(TestAction.INSTANCE, new TestRequest());
+                    testResponse = future.get();
+                } catch (Throwable t) {
+                    finalFailure = t;
+                }
+
+                //there can be only either one failure that causes the request to fail straightaway or success
+                assertThat(iteration.transport.failures() + iteration.transport.successes(), lessThanOrEqualTo(1));
+
+                if (iteration.transport.successes() == 1) {
+                    assertThat(finalFailure, nullValue());
+                    assertThat(testResponse, notNullValue());
+                } else {
+                    assertThat(testResponse, nullValue());
+                    assertThat(finalFailure, notNullValue());
+                    if (iteration.transport.failures() == 0) {
+                        assertThat(finalFailure, instanceOf(NoNodeAvailableException.class));
+                    }
+                }
+
+                assertThat(iteration.transport.triedNodes().size(), lessThanOrEqualTo(iteration.nodesCount));
+                assertThat(iteration.transport.triedNodes().size(), equalTo(iteration.transport.connectTransportExceptions() + iteration.transport.failures() + iteration.transport.successes()));
+            }
+        }
+    }
+
+    private static class TestRequest extends ActionRequest {
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    private static class TestResponse extends ActionResponse {
+
+    }
+
+    private static class TestAction extends ClientAction<TestRequest, TestResponse, TestRequestBuilder> {
+        static final String NAME = "test-action";
+        static final TestAction INSTANCE = new TestAction(NAME);
+
+        private TestAction(String name) {
+            super(name);
+        }
+
+        @Override
+        public TestRequestBuilder newRequestBuilder(Client client) {
+            //not needed
+            return null;
+        }
+
+        @Override
+        public TestResponse newResponse() {
+            return new TestResponse();
+        }
+    }
+
+    private static class TestRequestBuilder extends ActionRequestBuilder<TestRequest, TestResponse, TestRequestBuilder, Client> {
+
+        protected TestRequestBuilder(Client client, TestRequest request) {
+            super(client, request);
+        }
+
+        @Override
+        protected void doExecute(ActionListener<TestResponse> listener) {
+            //not needed
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -143,7 +143,7 @@ public final class InternalTestCluster extends TestCluster {
 
     static final boolean DEFAULT_ENABLE_RANDOM_BENCH_NODES = true;
 
-    private static final String NODE_MODE = nodeMode();
+    public static final String NODE_MODE = nodeMode();
 
     /* sorted map to make traverse order reproducible, concurrent since we do checks on it not within a sync block */
     private final NavigableMap<String, NodeAndClient> nodes = new TreeMap<>();

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -143,7 +143,7 @@ public final class InternalTestCluster extends TestCluster {
 
     static final boolean DEFAULT_ENABLE_RANDOM_BENCH_NODES = true;
 
-    public static final String NODE_MODE = nodeMode();
+    static final String NODE_MODE = nodeMode();
 
     /* sorted map to make traverse order reproducible, concurrent since we do checks on it not within a sync block */
     private final NavigableMap<String, NodeAndClient> nodes = new TreeMap<>();
@@ -255,7 +255,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
 
-    private static String nodeMode() {
+    public static String nodeMode() {
         Builder builder = ImmutableSettings.builder();
         if (Strings.isEmpty(System.getProperty("es.node.mode"))&& Strings.isEmpty(System.getProperty("es.node.local"))) {
             return "local"; // default if nothing is specified


### PR DESCRIPTION
The RetryListener was notified twice for each single failure, which caused some additional retries, but more importantly was making the client reach the maximum number of retries (number of connected nodes) too quickly, meanwhile ongoing retries which could succeed are not completed yet.

The `TransportService` already notifies the listener of any exception received from a separate thread through the request holder, no need to notify the retry listener again in any other place (either catch or `onFailure` method itself).
