### PR TITLE
Rename FieldMapper.termsFilter to fieldDataTermsFilter.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -248,7 +248,7 @@ public interface FieldMapper<T> extends Mapper {
 
     Filter termsFilter(List values, @Nullable QueryParseContext context);
 
-    Filter termsFilter(QueryParseContext parseContext, List values, @Nullable QueryParseContext context);
+    Filter fieldDataTermsFilter(List values, @Nullable QueryParseContext context);
 
     Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, @Nullable QueryParseContext context);
 

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -490,7 +490,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
      * A terms filter based on the field data cache
      */
     @Override
-    public Filter termsFilter(QueryParseContext fieldDataService, List values, @Nullable QueryParseContext context) {
+    public Filter fieldDataTermsFilter(List values, @Nullable QueryParseContext context) {
         // create with initial size large enough to avoid rehashing
         ObjectOpenHashSet<BytesRef> terms =
                 new ObjectOpenHashSet<>((int) (values.size() * (1 + ObjectOpenHashSet.DEFAULT_LOAD_FACTOR)));
@@ -498,7 +498,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             terms.add(indexedValueForSearch(values.get(i)));
         }
 
-        return FieldDataTermsFilter.newBytes(fieldDataService.getForField(this), terms);
+        return FieldDataTermsFilter.newBytes(context.getForField(this), terms);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -288,8 +288,8 @@ public abstract class NumberFieldMapper<T extends Number> extends AbstractFieldM
      * A terms filter based on the field data cache for numeric fields.
      */
     @Override
-    public Filter termsFilter(QueryParseContext fieldDataService, List values, @Nullable QueryParseContext context) {
-        IndexNumericFieldData fieldData = fieldDataService.getForField(this);
+    public Filter fieldDataTermsFilter(List values, @Nullable QueryParseContext context) {
+        IndexNumericFieldData fieldData = context.getForField(this);
         if (fieldData.getNumericType().isFloatingPoint()) {
             // create with initial size large enough to avoid rehashing
             DoubleOpenHashSet terms =

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -214,7 +214,7 @@ public class TermsFilterParser implements FilterParser {
                     return Queries.MATCH_NO_FILTER;
                 }
 
-                filter = fieldMapper.termsFilter(parseContext, terms, parseContext);
+                filter = fieldMapper.fieldDataTermsFilter(terms, parseContext);
                 if (cache != null && cache) {
                     filter = parseContext.cacheFilter(filter, cacheKey);
                 }

--- a/src/test/java/org/elasticsearch/index/search/FieldDataTermsFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/search/FieldDataTermsFilterTests.java
@@ -40,11 +40,11 @@ import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
 import org.elasticsearch.index.mapper.core.LongFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
 import org.elasticsearch.index.query.FilterParser;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParser;
+import org.elasticsearch.indices.fielddata.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.fielddata.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCacheListener;
@@ -163,7 +163,7 @@ public class FieldDataTermsFilterTests extends ElasticsearchTestCase {
         // filter from mapper
         result.clear(0, size);
         assertThat(result.cardinality(), equalTo(0));
-        result.or(strMapper.termsFilter(parseContext, cTerms, null)
+        result.or(strMapper.fieldDataTermsFilter(cTerms, parseContext)
                 .getDocIdSet(reader.getContext(), reader.getLiveDocs()).iterator());
         assertThat(result.cardinality(), equalTo(docs.size()));
         for (int i = 0; i < reader.maxDoc(); i++) {
@@ -214,7 +214,7 @@ public class FieldDataTermsFilterTests extends ElasticsearchTestCase {
         // filter from mapper
         result.clear(0, size);
         assertThat(result.cardinality(), equalTo(0));
-        result.or(lngMapper.termsFilter(parseContext, cTerms, null)
+        result.or(lngMapper.fieldDataTermsFilter(cTerms, parseContext)
                 .getDocIdSet(reader.getContext(), reader.getLiveDocs()).iterator());
         assertThat(result.cardinality(), equalTo(docs.size()));
         for (int i = 0; i < reader.maxDoc(); i++) {
@@ -253,7 +253,7 @@ public class FieldDataTermsFilterTests extends ElasticsearchTestCase {
         // filter from mapper
         result.clear(0, size);
         assertThat(result.cardinality(), equalTo(0));
-        result.or(dblMapper.termsFilter(parseContext, cTerms, null)
+        result.or(dblMapper.fieldDataTermsFilter(cTerms, parseContext)
                 .getDocIdSet(reader.getContext(), reader.getLiveDocs()).iterator());
         assertThat(result.cardinality(), equalTo(docs.size()));
         for (int i = 0; i < reader.maxDoc(); i++) {


### PR DESCRIPTION
FieldMapper has two methods
`Filter termsFilter(List values, @Nullable QueryParseContext)` which is supposed
to work on the inverted index and
`Filter termsFilter(QueryParseContext, List, QueryParseContext)` which is
supposed to work on field data. Let's rename the second one to
`fieldDataTermsFilter` and remove the unused `QueryParseContext`.
