### PR TITLE
Add multi_field support for Mapper externalValue (plugins)

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -248,10 +248,10 @@ public class DocumentMapper implements ToXContent {
     }
 
 
-    private CloseableThreadLocal<ParseContext> cache = new CloseableThreadLocal<ParseContext>() {
+    private CloseableThreadLocal<ParseContext.InternalParseContext> cache = new CloseableThreadLocal<ParseContext.InternalParseContext>() {
         @Override
-        protected ParseContext initialValue() {
-            return new ParseContext(index, indexSettings, docMapperParser, DocumentMapper.this, new ContentPath(0));
+        protected ParseContext.InternalParseContext initialValue() {
+            return new ParseContext.InternalParseContext(index, indexSettings, docMapperParser, DocumentMapper.this, new ContentPath(0));
         }
     };
 
@@ -484,7 +484,7 @@ public class DocumentMapper implements ToXContent {
     }
 
     public ParsedDocument parse(SourceToParse source, @Nullable ParseListener listener) throws MapperParsingException {
-        ParseContext context = cache.get();
+        ParseContext.InternalParseContext context = cache.get();
 
         if (source.type() != null && !source.type().equals(this.type)) {
             throw new MapperParsingException("Type mismatch, provide type [" + source.type() + "] but mapper is of type [" + this.type + "]");

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -916,7 +916,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
                 return;
             }
 
-            context.setWithinMultiFields();
+            context = context.createMultiFieldContext();
 
             ContentPath.Type origPathType = context.path().pathType();
             context.path().pathType(pathType);
@@ -927,8 +927,6 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             }
             context.path().remove();
             context.path().pathType(origPathType);
-
-            context.clearWithinMultiFields();
         }
 
         // No need for locking, because locking is taken care of in ObjectMapper#merge and DocumentMapper#merge
@@ -1055,7 +1053,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
          * Creates an copy of the current field with given field name and boost
          */
         public void parse(String field, ParseContext context) throws IOException {
-            context.setWithinCopyTo();
+            context = context.createCopyToContext();
             FieldMappers mappers = context.docMapper().mappers().indexName(field);
             if (mappers != null && !mappers.isEmpty()) {
                 mappers.mapper().parse(context);
@@ -1109,7 +1107,6 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
 
                 }
             }
-            context.clearWithinCopyTo();
         }
 
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
@@ -102,8 +102,7 @@ public class Murmur3FieldMapper extends LongFieldMapper {
         if (value != null) {
             final BytesRef bytes = new BytesRef(value.toString());
             final long hash = MurmurHash3.hash128(bytes.bytes, bytes.offset, bytes.length, 0, new MurmurHash3.Hash128()).h1;
-            context.externalValue(hash);
-            super.innerParseCreateField(context, fields);
+            super.innerParseCreateField(context.createExternalValueContext(hash), fields);
         }
 
     }

--- a/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -539,9 +539,8 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
         int min = enableGeohashPrefix ? 1 : geohash.length();
 
         for (int i = len; i >= min; i--) {
-            context.externalValue(geohash.substring(0, i));
             // side effect of this call is adding the field
-            geohashMapper.parse(context);
+            geohashMapper.parse(context.createExternalValueContext(geohash.substring(0, i)));
         }
     }
 
