### PR TITLE
Added three frequency levels for resource watching

### DIFF
--- a/src/main/java/org/elasticsearch/watcher/WatcherHandle.java
+++ b/src/main/java/org/elasticsearch/watcher/WatcherHandle.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.watcher;
+
+/**
+*
+*/
+public class WatcherHandle<W extends ResourceWatcher> {
+
+    private final ResourceWatcherService.ResourceMonitor monitor;
+    private final W watcher;
+
+    WatcherHandle(ResourceWatcherService.ResourceMonitor monitor, W watcher) {
+        this.monitor = monitor;
+        this.watcher = watcher;
+    }
+
+    public W watcher() {
+        return watcher;
+    }
+
+    public ResourceWatcherService.Frequency frequency() {
+        return monitor.frequency;
+    }
+
+    public void stop() {
+        monitor.watchers.remove(watcher);
+    }
+
+    public void resume() {
+        monitor.watchers.add(watcher);
+    }
+}

--- a/src/test/java/org/elasticsearch/watcher/ResourceWatcherServiceTests.java
+++ b/src/test/java/org/elasticsearch/watcher/ResourceWatcherServiceTests.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.watcher;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
+
+import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
+import static org.hamcrest.Matchers.*;
+
+/**
+ *
+ */
+public class ResourceWatcherServiceTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testSettings() throws Exception {
+        ThreadPool threadPool = new ThreadPool("test");
+
+        // checking the defaults
+        Settings settings = ImmutableSettings.builder().build();
+        ResourceWatcherService service = new ResourceWatcherService(settings, threadPool);
+        assertThat(service.highMonitor.interval, is(ResourceWatcherService.Frequency.HIGH.interval));
+        assertThat(service.mediumMonitor.interval, is(ResourceWatcherService.Frequency.MEDIUM.interval));
+        assertThat(service.lowMonitor.interval, is(ResourceWatcherService.Frequency.LOW.interval));
+
+        // checking bwc
+        settings = ImmutableSettings.builder()
+                .put("watcher.interval", "40s") // only applies to medium
+                .build();
+        service = new ResourceWatcherService(settings, threadPool);
+        assertThat(service.highMonitor.interval.millis(), is(timeValueSeconds(5).millis()));
+        assertThat(service.mediumMonitor.interval.millis(), is(timeValueSeconds(40).millis()));
+        assertThat(service.lowMonitor.interval.millis(), is(timeValueSeconds(60).millis()));
+
+        // checking custom
+        settings = ImmutableSettings.builder()
+                .put("watcher.interval.high", "10s")
+                .put("watcher.interval.medium", "20s")
+                .put("watcher.interval.low", "30s")
+                .build();
+        service = new ResourceWatcherService(settings, threadPool);
+        assertThat(service.highMonitor.interval.millis(), is(timeValueSeconds(10).millis()));
+        assertThat(service.mediumMonitor.interval.millis(), is(timeValueSeconds(20).millis()));
+        assertThat(service.lowMonitor.interval.millis(), is(timeValueSeconds(30).millis()));
+    }
+
+    @Test
+    public void testHandle() throws Exception {
+        ThreadPool threadPool = new ThreadPool("test");
+        Settings settings = ImmutableSettings.builder().build();
+        ResourceWatcherService service = new ResourceWatcherService(settings, threadPool);
+        ResourceWatcher watcher = new ResourceWatcher() {
+            @Override
+            public void init() {
+            }
+
+            @Override
+            public void checkAndNotify() {
+            }
+        };
+
+        // checking default freq
+        WatcherHandle handle = service.add(watcher);
+        assertThat(handle, notNullValue());
+        assertThat(handle.frequency(), equalTo(ResourceWatcherService.Frequency.MEDIUM));
+        assertThat(service.lowMonitor.watchers.size(), is(0));
+        assertThat(service.highMonitor.watchers.size(), is(0));
+        assertThat(service.mediumMonitor.watchers.size(), is(1));
+        handle.stop();
+        assertThat(service.mediumMonitor.watchers.size(), is(0));
+        handle.resume();
+        assertThat(service.mediumMonitor.watchers.size(), is(1));
+        handle.stop();
+
+        // checking custom freq
+        handle = service.add(watcher, ResourceWatcherService.Frequency.HIGH);
+        assertThat(handle, notNullValue());
+        assertThat(handle.frequency(), equalTo(ResourceWatcherService.Frequency.HIGH));
+        assertThat(service.lowMonitor.watchers.size(), is(0));
+        assertThat(service.mediumMonitor.watchers.size(), is(0));
+        assertThat(service.highMonitor.watchers.size(), is(1));
+        handle.stop();
+        assertThat(service.highMonitor.watchers.size(), is(0));
+        handle.resume();
+        assertThat(service.highMonitor.watchers.size(), is(1));
+    }
+}


### PR DESCRIPTION
 It's now possible to register watchers along with a specified check frequency. There are three frequencies: low, medium, high. Each one is associated with a check interval that determines how frequent the watchers will check for changes and notify listeners if needed. By default, the intervals are 5s, 30s and 60s respectively, but they can also be customized in the settings. also:
- Added the WatcherHandle construct by which one can stop it (remove it) and resume it (re add it). Also provides access to the watcher itself and the frequency by which it's checked
- Changed the default frequency to 30 seconds interval (used to be 60 seconds). The only watcher that is currently effected by this is the script watcher (now auto-loading scripts will auto-load every 30 seconds if changed)
