### PR TITLE
Prevent init script from returning when the service isn't actually started

### DIFF
--- a/src/deb/init.d/elasticsearch
+++ b/src/deb/init.d/elasticsearch
@@ -162,7 +162,21 @@ case "$1" in
 
 	# Start Daemon
 	start-stop-daemon --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
-	log_end_msg $?
+	return=$?
+	if [ $return -eq 0 ]
+	then
+		i=0
+		timeout=10
+		# Wait for the process to be properly started before exiting
+		until { cat "$PID_FILE" | xargs kill -0; } >/dev/null 2>&1
+		do
+			sleep 1
+			i=$(($i + 1))
+			[ $i -gt $timeout ] && log_end_msg 1
+		done
+	else
+		log_end_msg $return
+	fi
 	;;		
   stop)
 	log_daemon_msg "Stopping $DESC"


### PR DESCRIPTION
Hello,
Since the init script uses start-stop-daemon's `-b` option, it might return from _start_ before the service is actually started. If the init script's _status_ action is called immediately after that, It will return `elasticsearch is not running` and exit with a non-zero code.
This causes systems like Heartbeat to incorrectly start multiple instances of Elasticsearch at once.
This pull request aims at fixing this issue by waiting until the Elasticsearch process is started.
There might be a nicer way to achieve this but this is what came to mind.
