### PR TITLE
Make transport action name available in TransportAction base class

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -47,7 +47,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
     @Inject
     public TransportClusterHealthAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                         ClusterName clusterName) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, ClusterHealthAction.NAME, transportService, clusterService, threadPool);
         this.clusterName = clusterName;
     }
 
@@ -55,11 +55,6 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
     protected String executor() {
         // we block here...
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClusterHealthAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -45,17 +45,12 @@ public class TransportNodesHotThreadsAction extends TransportNodesOperationActio
     @Inject
     public TransportNodesHotThreadsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                           ClusterService clusterService, TransportService transportService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, NodesHotThreadsAction.NAME, clusterName, threadPool, clusterService, transportService);
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return NodesHotThreadsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -48,18 +48,13 @@ public class TransportNodesInfoAction extends TransportNodesOperationAction<Node
     public TransportNodesInfoAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                     ClusterService clusterService, TransportService transportService,
                                     NodeService nodeService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, NodesInfoAction.NAME, clusterName, threadPool, clusterService, transportService);
         this.nodeService = nodeService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return NodesInfoAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/TransportNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/TransportNodesRestartAction.java
@@ -58,7 +58,7 @@ public class TransportNodesRestartAction extends TransportNodesOperationAction<N
     public TransportNodesRestartAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                        ClusterService clusterService, TransportService transportService,
                                        Node node) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, NodesRestartAction.NAME, clusterName, threadPool, clusterService, transportService);
         this.node = node;
         disabled = componentSettings.getAsBoolean("disabled", false);
     }
@@ -71,11 +71,6 @@ public class TransportNodesRestartAction extends TransportNodesOperationAction<N
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return NodesRestartAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
@@ -54,7 +54,7 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
     @Inject
     public TransportNodesShutdownAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                         Node node, ClusterName clusterName) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, NodesShutdownAction.NAME, transportService, clusterService, threadPool);
         this.node = node;
         this.clusterName = clusterName;
         this.disabled = settings.getAsBoolean("action.disable_shutdown", componentSettings.getAsBoolean("disabled", false));
@@ -66,11 +66,6 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return NodesShutdownAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -48,18 +48,13 @@ public class TransportNodesStatsAction extends TransportNodesOperationAction<Nod
     public TransportNodesStatsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                      ClusterService clusterService, TransportService transportService,
                                      NodeService nodeService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, NodesStatsAction.NAME, clusterName, threadPool, clusterService, transportService);
         this.nodeService = nodeService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return NodesStatsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -43,18 +43,13 @@ public class TransportDeleteRepositoryAction extends TransportMasterNodeOperatio
     @Inject
     public TransportDeleteRepositoryAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                            RepositoriesService repositoriesService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, DeleteRepositoryAction.NAME, transportService, clusterService, threadPool);
         this.repositoriesService = repositoriesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteRepositoryAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -44,17 +44,12 @@ public class TransportGetRepositoriesAction extends TransportMasterNodeReadOpera
     @Inject
     public TransportGetRepositoriesAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                           ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, GetRepositoriesAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetRepositoriesAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -43,18 +43,13 @@ public class TransportPutRepositoryAction extends TransportMasterNodeOperationAc
     @Inject
     public TransportPutRepositoryAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                         RepositoriesService repositoriesService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, PutRepositoryAction.NAME, transportService, clusterService, threadPool);
         this.repositoriesService = repositoriesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return PutRepositoryAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -43,7 +43,7 @@ public class TransportClusterRerouteAction extends TransportMasterNodeOperationA
     @Inject
     public TransportClusterRerouteAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                          AllocationService allocationService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, ClusterRerouteAction.NAME, transportService, clusterService, threadPool);
         this.allocationService = allocationService;
     }
 
@@ -51,11 +51,6 @@ public class TransportClusterRerouteAction extends TransportMasterNodeOperationA
     protected String executor() {
         // we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClusterRerouteAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -56,7 +56,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
     @Inject
     public TransportClusterUpdateSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                                 AllocationService allocationService, @ClusterDynamicSettings DynamicSettings dynamicSettings) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, ClusterUpdateSettingsAction.NAME, transportService, clusterService, threadPool);
         this.allocationService = allocationService;
         this.dynamicSettings = dynamicSettings;
     }
@@ -64,11 +64,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
     @Override
     protected String executor() {
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClusterUpdateSettingsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -44,12 +44,7 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadO
 
     @Inject
     public TransportClusterSearchShardsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClusterSearchShardsAction.NAME;
+        super(settings, ClusterSearchShardsAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -43,18 +43,13 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeOperationA
     @Inject
     public TransportCreateSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                          ThreadPool threadPool, SnapshotsService snapshotsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, CreateSnapshotAction.NAME, transportService, clusterService, threadPool);
         this.snapshotsService = snapshotsService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.SNAPSHOT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return CreateSnapshotAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -42,18 +42,13 @@ public class TransportDeleteSnapshotAction extends TransportMasterNodeOperationA
     @Inject
     public TransportDeleteSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                          ThreadPool threadPool, SnapshotsService snapshotsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, DeleteSnapshotAction.NAME, transportService, clusterService, threadPool);
         this.snapshotsService = snapshotsService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteSnapshotAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -45,18 +45,13 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeOperationAct
     @Inject
     public TransportGetSnapshotsAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                        ThreadPool threadPool, SnapshotsService snapshotsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, GetSnapshotsAction.NAME, transportService, clusterService, threadPool);
         this.snapshotsService = snapshotsService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.SNAPSHOT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetSnapshotsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -44,18 +44,13 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeOperation
     @Inject
     public TransportRestoreSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                           ThreadPool threadPool, RestoreService restoreService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, RestoreSnapshotAction.NAME, transportService, clusterService, threadPool);
         this.restoreService = restoreService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.SNAPSHOT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return RestoreSnapshotAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -50,11 +50,13 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction<TransportNodesSnapshotsStatus.Request, TransportNodesSnapshotsStatus.NodesSnapshotStatus, TransportNodesSnapshotsStatus.NodeRequest, TransportNodesSnapshotsStatus.NodeSnapshotStatus> {
 
+    private static final String ACTION_NAME = "cluster/snapshot/status/nodes";
+
     private final SnapshotsService snapshotsService;
 
     @Inject
     public TransportNodesSnapshotsStatus(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, SnapshotsService snapshotsService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
         this.snapshotsService = snapshotsService;
     }
 
@@ -65,11 +67,6 @@ public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return "cluster/snapshot/status/nodes";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -55,7 +55,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeOperation
 
     @Inject
     public TransportSnapshotsStatusAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, SnapshotsService snapshotsService, TransportNodesSnapshotsStatus transportNodesSnapshotsStatus) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, SnapshotsStatusAction.NAME, transportService, clusterService, threadPool);
         this.snapshotsService = snapshotsService;
         this.transportNodesSnapshotsStatus = transportNodesSnapshotsStatus;
     }
