### PR TITLE
Share numeric date analyzer instances between mappings

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -186,9 +186,8 @@ public class DateFieldMapper extends NumberFieldMapper<Long> {
                               PostingsFormatProvider postingsProvider, DocValuesFormatProvider docValuesProvider, SimilarityProvider similarity,
 
                               Loading normsLoading, @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce, new NamedAnalyzer("_date/" + precisionStep,
-                new NumericDateAnalyzer(precisionStep, dateTimeFormatter.parser())),
-                new NamedAnalyzer("_date/max", new NumericDateAnalyzer(Integer.MAX_VALUE, dateTimeFormatter.parser())),
+        super(names, precisionStep, boost, fieldType, docValues, ignoreMalformed, coerce, NumericDateAnalyzer.buildNamedAnalyzer(dateTimeFormatter, precisionStep),
+                NumericDateAnalyzer.buildNamedAnalyzer(dateTimeFormatter, Integer.MAX_VALUE),
                 postingsProvider, docValuesProvider, similarity, normsLoading, fieldDataSettings, indexSettings, multiFields, copyTo);
         this.dateTimeFormatter = dateTimeFormatter;
         this.nullValue = nullValue;

--- a/src/test/java/org/elasticsearch/benchmark/mapping/ManyMappingsBenchmark.java
+++ b/src/test/java/org/elasticsearch/benchmark/mapping/ManyMappingsBenchmark.java
@@ -82,7 +82,7 @@ public class ManyMappingsBenchmark {
     private static final String TYPE_NAME = "type";
     private static final int FIELD_COUNT = 100000;
     private static final int DOC_COUNT = 10000000;
-    private static final boolean TWO_NODES = false;
+    private static final boolean TWO_NODES = true;
 
     public static void main(String[] args) throws Exception {
         System.setProperty("es.logger.prefix", "");


### PR DESCRIPTION
use similar mechanism that shares numeric analyzers for long/double/... for dates as well. This has nice memory save properties with many date fields mapping case, as well as analysis saves (thread local resources)
