### PR TITLE
When serializing HttpInfo, return null info if service is not started

### DIFF
--- a/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -281,7 +281,11 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
 
     @Override
     public HttpInfo info() {
-        return new HttpInfo(boundAddress(), maxContentLength.bytes());
+        BoundTransportAddress boundTransportAddress = boundAddress();
+        if (boundTransportAddress == null) {
+            return null;
+        }
+        return new HttpInfo(boundTransportAddress, maxContentLength.bytes());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -127,7 +127,11 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
     }
 
     public TransportInfo info() {
-        return new TransportInfo(boundAddress());
+        BoundTransportAddress boundTransportAddress = boundAddress();
+        if (boundTransportAddress == null) {
+            return null;
+        }
+        return new TransportInfo(boundTransportAddress);
     }
 
     public TransportStats stats() {


### PR DESCRIPTION
Http/TransportInfo throw NPE if the bound address is null and the info
object is serialized. There is a small window where at least the
HttpInfo can be requested before the service is fully started.
