### PR TITLE
Remove (mostly) unused 'failure' member from ShardSearchFailure.

### DIFF
--- a/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -43,15 +43,9 @@ public class ShardSearchFailure implements ShardOperationFailedException {
     private SearchShardTarget shardTarget;
     private String reason;
     private RestStatus status;
-    private transient Throwable failure;
 
     private ShardSearchFailure() {
 
-    }
-
-    @Nullable
-    public Throwable failure() {
-        return failure;
     }
 
     public ShardSearchFailure(Throwable t) {
@@ -59,7 +53,6 @@ public class ShardSearchFailure implements ShardOperationFailedException {
     }
 
     public ShardSearchFailure(Throwable t, @Nullable SearchShardTarget shardTarget) {
-        this.failure = t;
         Throwable actual = ExceptionsHelper.unwrapCause(t);
         if (actual != null && actual instanceof SearchException) {
             this.shardTarget = ((SearchException) actual).shard();

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
@@ -389,7 +389,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         ShardSearchFailure[] failures = response.getShardFailures();
         if (failures.length != expectedFailures) {
             for (ShardSearchFailure failure : failures) {
-                logger.error("Shard Failure: {}", failure.failure(), failure.toString());
+                logger.error("Shard Failure: {}", failure.reason(), failure.toString());
             }
             fail("Unexpected shard failures!");
         }

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
@@ -361,7 +361,7 @@ public class StatsTests extends AbstractNumericTests {
         ShardSearchFailure[] failures = response.getShardFailures();
         if (failures.length != expectedFailures) {
             for (ShardSearchFailure failure : failures) {
-                logger.error("Shard Failure: {}", failure.failure(), failure.toString());
+                logger.error("Shard Failure: {}", failure.reason(), failure.toString());
             }
             fail("Unexpected shard failures!");
         }


### PR DESCRIPTION
closes #6837