@@ -63,11 +63,6 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeOperation
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return SnapshotsStatusAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -44,7 +44,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadOperatio
     @Inject
     public TransportClusterStateAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                        ClusterName clusterName) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, ClusterStateAction.NAME, transportService, clusterService, threadPool);
         this.clusterName = clusterName;
     }
 
@@ -52,11 +52,6 @@ public class TransportClusterStateAction extends TransportMasterNodeReadOperatio
     protected String executor() {
         // very lightweight operation in memory, no need to fork to a thread
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClusterStateAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -66,7 +66,7 @@ public class TransportClusterStatsAction extends TransportNodesOperationAction<C
     public TransportClusterStatsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                        ClusterService clusterService, TransportService transportService,
                                        NodeService nodeService, IndicesService indicesService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, ClusterStatsAction.NAME, clusterName, threadPool, clusterService, transportService);
         this.nodeService = nodeService;
         this.indicesService = indicesService;
     }
@@ -74,11 +74,6 @@ public class TransportClusterStatsAction extends TransportNodesOperationAction<C
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClusterStatsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -37,13 +37,8 @@ public class TransportPendingClusterTasksAction extends TransportMasterNodeReadO
 
     @Inject
     public TransportPendingClusterTasksAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, PendingClusterTasksAction.NAME, transportService, clusterService, threadPool);
         this.clusterService = clusterService;
-    }
-
-    @Override
-    protected String transportAction() {
-        return PendingClusterTasksAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -52,7 +52,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
     @Inject
     public TransportIndicesAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                          ThreadPool threadPool, MetaDataIndexAliasesService indexAliasesService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, IndicesAliasesAction.NAME, transportService, clusterService, threadPool);
         this.indexAliasesService = indexAliasesService;
     }
 
@@ -60,11 +60,6 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
     protected String executor() {
         // we go async right away...
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return IndicesAliasesAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
@@ -35,12 +35,7 @@ public class TransportAliasesExistAction extends TransportMasterNodeReadOperatio
 
     @Inject
     public TransportAliasesExistAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
-    }
-
-    @Override
-    protected String transportAction() {
-        return AliasesExistAction.NAME;
+        super(settings, AliasesExistAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -38,12 +38,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadOperationA
 
     @Inject
     public TransportGetAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetAliasesAction.NAME;
+        super(settings, GetAliasesAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -60,7 +60,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
     @Inject
     public TransportAnalyzeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                   IndicesService indicesService, IndicesAnalysisService indicesAnalysisService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, AnalyzeAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.indicesAnalysisService = indicesAnalysisService;
     }
@@ -78,11 +78,6 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
     @Override
     protected AnalyzeResponse newResponse() {
         return new AnalyzeResponse();
-    }
-
-    @Override
-    protected String transportAction() {
-        return AnalyzeAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -58,7 +58,7 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
     public TransportClearIndicesCacheAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                             TransportService transportService, IndicesService indicesService, IndicesTermsFilterCache termsFilterCache,
                                             CacheRecycler cacheRecycler) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ClearIndicesCacheAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.termsFilterCache = termsFilterCache;
         this.cacheRecycler = cacheRecycler;
@@ -67,11 +67,6 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ClearIndicesCacheAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -46,7 +46,7 @@ public class TransportCloseIndexAction extends TransportMasterNodeOperationActio
     @Inject
     public TransportCloseIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                      ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, CloseIndexAction.NAME, transportService, clusterService, threadPool);
         this.indexStateService = indexStateService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
@@ -55,11 +55,6 @@ public class TransportCloseIndexAction extends TransportMasterNodeOperationActio
     protected String executor() {
         // no need to use a thread pool, we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return CloseIndexAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -44,7 +44,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeOperationActi
     @Inject
     public TransportCreateIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                       ThreadPool threadPool, MetaDataCreateIndexService createIndexService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, CreateIndexAction.NAME, transportService, clusterService, threadPool);
         this.createIndexService = createIndexService;
     }
 
@@ -52,11 +52,6 @@ public class TransportCreateIndexAction extends TransportMasterNodeOperationActi
     protected String executor() {
         // we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return CreateIndexAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -47,7 +47,7 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
     public TransportDeleteIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                       ThreadPool threadPool, MetaDataDeleteIndexService deleteIndexService,
                                       NodeSettingsService nodeSettingsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, DeleteIndexAction.NAME, transportService, clusterService, threadPool);
         this.deleteIndexService = deleteIndexService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
@@ -55,11 +55,6 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
     @Override
     protected String executor() {
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteIndexAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -41,18 +41,13 @@ public class TransportIndicesExistsAction extends TransportMasterNodeReadOperati
     @Inject
     public TransportIndicesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                         ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, IndicesExistsAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override
     protected String executor() {
         // lightweight in memory check
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return IndicesExistsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -40,18 +40,13 @@ public class TransportTypesExistsAction extends TransportMasterNodeReadOperation
     @Inject
     public TransportTypesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                       ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, TypesExistsAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override
     protected String executor() {
         // lightweight check
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return TypesExistsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -52,18 +52,13 @@ public class TransportFlushAction extends TransportBroadcastOperationAction<Flus
 
     @Inject
     public TransportFlushAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, FlushAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.FLUSH;
-    }
-
-    @Override
-    protected String transportAction() {
-        return FlushAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
@@ -73,7 +73,7 @@ public class TransportDeleteMappingAction extends TransportMasterNodeOperationAc
                                         ThreadPool threadPool, MetaDataMappingService metaDataMappingService,
                                         TransportDeleteByQueryAction deleteByQueryAction, TransportRefreshAction refreshAction,
                                         TransportFlushAction flushAction, NodeSettingsService nodeSettingsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, DeleteMappingAction.NAME, transportService, clusterService, threadPool);
         this.metaDataMappingService = metaDataMappingService;
         this.deleteByQueryAction = deleteByQueryAction;
         this.refreshAction = refreshAction;
@@ -85,11 +85,6 @@ public class TransportDeleteMappingAction extends TransportMasterNodeOperationAc
     protected String executor() {
         // no need for fork on another thread pool, we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteMappingAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -41,15 +41,13 @@ public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMap
 
     private final ClusterService clusterService;
     private final TransportGetFieldMappingsIndexAction shardAction;
-    private final String transportAction;
 
     @Inject
     public TransportGetFieldMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, TransportGetFieldMappingsIndexAction shardAction) {
-        super(settings, threadPool);
+        super(settings, GetFieldMappingsAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
-        this.transportAction = GetFieldMappingsAction.NAME;
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
     }
 
     @Override
@@ -133,7 +131,7 @@ public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMap
                     try {
                         channel.sendResponse(e);
                     } catch (Exception e1) {
-                        logger.warn("Failed to send error response for action [" + transportAction + "] and request [" + request + "]", e1);
+                        logger.warn("Failed to send error response for action [" + actionName + "] and request [" + request + "]", e1);
                     }
                 }
             });

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
@@ -56,6 +55,8 @@ import java.util.List;
  */
 public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomOperationAction<GetFieldMappingsIndexRequest, GetFieldMappingsResponse> {
 
+    private static final String ACTION_NAME = GetFieldMappingsAction.NAME + "/index";
+
     protected final ClusterService clusterService;
     private final IndicesService indicesService;
 
@@ -64,14 +65,9 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
                                                 TransportService transportService,
                                                 IndicesService indicesService,
                                                 ThreadPool threadPool) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
         this.clusterService = clusterService;
         this.indicesService = indicesService;
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetFieldMappingsAction.NAME + "/index";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -37,12 +37,7 @@ public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMa
 
     @Inject
     public TransportGetMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetMappingsAction.NAME;
