### PR TITLE
Update as-a-service.asciidoc

### DIFF
--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -67,6 +67,7 @@ Some RPM based distributions are using `chkconfig` to enable and disable service
 [source,sh]
 --------------------------------------------------
 sudo /sbin/chkconfig --add elasticsearch
+sudo /sbin/chkconfig on
 sudo service elasticsearch start
 --------------------------------------------------
 


### PR DESCRIPTION
There is a step missing where the auto-start on boot isn't enabled for RPM based installs.
