### PR TITLE
Remove setNextScore in SearchScript.

### DIFF
--- a/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -21,16 +21,59 @@ package org.elasticsearch.common.lucene.search.function;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Scorer;
 import org.elasticsearch.script.ExplainableSearchScript;
 import org.elasticsearch.script.SearchScript;
 
+import java.io.IOException;
 import java.util.Map;
 
 public class ScriptScoreFunction extends ScoreFunction {
 
+    static final class CannedScorer extends Scorer {
+        protected int docid;
+        protected float score;
+
+        public CannedScorer() {
+            super(null);
+        }
+
+        @Override
+        public int docID() {
+            return docid;
+        }
+
+        @Override
+        public float score() throws IOException {
+            return score;
+        }
+
+        @Override
+        public int freq() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long cost() {
+            return 1;
+        }
+    }
+
     private final String sScript;
 
     private final Map<String, Object> params;
+
+    private final CannedScorer scorer;
 
     private final SearchScript script;
     
@@ -40,6 +83,8 @@ public class ScriptScoreFunction extends ScoreFunction {
         this.sScript = sScript;
         this.params = params;
         this.script = script;
+        this.scorer = new CannedScorer();
+        script.setScorer(scorer);
     }
 
     @Override
@@ -50,7 +95,8 @@ public class ScriptScoreFunction extends ScoreFunction {
     @Override
     public double score(int docId, float subQueryScore) {
         script.setNextDocId(docId);
-        script.setNextScore(subQueryScore);
+        scorer.docid = docId;
+        scorer.score = subQueryScore;
         return script.runAsDouble();
     }
 
@@ -59,7 +105,8 @@ public class ScriptScoreFunction extends ScoreFunction {
         Explanation exp;
         if (script instanceof ExplainableSearchScript) {
             script.setNextDocId(docId);
-            script.setNextScore(subQueryExpl.getValue());
+            scorer.docid = docId;
+            scorer.score = subQueryExpl.getValue();
             exp = ((ExplainableSearchScript) script).explain(subQueryExpl);
         } else {
             double score = score(docId, subQueryExpl.getValue());

--- a/src/main/java/org/elasticsearch/script/AbstractSearchScript.java
+++ b/src/main/java/org/elasticsearch/script/AbstractSearchScript.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.lookup.FieldsLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -43,16 +44,6 @@ import java.util.Map;
 public abstract class AbstractSearchScript extends AbstractExecutableScript implements SearchScript {
 
     private SearchLookup lookup;
-
-    private float score = Float.NaN;
-
-    /**
-     * Returns the current score and only applicable when used as a scoring script in a custom score query!.
-     * For other cases, use {@link #doc()} and get the score from it.
-     */
-    protected final float score() {
-        return score;
-    }
 
     /**
      * Returns the doc lookup allowing to access field data (cached) values as well as the current document score
@@ -126,11 +117,6 @@ public abstract class AbstractSearchScript extends AbstractExecutableScript impl
     @Override
     public void setNextSource(Map<String, Object> source) {
         lookup.source().setNextSource(source);
-    }
-
-    @Override
-    public void setNextScore(float score) {
-        this.score = score;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/script/SearchScript.java
+++ b/src/main/java/org/elasticsearch/script/SearchScript.java
@@ -36,8 +36,6 @@ public interface SearchScript extends ExecutableScript, ReaderContextAware, Scor
 
     void setNextSource(Map<String, Object> source);
 
-    void setNextScore(float score);
-
     float runAsFloat();
 
     long runAsLong();

--- a/src/main/java/org/elasticsearch/script/expression/ExpressionScript.java
+++ b/src/main/java/org/elasticsearch/script/expression/ExpressionScript.java
@@ -38,65 +38,25 @@ import java.util.Map;
  */
 class ExpressionScript implements SearchScript {
 
-    /** Fake scorer for a single document */
-    static class CannedScorer extends Scorer {
-        protected int docid;
-        protected float score;
-
-        public CannedScorer() {
-            super(null);
-        }
-
-        @Override
-        public int docID() {
-            return docid;
-        }
-
-        @Override
-        public float score() throws IOException {
-            return score;
-        }
-
-        @Override
-        public int freq() throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int nextDoc() throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int advance(int target) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long cost() {
-            return 1;
-        }
-    }
-
     final Expression expression;
     final XSimpleBindings bindings;
-    final CannedScorer scorer;
     final ValueSource source;
-    final Map<String, CannedScorer> context;
     final ReplaceableConstValueSource specialValue; // _value
+    Map<String, Scorer> context;
+    Scorer scorer;
     FunctionValues values;
+    int docid;
 
     ExpressionScript(Expression e, XSimpleBindings b, ReplaceableConstValueSource v) {
         expression = e;
         bindings = b;
-        scorer = new CannedScorer();
-        context = Collections.singletonMap("scorer", scorer);
+        context = Collections.EMPTY_MAP;
         source = expression.getValueSource(bindings);
         specialValue = v;
     }
 
     double evaluate() {
-        return values.doubleVal(scorer.docid);
+        return values.doubleVal(docid);
     }
 
     @Override
@@ -116,17 +76,7 @@ class ExpressionScript implements SearchScript {
 
     @Override
     public void setNextDocId(int d) {
-        scorer.docid = d;
-    }
-
-    @Override
-    public void setNextScore(float score) {
-        // TODO: fix this API to remove setNextScore and just use a Scorer
-        // Expressions know if they use the score or not, and should be able to pull from the scorer only
-        // if they need it. Right now, score can only be used within a ScriptScoreFunction.  But there shouldn't
-        // be any reason a script values or aggregation can't use the score.  It is also possible
-        // these layers are preventing inlining of scoring into expressions.
-        scorer.score = score;
+        docid = d;
     }
 
     @Override
@@ -140,8 +90,8 @@ class ExpressionScript implements SearchScript {
 
     @Override
     public void setScorer(Scorer s) {
-         // noop: The scorer isn't actually ever set.  Instead setNextScore is called.
-         // NOTE: This seems broken.  Why can't we just use the scorer and get rid of setNextScore?
+        scorer = s;
+        context = Collections.singletonMap("scorer", scorer);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/script/groovy/GroovyScriptExecutionException.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovyScriptExecutionException.java
@@ -30,6 +30,9 @@ public class GroovyScriptExecutionException extends ElasticsearchException {
     public GroovyScriptExecutionException(String message) {
         super(message);
     }
+    public GroovyScriptExecutionException(String message, Throwable t) {
+        super(message, t);
+    }
 
     @Override
     public RestStatus status() {

--- a/src/test/java/org/elasticsearch/search/aggregations/support/FieldDataSourceTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/support/FieldDataSourceTests.java
@@ -91,10 +91,6 @@ public class FieldDataSourceTests extends ElasticsearchTestCase {
             }
 
             @Override
-            public void setNextScore(float score) {
-            }
-
-            @Override
             public float runAsFloat() {
                 throw new UnsupportedOperationException();
             }

--- a/src/test/java/org/elasticsearch/search/aggregations/support/ScriptValuesTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/support/ScriptValuesTests.java
@@ -82,10 +82,6 @@ public class ScriptValuesTests extends ElasticsearchTestCase {
         }
 
         @Override
-        public void setNextScore(float score) {
-        }
-
-        @Override
         public float runAsFloat() {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
While it would be nice to do this all the way up the chain (into
score functions), this at least removes the weird dual
setNextScore/setScorer for SearchScripts.