+        super(settings, GetMappingsAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -43,7 +43,7 @@ public class TransportPutMappingAction extends TransportMasterNodeOperationActio
     @Inject
     public TransportPutMappingAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                      ThreadPool threadPool, MetaDataMappingService metaDataMappingService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, PutMappingAction.NAME, transportService, clusterService, threadPool);
         this.metaDataMappingService = metaDataMappingService;
     }
 
@@ -51,11 +51,6 @@ public class TransportPutMappingAction extends TransportMasterNodeOperationActio
     protected String executor() {
         // we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return PutMappingAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -46,7 +46,7 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
     @Inject
     public TransportOpenIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, OpenIndexAction.NAME, transportService, clusterService, threadPool);
         this.indexStateService = indexStateService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
@@ -55,11 +55,6 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
     protected String executor() {
         // we go async right away...
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return OpenIndexAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -53,18 +53,13 @@ public class TransportOptimizeAction extends TransportBroadcastOperationAction<O
     @Inject
     public TransportOptimizeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                    TransportService transportService, IndicesService indicesService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, OptimizeAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.OPTIMIZE;
-    }
-
-    @Override
-    protected String transportAction() {
-        return OptimizeAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -66,14 +66,9 @@ public class TransportRecoveryAction extends
     public TransportRecoveryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                    TransportService transportService, IndicesService indicesService, RecoveryTarget recoveryTarget) {
 
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, RecoveryAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.recoveryTarget = recoveryTarget;
-    }
-
-    @Override
-    protected String transportAction() {
-        return RecoveryAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -53,18 +53,13 @@ public class TransportRefreshAction extends TransportBroadcastOperationAction<Re
     @Inject
     public TransportRefreshAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                   TransportService transportService, IndicesService indicesService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, RefreshAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.REFRESH;
-    }
-
-    @Override
-    protected String transportAction() {
-        return RefreshAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -57,18 +57,13 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
     @Inject
     public TransportIndicesSegmentsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                           IndicesService indicesService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, IndicesSegmentsAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return IndicesSegmentsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -46,13 +46,8 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadOperation
     @Inject
     public TransportGetSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                       ThreadPool threadPool, SettingsFilter settingsFilter) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, GetSettingsAction.NAME, transportService, clusterService, threadPool);
         this.settingsFilter = settingsFilter;
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetSettingsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -41,7 +41,7 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeOperationA
     @Inject
     public TransportUpdateSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                          MetaDataUpdateSettingsService updateSettingsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, UpdateSettingsAction.NAME, transportService, clusterService, threadPool);
         this.updateSettingsService = updateSettingsService;
     }
 
@@ -49,11 +49,6 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeOperationA
     protected String executor() {
         // we go async right away....
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return UpdateSettingsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -57,18 +57,13 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
     @Inject
     public TransportIndicesStatsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                        IndicesService indicesService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, IndicesStatsAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.MANAGEMENT;
-    }
-
-    @Override
-    protected String transportAction() {
-        return IndicesStatsAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -41,7 +41,7 @@ public class TransportDeleteIndexTemplateAction extends TransportMasterNodeOpera
     @Inject
     public TransportDeleteIndexTemplateAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                               ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, DeleteIndexTemplateAction.NAME, transportService, clusterService, threadPool);
         this.indexTemplateService = indexTemplateService;
     }
 
@@ -49,11 +49,6 @@ public class TransportDeleteIndexTemplateAction extends TransportMasterNodeOpera
     protected String executor() {
         // we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteIndexTemplateAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -41,12 +41,7 @@ public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadOpe
 
     @Inject
     public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetIndexTemplatesAction.NAME;
+        super(settings, GetIndexTemplatesAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -41,7 +41,7 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeOperatio
     @Inject
     public TransportPutIndexTemplateAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                            ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, PutIndexTemplateAction.NAME, transportService, clusterService, threadPool);
         this.indexTemplateService = indexTemplateService;
     }
 
@@ -49,11 +49,6 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeOperatio
     protected String executor() {
         // we go async right away...
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return PutIndexTemplateAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -73,7 +73,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
 
     @Inject
     public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ValidateQueryAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
@@ -90,11 +90,6 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
     @Override
     protected String executor() {
         return ThreadPool.Names.SEARCH;
-    }
-
-    @Override
-    protected String transportAction() {
-        return ValidateQueryAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -49,18 +49,13 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeOperationAct
 
     @Inject
     public TransportDeleteWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, DeleteWarmerAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override
     protected String executor() {
         // we go async right away
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteWarmerAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/TransportGetWarmersAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/TransportGetWarmersAction.java
@@ -38,12 +38,7 @@ public class TransportGetWarmersAction extends TransportClusterInfoAction<GetWar
 
     @Inject
     public TransportGetWarmersAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetWarmersAction.NAME;
+        super(settings, GetWarmersAction.NAME, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -54,18 +54,13 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
     @Inject
     public TransportPutWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                     TransportSearchAction searchAction) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, PutWarmerAction.NAME, transportService, clusterService, threadPool);
         this.searchAction = searchAction;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.SAME;
-    }
-
-    @Override
-    protected String transportAction() {
-        return PutWarmerAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
@@ -38,13 +38,8 @@ public class TransportAbortBenchmarkAction extends TransportMasterNodeOperationA
     @Inject
     public TransportAbortBenchmarkAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                          ThreadPool threadPool, BenchmarkService service) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, AbortBenchmarkAction.NAME, transportService, clusterService, threadPool);
         this.service = service;
