### PR TITLE
Collate option in PhraseSuggester should allow returning phrases with no matching docs

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -169,9 +169,14 @@ can contain misspellings (See parameter descriptions below).
     automatically made available as the `{{suggestion}}`  variable, which
     should be used in your query/filter.  You can still specify  your own
     template `params` -- the `suggestion` value will be added to the
-    variables you specify. You can also specify a `preference` to control
+    variables you specify. You can specify a `preference` to control
     on which shards the query is executed (see <<search-request-preference>>).
-    The default value is `_only_local`.
+    The default value is `_only_local`. Additionally, you can specify
+    a `prune` to control if all phrase suggestions will be
+    returned, when set to `true` the suggestions will have an additional
+    option `collate_match`, which will be `true` if matching documents
+    for the phrase was found, `false` otherwise. The default value for
+    `prune` is `false`.
 
 [source,js]
 --------------------------------------------------
@@ -195,6 +200,7 @@ curl -XPOST 'localhost:9200/_search' -d {
            },
            "params": {"field_name" : "title"}, <3>
            "preference": "_primary", <4>
+           "prune": true <5>
          }
        }
      }
@@ -207,6 +213,9 @@ curl -XPOST 'localhost:9200/_search' -d {
 <3> An additional `field_name` variable has been specified in
     `params` and is used by the `match` query.
 <4> The default `preference` has been changed to `_primary`.
+<5> All suggestions will be returned with an extra `collate_match`
+    option indicating whether the generated phrase matched any
+    document.
 
 ==== Smoothing Models
 

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -158,6 +158,12 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                             suggestion.setPreference(parser.text());
                         } else if ("params".equals(fieldName)) {
                             suggestion.setCollateScriptParams(parser.map());
+                        } else if ("prune".equals(fieldName)) {
+                            if (parser.isBooleanValue()) {
+                                suggestion.setCollatePrune(parser.booleanValue());
+                            } else {
+                                throw new ElasticsearchIllegalArgumentException("suggester[phrase][collate] prune must be either 'true' or 'false'");
+                            }
                         } else {
                             throw new ElasticsearchIllegalArgumentException(
                                     "suggester[phrase][collate] doesn't support field [" + fieldName + "]");

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -46,6 +46,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     private String collateFilter;
     private String collatePreference;
     private Map<String, Object> collateParams;
+    private Boolean collatePrune;
 
     public PhraseSuggestionBuilder(String name) {
         super(name, "phrase");
@@ -202,6 +203,14 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         return this;
     }
 
+    /**
+     * Sets whether to prune suggestions after collation
+     */
+    public PhraseSuggestionBuilder collatePrune(boolean collatePrune) {
+        this.collatePrune = collatePrune;
+        return this;
+    }
+
     @Override
     public XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
         if (realWordErrorLikelihood != null) {
@@ -259,6 +268,9 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
             }
             if (collateParams != null) {
                 builder.field("params", collateParams);
+            }
+            if (collatePrune != null) {
+                builder.field("prune", collatePrune.booleanValue());
             }
             builder.endObject();
         }

--- a/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -52,6 +52,7 @@ class PhraseSuggestionContext extends SuggestionContext {
     private WordScorer.WordScorerFactory scorer;
 
     private boolean requireUnigram = true;
+    private boolean prune = false;
 
     public PhraseSuggestionContext(Suggester<? extends PhraseSuggestionContext> suggester) {
         super(suggester);
@@ -219,6 +220,14 @@ class PhraseSuggestionContext extends SuggestionContext {
 
     void setCollateScriptParams(Map<String, Object> collateScriptParams) {
         this.collateScriptParams = collateScriptParams;
+    }
+
+    void setCollatePrune(boolean prune) {
+        this.prune = prune;
+    }
+
+    boolean collatePrune() {
+        return prune;
     }
 
 }

--- a/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
+++ b/src/test/java/org/elasticsearch/search/suggest/SuggestSearchTests.java
@@ -1096,7 +1096,7 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    public void suggestPhrasesInIndex() throws InterruptedException, ExecutionException, IOException {
+    public void testPhraseSuggesterCollate() throws InterruptedException, ExecutionException, IOException {
         CreateIndexRequestBuilder builder = prepareCreate("test").setSettings(settingsBuilder()
                 .put(indexSettings())
                 .put(SETTING_NUMBER_OF_SHARDS, 1) // A single shard will help to keep the tests repeatable.
@@ -1253,6 +1253,13 @@ public class SuggestSearchTests extends ElasticsearchIntegrationTest {
         } catch (ElasticsearchException e) {
             // expected
         }
+
+        // collate request with prune set to true
+        PhraseSuggestionBuilder phraseSuggestWithParamsAndReturn = suggest.collateFilter(null).collateQuery(collateWithParams).collateParams(params).collatePrune(true);
+        searchSuggest = searchSuggest("united states house of representatives elections in washington 2006", phraseSuggestWithParamsAndReturn);
+        assertSuggestionSize(searchSuggest, 0, 10, "title");
+        assertSuggestionPhraseCollateMatchExists(searchSuggest, "title", 2);
+
     }
 
     protected Suggest searchSuggest(SuggestionBuilder<?>... suggestion) {

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -314,6 +314,22 @@ public class ElasticsearchAssertions {
         assertVersionSerializable(searchSuggest);
     }
 
+    public static void assertSuggestionPhraseCollateMatchExists(Suggest searchSuggest, String key, int numberOfPhraseExists) {
+        int counter = 0;
+        assertThat(searchSuggest, notNullValue());
+        String msg = "Suggest result: " + searchSuggest.toString();
+        assertThat(msg, searchSuggest.size(), greaterThanOrEqualTo(1));
+        assertThat(msg, searchSuggest.getSuggestion(key).getName(), equalTo(key));
+
+        for (Suggest.Suggestion.Entry.Option option : searchSuggest.getSuggestion(key).getEntries().get(0).getOptions()) {
+            if (option.collateMatch()) {
+                counter++;
+            }
+        }
+
+        assertThat(counter, equalTo(numberOfPhraseExists));
+    }
+
     public static void assertSuggestion(Suggest searchSuggest, int entry, int ord, String key, String text) {
         assertThat(searchSuggest, notNullValue());
         String msg = "Suggest result: " + searchSuggest.toString();


### PR DESCRIPTION
The new option `return_all_phrases` in PhraseSuggester collate will allow the user to control whether all the generated suggestions would be returned. Setting the option will have an additional field `match_exists` in the suggestion options, indicating if there were matched documents for the phrase. The default value for this is `false`.

Currently the request would look as follows:

``` bash
curl -XPOST 'localhost:9200/_search' -d {
   "suggest" : {
     "text" : "Xor the Got-Jewel",
     "simple_phrase" : {
       "phrase" : {
         "field" :  "bigram",
         "size" :   1,
         "direct_generator" : [ {
           ...
         } ],
         "collate": {
           "query": { 
              ...
           },
           "return_all_phrases": true
         }
       }
     }
   }
 }
```

and the response looks as follows (only when `return_all_phrases` is set to `true`)

``` bash
"suggest" : {
    "simple_phrase" : [ {
      "text" : "Xor the Got-Jewel",
      "offset" : 0,
      "length" : 17,
      "options" : [ {
        "text" : ...,
        "highlighted": ...,
        "score" : ...,
        "match_exists" : true
      }, {
        "text" : ...,
        "highlighted": ...,
        "score" : ..,
        "match_exists": false
      } ]
    } ]
  }
```

Closes #6927
