### PR TITLE
Expose IndexWriter and VersionMap RAM usage

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -179,4 +179,8 @@ operations |9
 |`segments.count` |`sc`, `segmentsCount` |No |Number of segments |4
 |`segments.memory` |`sm`, `segmentsMemory` |No |Memory used by
 segments |1.4kb
+|`segments.index_writer_memory` |`siwm`, `segmentsIndexWriterMemory` |No
+|Memory used by index writer |1.2kb
+|`segments.version_map_memory` |`svmm`, `segmentsVersionMapMemory` |No
+|Memory used by version map |1.0kb
 |=======================================================================

--- a/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -53,7 +53,7 @@ public class SegmentsStats implements Streamable, ToXContent {
         this.indexWriterMemoryInBytes += indexWriterMemoryInBytes;
     }
 
-    public void addVersionMayMemoryInBytes(long versionMapMemoryInBytes) {
+    public void addVersionMapMemoryInBytes(long versionMapMemoryInBytes) {
         this.versionMapMemoryInBytes += versionMapMemoryInBytes;
     }
 
@@ -63,7 +63,7 @@ public class SegmentsStats implements Streamable, ToXContent {
         }
         add(mergeStats.count, mergeStats.memoryInBytes);
         addIndexWriterMemoryInBytes(mergeStats.indexWriterMemoryInBytes);
-        addVersionMayMemoryInBytes(mergeStats.versionMapMemoryInBytes);
+        addVersionMapMemoryInBytes(mergeStats.versionMapMemoryInBytes);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.engine;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -36,6 +37,8 @@ public class SegmentsStats implements Streamable, ToXContent {
 
     private long count;
     private long memoryInBytes;
+    private long indexWriterMemoryInBytes;
+    private long versionMapMemoryInBytes;
 
     public SegmentsStats() {
 
@@ -46,11 +49,21 @@ public class SegmentsStats implements Streamable, ToXContent {
         this.memoryInBytes += memoryInBytes;
     }
 
+    public void addIndexWriterMemoryInBytes(long indexWriterMemoryInBytes) {
+        this.indexWriterMemoryInBytes += indexWriterMemoryInBytes;
+    }
+
+    public void addVersionMayMemoryInBytes(long versionMapMemoryInBytes) {
+        this.versionMapMemoryInBytes += versionMapMemoryInBytes;
+    }
+
     public void add(SegmentsStats mergeStats) {
         if (mergeStats == null) {
             return;
         }
         add(mergeStats.count, mergeStats.memoryInBytes);
+        addIndexWriterMemoryInBytes(mergeStats.indexWriterMemoryInBytes);
+        addVersionMayMemoryInBytes(mergeStats.versionMapMemoryInBytes);
     }
 
     /**
@@ -71,6 +84,28 @@ public class SegmentsStats implements Streamable, ToXContent {
         return new ByteSizeValue(memoryInBytes);
     }
 
+    /**
+     * Estimation of the memory usage by index writer
+     */
+    public long getIndexWriterMemoryInBytes() {
+        return this.indexWriterMemoryInBytes;
+    }
+
+    public ByteSizeValue getIndexWriterMemory() {
+        return new ByteSizeValue(indexWriterMemoryInBytes);
+    }
+
+    /**
+     * Estimation of the memory usage by version map
+     */
+    public long getVersionMapMemoryInBytes() {
+        return this.versionMapMemoryInBytes;
+    }
+
+    public ByteSizeValue getVersionMapMemory() {
+        return new ByteSizeValue(versionMapMemoryInBytes);
+    }
+
     public static SegmentsStats readSegmentsStats(StreamInput in) throws IOException {
         SegmentsStats stats = new SegmentsStats();
         stats.readFrom(in);
@@ -82,6 +117,8 @@ public class SegmentsStats implements Streamable, ToXContent {
         builder.startObject(Fields.SEGMENTS);
         builder.field(Fields.COUNT, count);
         builder.byteSizeField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, memoryInBytes);
+        builder.byteSizeField(Fields.INDEX_WRITER_MEMORY_IN_BYTES, Fields.INDEX_WRITER_MEMORY, indexWriterMemoryInBytes);
+        builder.byteSizeField(Fields.VERSION_MAP_MEMORY_IN_BYTES, Fields.VERSION_MAP_MEMORY, versionMapMemoryInBytes);
         builder.endObject();
         return builder;
     }
@@ -91,17 +128,29 @@ public class SegmentsStats implements Streamable, ToXContent {
         static final XContentBuilderString COUNT = new XContentBuilderString("count");
         static final XContentBuilderString MEMORY = new XContentBuilderString("memory");
         static final XContentBuilderString MEMORY_IN_BYTES = new XContentBuilderString("memory_in_bytes");
+        static final XContentBuilderString INDEX_WRITER_MEMORY = new XContentBuilderString("index_writer_memory");
+        static final XContentBuilderString INDEX_WRITER_MEMORY_IN_BYTES = new XContentBuilderString("index_writer_memory_in_bytes");
+        static final XContentBuilderString VERSION_MAP_MEMORY = new XContentBuilderString("version_map_memory");
+        static final XContentBuilderString VERSION_MAP_MEMORY_IN_BYTES = new XContentBuilderString("version_map_memory_in_bytes");
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         count = in.readVLong();
         memoryInBytes = in.readLong();
+        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            indexWriterMemoryInBytes = in.readLong();
+            versionMapMemoryInBytes = in.readLong();
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(count);
         out.writeLong(memoryInBytes);
+        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            out.writeLong(indexWriterMemoryInBytes);
+            out.writeLong(versionMapMemoryInBytes);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1136,7 +1136,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 for (AtomicReaderContext reader : searcher.reader().leaves()) {
                     stats.add(1, getReaderRamBytesUsed(reader));
                 }
-                stats.addVersionMayMemoryInBytes(versionMap.ramBytesUsed());
+                stats.addVersionMapMemoryInBytes(versionMap.ramBytesUsed());
                 stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
                 return stats;
             } finally {

--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -1136,6 +1136,8 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
                 for (AtomicReaderContext reader : searcher.reader().leaves()) {
                     stats.add(1, getReaderRamBytesUsed(reader));
                 }
+                stats.addVersionMayMemoryInBytes(versionMap.ramBytesUsed());
+                stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
                 return stats;
             } finally {
                 searcher.close();

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -240,10 +240,10 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("segments.memory", "sibling:pri;alias:sm,segmentsMemory;default:false;text-align:right;desc:memory used by segments");
         table.addCell("pri.segments.memory", "default:false;text-align:right;desc:memory used by segments");
 
-        table.addCell("segments.index_writer_memory", "sibling:pri;alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
+        table.addCell("segments.index_writer_memory", "sibling:pri;alias:siwm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
         table.addCell("pri.segments.index_writer_memory", "default:false;text-align:right;desc:memory used by index writer");
 
-        table.addCell("segments.version_map_memory", "sibling:pri;alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by version map");
+        table.addCell("segments.version_map_memory", "sibling:pri;alias:svmm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
         table.addCell("pri.segments.version_map_memory", "default:false;text-align:right;desc:memory used by version map");
 
         table.addCell("warmer.current", "sibling:pri;alias:wc,warmerCurrent;default:false;text-align:right;desc:current warmer ops");

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -240,6 +240,12 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("segments.memory", "sibling:pri;alias:sm,segmentsMemory;default:false;text-align:right;desc:memory used by segments");
         table.addCell("pri.segments.memory", "default:false;text-align:right;desc:memory used by segments");
 
+        table.addCell("segments.index_writer_memory", "sibling:pri;alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
+        table.addCell("pri.segments.index_writer_memory", "default:false;text-align:right;desc:memory used by index writer");
+
+        table.addCell("segments.version_map_memory", "sibling:pri;alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by version map");
+        table.addCell("pri.segments.version_map_memory", "default:false;text-align:right;desc:memory used by version map");
+
         table.addCell("warmer.current", "sibling:pri;alias:wc,warmerCurrent;default:false;text-align:right;desc:current warmer ops");
         table.addCell("pri.warmer.current", "default:false;text-align:right;desc:current warmer ops");
 
@@ -412,6 +418,12 @@ public class RestIndicesAction extends AbstractCatAction {
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getSegments().getMemory());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getSegments().getMemory());
+
+            table.addCell(indexStats == null ? null : indexStats.getTotal().getSegments().getIndexWriterMemory());
+            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getSegments().getIndexWriterMemory());
+
+            table.addCell(indexStats == null ? null : indexStats.getTotal().getSegments().getVersionMapMemory());
+            table.addCell(indexStats == null ? null : indexStats.getPrimaries().getSegments().getVersionMapMemory());
 
             table.addCell(indexStats == null ? null : indexStats.getTotal().getWarmer().current());
             table.addCell(indexStats == null ? null : indexStats.getPrimaries().getWarmer().current());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -169,8 +169,8 @@ public class RestNodesAction extends AbstractCatAction {
 
         table.addCell("segments.count", "alias:sc,segmentsCount;default:false;text-align:right;desc:number of segments");
         table.addCell("segments.memory", "alias:sm,segmentsMemory;default:false;text-align:right;desc:memory used by segments");
-        table.addCell("segments.index_writer_memory", "alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
-        table.addCell("segments.version_map_memory", "alias:sm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
+        table.addCell("segments.index_writer_memory", "alias:siwm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
+        table.addCell("segments.version_map_memory", "alias:svmm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
 
         table.addCell("suggest.current", "alias:suc,suggestCurrent;default:false;text-align:right;desc:number of current suggest ops");
         table.addCell("suggest.time", "alias:suti,suggestTime;default:false;text-align:right;desc:time spend in suggest");

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -169,6 +169,8 @@ public class RestNodesAction extends AbstractCatAction {
 
         table.addCell("segments.count", "alias:sc,segmentsCount;default:false;text-align:right;desc:number of segments");
         table.addCell("segments.memory", "alias:sm,segmentsMemory;default:false;text-align:right;desc:memory used by segments");
+        table.addCell("segments.index_writer_memory", "alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
+        table.addCell("segments.version_map_memory", "alias:sm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
 
         table.addCell("suggest.current", "alias:suc,suggestCurrent;default:false;text-align:right;desc:number of current suggest ops");
         table.addCell("suggest.time", "alias:suti,suggestTime;default:false;text-align:right;desc:time spend in suggest");
@@ -271,6 +273,8 @@ public class RestNodesAction extends AbstractCatAction {
 
             table.addCell(stats == null ? null : stats.getIndices().getSegments().getCount());
             table.addCell(stats == null ? null : stats.getIndices().getSegments().getMemory());
+            table.addCell(stats == null ? null : stats.getIndices().getSegments().getIndexWriterMemory());
+            table.addCell(stats == null ? null : stats.getIndices().getSegments().getVersionMapMemory());
 
             table.addCell(stats == null ? null : stats.getIndices().getSuggest().getCurrent());
             table.addCell(stats == null ? null : stats.getIndices().getSuggest().getTime());

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -145,8 +145,8 @@ public class RestShardsAction extends AbstractCatAction {
 
         table.addCell("segments.count", "alias:sc,segmentsCount;default:false;text-align:right;desc:number of segments");
         table.addCell("segments.memory", "alias:sm,segmentsMemory;default:false;text-align:right;desc:memory used by segments");
-        table.addCell("segments.index_writer_memory", "alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
-        table.addCell("segments.version_map_memory", "alias:sm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
+        table.addCell("segments.index_writer_memory", "alias:siwm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
+        table.addCell("segments.version_map_memory", "alias:svmm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
 
         table.addCell("warmer.current", "alias:wc,warmerCurrent;default:false;text-align:right;desc:current warmer ops");
         table.addCell("warmer.total", "alias:wto,warmerTotal;default:false;text-align:right;desc:total warmer ops");

--- a/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -145,6 +145,8 @@ public class RestShardsAction extends AbstractCatAction {
 
         table.addCell("segments.count", "alias:sc,segmentsCount;default:false;text-align:right;desc:number of segments");
         table.addCell("segments.memory", "alias:sm,segmentsMemory;default:false;text-align:right;desc:memory used by segments");
+        table.addCell("segments.index_writer_memory", "alias:sm,segmentsIndexWriterMemory;default:false;text-align:right;desc:memory used by index writer");
+        table.addCell("segments.version_map_memory", "alias:sm,segmentsVersionMapMemory;default:false;text-align:right;desc:memory used by version map");
 
         table.addCell("warmer.current", "alias:wc,warmerCurrent;default:false;text-align:right;desc:current warmer ops");
         table.addCell("warmer.total", "alias:wto,warmerTotal;default:false;text-align:right;desc:total warmer ops");
@@ -242,6 +244,8 @@ public class RestShardsAction extends AbstractCatAction {
 
             table.addCell(shardStats == null ? null : shardStats.getSegments().getCount());
             table.addCell(shardStats == null ? null : shardStats.getSegments().getMemory());
+            table.addCell(shardStats == null ? null : shardStats.getSegments().getIndexWriterMemory());
+            table.addCell(shardStats == null ? null : shardStats.getSegments().getVersionMapMemory());
 
             table.addCell(shardStats == null ? null : shardStats.getWarmer().current());
             table.addCell(shardStats == null ? null : shardStats.getWarmer().total());

--- a/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
+++ b/src/test/java/org/elasticsearch/indices/stats/SimpleIndexStatsTests.java
@@ -202,6 +202,9 @@ public class SimpleIndexStatsTests extends ElasticsearchIntegrationTest {
         assertThat(stats.getTotal().getSegments().getCount(), equalTo((long)test1.totalNumShards));
         assumeTrue(org.elasticsearch.Version.CURRENT.luceneVersion != Version.LUCENE_46);
         assertThat(stats.getTotal().getSegments().getMemoryInBytes(), greaterThan(0l));
+        //TODO add tests for new stat entries
+        //assertThat(stats.getTotal().getSegments().getIndexWriterMemoryInBytes(), greaterThan(0l));
+        //assertThat(stats.getTotal().getSegments().getVersionMapMemoryInBytes(), greaterThan(0l));
     }
 
     @Test


### PR DESCRIPTION
Implements exposing the IndexWriter and VersionMap RAM usage added in #6443 to the _cat endpoint. 

Closes #6483