-    }
-
-    @Override
-    protected String transportAction() {
-        return AbortBenchmarkAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkAction.java
@@ -39,13 +39,8 @@ public class TransportBenchmarkAction extends TransportMasterNodeOperationAction
     @Inject
     public TransportBenchmarkAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     ThreadPool threadPool, BenchmarkService service) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, BenchmarkAction.NAME, transportService, clusterService, threadPool);
         this.service = service;
-    }
-
-    @Override
-    protected String transportAction() {
-        return BenchmarkAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkStatusAction.java
@@ -39,13 +39,8 @@ public class TransportBenchmarkStatusAction extends TransportMasterNodeOperation
     @Inject
     public TransportBenchmarkStatusAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                           ThreadPool threadPool, BenchmarkService service) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, BenchmarkStatusAction.NAME, transportService, clusterService, threadPool);
         this.service = service;
-    }
-
-    @Override
-    protected String transportAction() {
-        return BenchmarkStatusAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -77,7 +77,7 @@ public class TransportBulkAction extends TransportAction<BulkRequest, BulkRespon
     @Inject
     public TransportBulkAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService,
                                TransportShardBulkAction shardBulkAction, TransportCreateIndexAction createIndexAction) {
-        super(settings, threadPool);
+        super(settings, BulkAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.shardBulkAction = shardBulkAction;
         this.createIndexAction = createIndexAction;

--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -75,6 +75,8 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
     private final static String OP_TYPE_UPDATE = "update";
     private final static String OP_TYPE_DELETE = "delete";
 
+    private static final String ACTION_NAME = BulkAction.NAME + "/shard";
+
     private final MappingUpdatedAction mappingUpdatedAction;
     private final UpdateHelper updateHelper;
     private final boolean allowIdGeneration;
@@ -83,7 +85,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
     public TransportShardBulkAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
                                     MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper) {
-        super(settings, transportService, clusterService, indicesService, threadPool, shardStateAction);
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
         this.mappingUpdatedAction = mappingUpdatedAction;
         this.updateHelper = updateHelper;
         this.allowIdGeneration = settings.getAsBoolean("action.allow_id_generation", true);
@@ -117,11 +119,6 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
     @Override
     protected BulkShardResponse newResponseInstance() {
         return new BulkShardResponse();
-    }
-
-    @Override
-    protected String transportAction() {
-        return BulkAction.NAME + "/shard";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -77,7 +77,7 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
     public TransportCountAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                 IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler,
                                 PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, CountAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
@@ -94,11 +94,6 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
     @Override
     protected String executor() {
         return ThreadPool.Names.SEARCH;
-    }
-
-    @Override
-    protected String transportAction() {
-        return CountAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -64,7 +64,7 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     public TransportDeleteAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                  IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
                                  TransportCreateIndexAction createIndexAction, TransportIndexDeleteAction indexDeleteAction) {
-        super(settings, transportService, clusterService, indicesService, threadPool, shardStateAction);
+        super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
         this.createIndexAction = createIndexAction;
         this.indexDeleteAction = indexDeleteAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);
@@ -164,11 +164,6 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     @Override
     protected DeleteResponse newResponseInstance() {
         return new DeleteResponse();
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
@@ -38,10 +38,12 @@ import java.util.List;
  */
 public class TransportIndexDeleteAction extends TransportIndexReplicationOperationAction<IndexDeleteRequest, IndexDeleteResponse, ShardDeleteRequest, ShardDeleteRequest, ShardDeleteResponse> {
 
+    private static final String ACTION_NAME = "indices/index/delete";
+
     @Inject
     public TransportIndexDeleteAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                       ThreadPool threadPool, TransportShardDeleteAction deleteAction) {
-        super(settings, transportService, clusterService, threadPool, deleteAction);
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, deleteAction);
     }
 
     @Override
@@ -57,11 +59,6 @@ public class TransportIndexDeleteAction extends TransportIndexReplicationOperati
     @Override
     protected boolean accumulateExceptions() {
         return false;
-    }
-
-    @Override
-    protected String transportAction() {
-        return "indices/index/delete";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
@@ -42,11 +42,13 @@ import org.elasticsearch.transport.TransportService;
  */
 public class TransportShardDeleteAction extends TransportShardReplicationOperationAction<ShardDeleteRequest, ShardDeleteRequest, ShardDeleteResponse> {
 
+    private static final String ACTION_NAME = "indices/index/b_shard/delete";
+
     @Inject
     public TransportShardDeleteAction(Settings settings, TransportService transportService,
                                       ClusterService clusterService, IndicesService indicesService, ThreadPool threadPool,
                                       ShardStateAction shardStateAction) {
-        super(settings, transportService, clusterService, indicesService, threadPool, shardStateAction);
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
     }
 
     @Override
@@ -67,11 +69,6 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
     @Override
     protected ShardDeleteResponse newResponseInstance() {
         return new ShardDeleteResponse();
-    }
-
-    @Override
-    protected String transportAction() {
-        return "indices/index/b_shard/delete";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -47,7 +47,7 @@ public class TransportDeleteByQueryAction extends TransportIndicesReplicationOpe
     public TransportDeleteByQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                         ThreadPool threadPool, TransportIndexDeleteByQueryAction indexDeleteByQueryAction,
                                         NodeSettingsService nodeSettingsService) {
-        super(settings, transportService, clusterService, threadPool, indexDeleteByQueryAction);
+        super(settings, DeleteByQueryAction.NAME, transportService, clusterService, threadPool, indexDeleteByQueryAction);
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
 
@@ -82,11 +82,6 @@ public class TransportDeleteByQueryAction extends TransportIndicesReplicationOpe
     @Override
     protected boolean accumulateExceptions() {
         return false;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteByQueryAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
@@ -38,10 +38,12 @@ import java.util.List;
  */
 public class TransportIndexDeleteByQueryAction extends TransportIndexReplicationOperationAction<IndexDeleteByQueryRequest, IndexDeleteByQueryResponse, ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> {
 
+    private static final String ACTION_NAME = DeleteByQueryAction.NAME + "/index";
+
     @Inject
     public TransportIndexDeleteByQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                              ThreadPool threadPool, TransportShardDeleteByQueryAction shardDeleteByQueryAction) {
-        super(settings, transportService, clusterService, threadPool, shardDeleteByQueryAction);
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, shardDeleteByQueryAction);
     }
 
     @Override
@@ -57,11 +59,6 @@ public class TransportIndexDeleteByQueryAction extends TransportIndexReplication
     @Override
     protected boolean accumulateExceptions() {
         return true;
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteByQueryAction.NAME + "/index";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -54,6 +54,8 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
 
     public final static String DELETE_BY_QUERY_API = "delete_by_query";
 
+    private static final String ACTION_NAME = DeleteByQueryAction.NAME + "/shard";
+
     private final ScriptService scriptService;
     private final CacheRecycler cacheRecycler;
     private final PageCacheRecycler pageCacheRecycler;
@@ -64,7 +66,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
                                              ClusterService clusterService, IndicesService indicesService, ThreadPool threadPool,
                                              ShardStateAction shardStateAction, ScriptService scriptService, CacheRecycler cacheRecycler,
                                              PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, transportService, clusterService, indicesService, threadPool, shardStateAction);
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;
@@ -94,11 +96,6 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
     @Override
     protected ShardDeleteByQueryResponse newResponseInstance() {
         return new ShardDeleteByQueryResponse();
-    }
-
-    @Override
-    protected String transportAction() {
-        return DeleteByQueryAction.NAME + "/shard";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -74,7 +74,7 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
                                   TransportService transportService, IndicesService indicesService,
                                   ScriptService scriptService, CacheRecycler cacheRecycler,
                                   PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ExplainAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
@@ -86,10 +86,6 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
     protected void doExecute(ExplainRequest request, ActionListener<ExplainResponse> listener) {
         request.nowInMillis = System.currentTimeMillis();
         super.doExecute(request, listener);
-    }
-
-    protected String transportAction() {
-        return ExplainAction.NAME;
     }
 
     protected String executor() {

--- a/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -50,7 +50,7 @@ public class TransportGetAction extends TransportShardSingleOperationAction<GetR
     @Inject
     public TransportGetAction(Settings settings, ClusterService clusterService, TransportService transportService,
                               IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, GetAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
 
         this.realtime = settings.getAsBoolean("action.get.realtime", true);
@@ -59,11 +59,6 @@ public class TransportGetAction extends TransportShardSingleOperationAction<GetR
     @Override
     protected String executor() {
         return ThreadPool.Names.GET;
-    }
-
-    @Override
-    protected String transportAction() {
-        return GetAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -46,7 +46,7 @@ public class TransportMultiGetAction extends TransportAction<MultiGetRequest, Mu
 
     @Inject
     public TransportMultiGetAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportShardMultiGetAction shardAction) {
-        super(settings, threadPool);
+        super(settings, MultiGetAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
 

--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -42,6 +42,8 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportShardMultiGetAction extends TransportShardSingleOperationAction<MultiGetShardRequest, MultiGetShardResponse> {
 
+    private static final String ACTION_NAME = MultiGetAction.NAME + "/shard";
+
     private final IndicesService indicesService;
 
     private final boolean realtime;
@@ -49,7 +51,7 @@ public class TransportShardMultiGetAction extends TransportShardSingleOperationA
     @Inject
     public TransportShardMultiGetAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                         IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
 
         this.realtime = settings.getAsBoolean("action.get.realtime", true);
@@ -58,11 +60,6 @@ public class TransportShardMultiGetAction extends TransportShardSingleOperationA
     @Override
     protected String executor() {
         return ThreadPool.Names.GET;
-    }
-
-    @Override
-    protected String transportAction() {
-        return MultiGetAction.NAME + "/shard";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -72,7 +72,7 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
     public TransportIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                 IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
                                 TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction) {
-        super(settings, transportService, clusterService, indicesService, threadPool, shardStateAction);
+        super(settings, IndexAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
         this.createIndexAction = createIndexAction;
         this.mappingUpdatedAction = mappingUpdatedAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);
@@ -144,11 +144,6 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
     @Override
     protected IndexResponse newResponseInstance() {
         return new IndexResponse();
-    }
-
-    @Override
-    protected String transportAction() {
-        return IndexAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -79,7 +79,7 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
     @Inject
     public TransportMoreLikeThisAction(Settings settings, ThreadPool threadPool, TransportSearchAction searchAction, TransportGetAction getAction,
                                        ClusterService clusterService, IndicesService indicesService, TransportService transportService) {
-        super(settings, threadPool);
+        super(settings, MoreLikeThisAction.NAME, threadPool);
         this.searchAction = searchAction;
         this.getAction = getAction;
         this.indicesService = indicesService;

--- a/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -61,7 +61,7 @@ public class TransportMultiPercolateAction extends TransportAction<MultiPercolat
     public TransportMultiPercolateAction(Settings settings, ThreadPool threadPool, TransportShardMultiPercolateAction shardMultiPercolateAction,
                                          ClusterService clusterService, TransportService transportService, PercolatorService percolatorService,
                                          TransportMultiGetAction multiGetAction) {
-        super(settings, threadPool);
+        super(settings, MultiPercolateAction.NAME, threadPool);
         this.shardMultiPercolateAction = shardMultiPercolateAction;
         this.clusterService = clusterService;
         this.percolatorService = percolatorService;

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -61,7 +61,7 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
     public TransportPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                     TransportService transportService, PercolatorService percolatorService,
                                     TransportGetAction getAction) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, PercolateAction.NAME, threadPool, clusterService, transportService);
         this.percolatorService = percolatorService;
         this.getAction = getAction;
     }
@@ -100,11 +100,6 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
     @Override
     protected PercolateRequest newRequest() {
         return new PercolateRequest();
-    }
-
-    @Override
-    protected String transportAction() {
-        return PercolateAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -50,15 +50,12 @@ public class TransportShardMultiPercolateAction extends TransportShardSingleOper
 
     private final PercolatorService percolatorService;
 
+    private static final String ACTION_NAME = "mpercolate/shard";
+
     @Inject
     public TransportShardMultiPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, PercolatorService percolatorService) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
         this.percolatorService = percolatorService;
-    }
-
-    @Override
-    protected String transportAction() {
-        return "mpercolate/shard";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
@@ -51,7 +51,7 @@ public class TransportClearScrollAction extends TransportAction<ClearScrollReque
 
     @Inject
     public TransportClearScrollAction(Settings settings, TransportService transportService, ThreadPool threadPool, ClusterService clusterService, SearchServiceTransportAction searchServiceTransportAction) {
-        super(settings, threadPool);
+        super(settings, ClearScrollAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.searchServiceTransportAction = searchServiceTransportAction;
         transportService.registerHandler(ClearScrollAction.NAME, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -45,7 +45,7 @@ public class TransportMultiSearchAction extends TransportAction<MultiSearchReque
 
     @Inject
     public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportSearchAction searchAction) {
-        super(settings, threadPool);
+        super(settings, MultiSearchAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.searchAction = searchAction;
 

--- a/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -60,7 +60,7 @@ public class TransportSearchAction extends TransportAction<SearchRequest, Search
                                  TransportSearchQueryAndFetchAction queryAndFetchAction,
                                  TransportSearchScanAction scanAction,
                                  TransportSearchCountAction countAction) {
-        super(settings, threadPool);
+        super(settings, SearchAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.dfsQueryThenFetchAction = dfsQueryThenFetchAction;
         this.queryThenFetchAction = queryThenFetchAction;

--- a/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
@@ -52,7 +52,7 @@ public class TransportSearchScrollAction extends TransportAction<SearchScrollReq
                                        TransportSearchScrollQueryThenFetchAction queryThenFetchAction,
                                        TransportSearchScrollQueryAndFetchAction queryAndFetchAction,
                                        TransportSearchScrollScanAction scanAction) {
-        super(settings, threadPool);
+        super(settings, SearchScrollAction.NAME, threadPool);
         this.queryThenFetchAction = queryThenFetchAction;
         this.queryAndFetchAction = queryAndFetchAction;
         this.scanAction = scanAction;

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -70,7 +70,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
 
     public TransportSearchTypeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                      SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool);
+        super(settings, SearchAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.searchService = searchService;
         this.searchPhaseController = searchPhaseController;

--- a/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -67,7 +67,7 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
     @Inject
     public TransportSuggestAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                   IndicesService indicesService, SuggestPhase suggestPhase) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, SuggestAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.suggestPhase = suggestPhase;
     }
@@ -75,11 +75,6 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
     @Override
     protected String executor() {
         return ThreadPool.Names.SUGGEST;
-    }
-
-    @Override
-    protected String transportAction() {
-        return SuggestAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -35,9 +35,11 @@ import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
 public abstract class TransportAction<Request extends ActionRequest, Response extends ActionResponse> extends AbstractComponent {
 
     protected final ThreadPool threadPool;
+    protected final String actionName;
 
-    protected TransportAction(Settings settings, ThreadPool threadPool) {
+    protected TransportAction(Settings settings, String actionName, ThreadPool threadPool) {
         super(settings);
+        this.actionName = actionName;
         this.threadPool = threadPool;
     }
 

--- a/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
@@ -50,21 +50,18 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
     protected final ClusterService clusterService;
     protected final TransportService transportService;
 
-    final String transportAction;
     final String transportShardAction;
     final String executor;
 
-    protected TransportBroadcastOperationAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, threadPool);
+    protected TransportBroadcastOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
+        super(settings, actionName, threadPool);
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.threadPool = threadPool;
-
-        this.transportAction = transportAction();
-        this.transportShardAction = transportAction() + "/s";
+        this.transportShardAction = actionName + "/s";
         this.executor = executor();
 
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
         transportService.registerHandler(transportShardAction, new ShardTransportHandler());
     }
 
@@ -72,8 +69,6 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
     protected void doExecute(Request request, ActionListener<Response> listener) {
         new AsyncBroadcastAction(request, listener).start();
     }
-
-    protected abstract String transportAction();
 
     protected abstract String executor();
 

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
@@ -45,21 +45,17 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
 
     protected final ClusterService clusterService;
 
-    final String transportAction;
     final String executor;
 
-    protected TransportMasterNodeOperationAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, threadPool);
+    protected TransportMasterNodeOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
+        super(settings, actionName, threadPool);
         this.transportService = transportService;
         this.clusterService = clusterService;
 
-        this.transportAction = transportAction();
         this.executor = executor();
 
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
     }
-
-    protected abstract String transportAction();
 
     protected abstract String executor();
 
@@ -186,7 +182,7 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
                 return;
             }
             processBeforeDelegationToMaster(request, clusterState);
-            transportService.sendRequest(nodes.masterNode(), transportAction, request, new BaseTransportResponseHandler<Response>() {
+            transportService.sendRequest(nodes.masterNode(), actionName, request, new BaseTransportResponseHandler<Response>() {
                 @Override
                 public Response newInstance() {
                     return newResponse();

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadOperationAction.java
@@ -35,8 +35,8 @@ public abstract class TransportMasterNodeReadOperationAction<Request extends Mas
 
     private Boolean forceLocal;
 
-    protected TransportMasterNodeReadOperationAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+    protected TransportMasterNodeReadOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
+        super(settings, actionName, transportService, clusterService, threadPool);
         this.forceLocal = settings.getAsBoolean(FORCE_LOCAL_SETTING, null);
     }
 

--- a/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -32,8 +32,8 @@ import org.elasticsearch.transport.TransportService;
  */
 public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeReadOperationAction<Request, Response> {
 
-    public TransportClusterInfoAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, transportService, clusterService, threadPool);
+    public TransportClusterInfoAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
+        super(settings, actionName, transportService, clusterService, threadPool);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
@@ -48,23 +47,20 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
 
     protected final TransportService transportService;
 
-    final String transportAction;
     final String transportNodeAction;
     final String executor;
 
-    @Inject
-    public TransportNodesOperationAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
+    protected TransportNodesOperationAction(Settings settings, String actionName, ClusterName clusterName, ThreadPool threadPool,
                                          ClusterService clusterService, TransportService transportService) {
-        super(settings, threadPool);
+        super(settings, actionName, threadPool);
         this.clusterName = clusterName;
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportAction = transportAction();
-        this.transportNodeAction = transportAction() + "/n";
+        this.transportNodeAction = actionName + "/n";
         this.executor = executor();
 
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
         transportService.registerHandler(transportNodeAction, new NodeTransportHandler());
     }
 
@@ -72,8 +68,6 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
     protected void doExecute(Request request, ActionListener<Response> listener) {
         new AsyncAction(request, listener).start();
     }
-
-    protected abstract String transportAction();
 
     protected boolean transportCompress() {
         return false;
@@ -267,7 +261,7 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
 
         @Override
         public String toString() {
-            return transportAction;
+            return actionName;
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndexReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndexReplicationOperationAction.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BaseTransportRequestHandler;
@@ -52,14 +51,13 @@ public abstract class TransportIndexReplicationOperationAction<Request extends I
 
     protected final TransportShardReplicationOperationAction<ShardRequest, ShardReplicaRequest, ShardResponse> shardAction;
 
-    @Inject
-    public TransportIndexReplicationOperationAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                                    TransportShardReplicationOperationAction<ShardRequest, ShardReplicaRequest, ShardResponse> shardAction) {
-        super(settings, threadPool);
+    protected TransportIndexReplicationOperationAction(Settings settings, String actionName,  TransportService transportService, ClusterService clusterService,
+                                                    ThreadPool threadPool, TransportShardReplicationOperationAction<ShardRequest, ShardReplicaRequest, ShardResponse> shardAction) {
+        super(settings, actionName, threadPool);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
 
-        transportService.registerHandler(transportAction(), new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
     }
 
     @Override
@@ -145,8 +143,6 @@ public abstract class TransportIndexReplicationOperationAction<Request extends I
 
     protected abstract Response newResponseInstance(Request request, List<ShardResponse> shardResponses, int failuresCount, List<ShardOperationFailedException> shardFailures);
 
-    protected abstract String transportAction();
-
     protected abstract GroupShardsIterator shards(Request request) throws ElasticsearchException;
 
     protected abstract ShardRequest newShardRequestInstance(Request request, int shardId);
@@ -210,7 +206,7 @@ public abstract class TransportIndexReplicationOperationAction<Request extends I
                     try {
                         channel.sendResponse(e);
                     } catch (Exception e1) {
-                        logger.warn("Failed to send error response for action [" + transportAction() + "] and request [" + request + "]", e1);
+                        logger.warn("Failed to send error response for action [" + actionName + "] and request [" + request + "]", e1);
                     }
                 }
             });

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BaseTransportRequestHandler;
@@ -48,19 +47,13 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
 
     protected final TransportIndexReplicationOperationAction<IndexRequest, IndexResponse, ShardRequest, ShardReplicaRequest, ShardResponse> indexAction;
 
-
-    final String transportAction;
-
-    @Inject
-    public TransportIndicesReplicationOperationAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
+    protected TransportIndicesReplicationOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                                       TransportIndexReplicationOperationAction<IndexRequest, IndexResponse, ShardRequest, ShardReplicaRequest, ShardResponse> indexAction) {
-        super(settings, threadPool);
+        super(settings, actionName, threadPool);
         this.clusterService = clusterService;
         this.indexAction = indexAction;
 
-        this.transportAction = transportAction();
-
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
     }
 
 
@@ -125,8 +118,6 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
 
     protected abstract Response newResponseInstance(Request request, AtomicReferenceArray indexResponses);
 
-    protected abstract String transportAction();
-
     protected abstract IndexRequest newIndexRequestInstance(Request request, String index, Set<String> routing, long startTimeInMillis);
 
     protected abstract boolean accumulateExceptions();
@@ -166,7 +157,7 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
                     try {
                         channel.sendResponse(e);
                     } catch (Exception e1) {
-                        logger.warn("Failed to send error response for action [" + transportAction + "] and request [" + request + "]", e1);
+                        logger.warn("Failed to send error response for action [" + actionName + "] and request [" + request + "]", e1);
                     }
                 }
             });

--- a/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
@@ -47,20 +47,18 @@ public abstract class TransportSingleCustomOperationAction<Request extends Singl
 
     protected final TransportService transportService;
 
-    final String transportAction;
     final String transportShardAction;
     final String executor;
 
-    protected TransportSingleCustomOperationAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, threadPool);
+    protected TransportSingleCustomOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
+        super(settings, actionName, threadPool);
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportAction = transportAction();
-        this.transportShardAction = transportAction() + "/s";
+        this.transportShardAction = actionName + "/s";
         this.executor = executor();
 
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
         transportService.registerHandler(transportShardAction, new ShardTransportHandler());
     }
 
@@ -68,8 +66,6 @@ public abstract class TransportSingleCustomOperationAction<Request extends Singl
     protected void doExecute(Request request, ActionListener<Response> listener) {
         new AsyncSingleAction(request, listener).start();
     }
-
-    protected abstract String transportAction();
 
     protected abstract String executor();
 

--- a/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -51,18 +51,16 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
 
     protected final TransportService transportService;
 
-    final String transportAction;
     final String executor;
 
-    protected TransportInstanceSingleOperationAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, threadPool);
+    protected TransportInstanceSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
+        super(settings, actionName, threadPool);
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportAction = transportAction();
         this.executor = executor();
 
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
     }
 
     @Override
@@ -71,8 +69,6 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
     }
 
     protected abstract String executor();
-
-    protected abstract String transportAction();
 
     protected abstract void shardOperation(Request request, ActionListener<Response> listener) throws ElasticsearchException;
 
@@ -212,7 +208,7 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
                 }
             } else {
                 DiscoveryNode node = nodes.get(shard.currentNodeId());
-                transportService.sendRequest(node, transportAction, request, transportOptions(), new BaseTransportResponseHandler<Response>() {
+                transportService.sendRequest(node, actionName, request, transportOptions(), new BaseTransportResponseHandler<Response>() {
 
                     @Override
                     public Response newInstance() {

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -52,20 +52,18 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
 
     protected final TransportService transportService;
 
-    final String transportAction;
     final String transportShardAction;
     final String executor;
 
-    protected TransportShardSingleOperationAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, threadPool);
+    protected TransportShardSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
+        super(settings, actionName, threadPool);
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportAction = transportAction();
-        this.transportShardAction = transportAction() + "/s";
+        this.transportShardAction = actionName + "/s";
         this.executor = executor();
 
-        transportService.registerHandler(transportAction, new TransportHandler());
+        transportService.registerHandler(actionName, new TransportHandler());
         transportService.registerHandler(transportShardAction, new ShardTransportHandler());
     }
 
@@ -73,8 +71,6 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
     protected void doExecute(Request request, ActionListener<Response> listener) {
         new AsyncSingleAction(request, listener).start();
     }
-
-    protected abstract String transportAction();
 
     protected abstract String executor();
 

--- a/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
@@ -47,7 +47,7 @@ public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVe
     @Inject
     public TransportMultiTermVectorsAction(Settings settings, ThreadPool threadPool, TransportService transportService,
                                            ClusterService clusterService, TransportSingleShardMultiTermsVectorAction shardAction) {
-        super(settings, threadPool);
+        super(settings, MultiTermVectorsAction.NAME, threadPool);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
 

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
@@ -40,21 +40,18 @@ public class TransportSingleShardMultiTermsVectorAction extends TransportShardSi
 
     private final IndicesService indicesService;
 
+    private static final String ACTION_NAME = MultiTermVectorsAction.NAME + "/shard";
+
     @Inject
     public TransportSingleShardMultiTermsVectorAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                                       IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
     @Override
     protected String executor() {
         return ThreadPool.Names.GET;
-    }
-
-    @Override
-    protected String transportAction() {
-        return MultiTermVectorsAction.NAME + "/shard";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
@@ -45,7 +45,7 @@ public class TransportSingleShardTermVectorAction extends TransportShardSingleOp
     @Inject
     public TransportSingleShardTermVectorAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                                 IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, TermVectorAction.NAME, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
     }
 
@@ -53,11 +53,6 @@ public class TransportSingleShardTermVectorAction extends TransportShardSingleOp
     protected String executor() {
         // TODO: Is this the right pool to execute this on?
         return ThreadPool.Names.GET;
-    }
-
-    @Override
-    protected String transportAction() {
-        return TermVectorAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -73,17 +73,12 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     public TransportUpdateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                  TransportIndexAction indexAction, TransportDeleteAction deleteAction, TransportCreateIndexAction createIndexAction,
                                  UpdateHelper updateHelper) {
-        super(settings, threadPool, clusterService, transportService);
+        super(settings, UpdateAction.NAME, threadPool, clusterService, transportService);
         this.indexAction = indexAction;
         this.deleteAction = deleteAction;
         this.createIndexAction = createIndexAction;
         this.updateHelper = updateHelper;
         this.autoCreateIndex = new AutoCreateIndex(settings);
-    }
-
-    @Override
-    protected String transportAction() {
-        return UpdateAction.NAME;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -65,6 +65,8 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
 
     public static final String INDICES_MAPPING_ADDITIONAL_MAPPING_CHANGE_TIME = "indices.mapping.additional_mapping_change_time";
 
+    private static final String ACTION_NAME = "cluster/mappingUpdated";
+
     private final AtomicLong mappingUpdateOrderGen = new AtomicLong();
     private final MetaDataMappingService metaDataMappingService;
 
@@ -87,7 +89,7 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
     @Inject
     public MappingUpdatedAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
                                 MetaDataMappingService metaDataMappingService, NodeSettingsService nodeSettingsService) {
-        super(settings, transportService, clusterService, threadPool);
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool);
         this.metaDataMappingService = metaDataMappingService;
         // this setting should probably always be 0, just add the option to wait for more changes within a time window
         this.additionalMappingChangeTime = settings.getAsTime(INDICES_MAPPING_ADDITIONAL_MAPPING_CHANGE_TIME, TimeValue.timeValueMillis(0));
@@ -111,11 +113,6 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
     public void updateMappingOnMaster(String index, DocumentMapper documentMapper, String indexUUID, MappingUpdateListener listener) {
         assert !documentMapper.type().equals(MapperService.DEFAULT_MAPPING) : "_default_ mapping should not be updated";
         masterMappingUpdater.add(new MappingChange(documentMapper, index, indexUUID, listener));
-    }
-
-    @Override
-    protected String transportAction() {
-        return "cluster/mappingUpdated";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/TransportNodesListGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/TransportNodesListGatewayMetaState.java
@@ -46,11 +46,13 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesListGatewayMetaState extends TransportNodesOperationAction<TransportNodesListGatewayMetaState.Request, TransportNodesListGatewayMetaState.NodesLocalGatewayMetaState, TransportNodesListGatewayMetaState.NodeRequest, TransportNodesListGatewayMetaState.NodeLocalGatewayMetaState> {
 
+    private static final String ACTION_NAME = "/gateway/local/meta-state";
+
     private LocalGatewayMetaState metaState;
 
     @Inject
     public TransportNodesListGatewayMetaState(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
     }
 
     TransportNodesListGatewayMetaState init(LocalGatewayMetaState metaState) {
@@ -65,11 +67,6 @@ public class TransportNodesListGatewayMetaState extends TransportNodesOperationA
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return "/gateway/local/meta-state";
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
@@ -47,11 +47,14 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesListGatewayStartedShards extends TransportNodesOperationAction<TransportNodesListGatewayStartedShards.Request, TransportNodesListGatewayStartedShards.NodesLocalGatewayStartedShards, TransportNodesListGatewayStartedShards.NodeRequest, TransportNodesListGatewayStartedShards.NodeLocalGatewayStartedShards> {
 
+    private static final String ACTION_NAME = "/gateway/local/started-shards";
+
+
     private LocalGatewayShardsState shardsState;
 
     @Inject
     public TransportNodesListGatewayStartedShards(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
     }
 
     TransportNodesListGatewayStartedShards initGateway(LocalGatewayShardsState shardsState) {
@@ -66,11 +69,6 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return "/gateway/local/started-shards";
     }
 
     @Override
@@ -145,6 +143,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
             super(nodesIds.toArray(new String[nodesIds.size()]));
             this.shardId = shardId;
         }
+
         public Request(ShardId shardId, String... nodesIds) {
             super(nodesIds);
             this.shardId = shardId;

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -60,6 +60,8 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesListShardStoreMetaData extends TransportNodesOperationAction<TransportNodesListShardStoreMetaData.Request, TransportNodesListShardStoreMetaData.NodesStoreFilesMetaData, TransportNodesListShardStoreMetaData.NodeRequest, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> {
 
+    private static final String ACTION_NAME = "/cluster/nodes/indices/shard/store";
+
     private final IndicesService indicesService;
 
     private final NodeEnvironment nodeEnv;
@@ -67,7 +69,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
     @Inject
     public TransportNodesListShardStoreMetaData(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                                 IndicesService indicesService, NodeEnvironment nodeEnv) {
-        super(settings, clusterName, threadPool, clusterService, transportService);
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.nodeEnv = nodeEnv;
     }
@@ -79,11 +81,6 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
     @Override
     protected String executor() {
         return ThreadPool.Names.GENERIC;
-    }
-
-    @Override
-    protected String transportAction() {
-        return "/cluster/nodes/indices/shard/store";
     }
 
     @Override


### PR DESCRIPTION
Each transport action is associated with at least an action name, which is the action name that gets serialized together with the request and identifies what to do with the request itself. Also, the action name is the name of the registered transport handler that handles incoming request for the transport action.

This PR makes the action name available in a generic manner in the TransportAction base class, so that it can be used when needed by subclasses, or in the base class for instance for action filtering.
