### PR TITLE
ElasticSearch's init script should run after NTP and syslog are up.

### DIFF
--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -13,6 +13,7 @@
 # Provides:          elasticsearch
 # Required-Start:    $network $remote_fs $named
 # Required-Stop:     $network $remote_fs $named
+# Should-Start:      $syslog ntp
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Starts elasticsearch

--- a/src/rpm/init.d/elasticsearch
+++ b/src/rpm/init.d/elasticsearch
@@ -10,6 +10,7 @@
 # Provides: Elasticsearch
 # Required-Start: $network $named
 # Required-Stop: $network $named
+# Should-Start: ntp $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: This service manages the elasticsearch daemon


### PR DESCRIPTION
Closes #6832
