### PR TITLE
Allow GET access to _all field (return value was always null before)

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -56,7 +56,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 /**
  *
  */
-public class AllFieldMapper extends AbstractFieldMapper<Void> implements InternalMapper, RootMapper {
+public class AllFieldMapper extends AbstractFieldMapper<String> implements InternalMapper, RootMapper {
 
     public interface IncludeInAll extends Mapper {
 
@@ -237,15 +237,13 @@ public class AllFieldMapper extends AbstractFieldMapper<Void> implements Interna
         }
         return analyzer;
     }
-
+    
     @Override
-    public Void value(Object value) {
-        return null;
-    }
-
-    @Override
-    public Object valueForSearch(Object value) {
-        return null;
+    public String value(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -887,7 +887,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testGet_allField() throws Exception {
-        client().admin().indices().prepareCreate("my-index")
+        prepareCreate("my-index")
                 .addMapping("my-type1", jsonBuilder()
                         .startObject()
                         .startObject("my-type1")
@@ -902,9 +902,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
                         .endObject()
                         .endObject())
                 .get();
-        client().prepareIndex("my-index", "my-type1", "1")
-                .setSource(jsonBuilder().startObject().field("some_field", "some text").endObject())
-                .get();
+        index("my-index", "my-type1", "1", "some_field", "some text");
         refresh();
 
         GetResponse getResponse = client().prepareGet("my-index", "my-type1", "1").setFields("_all").get();

--- a/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -885,4 +885,30 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         assertThat(getResponse.getField(field).getValues().get(1).toString(), equalTo("value2"));
     }
 
+    @Test
+    public void testGet_allField() throws Exception {
+        client().admin().indices().prepareCreate("my-index")
+                .addMapping("my-type1", jsonBuilder()
+                        .startObject()
+                        .startObject("my-type1")
+                        .startObject("_all")
+                        .field("store", true)
+                        .endObject()
+                        .startObject("properties")
+                        .startObject("some_field")
+                        .field("type", "string")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject())
+                .get();
+        client().prepareIndex("my-index", "my-type1", "1")
+                .setSource(jsonBuilder().startObject().field("some_field", "some text").endObject())
+                .get();
+        refresh();
+
+        GetResponse getResponse = client().prepareGet("my-index", "my-type1", "1").setFields("_all").get();
+        assertNotNull(getResponse.getField("_all").getValue());
+        assertThat(getResponse.getField("_all").getValue().toString(), equalTo("some text" + " "));
+    }
 }


### PR DESCRIPTION
GET only returned null even when stored if requested with GET like this:

`curl -XGET "http://localhost:9200/test/test/1?fields=_all"`

Instead, it should simply behave like a String field and return the concatenated fields as String.