@@ -580,10 +579,8 @@ public class GeoPointFieldMapper extends AbstractFieldMapper<GeoPoint> implement
             parseGeohashField(context, geohash);
         }
         if (enableLatLon) {
-            context.externalValue(point.lat());
-            latMapper.parse(context);
-            context.externalValue(point.lon());
-            lonMapper.parse(context);
+            latMapper.parse(context.createExternalValueContext(point.lat()));
+            lonMapper.parse(context.createExternalValueContext(point.lon()));
         }
         if (hasDocValues()) {
             CustomGeoPointDocValuesField field = (CustomGeoPointDocValuesField) context.doc().getByKey(names().indexName());

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/RegisterExternalTypes.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/RegisterExternalTypes.java
@@ -28,11 +28,15 @@ import org.elasticsearch.index.settings.IndexSettings;
 
 public class RegisterExternalTypes extends AbstractIndexComponent {
     public static final String EXTERNAL = "external";
+    public static final String EXTERNAL_BIS = "external_bis";
+    public static final String EXTERNAL_UPPER = "external_upper";
 
     @Inject
     public RegisterExternalTypes(Index index, @IndexSettings Settings indexSettings, MapperService mapperService) {
         super(index, indexSettings);
 
-        mapperService.documentMapperParser().putTypeParser(EXTERNAL, new ExternalMapper.TypeParser());
+        mapperService.documentMapperParser().putTypeParser(EXTERNAL, new ExternalMapper.TypeParser(EXTERNAL, "foo"));
+        mapperService.documentMapperParser().putTypeParser(EXTERNAL_BIS, new ExternalMapper.TypeParser(EXTERNAL_BIS, "bar"));
+        mapperService.documentMapperParser().putTypeParser(EXTERNAL_UPPER, new ExternalMapper.TypeParser(EXTERNAL_UPPER, "FOO BAR"));
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.externalvalues;
+
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.test.ElasticsearchSingleNodeLuceneTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ */
+public class SimpleExternalMappingTests extends ElasticsearchSingleNodeLuceneTestCase {
+
+    @Test
+    public void testExternalValues() throws Exception {
+        MapperService mapperService = createIndex("test").mapperService();
+        mapperService.documentMapperParser().putTypeParser(RegisterExternalTypes.EXTERNAL,
+                new ExternalMapper.TypeParser(RegisterExternalTypes.EXTERNAL, "foo"));
+
+        DocumentMapper documentMapper = mapperService.documentMapperParser().parse(
+                XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                    .startObject("field").field("type", "external").endObject()
+                .endObject()
+            .endObject().endObject().string()
+        );
+
+        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                    .field("field", "1234")
+                .endObject()
+                .bytes());
+
+        assertThat(doc.rootDoc().getField("field.bool"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.bool").stringValue(), is("T"));
+
+        assertThat(doc.rootDoc().getField("field.point"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.point").stringValue(), is("42.0,51.0"));
+
+        assertThat(doc.rootDoc().getField("field.shape"), notNullValue());
+
+        assertThat(doc.rootDoc().getField("field.field"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.field").stringValue(), is("foo"));
+
+
+    }
+
+    @Test
+    public void testExternalValuesWithMultifield() throws Exception {
+        MapperService mapperService = createIndex("test").mapperService();
+        mapperService.documentMapperParser().putTypeParser(RegisterExternalTypes.EXTERNAL,
+                new ExternalMapper.TypeParser(RegisterExternalTypes.EXTERNAL, "foo"));
+
+        DocumentMapper documentMapper = mapperService.documentMapperParser().parse(
+                XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject("field")
+                    .field("type", RegisterExternalTypes.EXTERNAL)
+                    .startObject("fields")
+                        .startObject("field")
+                            .field("type", "string")
+                            .field("stored", "yes")
+                            .startObject("fields")
+                                .startObject("raw")
+                                    .field("type", "string")
+                                    .field("index", "not_analyzed")
+                                    .field("stored", "yes")
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject().endObject().endObject()
+                .string());
+
+        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                    .field("field", "1234")
+                .endObject()
+                .bytes());
+
+        assertThat(doc.rootDoc().getField("field.bool"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.bool").stringValue(), is("T"));
+
+        assertThat(doc.rootDoc().getField("field.point"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.point").stringValue(), is("42.0,51.0"));
+
+        assertThat(doc.rootDoc().getField("field.shape"), notNullValue());
+
+        assertThat(doc.rootDoc().getField("field.field"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.field").stringValue(), is("foo"));
+
+        assertThat(doc.rootDoc().getField("field.field.raw"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.field.raw").stringValue(), is("foo"));
+    }
+
+    @Test
+    public void testExternalValuesWithMultifieldTwoLevels() throws Exception {
+        MapperService mapperService = createIndex("test").mapperService();
+
+        mapperService.documentMapperParser().putTypeParser(RegisterExternalTypes.EXTERNAL,
+                new ExternalMapper.TypeParser(RegisterExternalTypes.EXTERNAL, "foo"));
+        mapperService.documentMapperParser().putTypeParser(RegisterExternalTypes.EXTERNAL_BIS,
+                new ExternalMapper.TypeParser(RegisterExternalTypes.EXTERNAL_BIS, "bar"));
+
+        DocumentMapper documentMapper = mapperService.documentMapperParser().parse(
+                XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject("field")
+                    .field("type", RegisterExternalTypes.EXTERNAL)
+                    .startObject("fields")
+                        .startObject("field")
+                            .field("type", "string")
+                            .startObject("fields")
+                                .startObject("generated")
+                                    .field("type", RegisterExternalTypes.EXTERNAL_BIS)
+                                .endObject()
+                                .startObject("raw")
+                                    .field("type", "string")
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                        .startObject("raw")
+                            .field("type", "string")
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject().endObject().endObject()
+                .string());
+
+        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "1234")
+                .endObject()
+                .bytes());
+
+        assertThat(doc.rootDoc().getField("field.bool"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.bool").stringValue(), is("T"));
+
+        assertThat(doc.rootDoc().getField("field.point"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.point").stringValue(), is("42.0,51.0"));
+
+        assertThat(doc.rootDoc().getField("field.shape"), notNullValue());
+
+        assertThat(doc.rootDoc().getField("field.field"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.field").stringValue(), is("foo"));
+
+        assertThat(doc.rootDoc().getField("field.field.generated.generated"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.field.generated.generated").stringValue(), is("bar"));
+
+        assertThat(doc.rootDoc().getField("field.field.raw"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.field.raw").stringValue(), is("foo"));
+
+        assertThat(doc.rootDoc().getField("field.raw"), notNullValue());
+        assertThat(doc.rootDoc().getField("field.raw").stringValue(), is("foo"));
+    }
+}


### PR DESCRIPTION
In context of mapper attachment and other mapper plugins, when dealing with multi fields, sub fields never get the `externalValue` although it was set.

Related to https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/57

Closes #5402.
