### PR TITLE
Introduced pluggable filter chain to be able to filter transport actions execution

### DIFF
--- a/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
@@ -91,10 +92,10 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
 import org.elasticsearch.action.admin.indices.open.TransportOpenIndexAction;
 import org.elasticsearch.action.admin.indices.optimize.OptimizeAction;
 import org.elasticsearch.action.admin.indices.optimize.TransportOptimizeAction;
-import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
-import org.elasticsearch.action.admin.indices.refresh.TransportRefreshAction;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
 import org.elasticsearch.action.admin.indices.recovery.TransportRecoveryAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
+import org.elasticsearch.action.admin.indices.refresh.TransportRefreshAction;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.segments.TransportIndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
@@ -149,13 +150,17 @@ import org.elasticsearch.action.search.*;
 import org.elasticsearch.action.search.type.*;
 import org.elasticsearch.action.suggest.SuggestAction;
 import org.elasticsearch.action.suggest.TransportSuggestAction;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.termvector.*;
 import org.elasticsearch.action.update.TransportUpdateAction;
 import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -164,6 +169,7 @@ import java.util.Map;
 public class ActionModule extends AbstractModule {
 
     private final Map<String, ActionEntry> actions = Maps.newHashMap();
+    private final List<Class<? extends ActionFilter>> actionFilters = Lists.newArrayList();
 
     static class ActionEntry<Request extends ActionRequest, Response extends ActionResponse> {
         public final GenericAction<Request, Response> action;
@@ -198,8 +204,19 @@ public class ActionModule extends AbstractModule {
         actions.put(action.name(), new ActionEntry<>(action, transportAction, supportTransportActions));
     }
 
+    public ActionModule registerFilter(Class<? extends ActionFilter> actionFilter) {
+        actionFilters.add(actionFilter);
+        return this;
+    }
+
     @Override
     protected void configure() {
+
+        Multibinder<ActionFilter> actionFilterMultibinder = Multibinder.newSetBinder(binder(), ActionFilter.class);
+        for (Class<? extends ActionFilter> actionFilter : actionFilters) {
+            actionFilterMultibinder.addBinding().to(actionFilter);
+        }
+        bind(ActionFilters.class).asEagerSingleton();
 
         registerAction(NodesInfoAction.INSTANCE, TransportNodesInfoAction.class);
         registerAction(NodesStatsAction.INSTANCE, TransportNodesStatsAction.class);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.health;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -46,8 +47,8 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
 
     @Inject
     public TransportClusterHealthAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                        ClusterName clusterName) {
-        super(settings, ClusterHealthAction.NAME, transportService, clusterService, threadPool);
+                                        ClusterName clusterName, ActionFilters actionFilters) {
+        super(settings, ClusterHealthAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.clusterName = clusterName;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.NodeOperationRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -44,8 +45,8 @@ public class TransportNodesHotThreadsAction extends TransportNodesOperationActio
 
     @Inject
     public TransportNodesHotThreadsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
-                                          ClusterService clusterService, TransportService transportService) {
-        super(settings, NodesHotThreadsAction.NAME, clusterName, threadPool, clusterService, transportService);
+                                          ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, NodesHotThreadsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.cluster.node.info;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.NodeOperationRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -47,8 +48,8 @@ public class TransportNodesInfoAction extends TransportNodesOperationAction<Node
     @Inject
     public TransportNodesInfoAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                     ClusterService clusterService, TransportService transportService,
-                                    NodeService nodeService) {
-        super(settings, NodesInfoAction.NAME, clusterName, threadPool, clusterService, transportService);
+                                    NodeService nodeService, ActionFilters actionFilters) {
+        super(settings, NodesInfoAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.nodeService = nodeService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/TransportNodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/TransportNodesRestartAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.cluster.node.restart;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.NodeOperationRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -57,8 +58,8 @@ public class TransportNodesRestartAction extends TransportNodesOperationAction<N
     @Inject
     public TransportNodesRestartAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                        ClusterService clusterService, TransportService transportService,
-                                       Node node) {
-        super(settings, NodesRestartAction.NAME, clusterName, threadPool, clusterService, transportService);
+                                       Node node, ActionFilters actionFilters) {
+        super(settings, NodesRestartAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.node = node;
         disabled = componentSettings.getAsBoolean("disabled", false);
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -53,8 +54,8 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
 
     @Inject
     public TransportNodesShutdownAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                        Node node, ClusterName clusterName) {
-        super(settings, NodesShutdownAction.NAME, transportService, clusterService, threadPool);
+                                        Node node, ClusterName clusterName, ActionFilters actionFilters) {
+        super(settings, NodesShutdownAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.node = node;
         this.clusterName = clusterName;
         this.disabled = settings.getAsBoolean("action.disable_shutdown", componentSettings.getAsBoolean("disabled", false));

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.node.stats;
 
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.NodeOperationRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -47,8 +48,8 @@ public class TransportNodesStatsAction extends TransportNodesOperationAction<Nod
     @Inject
     public TransportNodesStatsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                      ClusterService clusterService, TransportService transportService,
-                                     NodeService nodeService) {
-        super(settings, NodesStatsAction.NAME, clusterName, threadPool, clusterService, transportService);
+                                     NodeService nodeService, ActionFilters actionFilters) {
+        super(settings, NodesStatsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.nodeService = nodeService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.repositories.delete;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,8 +43,8 @@ public class TransportDeleteRepositoryAction extends TransportMasterNodeOperatio
 
     @Inject
     public TransportDeleteRepositoryAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                           RepositoriesService repositoriesService, ThreadPool threadPool) {
-        super(settings, DeleteRepositoryAction.NAME, transportService, clusterService, threadPool);
+                                           RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, DeleteRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.repositoriesService = repositoriesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.cluster.repositories.get;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,8 +44,8 @@ public class TransportGetRepositoriesAction extends TransportMasterNodeReadOpera
 
     @Inject
     public TransportGetRepositoriesAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                          ThreadPool threadPool) {
-        super(settings, GetRepositoriesAction.NAME, transportService, clusterService, threadPool);
+                                          ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, GetRepositoriesAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.repositories.put;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,8 +43,8 @@ public class TransportPutRepositoryAction extends TransportMasterNodeOperationAc
 
     @Inject
     public TransportPutRepositoryAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                        RepositoriesService repositoriesService, ThreadPool threadPool) {
-        super(settings, PutRepositoryAction.NAME, transportService, clusterService, threadPool);
+                                        RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, PutRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.repositoriesService = repositoriesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.reroute;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
@@ -42,8 +43,8 @@ public class TransportClusterRerouteAction extends TransportMasterNodeOperationA
 
     @Inject
     public TransportClusterRerouteAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                         AllocationService allocationService) {
-        super(settings, ClusterRerouteAction.NAME, transportService, clusterService, threadPool);
+                                         AllocationService allocationService, ActionFilters actionFilters) {
+        super(settings, ClusterRerouteAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.allocationService = allocationService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.settings;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
@@ -55,8 +56,8 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
 
     @Inject
     public TransportClusterUpdateSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                                AllocationService allocationService, @ClusterDynamicSettings DynamicSettings dynamicSettings) {
-        super(settings, ClusterUpdateSettingsAction.NAME, transportService, clusterService, threadPool);
+                                                AllocationService allocationService, @ClusterDynamicSettings DynamicSettings dynamicSettings, ActionFilters actionFilters) {
+        super(settings, ClusterUpdateSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.allocationService = allocationService;
         this.dynamicSettings = dynamicSettings;
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.shards;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,8 +44,8 @@ import static com.google.common.collect.Sets.newHashSet;
 public class TransportClusterSearchShardsAction extends TransportMasterNodeReadOperationAction<ClusterSearchShardsRequest, ClusterSearchShardsResponse> {
 
     @Inject
-    public TransportClusterSearchShardsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, ClusterSearchShardsAction.NAME, transportService, clusterService, threadPool);
+    public TransportClusterSearchShardsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, ClusterSearchShardsAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.create;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,8 +43,8 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeOperationA
 
     @Inject
     public TransportCreateSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, SnapshotsService snapshotsService) {
-        super(settings, CreateSnapshotAction.NAME, transportService, clusterService, threadPool);
+                                         ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters) {
+        super(settings, CreateSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.snapshotsService = snapshotsService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.delete;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -41,8 +42,8 @@ public class TransportDeleteSnapshotAction extends TransportMasterNodeOperationA
 
     @Inject
     public TransportDeleteSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, SnapshotsService snapshotsService) {
-        super(settings, DeleteSnapshotAction.NAME, transportService, clusterService, threadPool);
+                                         ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters) {
+        super(settings, DeleteSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.snapshotsService = snapshotsService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.get;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -44,8 +45,8 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeOperationAct
 
     @Inject
     public TransportGetSnapshotsAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                       ThreadPool threadPool, SnapshotsService snapshotsService) {
-        super(settings, GetSnapshotsAction.NAME, transportService, clusterService, threadPool);
+                                       ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters) {
+        super(settings, GetSnapshotsAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.snapshotsService = snapshotsService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,8 +44,8 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeOperation
 
     @Inject
     public TransportRestoreSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                          ThreadPool threadPool, RestoreService restoreService) {
-        super(settings, RestoreSnapshotAction.NAME, transportService, clusterService, threadPool);
+                                          ThreadPool threadPool, RestoreService restoreService, ActionFilters actionFilters) {
+        super(settings, RestoreSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.restoreService = restoreService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -55,8 +56,8 @@ public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction
     private final SnapshotsService snapshotsService;
 
     @Inject
-    public TransportNodesSnapshotsStatus(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, SnapshotsService snapshotsService) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
+    public TransportNodesSnapshotsStatus(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, SnapshotsService snapshotsService, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.snapshotsService = snapshotsService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -54,8 +55,8 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeOperation
     private final TransportNodesSnapshotsStatus transportNodesSnapshotsStatus;
 
     @Inject
-    public TransportSnapshotsStatusAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, SnapshotsService snapshotsService, TransportNodesSnapshotsStatus transportNodesSnapshotsStatus) {
-        super(settings, SnapshotsStatusAction.NAME, transportService, clusterService, threadPool);
+    public TransportSnapshotsStatusAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, SnapshotsService snapshotsService, TransportNodesSnapshotsStatus transportNodesSnapshotsStatus, ActionFilters actionFilters) {
+        super(settings, SnapshotsStatusAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.snapshotsService = snapshotsService;
         this.transportNodesSnapshotsStatus = transportNodesSnapshotsStatus;
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.state;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -43,8 +44,8 @@ public class TransportClusterStateAction extends TransportMasterNodeReadOperatio
 
     @Inject
     public TransportClusterStateAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                       ClusterName clusterName) {
-        super(settings, ClusterStateAction.NAME, transportService, clusterService, threadPool);
+                                       ClusterName clusterName, ActionFilters actionFilters) {
+        super(settings, ClusterStateAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.clusterName = clusterName;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.NodeOperationRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
 import org.elasticsearch.cluster.ClusterName;
@@ -65,8 +66,8 @@ public class TransportClusterStatsAction extends TransportNodesOperationAction<C
     @Inject
     public TransportClusterStatsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                        ClusterService clusterService, TransportService transportService,
-                                       NodeService nodeService, IndicesService indicesService) {
-        super(settings, ClusterStatsAction.NAME, clusterName, threadPool, clusterService, transportService);
+                                       NodeService nodeService, IndicesService indicesService, ActionFilters actionFilters) {
+        super(settings, ClusterStatsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.nodeService = nodeService;
         this.indicesService = indicesService;
     }

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.tasks;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -36,8 +37,8 @@ public class TransportPendingClusterTasksAction extends TransportMasterNodeReadO
     private final ClusterService clusterService;
 
     @Inject
-    public TransportPendingClusterTasksAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, PendingClusterTasksAction.NAME, transportService, clusterService, threadPool);
+    public TransportPendingClusterTasksAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, PendingClusterTasksAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.clusterService = clusterService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -51,8 +52,8 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeOperationA
 
     @Inject
     public TransportIndicesAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, MetaDataIndexAliasesService indexAliasesService) {
-        super(settings, IndicesAliasesAction.NAME, transportService, clusterService, threadPool);
+                                         ThreadPool threadPool, MetaDataIndexAliasesService indexAliasesService, ActionFilters actionFilters) {
+        super(settings, IndicesAliasesAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.indexAliasesService = indexAliasesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/TransportAliasesExistAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.alias.exists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -34,8 +35,8 @@ import org.elasticsearch.transport.TransportService;
 public class TransportAliasesExistAction extends TransportMasterNodeReadOperationAction<GetAliasesRequest, AliasesExistResponse> {
 
     @Inject
-    public TransportAliasesExistAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, AliasesExistAction.NAME, transportService, clusterService, threadPool);
+    public TransportAliasesExistAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, AliasesExistAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,8 +38,8 @@ import java.util.List;
 public class TransportGetAliasesAction extends TransportMasterNodeReadOperationAction<GetAliasesRequest, GetAliasesResponse> {
 
     @Inject
-    public TransportGetAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, GetAliasesAction.NAME, transportService, clusterService, threadPool);
+    public TransportGetAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, GetAliasesAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -27,6 +27,7 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.custom.TransportSingleCustomOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -59,8 +60,8 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
 
     @Inject
     public TransportAnalyzeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                  IndicesService indicesService, IndicesAnalysisService indicesAnalysisService) {
-        super(settings, AnalyzeAction.NAME, threadPool, clusterService, transportService);
+                                  IndicesService indicesService, IndicesAnalysisService indicesAnalysisService, ActionFilters actionFilters) {
+        super(settings, AnalyzeAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.indicesAnalysisService = indicesAnalysisService;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.cache.clear;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -57,8 +58,8 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
     @Inject
     public TransportClearIndicesCacheAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                             TransportService transportService, IndicesService indicesService, IndicesTermsFilterCache termsFilterCache,
-                                            CacheRecycler cacheRecycler) {
-        super(settings, ClearIndicesCacheAction.NAME, threadPool, clusterService, transportService);
+                                            CacheRecycler cacheRecycler, ActionFilters actionFilters) {
+        super(settings, ClearIndicesCacheAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.termsFilterCache = termsFilterCache;
         this.cacheRecycler = cacheRecycler;

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.close;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -45,8 +46,8 @@ public class TransportCloseIndexAction extends TransportMasterNodeOperationActio
 
     @Inject
     public TransportCloseIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService) {
-        super(settings, CloseIndexAction.NAME, transportService, clusterService, threadPool);
+                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
+        super(settings, CloseIndexAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.indexStateService = indexStateService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.create;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,8 +44,8 @@ public class TransportCreateIndexAction extends TransportMasterNodeOperationActi
 
     @Inject
     public TransportCreateIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                      ThreadPool threadPool, MetaDataCreateIndexService createIndexService) {
-        super(settings, CreateIndexAction.NAME, transportService, clusterService, threadPool);
+                                      ThreadPool threadPool, MetaDataCreateIndexService createIndexService, ActionFilters actionFilters) {
+        super(settings, CreateIndexAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.createIndexService = createIndexService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.delete;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -46,8 +47,8 @@ public class TransportDeleteIndexAction extends TransportMasterNodeOperationActi
     @Inject
     public TransportDeleteIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                       ThreadPool threadPool, MetaDataDeleteIndexService deleteIndexService,
-                                      NodeSettingsService nodeSettingsService) {
-        super(settings, DeleteIndexAction.NAME, transportService, clusterService, threadPool);
+                                      NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
+        super(settings, DeleteIndexAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.deleteIndexService = deleteIndexService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.exists.indices;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -40,8 +41,8 @@ public class TransportIndicesExistsAction extends TransportMasterNodeReadOperati
 
     @Inject
     public TransportIndicesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                        ThreadPool threadPool) {
-        super(settings, IndicesExistsAction.NAME, transportService, clusterService, threadPool);
+                                        ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, IndicesExistsAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.admin.indices.exists.types;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,8 +40,8 @@ public class TransportTypesExistsAction extends TransportMasterNodeReadOperation
 
     @Inject
     public TransportTypesExistsAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                      ThreadPool threadPool) {
-        super(settings, TypesExistsAction.NAME, transportService, clusterService, threadPool);
+                                      ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, TypesExistsAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.flush;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -51,8 +52,8 @@ public class TransportFlushAction extends TransportBroadcastOperationAction<Flus
     private final IndicesService indicesService;
 
     @Inject
-    public TransportFlushAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService) {
-        super(settings, FlushAction.NAME, threadPool, clusterService, transportService);
+    public TransportFlushAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
+        super(settings, FlushAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/TransportDeleteMappingAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.admin.indices.refresh.TransportRefreshAction;
 import org.elasticsearch.action.deletebyquery.DeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.IndexDeleteByQueryResponse;
 import org.elasticsearch.action.deletebyquery.TransportDeleteByQueryAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationResponse;
@@ -72,8 +73,8 @@ public class TransportDeleteMappingAction extends TransportMasterNodeOperationAc
     public TransportDeleteMappingAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                         ThreadPool threadPool, MetaDataMappingService metaDataMappingService,
                                         TransportDeleteByQueryAction deleteByQueryAction, TransportRefreshAction refreshAction,
-                                        TransportFlushAction flushAction, NodeSettingsService nodeSettingsService) {
-        super(settings, DeleteMappingAction.NAME, transportService, clusterService, threadPool);
+                                        TransportFlushAction flushAction, NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
+        super(settings, DeleteMappingAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.metaDataMappingService = metaDataMappingService;
         this.deleteByQueryAction = deleteByQueryAction;
         this.refreshAction = refreshAction;

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,8 +44,8 @@ public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMap
     private final TransportGetFieldMappingsIndexAction shardAction;
 
     @Inject
-    public TransportGetFieldMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, TransportGetFieldMappingsIndexAction shardAction) {
-        super(settings, GetFieldMappingsAction.NAME, threadPool);
+    public TransportGetFieldMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, TransportGetFieldMappingsIndexAction shardAction, ActionFilters actionFilters) {
+        super(settings, GetFieldMappingsAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
         transportService.registerHandler(actionName, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.custom.TransportSingleCustomOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -64,8 +65,8 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
     public TransportGetFieldMappingsIndexAction(Settings settings, ClusterService clusterService,
                                                 TransportService transportService,
                                                 IndicesService indicesService,
-                                                ThreadPool threadPool) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
+                                                ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters);
         this.clusterService = clusterService;
         this.indicesService = indicesService;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.info.TransportClusterInfoAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -36,8 +37,8 @@ import org.elasticsearch.transport.TransportService;
 public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMappingsRequest, GetMappingsResponse> {
 
     @Inject
-    public TransportGetMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, GetMappingsAction.NAME, transportService, clusterService, threadPool);
+    public TransportGetMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, GetMappingsAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.mapping.put;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,8 +43,8 @@ public class TransportPutMappingAction extends TransportMasterNodeOperationActio
 
     @Inject
     public TransportPutMappingAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                     ThreadPool threadPool, MetaDataMappingService metaDataMappingService) {
-        super(settings, PutMappingAction.NAME, transportService, clusterService, threadPool);
+                                     ThreadPool threadPool, MetaDataMappingService metaDataMappingService, ActionFilters actionFilters) {
+        super(settings, PutMappingAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.metaDataMappingService = metaDataMappingService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.open;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -45,8 +46,8 @@ public class TransportOpenIndexAction extends TransportMasterNodeOperationAction
 
     @Inject
     public TransportOpenIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                    ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService) {
-        super(settings, OpenIndexAction.NAME, transportService, clusterService, threadPool);
+                                    ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
+        super(settings, OpenIndexAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.indexStateService = indexStateService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.optimize;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -52,8 +53,8 @@ public class TransportOptimizeAction extends TransportBroadcastOperationAction<O
 
     @Inject
     public TransportOptimizeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                   TransportService transportService, IndicesService indicesService) {
-        super(settings, OptimizeAction.NAME, threadPool, clusterService, transportService);
+                                   TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
+        super(settings, OptimizeAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.recovery;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
@@ -64,9 +65,9 @@ public class TransportRecoveryAction extends
 
     @Inject
     public TransportRecoveryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                   TransportService transportService, IndicesService indicesService, RecoveryTarget recoveryTarget) {
+                                   TransportService transportService, IndicesService indicesService, RecoveryTarget recoveryTarget, ActionFilters actionFilters) {
 
-        super(settings, RecoveryAction.NAME, threadPool, clusterService, transportService);
+        super(settings, RecoveryAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.recoveryTarget = recoveryTarget;
     }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -52,8 +53,8 @@ public class TransportRefreshAction extends TransportBroadcastOperationAction<Re
 
     @Inject
     public TransportRefreshAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                  TransportService transportService, IndicesService indicesService) {
-        super(settings, RefreshAction.NAME, threadPool, clusterService, transportService);
+                                  TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
+        super(settings, RefreshAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.segments;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
@@ -56,8 +57,8 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
 
     @Inject
     public TransportIndicesSegmentsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                          IndicesService indicesService) {
-        super(settings, IndicesSegmentsAction.NAME, threadPool, clusterService, transportService);
+                                          IndicesService indicesService, ActionFilters actionFilters) {
+        super(settings, IndicesSegmentsAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.settings.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -45,8 +46,8 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadOperation
 
     @Inject
     public TransportGetSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                      ThreadPool threadPool, SettingsFilter settingsFilter) {
-        super(settings, GetSettingsAction.NAME, transportService, clusterService, threadPool);
+                                      ThreadPool threadPool, SettingsFilter settingsFilter, ActionFilters actionFilters) {
+        super(settings, GetSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.settingsFilter = settingsFilter;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -40,8 +41,8 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeOperationA
 
     @Inject
     public TransportUpdateSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                         MetaDataUpdateSettingsService updateSettingsService) {
-        super(settings, UpdateSettingsAction.NAME, transportService, clusterService, threadPool);
+                                         MetaDataUpdateSettingsService updateSettingsService, ActionFilters actionFilters) {
+        super(settings, UpdateSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.updateSettingsService = updateSettingsService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.stats;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
@@ -56,8 +57,8 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
 
     @Inject
     public TransportIndicesStatsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                       IndicesService indicesService) {
-        super(settings, IndicesStatsAction.NAME, threadPool, clusterService, transportService);
+                                       IndicesService indicesService, ActionFilters actionFilters) {
+        super(settings, IndicesStatsAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.admin.indices.template.delete;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -40,8 +41,8 @@ public class TransportDeleteIndexTemplateAction extends TransportMasterNodeOpera
 
     @Inject
     public TransportDeleteIndexTemplateAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                              ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService) {
-        super(settings, DeleteIndexTemplateAction.NAME, transportService, clusterService, threadPool);
+                                              ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService, ActionFilters actionFilters) {
+        super(settings, DeleteIndexTemplateAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.indexTemplateService = indexTemplateService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -22,6 +22,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -40,8 +41,8 @@ import java.util.List;
 public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadOperationAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
 
     @Inject
-    public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, GetIndexTemplatesAction.NAME, transportService, clusterService, threadPool);
+    public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, GetIndexTemplatesAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.admin.indices.template.put;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -40,8 +41,8 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeOperatio
 
     @Inject
     public TransportPutIndexTemplateAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                           ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService) {
-        super(settings, PutIndexTemplateAction.NAME, transportService, clusterService, threadPool);
+                                           ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService, ActionFilters actionFilters) {
+        super(settings, PutIndexTemplateAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.indexTemplateService = indexTemplateService;
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.validate.query;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -72,8 +73,8 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
     private final BigArrays bigArrays;
 
     @Inject
-    public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, ValidateQueryAction.NAME, threadPool, clusterService, transportService);
+    public TransportValidateQueryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, ActionFilters actionFilters) {
+        super(settings, ValidateQueryAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices.warmer.delete;
 import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
@@ -48,8 +49,8 @@ import java.util.List;
 public class TransportDeleteWarmerAction extends TransportMasterNodeOperationAction<DeleteWarmerRequest, DeleteWarmerResponse> {
 
     @Inject
-    public TransportDeleteWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, DeleteWarmerAction.NAME, transportService, clusterService, threadPool);
+    public TransportDeleteWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, DeleteWarmerAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/TransportGetWarmersAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/TransportGetWarmersAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.warmer.get;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.info.TransportClusterInfoAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,8 +38,8 @@ import org.elasticsearch.transport.TransportService;
 public class TransportGetWarmersAction extends TransportClusterInfoAction<GetWarmersRequest, GetWarmersResponse> {
 
     @Inject
-    public TransportGetWarmersAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, GetWarmersAction.NAME, transportService, clusterService, threadPool);
+    public TransportGetWarmersAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, GetWarmersAction.NAME, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterService;
@@ -53,8 +54,8 @@ public class TransportPutWarmerAction extends TransportMasterNodeOperationAction
 
     @Inject
     public TransportPutWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                    TransportSearchAction searchAction) {
-        super(settings, PutWarmerAction.NAME, transportService, clusterService, threadPool);
+                                    TransportSearchAction searchAction, ActionFilters actionFilters) {
+        super(settings, PutWarmerAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.searchAction = searchAction;
     }
 

--- a/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportAbortBenchmarkAction.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.bench;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -37,8 +38,8 @@ public class TransportAbortBenchmarkAction extends TransportMasterNodeOperationA
 
     @Inject
     public TransportAbortBenchmarkAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, BenchmarkService service) {
-        super(settings, AbortBenchmarkAction.NAME, transportService, clusterService, threadPool);
+                                         ThreadPool threadPool, BenchmarkService service, ActionFilters actionFilters) {
+        super(settings, AbortBenchmarkAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.service = service;
     }
 

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkAction.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.bench;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -38,8 +39,8 @@ public class TransportBenchmarkAction extends TransportMasterNodeOperationAction
 
     @Inject
     public TransportBenchmarkAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                    ThreadPool threadPool, BenchmarkService service) {
-        super(settings, BenchmarkAction.NAME, transportService, clusterService, threadPool);
+                                    ThreadPool threadPool, BenchmarkService service, ActionFilters actionFilters) {
+        super(settings, BenchmarkAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.service = service;
     }
 

--- a/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/TransportBenchmarkStatusAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.bench;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.inject.Inject;
@@ -38,8 +39,8 @@ public class TransportBenchmarkStatusAction extends TransportMasterNodeOperation
 
     @Inject
     public TransportBenchmarkStatusAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                          ThreadPool threadPool, BenchmarkService service) {
-        super(settings, BenchmarkStatusAction.NAME, transportService, clusterService, threadPool);
+                                          ThreadPool threadPool, BenchmarkService service, ActionFilters actionFilters) {
+        super(settings, BenchmarkStatusAction.NAME, transportService, clusterService, threadPool, actionFilters);
         this.service = service;
     }
 

--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -76,8 +77,8 @@ public class TransportBulkAction extends TransportAction<BulkRequest, BulkRespon
 
     @Inject
     public TransportBulkAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService,
-                               TransportShardBulkAction shardBulkAction, TransportCreateIndexAction createIndexAction) {
-        super(settings, BulkAction.NAME, threadPool);
+                               TransportShardBulkAction shardBulkAction, TransportCreateIndexAction createIndexAction, ActionFilters actionFilters) {
+        super(settings, BulkAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.shardBulkAction = shardBulkAction;
         this.createIndexAction = createIndexAction;

--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.action.update.UpdateHelper;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -84,8 +85,8 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
     @Inject
     public TransportShardBulkAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                    MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper) {
-        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
+                                    MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
         this.mappingUpdatedAction = mappingUpdatedAction;
         this.updateHelper = updateHelper;
         this.allowIdGeneration = settings.getAsBoolean("action.allow_id_generation", true);

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.count;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -76,8 +77,8 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
     @Inject
     public TransportCountAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                 IndicesService indicesService, ScriptService scriptService, CacheRecycler cacheRecycler,
-                                PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, CountAction.NAME, threadPool, clusterService, transportService);
+                                PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, ActionFilters actionFilters) {
+        super(settings, CountAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;

--- a/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.delete.index.IndexDeleteRequest;
 import org.elasticsearch.action.delete.index.IndexDeleteResponse;
 import org.elasticsearch.action.delete.index.ShardDeleteResponse;
 import org.elasticsearch.action.delete.index.TransportIndexDeleteAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -63,8 +64,8 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     @Inject
     public TransportDeleteAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                  IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                 TransportCreateIndexAction createIndexAction, TransportIndexDeleteAction indexDeleteAction) {
-        super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
+                                 TransportCreateIndexAction createIndexAction, TransportIndexDeleteAction indexDeleteAction, ActionFilters actionFilters) {
+        super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
         this.createIndexAction = createIndexAction;
         this.indexDeleteAction = indexDeleteAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.delete.index;
 
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportIndexReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,8 +43,8 @@ public class TransportIndexDeleteAction extends TransportIndexReplicationOperati
 
     @Inject
     public TransportIndexDeleteAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                      ThreadPool threadPool, TransportShardDeleteAction deleteAction) {
-        super(settings, ACTION_NAME, transportService, clusterService, threadPool, deleteAction);
+                                      ThreadPool threadPool, TransportShardDeleteAction deleteAction, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, deleteAction, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.delete.index;
 
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -47,8 +48,8 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
     @Inject
     public TransportShardDeleteAction(Settings settings, TransportService transportService,
                                       ClusterService clusterService, IndicesService indicesService, ThreadPool threadPool,
-                                      ShardStateAction shardStateAction) {
-        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
+                                      ShardStateAction shardStateAction, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.deletebyquery;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.replication.TransportIndicesReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -46,8 +47,8 @@ public class TransportDeleteByQueryAction extends TransportIndicesReplicationOpe
     @Inject
     public TransportDeleteByQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                         ThreadPool threadPool, TransportIndexDeleteByQueryAction indexDeleteByQueryAction,
-                                        NodeSettingsService nodeSettingsService) {
-        super(settings, DeleteByQueryAction.NAME, transportService, clusterService, threadPool, indexDeleteByQueryAction);
+                                        NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
+        super(settings, DeleteByQueryAction.NAME, transportService, clusterService, threadPool, indexDeleteByQueryAction, actionFilters);
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
 

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.deletebyquery;
 
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportIndexReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,8 +43,8 @@ public class TransportIndexDeleteByQueryAction extends TransportIndexReplication
 
     @Inject
     public TransportIndexDeleteByQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                             ThreadPool threadPool, TransportShardDeleteByQueryAction shardDeleteByQueryAction) {
-        super(settings, ACTION_NAME, transportService, clusterService, threadPool, shardDeleteByQueryAction);
+                                             ThreadPool threadPool, TransportShardDeleteByQueryAction shardDeleteByQueryAction, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, shardDeleteByQueryAction, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.deletebyquery;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.search.Filter;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -65,8 +66,8 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
     public TransportShardDeleteByQueryAction(Settings settings, TransportService transportService,
                                              ClusterService clusterService, IndicesService indicesService, ThreadPool threadPool,
                                              ShardStateAction shardStateAction, ScriptService scriptService, CacheRecycler cacheRecycler,
-                                             PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
+                                             PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.RoutingMissingException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -73,8 +74,8 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
     public TransportExplainAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                   TransportService transportService, IndicesService indicesService,
                                   ScriptService scriptService, CacheRecycler cacheRecycler,
-                                  PageCacheRecycler pageCacheRecycler, BigArrays bigArrays) {
-        super(settings, ExplainAction.NAME, threadPool, clusterService, transportService);
+                                  PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, ActionFilters actionFilters) {
+        super(settings, ExplainAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;

--- a/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.RoutingMissingException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -49,8 +50,8 @@ public class TransportGetAction extends TransportShardSingleOperationAction<GetR
 
     @Inject
     public TransportGetAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                              IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, GetAction.NAME, threadPool, clusterService, transportService);
+                              IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, GetAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
 
         this.realtime = settings.getAsBoolean("action.get.realtime", true);

--- a/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.get;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -45,8 +46,8 @@ public class TransportMultiGetAction extends TransportAction<MultiGetRequest, Mu
     private final TransportShardMultiGetAction shardAction;
 
     @Inject
-    public TransportMultiGetAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportShardMultiGetAction shardAction) {
-        super(settings, MultiGetAction.NAME, threadPool);
+    public TransportMultiGetAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportShardMultiGetAction shardAction, ActionFilters actionFilters) {
+        super(settings, MultiGetAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
 

--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.get;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -50,8 +51,8 @@ public class TransportShardMultiGetAction extends TransportShardSingleOperationA
 
     @Inject
     public TransportShardMultiGetAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                        IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
+                                        IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
 
         this.realtime = settings.getAsBoolean("action.get.realtime", true);

--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -71,8 +72,8 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
     @Inject
     public TransportIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                 IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction) {
-        super(settings, IndexAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction);
+                                TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction, ActionFilters actionFilters) {
+        super(settings, IndexAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
         this.createIndexAction = createIndexAction;
         this.mappingUpdatedAction = mappingUpdatedAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);

--- a/src/main/java/org/elasticsearch/action/indexedscripts/delete/TransportDeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/delete/TransportDeleteIndexedScriptAction.java
@@ -20,8 +20,9 @@
 package org.elasticsearch.action.indexedscripts.delete;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DelegatingActionListener;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
@@ -40,8 +41,8 @@ public class TransportDeleteIndexedScriptAction extends HandledTransportAction<D
 
     @Inject
     public TransportDeleteIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
-                                              Client client, TransportService transportService) {
-        super(settings, DeleteIndexedScriptAction.NAME, threadPool, transportService);
+                                              Client client, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, DeleteIndexedScriptAction.NAME, threadPool, transportService, actionFilters);
         this.scriptService = scriptService;
         this.client = client;
     }

--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.indexedscripts.get;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
@@ -40,8 +41,8 @@ public class TransportGetIndexedScriptAction extends HandledTransportAction<GetI
 
     @Inject
     public TransportGetIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
-                                           TransportService transportService, Client client) {
-        super(settings, GetIndexedScriptAction.NAME, threadPool,transportService);
+                                           TransportService transportService, Client client, ActionFilters actionFilters) {
+        super(settings, GetIndexedScriptAction.NAME, threadPool,transportService,  actionFilters);
         this.scriptService = scriptService;
         this.client = client;
     }

--- a/src/main/java/org/elasticsearch/action/indexedscripts/put/TransportPutIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/put/TransportPutIndexedScriptAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.indexedscripts.put;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DelegatingActionListener;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -41,8 +42,8 @@ public class TransportPutIndexedScriptAction extends HandledTransportAction<PutI
     @Inject
     public TransportPutIndexedScriptAction(Settings settings, ThreadPool threadPool,
                                            ScriptService scriptService, Client client,
-                                           TransportService transportService) {
-        super(settings, PutIndexedScriptAction.NAME, threadPool, transportService);
+                                           TransportService transportService, ActionFilters actionFilters) {
+        super(settings, PutIndexedScriptAction.NAME, threadPool, transportService, actionFilters);
         this.client = client;
         this.scriptService = scriptService;
     }

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.get.TransportGetAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -78,8 +79,8 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
 
     @Inject
     public TransportMoreLikeThisAction(Settings settings, ThreadPool threadPool, TransportSearchAction searchAction, TransportGetAction getAction,
-                                       ClusterService clusterService, IndicesService indicesService, TransportService transportService) {
-        super(settings, MoreLikeThisAction.NAME, threadPool);
+                                       ClusterService clusterService, IndicesService indicesService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, MoreLikeThisAction.NAME, threadPool, actionFilters);
         this.searchAction = searchAction;
         this.getAction = getAction;
         this.indicesService = indicesService;

--- a/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.get.*;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.cluster.ClusterService;
@@ -60,8 +61,8 @@ public class TransportMultiPercolateAction extends TransportAction<MultiPercolat
     @Inject
     public TransportMultiPercolateAction(Settings settings, ThreadPool threadPool, TransportShardMultiPercolateAction shardMultiPercolateAction,
                                          ClusterService clusterService, TransportService transportService, PercolatorService percolatorService,
-                                         TransportMultiGetAction multiGetAction) {
-        super(settings, MultiPercolateAction.NAME, threadPool);
+                                         TransportMultiGetAction multiGetAction, ActionFilters actionFilters) {
+        super(settings, MultiPercolateAction.NAME, threadPool, actionFilters);
         this.shardMultiPercolateAction = shardMultiPercolateAction;
         this.clusterService = clusterService;
         this.percolatorService = percolatorService;

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.TransportGetAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -60,8 +61,8 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
     @Inject
     public TransportPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                     TransportService transportService, PercolatorService percolatorService,
-                                    TransportGetAction getAction) {
-        super(settings, PercolateAction.NAME, threadPool, clusterService, transportService);
+                                    TransportGetAction getAction, ActionFilters actionFilters) {
+        super(settings, PercolateAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.percolatorService = percolatorService;
         this.getAction = getAction;
     }

--- a/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.percolate;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
@@ -53,8 +54,8 @@ public class TransportShardMultiPercolateAction extends TransportShardSingleOper
     private static final String ACTION_NAME = "mpercolate/shard";
 
     @Inject
-    public TransportShardMultiPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, PercolatorService percolatorService) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
+    public TransportShardMultiPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, PercolatorService percolatorService, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters);
         this.percolatorService = percolatorService;
     }
 

--- a/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -50,8 +51,8 @@ public class TransportClearScrollAction extends TransportAction<ClearScrollReque
     private final SearchServiceTransportAction searchServiceTransportAction;
 
     @Inject
-    public TransportClearScrollAction(Settings settings, TransportService transportService, ThreadPool threadPool, ClusterService clusterService, SearchServiceTransportAction searchServiceTransportAction) {
-        super(settings, ClearScrollAction.NAME, threadPool);
+    public TransportClearScrollAction(Settings settings, TransportService transportService, ThreadPool threadPool, ClusterService clusterService, SearchServiceTransportAction searchServiceTransportAction, ActionFilters actionFilters) {
+        super(settings, ClearScrollAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.searchServiceTransportAction = searchServiceTransportAction;
         transportService.registerHandler(ClearScrollAction.NAME, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -44,8 +45,8 @@ public class TransportMultiSearchAction extends TransportAction<MultiSearchReque
     private final TransportSearchAction searchAction;
 
     @Inject
-    public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportSearchAction searchAction) {
-        super(settings, MultiSearchAction.NAME, threadPool);
+    public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportSearchAction searchAction, ActionFilters actionFilters) {
+        super(settings, MultiSearchAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.searchAction = searchAction;
 

--- a/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.type.*;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -59,8 +60,8 @@ public class TransportSearchAction extends TransportAction<SearchRequest, Search
                                  TransportSearchDfsQueryAndFetchAction dfsQueryAndFetchAction,
                                  TransportSearchQueryAndFetchAction queryAndFetchAction,
                                  TransportSearchScanAction scanAction,
-                                 TransportSearchCountAction countAction) {
-        super(settings, SearchAction.NAME, threadPool);
+                                 TransportSearchCountAction countAction, ActionFilters actionFilters) {
+        super(settings, SearchAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.dfsQueryThenFetchAction = dfsQueryThenFetchAction;
         this.queryThenFetchAction = queryThenFetchAction;

--- a/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.type.ParsedScrollId;
 import org.elasticsearch.action.search.type.TransportSearchScrollQueryAndFetchAction;
 import org.elasticsearch.action.search.type.TransportSearchScrollQueryThenFetchAction;
 import org.elasticsearch.action.search.type.TransportSearchScrollScanAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -51,8 +52,8 @@ public class TransportSearchScrollAction extends TransportAction<SearchScrollReq
     public TransportSearchScrollAction(Settings settings, ThreadPool threadPool, TransportService transportService,
                                        TransportSearchScrollQueryThenFetchAction queryThenFetchAction,
                                        TransportSearchScrollQueryAndFetchAction queryAndFetchAction,
-                                       TransportSearchScrollScanAction scanAction) {
-        super(settings, SearchScrollAction.NAME, threadPool);
+                                       TransportSearchScrollScanAction scanAction, ActionFilters actionFilters) {
+        super(settings, SearchScrollAction.NAME, threadPool, actionFilters);
         this.queryThenFetchAction = queryThenFetchAction;
         this.queryAndFetchAction = queryAndFetchAction;
         this.scanAction = scanAction;

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.search.type;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -45,8 +46,8 @@ public class TransportSearchCountAction extends TransportSearchTypeAction {
 
     @Inject
     public TransportSearchCountAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                      SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController);
+                                      SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -48,8 +49,8 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
 
     @Inject
     public TransportSearchDfsQueryAndFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                                 SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController);
+                                                 SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -54,8 +55,8 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
 
     @Inject
     public TransportSearchDfsQueryThenFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                                  SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController);
+                                                  SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -46,8 +47,8 @@ public class TransportSearchQueryAndFetchAction extends TransportSearchTypeActio
 
     @Inject
     public TransportSearchQueryAndFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                              SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController);
+                                              SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -50,8 +51,8 @@ public class TransportSearchQueryThenFetchAction extends TransportSearchTypeActi
 
     @Inject
     public TransportSearchQueryThenFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                               SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController);
+                                               SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -43,8 +44,8 @@ public class TransportSearchScanAction extends TransportSearchTypeAction {
 
     @Inject
     public TransportSearchScanAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                     SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController);
+                                     SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.search.*;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterService;
@@ -69,8 +70,8 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
     protected final SearchPhaseController searchPhaseController;
 
     public TransportSearchTypeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                     SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController) {
-        super(settings, SearchAction.NAME, threadPool);
+                                     SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
+        super(settings, SearchAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.searchService = searchService;
         this.searchPhaseController = searchPhaseController;

--- a/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.suggest;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
@@ -66,8 +67,8 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
 
     @Inject
     public TransportSuggestAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                  IndicesService indicesService, SuggestPhase suggestPhase) {
-        super(settings, SuggestAction.NAME, threadPool, clusterService, transportService);
+                                  IndicesService indicesService, SuggestPhase suggestPhase, ActionFilters actionFilters) {
+        super(settings, SuggestAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.suggestPhase = suggestPhase;
     }

--- a/src/main/java/org/elasticsearch/action/support/ActionFilter.java
+++ b/src/main/java/org/elasticsearch/action/support/ActionFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+
+/**
+ * A filter allowing to filter transport actions
+ */
+public interface ActionFilter {
+
+    /**
+     * Filters the actual execution of the request by either sending a response through the {@link ActionListener}
+     * or continuing the filters execution through the {@link ActionFilterChain}
+     */
+    void process(final String action, final ActionRequest actionRequest, final ActionListener actionListener, final ActionFilterChain actionFilterChain);
+
+    /**
+     * The position of the filter in the chain. Execution is done from lowest order to highest.
+     */
+    int order();
+}

--- a/src/main/java/org/elasticsearch/action/support/ActionFilterChain.java
+++ b/src/main/java/org/elasticsearch/action/support/ActionFilterChain.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+
+/**
+ * A filter chain allowing to continue and process the transport action request
+ */
+public interface ActionFilterChain {
+
+    /**
+     * Continue processing the request. Should only be called if a response has not been sent through the {@link ActionListener}
+     */
+    void continueProcessing(final String action, final ActionRequest request, final ActionListener actionListener);
+}

--- a/src/main/java/org/elasticsearch/action/support/ActionFilters.java
+++ b/src/main/java/org/elasticsearch/action/support/ActionFilters.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.common.inject.Inject;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Set;
+
+/**
+ * Holds the action filters injected through plugins, properly sorted by {@link org.elasticsearch.action.support.ActionFilter#order()}
+ */
+public class ActionFilters {
+
+    private final ActionFilter[] filters;
+
+    @Inject
+    public ActionFilters(Set<ActionFilter> actionFilters) {
+        this.filters = actionFilters.toArray(new ActionFilter[actionFilters.size()]);
+        Arrays.sort(filters, new Comparator<ActionFilter>() {
+            @Override
+            public int compare(ActionFilter o1, ActionFilter o2) {
+                return Integer.compare(o1.order(), o2.order());
+            }
+        });
+    }
+
+    /**
+     * Returns the action filters that have been injected
+     */
+    public ActionFilter[] filters() {
+        return filters;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -38,8 +38,8 @@ public abstract class HandledTransportAction<Request extends ActionRequest, Resp
      */
     public abstract Request newRequestInstance();
 
-    protected HandledTransportAction(Settings settings, String actionName, ThreadPool threadPool, TransportService transportService){
-        super(settings, actionName, threadPool);
+    protected HandledTransportAction(Settings settings, String actionName, ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters){
+        super(settings, actionName, threadPool, actionFilters);
         transportService.registerHandler(actionName, new TransportHandler() {
             @Override
             public Request newInstance(){

--- a/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -36,14 +36,16 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
 
     protected final ThreadPool threadPool;
     protected final String actionName;
+    private final ActionFilter[] filters;
 
-    protected TransportAction(Settings settings, String actionName, ThreadPool threadPool) {
+    protected TransportAction(Settings settings, String actionName, ThreadPool threadPool, ActionFilters actionFilters) {
         super(settings);
         this.actionName = actionName;
+        this.filters = actionFilters.filters();
         this.threadPool = threadPool;
     }
 
-    public ActionFuture<Response> execute(Request request) throws ElasticsearchException {
+    public final ActionFuture<Response> execute(Request request) throws ElasticsearchException {
         PlainActionFuture<Response> future = newFuture();
         // since we don't have a listener, and we release a possible lock with the future
         // there is no need to execute it under a listener thread
@@ -52,21 +54,26 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
         return future;
     }
 
-    public void execute(Request request, ActionListener<Response> listener) {
+    public final void execute(Request request, ActionListener<Response> listener) {
+        if (forceThreadedListener()) {
+            request.listenerThreaded(true);
+        }
         if (request.listenerThreaded()) {
             listener = new ThreadedActionListener<>(threadPool, listener, logger);
         }
+
         ActionRequestValidationException validationException = request.validate();
         if (validationException != null) {
             listener.onFailure(validationException);
             return;
         }
-        try {
-            doExecute(request, listener);
-        } catch (Throwable e) {
-            logger.trace("Error during transport action execution.", e);
-            listener.onFailure(e);
-        }
+
+        ActionFilterChain actionFilterChain = new TransportActionFilterChain();
+        actionFilterChain.continueProcessing(actionName, request, listener);
+    }
+
+    protected boolean forceThreadedListener() {
+        return false;
     }
 
     protected abstract void doExecute(Request request, ActionListener<Response> listener);
@@ -124,6 +131,31 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
                 /* we don't care if that takes long since we are shutting down. But if we not respond somebody could wait
                  * for the response on the listener side which could be a remote machine so make sure we push it out there.*/
                 listener.onFailure(e);
+            }
+        }
+    }
+
+    private class TransportActionFilterChain implements ActionFilterChain {
+
+        private volatile int index = 0;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void continueProcessing(String action, ActionRequest actionRequest, ActionListener actionListener) {
+            int i = index++;
+            try {
+                if (i < filters.length) {
+                    filters[i].process(action, actionRequest, actionListener, this);
+                } else if (i == filters.length) {
+                    ActionListener<Response> listener = (ActionListener<Response>) actionListener;
+                    Request request = (Request) actionRequest;
+                    doExecute(request, listener);
+                } else {
+                    actionListener.onFailure(new IllegalStateException("continueProcessing was called too many times"));
+                }
+            } catch(Throwable t) {
+                logger.trace("Error during transport action execution.", t);
+                actionListener.onFailure(t);
             }
         }
     }

--- a/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -68,8 +68,12 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
             return;
         }
 
-        ActionFilterChain actionFilterChain = new TransportActionFilterChain();
-        actionFilterChain.continueProcessing(actionName, request, listener);
+        if (filters.length == 0) {
+            doExecute(request, listener);
+        } else {
+            ActionFilterChain actionFilterChain = new TransportActionFilterChain();
+            actionFilterChain.continueProcessing(actionName, request, listener);
+        }
     }
 
     protected boolean forceThreadedListener() {

--- a/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.broadcast;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterService;
@@ -53,8 +54,8 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
     final String transportShardAction;
     final String executor;
 
-    protected TransportBroadcastOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, actionName, threadPool);
+    protected TransportBroadcastOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.threadPool = threadPool;

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeOperationAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.master;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterService;
@@ -47,8 +48,8 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
 
     final String executor;
 
-    protected TransportMasterNodeOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, actionName, threadPool);
+    protected TransportMasterNodeOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.transportService = transportService;
         this.clusterService = clusterService;
 
@@ -78,11 +79,10 @@ public abstract class TransportMasterNodeOperationAction<Request extends MasterN
     }
 
     @Override
-    public void execute(Request request, ActionListener<Response> listener) {
+    protected boolean forceThreadedListener() {
         // since the callback is async, we typically can get called from within an event in the cluster service
         // or something similar, so make sure we are threaded so we won't block it.
-        request.listenerThreaded(true);
-        super.execute(request, listener);
+        return true;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadOperationAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.support.master;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -35,8 +36,8 @@ public abstract class TransportMasterNodeReadOperationAction<Request extends Mas
 
     private Boolean forceLocal;
 
-    protected TransportMasterNodeReadOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, actionName, transportService, clusterService, threadPool);
+    protected TransportMasterNodeReadOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, actionName, transportService, clusterService, threadPool, actionFilters);
         this.forceLocal = settings.getAsBoolean(FORCE_LOCAL_SETTING, null);
     }
 

--- a/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.support.master.info;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -32,8 +33,8 @@ import org.elasticsearch.transport.TransportService;
  */
 public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeReadOperationAction<Request, Response> {
 
-    public TransportClusterInfoAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool) {
-        super(settings, actionName, transportService, clusterService, threadPool);
+    public TransportClusterInfoAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, actionName, transportService, clusterService, threadPool, actionFilters);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.NoSuchNodeException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -51,8 +52,8 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
     final String executor;
 
     protected TransportNodesOperationAction(Settings settings, String actionName, ClusterName clusterName, ThreadPool threadPool,
-                                         ClusterService clusterService, TransportService transportService) {
-        super(settings, actionName, threadPool);
+                                            ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterName = clusterName;
         this.clusterService = clusterService;
         this.transportService = transportService;

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndexReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndexReplicationOperationAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -51,9 +52,9 @@ public abstract class TransportIndexReplicationOperationAction<Request extends I
 
     protected final TransportShardReplicationOperationAction<ShardRequest, ShardReplicaRequest, ShardResponse> shardAction;
 
-    protected TransportIndexReplicationOperationAction(Settings settings, String actionName,  TransportService transportService, ClusterService clusterService,
-                                                    ThreadPool threadPool, TransportShardReplicationOperationAction<ShardRequest, ShardReplicaRequest, ShardResponse> shardAction) {
-        super(settings, actionName, threadPool);
+    protected TransportIndexReplicationOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService,
+                                                       ThreadPool threadPool, TransportShardReplicationOperationAction<ShardRequest, ShardReplicaRequest, ShardResponse> shardAction, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
 

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportIndicesReplicationOperationAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.replication;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -48,8 +49,8 @@ public abstract class TransportIndicesReplicationOperationAction<Request extends
     protected final TransportIndexReplicationOperationAction<IndexRequest, IndexResponse, ShardRequest, ShardReplicaRequest, ShardResponse> indexAction;
 
     protected TransportIndicesReplicationOperationAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                                      TransportIndexReplicationOperationAction<IndexRequest, IndexResponse, ShardRequest, ShardReplicaRequest, ShardResponse> indexAction) {
-        super(settings, actionName, threadPool);
+                                                         TransportIndexReplicationOperationAction<IndexRequest, IndexResponse, ShardRequest, ShardReplicaRequest, ShardResponse> indexAction, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.indexAction = indexAction;
 

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.WriteConsistencyLevel;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterService;
@@ -77,8 +78,8 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
 
     protected TransportShardReplicationOperationAction(Settings settings, String actionName, TransportService transportService,
                                                        ClusterService clusterService, IndicesService indicesService,
-                                                       ThreadPool threadPool, ShardStateAction shardStateAction) {
-        super(settings, actionName, threadPool);
+                                                       ThreadPool threadPool, ShardStateAction shardStateAction, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.indicesService = indicesService;

--- a/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -50,8 +51,8 @@ public abstract class TransportSingleCustomOperationAction<Request extends Singl
     final String transportShardAction;
     final String executor;
 
-    protected TransportSingleCustomOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, actionName, threadPool);
+    protected TransportSingleCustomOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.transportService = transportService;
 

--- a/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.UnavailableShardsException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -53,8 +54,8 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
 
     final String executor;
 
-    protected TransportInstanceSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, actionName, threadPool);
+    protected TransportInstanceSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.transportService = transportService;
 

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterService;
@@ -55,8 +56,8 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
     final String transportShardAction;
     final String executor;
 
-    protected TransportShardSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, actionName, threadPool);
+    protected TransportShardSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, actionName, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.transportService = transportService;
 

--- a/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.termvector;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -46,8 +47,8 @@ public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVe
 
     @Inject
     public TransportMultiTermVectorsAction(Settings settings, ThreadPool threadPool, TransportService transportService,
-                                           ClusterService clusterService, TransportSingleShardMultiTermsVectorAction shardAction) {
-        super(settings, MultiTermVectorsAction.NAME, threadPool);
+                                           ClusterService clusterService, TransportSingleShardMultiTermsVectorAction shardAction, ActionFilters actionFilters) {
+        super(settings, MultiTermVectorsAction.NAME, threadPool, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
 

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.termvector;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -44,8 +45,8 @@ public class TransportSingleShardMultiTermsVectorAction extends TransportShardSi
 
     @Inject
     public TransportSingleShardMultiTermsVectorAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                                      IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService);
+                                                      IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardTermVectorAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.termvector;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.RoutingMissingException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.shard.TransportShardSingleOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -44,8 +45,8 @@ public class TransportSingleShardTermVectorAction extends TransportShardSingleOp
 
     @Inject
     public TransportSingleShardTermVectorAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                                IndicesService indicesService, ThreadPool threadPool) {
-        super(settings, TermVectorAction.NAME, threadPool, clusterService, transportService);
+                                                IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
+        super(settings, TermVectorAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
     }
 

--- a/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -35,6 +35,7 @@ import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.index.TransportIndexAction;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.instance.TransportInstanceSingleOperationAction;
@@ -73,8 +74,8 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     @Inject
     public TransportUpdateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                  TransportIndexAction indexAction, TransportDeleteAction deleteAction, TransportCreateIndexAction createIndexAction,
-                                 UpdateHelper updateHelper) {
-        super(settings, UpdateAction.NAME, threadPool, clusterService, transportService);
+                                 UpdateHelper updateHelper, ActionFilters actionFilters) {
+        super(settings, UpdateAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indexAction = indexAction;
         this.deleteAction = deleteAction;
         this.createIndexAction = createIndexAction;

--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequest;
 import org.elasticsearch.action.support.master.TransportMasterNodeOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -88,8 +89,8 @@ public class MappingUpdatedAction extends TransportMasterNodeOperationAction<Map
 
     @Inject
     public MappingUpdatedAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                MetaDataMappingService metaDataMappingService, NodeSettingsService nodeSettingsService) {
-        super(settings, ACTION_NAME, transportService, clusterService, threadPool);
+                                MetaDataMappingService metaDataMappingService, NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, actionFilters);
         this.metaDataMappingService = metaDataMappingService;
         // this setting should probably always be 0, just add the option to wait for more changes within a time window
         this.additionalMappingChangeTime = settings.getAsTime(INDICES_MAPPING_ADDITIONAL_MAPPING_CHANGE_TIME, TimeValue.timeValueMillis(0));

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/TransportNodesListGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/TransportNodesListGatewayMetaState.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -51,8 +52,8 @@ public class TransportNodesListGatewayMetaState extends TransportNodesOperationA
     private LocalGatewayMetaState metaState;
 
     @Inject
-    public TransportNodesListGatewayMetaState(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
+    public TransportNodesListGatewayMetaState(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
     }
 
     TransportNodesListGatewayMetaState init(LocalGatewayMetaState metaState) {

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -53,8 +54,8 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesOperat
     private LocalGatewayShardsState shardsState;
 
     @Inject
-    public TransportNodesListGatewayStartedShards(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
+    public TransportNodesListGatewayStartedShards(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
     }
 
     TransportNodesListGatewayStartedShards initGateway(LocalGatewayShardsState shardsState) {

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -68,8 +69,8 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesOperatio
 
     @Inject
     public TransportNodesListShardStoreMetaData(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                                IndicesService indicesService, NodeEnvironment nodeEnv) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService);
+                                                IndicesService indicesService, NodeEnvironment nodeEnv, ActionFilters actionFilters) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.nodeEnv = nodeEnv;
     }

--- a/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -197,7 +197,7 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
         TestFilter(int order, Operation operation) {
             this.order = order;
             this.operation = operation;
-            this.callback = operation.callback;
+            this.callback = operation;
         }
 
         TestFilter(int order, Callback callback) {
@@ -221,32 +221,25 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
         }
     }
 
-    private static enum Operation {
-
-        CONTINUE_PROCESSING(new Callback() {
+    private static enum Operation implements Callback {
+        CONTINUE_PROCESSING {
             @Override
             public void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
                 actionFilterChain.continueProcessing(action, actionRequest, actionListener);
             }
-        }),
-        LISTENER_RESPONSE(new Callback() {
+        },
+        LISTENER_RESPONSE {
             @Override
             @SuppressWarnings("unchecked")
             public void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
                 actionListener.onResponse(new TestResponse());
             }
-        }),
-        LISTENER_FAILURE(new Callback() {
+        },
+        LISTENER_FAILURE {
             @Override
             public void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
                 actionListener.onFailure(new ElasticsearchTimeoutException(""));
             }
-        });
-
-        private final Callback callback;
-
-        Operation(Callback callback) {
-            this.callback = callback;
         }
     }
 

--- a/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -33,11 +33,10 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 
 public class TransportActionFilterChainTests extends ElasticsearchTestCase {
 
@@ -172,7 +171,9 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
             }
         });
 
-        latch.await();
+        if (!latch.await(10, TimeUnit.SECONDS)) {
+            fail("timeout waiting for the filter to notify the listener as many times as expected");
+        }
 
         assertThat(testFilter.runs.get(), equalTo(1));
         assertThat(testFilter.lastActionName, equalTo(actionName));

--- a/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+public class TransportActionFilterChainTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testActionFilters() throws ExecutionException, InterruptedException {
+
+        int numFilters = randomInt(10);
+        Set<Integer> orders = new HashSet<>(numFilters);
+        while (orders.size() < numFilters) {
+            orders.add(randomInt(10));
+        }
+
+        Set<ActionFilter> filters = new HashSet<>();
+        for (Integer order : orders) {
+            filters.add(new TestFilter(order, randomFrom(Operation.values())));
+        }
+
+        String actionName = randomAsciiOfLength(randomInt(30));
+        ActionFilters actionFilters = new ActionFilters(filters);
+        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(ImmutableSettings.EMPTY, actionName, null, actionFilters) {
+            @Override
+            protected void doExecute(TestRequest request, ActionListener<TestResponse> listener) {
+                listener.onResponse(new TestResponse());
+            }
+        };
+
+        ArrayList<ActionFilter> actionFiltersByOrder = Lists.newArrayList(filters);
+        Collections.sort(actionFiltersByOrder, new Comparator<ActionFilter>() {
+            @Override
+            public int compare(ActionFilter o1, ActionFilter o2) {
+                return Integer.compare(o1.order(), o2.order());
+            }
+        });
+
+        List<ActionFilter> expectedActionFilters = Lists.newArrayList();
+        boolean errorExpected = false;
+        for (ActionFilter filter : actionFiltersByOrder) {
+            TestFilter testFilter = (TestFilter) filter;
+            expectedActionFilters.add(testFilter);
+            if (testFilter.operation == Operation.LISTENER_FAILURE) {
+                errorExpected = true;
+            }
+            if (!(testFilter.operation == Operation.CONTINUE_PROCESSING) ) {
+                break;
+            }
+        }
+
+        PlainListenableActionFuture<TestResponse> future = new PlainListenableActionFuture<>(false, null);
+        transportAction.execute(new TestRequest(), future);
+        try {
+            assertThat(future.get(), notNullValue());
+            assertThat("shouldn't get here if an error is expected", errorExpected, equalTo(false));
+        } catch(Throwable t) {
+            assertThat("shouldn't get here if an error is not expected " + t.getMessage(), errorExpected, equalTo(true));
+        }
+
+        List<TestFilter> testFiltersByLastExecution = Lists.newArrayList();
+        for (ActionFilter actionFilter : actionFilters.filters()) {
+            testFiltersByLastExecution.add((TestFilter) actionFilter);
+        }
+        Collections.sort(testFiltersByLastExecution, new Comparator<TestFilter>() {
+            @Override
+            public int compare(TestFilter o1, TestFilter o2) {
+                return Long.compare(o1.lastExecution, o2.lastExecution);
+            }
+        });
+
+        ArrayList<TestFilter> finalTestFilters = Lists.newArrayList();
+        for (ActionFilter filter : testFiltersByLastExecution) {
+            TestFilter testFilter = (TestFilter) filter;
+            finalTestFilters.add(testFilter);
+            if (!(testFilter.operation == Operation.CONTINUE_PROCESSING) ) {
+                break;
+            }
+        }
+
+        assertThat(finalTestFilters.size(), equalTo(expectedActionFilters.size()));
+        for (int i = 0; i < finalTestFilters.size(); i++) {
+            TestFilter testFilter = finalTestFilters.get(i);
+            assertThat(testFilter, equalTo(expectedActionFilters.get(i)));
+            assertThat(testFilter.runs.get(), equalTo(1));
+            assertThat(testFilter.lastActionName, equalTo(actionName));
+        }
+    }
+
+    @Test
+    public void testTooManyContinueProcessing() throws ExecutionException, InterruptedException {
+
+        final int additionalContinueCount = randomInt(10);
+
+        TestFilter testFilter = new TestFilter(randomInt(), new Callback() {
+            @Override
+            public void execute(final String action, final ActionRequest actionRequest, final ActionListener actionListener, final ActionFilterChain actionFilterChain) {
+                for (int i = 0; i <= additionalContinueCount; i++) {
+                    new Thread() {
+                        @Override
+                        public void run() {
+                            actionFilterChain.continueProcessing(action, actionRequest, actionListener);
+                        }
+                    }.start();
+                }
+            }
+        });
+
+        Set<ActionFilter> filters = new HashSet<>();
+        filters.add(testFilter);
+
+        String actionName = randomAsciiOfLength(randomInt(30));
+        ActionFilters actionFilters = new ActionFilters(filters);
+        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(ImmutableSettings.EMPTY, actionName, null, actionFilters) {
+            @Override
+            protected void doExecute(TestRequest request, ActionListener<TestResponse> listener) {
+                listener.onResponse(new TestResponse());
+            }
+        };
+
+        final CountDownLatch latch = new CountDownLatch(additionalContinueCount + 1);
+        final AtomicInteger responses = new AtomicInteger();
+        final List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        transportAction.execute(new TestRequest(), new ActionListener<TestResponse>() {
+            @Override
+            public void onResponse(TestResponse testResponse) {
+                responses.incrementAndGet();
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                failures.add(e);
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+
+        assertThat(testFilter.runs.get(), equalTo(1));
+        assertThat(testFilter.lastActionName, equalTo(actionName));
+
+        assertThat(responses.get(), equalTo(1));
+        assertThat(failures.size(), equalTo(additionalContinueCount));
+        for (Throwable failure : failures) {
+            assertThat(failure, instanceOf(IllegalStateException.class));
+        }
+    }
+
+    private static class TestFilter implements ActionFilter {
+        private final int order;
+        private final Operation operation;
+        private final Callback callback;
+
+        AtomicInteger runs = new AtomicInteger();
+        volatile String lastActionName;
+        volatile long lastExecution = Long.MAX_VALUE; //the filters that don't run will go last in the sorted list
+
+        TestFilter(int order, Operation operation) {
+            this.order = order;
+            this.operation = operation;
+            this.callback = operation.callback;
+        }
+
+        TestFilter(int order, Callback callback) {
+            this.order = order;
+            this.operation = null; //custom operation
+            this.callback = callback;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void process(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
+            this.runs.incrementAndGet();
+            this.lastActionName = action;
+            this.lastExecution = System.nanoTime();
+            this.callback.execute(action, actionRequest, actionListener, actionFilterChain);
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+    }
+
+    private static enum Operation {
+
+        CONTINUE_PROCESSING(new Callback() {
+            @Override
+            public void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
+                actionFilterChain.continueProcessing(action, actionRequest, actionListener);
+            }
+        }),
+        LISTENER_RESPONSE(new Callback() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
+                actionListener.onResponse(new TestResponse());
+            }
+        }),
+        LISTENER_FAILURE(new Callback() {
+            @Override
+            public void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
+                actionListener.onFailure(new ElasticsearchTimeoutException(""));
+            }
+        });
+
+        private final Callback callback;
+
+        Operation(Callback callback) {
+            this.callback = callback;
+        }
+    }
+
+    private static interface Callback {
+        void execute(String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain);
+    }
+
+    private static class TestRequest extends ActionRequest {
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    private static class TestResponse extends ActionResponse {
+
+    }
+}

--- a/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -76,10 +76,10 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
         for (ActionFilter filter : actionFiltersByOrder) {
             TestFilter testFilter = (TestFilter) filter;
             expectedActionFilters.add(testFilter);
-            if (testFilter.operation == Operation.LISTENER_FAILURE) {
+            if (testFilter.callback == Operation.LISTENER_FAILURE) {
                 errorExpected = true;
             }
-            if (!(testFilter.operation == Operation.CONTINUE_PROCESSING) ) {
+            if (!(testFilter.callback == Operation.CONTINUE_PROCESSING) ) {
                 break;
             }
         }
@@ -108,7 +108,7 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
         for (ActionFilter filter : testFiltersByLastExecution) {
             TestFilter testFilter = (TestFilter) filter;
             finalTestFilters.add(testFilter);
-            if (!(testFilter.operation == Operation.CONTINUE_PROCESSING) ) {
+            if (!(testFilter.callback == Operation.CONTINUE_PROCESSING) ) {
                 break;
             }
         }
@@ -187,22 +187,14 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
 
     private static class TestFilter implements ActionFilter {
         private final int order;
-        private final Operation operation;
         private final Callback callback;
 
         AtomicInteger runs = new AtomicInteger();
         volatile String lastActionName;
         volatile long lastExecution = Long.MAX_VALUE; //the filters that don't run will go last in the sorted list
 
-        TestFilter(int order, Operation operation) {
-            this.order = order;
-            this.operation = operation;
-            this.callback = operation;
-        }
-
         TestFilter(int order, Callback callback) {
             this.order = order;
-            this.operation = null; //custom operation
             this.callback = callback;
         }
 


### PR DESCRIPTION
It's now possible to inject action filters from plugins via `ActionModule#registerFilter` through the following code:

```
    public void onModule(ActionModule actionModule) {
          actionModule.registerFilter(MyFilter.class);
    }
```

Also made `TransportAction#execute` methods final to enforce the execution of the filter chain. By default the chain is empty though.

Note that the action filter chain is executed right after the request validation, as the filters might rely on a valid request to do their work.
