### PR TITLE
Controlled repeat filter

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
+++ b/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
@@ -518,7 +518,7 @@ public class AnalysisModule extends AbstractModule {
             tokenFiltersBindings.processTokenFilter("apostrophe", ApostropheFilterFactory.class);
             tokenFiltersBindings.processTokenFilter("classic", ClassicFilterFactory.class);
 
-
+            tokenFiltersBindings.processTokenFilter("controlled_repeat", ControlledRepeatRepeaterFilterFactory.class);
         }
 
         @Override

--- a/src/main/java/org/elasticsearch/index/analysis/ControlledRepeatFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ControlledRepeatFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.elasticsearch.ElasticsearchException;
+
+import java.io.IOException;
+
+/**
+ * Repeats terms based on configuration from
+ * {@linkplain ControlledRepeatControllerFilter}.
+ */
+public final class ControlledRepeatFilter extends TokenFilter {
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private final PositionIncrementAttribute posInc = addAttribute(PositionIncrementAttribute.class);
+    private State state;
+    private int currentRepeats;
+    /**
+     * Maximum number of repeats. -1 is a sentinal for not yet having read the
+     * number from the token stream.
+     */
+    private int maxRepeats;
+
+    protected ControlledRepeatFilter(TokenStream input) {
+        super(input);
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+        if (state != null) {
+            restoreState(state);
+            posInc.setPositionIncrement(0);
+            currentRepeats++;
+            if (currentRepeats >= maxRepeats) {
+                state = null;
+            }
+            return true;
+        }
+        if (!input.incrementToken()) {
+            return false;
+        }
+        if (maxRepeats == -1) {
+            try {
+                maxRepeats = Integer.parseInt(termAtt.toString());
+            } catch (NumberFormatException e) {
+                throw new ElasticsearchException("Could not parse repeat count in first token:  " + termAtt, e);
+            }
+            if (maxRepeats < 0) {
+                throw new ElasticsearchException("Repeats must be > 0 but was:  " + termAtt);
+            }
+            if (!input.incrementToken()) {
+                return false;
+            }
+        }
+        if (maxRepeats > 0) {
+            state = captureState();
+            currentRepeats = 0;
+        }
+        return true;
+    }
+
+    @Override
+    public void reset() throws IOException {
+        super.reset();
+        state = null;
+        currentRepeats = 0;
+        maxRepeats = -1;
+    }
+}

--- a/src/main/java/org/elasticsearch/index/analysis/ControlledRepeatRepeaterFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/ControlledRepeatRepeaterFilterFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+
+public class ControlledRepeatRepeaterFilterFactory extends AbstractTokenFilterFactory {
+    @Inject
+    public ControlledRepeatRepeaterFilterFactory(Index index, Settings indexSettings, String name, Settings settings) {
+        super(index, indexSettings, name, settings);
+    }
+
+    @Override
+    public TokenStream create(TokenStream tokenStream) {
+        return new ControlledRepeatFilter(tokenStream);
+    }
+}

--- a/src/test/java/org/elasticsearch/index/analysis/ControlledRepeatFilterTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/ControlledRepeatFilterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.test.ElasticsearchTokenStreamTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+
+public class ControlledRepeatFilterTest extends ElasticsearchTokenStreamTestCase {
+    @Test
+    public void noRepeat() throws IOException {
+        testCase("0 foo bar baz", "foo", "bar", "baz");
+    }
+
+    @Test
+    public void single() throws IOException {
+        testCase("1 foo bar baz", "foo", "foo", "bar", "bar", "baz", "baz");
+    }
+
+    @Test
+    public void five() throws IOException {
+        testCase("4 foo", "foo", "foo", "foo", "foo", "foo");
+    }
+
+    @Test(expected=ElasticsearchException.class)
+    public void negative() throws IOException {
+        testCase("-1 foo");
+    }
+
+    @Test(expected=ElasticsearchException.class)
+    public void notAnInteger() throws IOException {
+        testCase("foo");
+    }
+
+    private void testCase(String source, String... expected) throws IOException {
+        AnalysisService analysisService = AnalysisTestsHelper.createAnalysisServiceFromSettings(settingsBuilder().build());
+        TokenFilterFactory filter = analysisService.tokenFilter("controlled_repeat");
+        Tokenizer tokenizer = new WhitespaceTokenizer(TEST_VERSION_CURRENT, new StringReader(source));
+        assertTokenStreamContents(filter.create(tokenizer), expected);
+    }
+
+}

--- a/src/test/java/org/elasticsearch/index/analysis/WeightedAllFieldIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/WeightedAllFieldIntegrationTests.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.matchPhraseQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+
+public class WeightedAllFieldIntegrationTests extends ElasticsearchIntegrationTest {
+    @Test
+    public void termQueryFindsTopWeightedTerm() throws IOException, InterruptedException, ExecutionException {
+        setup();
+        SearchResponse response = client().prepareSearch("test").setQuery(termQuery("test", "test")).get();
+        assertFirstHit(response, hasId("1"));
+        assertSecondHit(response, hasId("2"));
+    }
+
+    @Test
+    public void phraseQueryFindsTopWeightedPhrase() throws IOException, InterruptedException, ExecutionException {
+        setup();
+        SearchResponse response = client().prepareSearch("test").setQuery(matchPhraseQuery("test", "foo bar")).get();
+        assertFirstHit(response, hasId("2"));
+        assertSecondHit(response, hasId("1"));
+    }
+
+    private void setup() throws IOException, InterruptedException, ExecutionException {
+        assertAcked(prepareCreate("test").setSettings(
+                settingsBuilder().put(indexSettings()).put("analysis.analyzer.repeated.type", "custom")
+                        .put("analysis.analyzer.repeated.tokenizer", "standard")
+                        .putArray("analysis.analyzer.repeated.filter", "standard", "controlled_repeat")).addMapping(
+                "test",
+                jsonBuilder().startObject().startObject("test").startObject("properties").startObject("test")
+                        .field("type", "string")
+                        .field("index_analyzer", "repeated")
+                        .field("search_analyzer", "standard")
+                .endObject().endObject().endObject().endObject()));
+        indexRandom(true, 
+                client().prepareIndex("test", "test", "1").setSource("test", new String[] { "5 test", "1 foo bar" }),
+                client().prepareIndex("test", "test", "2").setSource("test", new String[] { "5 foo bar", "1 test" }));
+    }
+}


### PR DESCRIPTION
Adds filter that repeats every token it recieves a configured number of times.
That number of times is the integer value of the first token it receives.

Closes #6847
