### PR TITLE
Added more utility methods to Settings

### DIFF
--- a/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
+++ b/src/main/java/org/elasticsearch/common/settings/ImmutableSettings.java
@@ -219,6 +219,11 @@ public class ImmutableSettings implements Settings {
     }
 
     @Override
+    public Settings getAsSettings(String setting) {
+        return getByPrefix(setting + ".");
+    }
+
+    @Override
     public String get(String setting) {
         String retVal = settings.get(setting);
         if (retVal != null) {
@@ -561,6 +566,20 @@ public class ImmutableSettings implements Settings {
         } catch (Exception e) {
             throw new SettingsException("Failed to parse version setting [" + setting + "] with value [" + sValue + "]", e);
         }
+    }
+
+    @Override
+    public Set<String> names() {
+        Set<String> names = new HashSet<>();
+        for (String key : settings.keySet()) {
+            int i = key.indexOf(".");
+            if (i < 0) {
+                names.add(key);
+            } else {
+                names.add(key.substring(0, i));
+            }
+        }
+        return names;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Immutable settings allowing to control the configuration.
@@ -57,6 +58,11 @@ public interface Settings extends ToXContent {
      * A settings that are filtered (and key is removed) with the specified prefix.
      */
     Settings getByPrefix(String prefix);
+
+    /**
+     * Returns the settings mapped to the given setting name.
+     */
+    Settings getAsSettings(String setting);
 
     /**
      * The class loader associated with this settings, or {@link org.elasticsearch.common.Classes#getDefaultClassLoader()}
@@ -311,6 +317,11 @@ public interface Settings extends ToXContent {
      * Returns a parsed version.
      */
     Version getAsVersion(String setting, Version defaultVersion) throws SettingsException;
+
+    /**
+     * @return  The direct keys of this settings
+     */
+    Set<String> names();
 
     /**
      * Returns the settings as delimited string.

--- a/src/test/java/org/elasticsearch/common/settings/ImmutableSettingsTests.java
+++ b/src/test/java/org/elasticsearch/common/settings/ImmutableSettingsTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.*;
@@ -183,5 +184,38 @@ public class ImmutableSettingsTests extends ElasticsearchTestCase {
                 Matchers.<String, Object>hasEntry("foo", "abc"),
                 Matchers.<String, Object>hasEntry("foo.bar", "def"),
                 Matchers.<String, Object>hasEntry("foo.baz", "ghi")));
+    }
+
+    @Test
+    public void testGetAsSettings() {
+        Settings settings = settingsBuilder()
+                .put("foo", "abc")
+                .put("foo.bar", "def")
+                .put("foo.baz", "ghi").build();
+
+        Settings fooSettings = settings.getAsSettings("foo");
+        assertThat(fooSettings.get("bar"), equalTo("def"));
+        assertThat(fooSettings.get("baz"), equalTo("ghi"));
+    }
+
+    @Test
+    public void testNames() {
+        Settings settings = settingsBuilder()
+                .put("bar", "baz")
+                .put("foo", "abc")
+                .put("foo.bar", "def")
+                .put("foo.baz", "ghi").build();
+
+        Set<String> names = settings.names();
+        assertThat(names.size(), equalTo(2));
+        assertTrue(names.contains("bar"));
+        assertTrue(names.contains("foo"));
+
+        Settings fooSettings = settings.getAsSettings("foo");
+        names = fooSettings.names();
+        assertThat(names.size(), equalTo(2));
+        assertTrue(names.contains("bar"));
+        assertTrue(names.contains("baz"));
+
     }
 }


### PR DESCRIPTION
- names() to return the direct settings names
- getAsSettings(String) to return the settings mapped to the given name (like getByPrefix(...) except no need to provide a tailing '.')
