### PR TITLE
Test: Add ElasticsearchSingleNodeTest.

### DIFF
--- a/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterCachingTests.java
+++ b/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterCachingTests.java
@@ -22,48 +22,22 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.cache.recycler.CacheRecyclerModule;
-import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedString;
-import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
-import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.inject.util.Providers;
 import org.elasticsearch.common.lucene.search.AndFilter;
 import org.elasticsearch.common.lucene.search.CachedFilter;
 import org.elasticsearch.common.lucene.search.NoCacheFilter;
 import org.elasticsearch.common.lucene.search.XBooleanFilter;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.settings.SettingsModule;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexNameModule;
-import org.elasticsearch.index.analysis.AnalysisModule;
-import org.elasticsearch.index.cache.IndexCacheModule;
-import org.elasticsearch.index.codec.CodecModule;
-import org.elasticsearch.index.engine.IndexEngineModule;
-import org.elasticsearch.index.fielddata.IndexFieldDataModule;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.MapperServiceModule;
-import org.elasticsearch.index.query.functionscore.FunctionScoreModule;
 import org.elasticsearch.index.search.child.TestSearchContext;
-import org.elasticsearch.index.settings.IndexSettingsModule;
-import org.elasticsearch.index.similarity.SimilarityModule;
-import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.fielddata.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.indices.query.IndicesQueriesModule;
-import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.elasticsearch.test.index.service.StubIndexService;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPoolModule;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -76,44 +50,18 @@ import static org.hamcrest.Matchers.is;
 /**
  *
  */
-public class IndexQueryParserFilterCachingTests extends ElasticsearchTestCase {
+public class IndexQueryParserFilterCachingTests extends ElasticsearchSingleNodeTest {
 
-    private static Injector injector;
+    private Injector injector;
+    private IndexQueryParserService queryParser;
 
-    private static IndexQueryParserService queryParser;
-
-    @BeforeClass
-    public static void setupQueryParser() throws IOException {
+    @Before
+    public void setup() throws IOException {
         Settings settings = ImmutableSettings.settingsBuilder()
                 .put("index.cache.filter.type", "weighted")
                 .put("name", "IndexQueryParserFilterCachingTests")
                 .build();
-        Index index = new Index("test");
-        injector = new ModulesBuilder().add(
-                new CacheRecyclerModule(settings),
-                new CodecModule(settings),
-                new SettingsModule(settings),
-                new ThreadPoolModule(settings),
-                new IndicesQueriesModule(),
-                new ScriptModule(settings),
-                new MapperServiceModule(),
-                new IndexSettingsModule(index, settings),
-                new IndexCacheModule(settings),
-                new AnalysisModule(settings),
-                new IndexEngineModule(settings),
-                new SimilarityModule(settings),
-                new IndexQueryParserModule(settings),
-                new IndexNameModule(index),
-                new FunctionScoreModule(),
-                new IndexFieldDataModule(settings),
-                new AbstractModule() {
-                    @Override
-                    protected void configure() {
-                        bind(ClusterService.class).toProvider(Providers.of((ClusterService) null));
-                        bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
-                    }
-                }
-        ).createInjector();
+        injector = createIndex("test", settings).injector();
 
         injector.getInstance(IndexFieldDataService.class).setIndexService((new StubIndexService(injector.getInstance(MapperService.class))));
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/query/mapping.json");
@@ -124,23 +72,9 @@ public class IndexQueryParserFilterCachingTests extends ElasticsearchTestCase {
         queryParser = injector.getInstance(IndexQueryParserService.class);
     }
 
-    @AfterClass
-    public static void close() {
-        injector.getInstance(ThreadPool.class).shutdownNow();
-        queryParser = null;
-        injector = null;
-    }
-
     private IndexQueryParserService queryParser() throws IOException {
         return this.queryParser;
     }
-
-    private BytesRef longToPrefixCoded(long val, int shift) {
-        BytesRef bytesRef = new BytesRef();
-        NumericUtils.longToPrefixCoded(val, shift, bytesRef);
-        return bytesRef;
-    }
-
 
     @Test
     public void testNoFilterParsing() throws IOException {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.node.internal.InternalNode;
+import org.junit.After;
+
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * A test that keep a single node started for all tests that can be used to get
+ * references to Guice injectors in unit tests.
+ */
+public class ElasticsearchSingleNodeTest extends ElasticsearchTestCase {
+
+    private static final Node node = node();
+
+    @After
+    public void after() {
+        node.client().admin().indices().prepareDelete("*").get();
+    }
+
+    /**
+     * Same as {@link #node(Settings) node(ImmutableSettings.EMPTY)}.
+     */
+    public static Node node() {
+        return node(ImmutableSettings.EMPTY);
+    }
+
+    public static Node node(Settings settings) {
+        return NodeBuilder.nodeBuilder().local(true).data(true).settings(ImmutableSettings.builder()
+                .put("cluster.name", "__single_node_")
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(settings)
+                .put("http.enabled", false)
+                .put("index.store.type", "ram")
+                .put("gateway.type", "none")).build().start();
+    }
+
+    public static <T> T getInstanceFromNode(Class<T> clazz, Node node) {
+        return ((InternalNode) node).injector().getInstance(clazz);
+    }
+
+    public static IndexService createIndex(String index) {
+        return createIndex(index, ImmutableSettings.EMPTY);
+    }
+
+    public static IndexService createIndex(String index, Settings settings) {
+        node.client().admin().indices().prepareCreate(index).setSettings(settings).get();
+        // Wait for the index to be allocated so that cluster state updates don't override
+        // changes that would have been done locally
+        ClusterHealthResponse health = node.client().admin().cluster()
+                .health(Requests.clusterHealthRequest(index).waitForYellowStatus().waitForEvents(Priority.LANGUID).waitForRelocatingShards(0)).actionGet();
+        assertThat(health.getStatus(), lessThanOrEqualTo(ClusterHealthStatus.YELLOW));
+        IndicesService instanceFromNode = getInstanceFromNode(IndicesService.class, node);
+        return instanceFromNode.indexService(index);
+    }
+}


### PR DESCRIPTION
This test makes it easy to create a lightweight node (no http, indices stored
in RAM, ...) whose main purpose is to get an instance of the Guice injector
for unit tests.

This should help not have to update lots of unit tests when we add a new
Guice dependency.
