### PR TITLE
Make XContentBuilder Releasable

### DIFF
--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -25,7 +25,6 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.lucene.util.CollectionUtil;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -48,6 +47,7 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.compress.CompressedString;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -491,7 +491,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     } catch (Exception e) {
                         logger.warn("[{}] failed to read template [{}] from config", e, request.index(), templatesFile.getAbsolutePath());
                     } finally {
-                        IOUtils.closeWhileHandlingException(parser);
+                        Releasables.closeWhileHandlingException(parser);
                     }
                 }
             }

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.BytesStream;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -47,7 +48,7 @@ import java.util.Map;
 /**
  *
  */
-public final class XContentBuilder implements BytesStream {
+public final class XContentBuilder implements BytesStream, Releasable {
 
     public static enum FieldCaseConversion {
         /**
@@ -1094,8 +1095,6 @@ public final class XContentBuilder implements BytesStream {
 
     /**
      * Returns a string representation of the builder (only applicable for text based xcontent).
-     * <p/>
-     * <p>Only applicable when the builder is constructed with {@link FastByteArrayOutputStream}.
      */
     public String string() throws IOException {
         close();

--- a/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.xcontent;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lease.Releasable;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -35,7 +36,7 @@ import java.util.Map;
  *     XContentParser parser = xContentType.xContent().createParser("{\"key\" : \"value\"}");
  * </pre>
  */
-public interface XContentParser extends Closeable {
+public interface XContentParser extends Releasable {
 
     enum Token {
         START_OBJECT {
@@ -196,6 +197,4 @@ public interface XContentParser extends Closeable {
     boolean booleanValue() throws IOException;
 
     byte[] binaryValue() throws IOException;
-
-    void close();
 }

--- a/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/src/main/java/org/elasticsearch/search/SearchService.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
@@ -39,6 +38,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
@@ -611,7 +611,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
             } catch (IOException e) {
                 throw new ElasticsearchParseException("Failed to parse template", e);
             } finally {
-                IOUtils.closeWhileHandlingException(parser);
+                Releasables.closeWhileHandlingException(parser);
             }
 
             if (templateContext == null || !hasLength(templateContext.template())) {


### PR DESCRIPTION
make the builder releasable (auto closeable), and use it in shards state
also make XContentParser releasable (AutoCloseable) and not closeable since it doesn't throw an IOException
