### PR TITLE
Don't close/reopen IndexWriter when changing RAM buffer size

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/internal/InternalEngine.java
@@ -234,7 +234,7 @@ public class InternalEngine extends AbstractIndexShardComponent implements Engin
             if (indexingBufferSize == Engine.INACTIVE_SHARD_INDEXING_BUFFER && preValue != Engine.INACTIVE_SHARD_INDEXING_BUFFER) {
                 logger.debug("updating index_buffer_size from [{}] to (inactive) [{}]", preValue, indexingBufferSize);
                 try {
-                    flush(new Flush().type(Flush.Type.NEW_WRITER));
+                    flush(new Flush().type(Flush.Type.COMMIT));
                 } catch (EngineClosedException e) {
                     // ignore
                 } catch (FlushNotAllowedEngineException e) {


### PR DESCRIPTION
Today we close/reopen IW when we change the RAM buffer but that's
costly because it means the next NRT reader is a full reopen.  The RAM
buffer size setting is a live one in IndexWriter, even if there are no
buffered docs in RAM when you call it.

Separately it would be nice if Lucene let you manage a "reader pool"
that could outlive individual IW instances ...
