### PR TITLE
Completion mapping type throws a misleading error on null value

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -286,6 +286,8 @@ public interface FieldMapper<T> extends Mapper {
 
     boolean isSortable();
 
+    boolean supportsNullValue();
+
     boolean hasDocValues();
 
     Loading normsLoading(Loading defaultLoading);

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -842,6 +842,11 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
         return true;
     }
 
+    @Override
+    public boolean supportsNullValue() {
+        return true;
+    }
+
     public boolean hasDocValues() {
         return docValues;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -452,6 +452,11 @@ public class CompletionFieldMapper extends AbstractFieldMapper<String> {
     }
 
     @Override
+    public boolean supportsNullValue() {
+        return false;
+    }
+
+    @Override
     public FieldType defaultFieldType() {
         return Defaults.FIELD_TYPE;
     }

--- a/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -532,6 +532,11 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll {
         // we can only handle null values if we have mappings for them
         Mapper mapper = mappers.get(lastFieldName);
         if (mapper != null) {
+            if (mapper instanceof FieldMapper) {
+                if (!((FieldMapper) mapper).supportsNullValue()) {
+                    throw new MapperParsingException("no object mapping found for null value in [" + lastFieldName + "]");
+                }
+            }
             mapper.parse(context);
         }
     }


### PR DESCRIPTION
When the mapper service gets a null value for a field, it tries to parse it with the mapper of any previously seen field, if that mapper happens to be CompletionMapper, it throws an error, as it only accepts certain fields.

Closes #6399
