### PR TITLE
Make ScoreAccessor utility class publicly available for other script engines

### DIFF
--- a/src/main/java/org/elasticsearch/script/ScoreAccessor.java
+++ b/src/main/java/org/elasticsearch/script/ScoreAccessor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.search.lookup.DocLookup;
+
+import java.io.IOException;
+
+/**
+ * A float encapsulation that dynamically accesses the score of a document.
+ *
+ * The provided {@link DocLookup} is used to retrieve the score
+ * for the current document.
+ */
+public final class ScoreAccessor extends Number {
+
+    final DocLookup doc;
+
+    public ScoreAccessor(DocLookup d) {
+        doc = d;
+    }
+
+    float score() {
+        try {
+            return doc.score();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not get score", e);
+        }
+    }
+
+    @Override
+    public int intValue() {
+        return (int)score();
+    }
+
+    @Override
+    public long longValue() {
+        return (long)score();
+    }
+
+    @Override
+    public float floatValue() {
+        return score();
+    }
+
+    @Override
+    public double doubleValue() {
+        return score();
+    }
+}

--- a/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -41,11 +41,7 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptEngineService;
-import org.elasticsearch.script.ScriptException;
-import org.elasticsearch.script.SearchScript;
-import org.elasticsearch.search.lookup.DocLookup;
+import org.elasticsearch.script.*;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -201,7 +197,7 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             this.logger = logger;
             this.variables = script.getBinding().getVariables();
             // Add the _score variable, which will access score from lookup.doc()
-            this.variables.put("_score", new ScoreAccessor());
+            this.variables.put("_score", new ScoreAccessor(lookup.doc()));
         }
 
         @Override
@@ -270,42 +266,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             return value;
         }
 
-        /**
-         * Float encapsulation that allows updating the value with public
-         * member access. This is used to encapsulate the _score of a document
-         * so that updating the _score for the next document incurs only the
-         * overhead of setting a member variable
-         */
-        private final class ScoreAccessor extends Number {
-
-            float score() {
-                try {
-                    return lookup.doc().score();
-                } catch (IOException e) {
-                    throw new GroovyScriptExecutionException("Could not get score", e);
-                }
-            }
-
-            @Override
-            public int intValue() {
-                return (int)score();
-            }
-
-            @Override
-            public long longValue() {
-                return (long)score();
-            }
-
-            @Override
-            public float floatValue() {
-                return score();
-            }
-
-            @Override
-            public double doubleValue() {
-                return score();
-            }
-        }
     }
 
     /**
@@ -353,4 +313,5 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             return super.transform(newExpr);
         }
     }
+
 }


### PR DESCRIPTION
With the removal of setNextScore in #6864, script engines must use
the Scorer to find the score of a document.  The DocLookup is updated
appropriately to do this, but most script engines require a Number to be
bound for numeric variables.  Groovy already had an encapsulation for
this funtionality, and this moves it out to be shared with other script
engines.
