### PR TITLE
Core: Add extra write consistency validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1218,6 +1218,11 @@
                                 <bundledSignature>jdk-unsafe</bundledSignature>
                                 <bundledSignature>jdk-deprecated</bundledSignature>
                             </bundledSignatures>
+                            <excludes>
+                                <!-- start exclude for test GC simulation using Thread.suspend -->
+                                <exclude>org/elasticsearch/test/disruption/LongGCDisruption.class</exclude>
+                                <!-- end exclude for Channels -->
+                            </excludes>
                             <signaturesFiles>
                                 <signaturesFile>test-signatures.txt</signaturesFile>
                                 <signaturesFile>all-signatures.txt</signaturesFile>

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -140,8 +140,13 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeOpe
                     @Override
                     public void onFailure(String source, Throwable t) {
                         //if the reroute fails we only log
-                        logger.debug("failed to perform [{}]", t, source);
-                        listener.onFailure(new ElasticsearchException("reroute after update settings failed", t));
+                        if (t instanceof ClusterService.NoLongerMasterException) {
+                            logger.debug("failed to preform reroute after cluster settings were updated - current node is no longer a master");
+                            listener.onResponse(new ClusterUpdateSettingsResponse(updateSettingsAcked, transientUpdates.build(), persistentUpdates.build()));
+                        } else {
+                            logger.debug("failed to perform [{}]", t, source);
+                            listener.onFailure(new ElasticsearchException("reroute after update settings failed", t));
+                        }
                     }
 
                     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -173,12 +173,12 @@ public class TransportRecoveryAction extends
 
     @Override
     protected ClusterBlockException checkGlobalBlock(ClusterState state, RecoveryRequest request) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
     }
 
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, RecoveryRequest request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA, concreteIndices);
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, concreteIndices);
     }
 
     static class ShardRecoveryRequest extends BroadcastShardOperationRequest {

--- a/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -299,6 +299,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
             BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId.index().name(), shardId.id(), bulkRequest.refresh(), requests.toArray(new BulkItemRequest[requests.size()]));
             bulkShardRequest.replicationType(bulkRequest.replicationType());
             bulkShardRequest.consistencyLevel(bulkRequest.consistencyLevel());
+            bulkShardRequest.validateWriteConsistency(bulkRequest.validateWriteConsistency());
             bulkShardRequest.timeout(bulkRequest.timeout());
             shardBulkAction.execute(bulkShardRequest, new ActionListener<BulkShardResponse>() {
                 @Override

--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -57,6 +57,7 @@ import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequestOptions;
@@ -82,8 +83,9 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
     @Inject
     public TransportShardBulkAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                    MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
+                                    MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper, ActionFilters actionFilters,
+                                    TransportShardActive transportShardActive) {
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters, transportShardActive);
         this.mappingUpdatedAction = mappingUpdatedAction;
         this.updateHelper = updateHelper;
         this.allowIdGeneration = settings.getAsBoolean("action.allow_id_generation", true);

--- a/src/main/java/org/elasticsearch/action/delete/IndexDeleteRequest.java
+++ b/src/main/java/org/elasticsearch/action/delete/IndexDeleteRequest.java
@@ -33,7 +33,7 @@ class IndexDeleteRequest extends IndexReplicationOperationRequest<IndexDeleteReq
     private final long version;
 
     IndexDeleteRequest(DeleteRequest request, String concreteIndex) {
-        super(concreteIndex, request.timeout(), request.replicationType(), request.consistencyLevel());
+        super(concreteIndex, request.timeout(), request.replicationType(), request.consistencyLevel(), request.validateWriteConsistency());
         this.type = request.type();
         this.id = request.id();
         this.refresh = request.refresh();

--- a/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -58,8 +59,9 @@ public class TransportDeleteAction extends TransportShardReplicationOperationAct
     @Inject
     public TransportDeleteAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                  IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                 TransportCreateIndexAction createIndexAction, TransportIndexDeleteAction indexDeleteAction, ActionFilters actionFilters) {
-        super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
+                                 TransportCreateIndexAction createIndexAction, TransportIndexDeleteAction indexDeleteAction, 
+                                 ActionFilters actionFilters, TransportShardActive transportShardActive) {
+        super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters, transportShardActive);
         this.createIndexAction = createIndexAction;
         this.indexDeleteAction = indexDeleteAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);

--- a/src/main/java/org/elasticsearch/action/delete/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/TransportShardDeleteAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -46,8 +47,8 @@ public class TransportShardDeleteAction extends TransportShardReplicationOperati
     @Inject
     public TransportShardDeleteAction(Settings settings, TransportService transportService,
                                       ClusterService clusterService, IndicesService indicesService, ThreadPool threadPool,
-                                      ShardStateAction shardStateAction, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
+                                      ShardStateAction shardStateAction, ActionFilters actionFilters, TransportShardActive transportShardActive) {
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters, transportShardActive);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/IndexDeleteByQueryRequest.java
@@ -40,7 +40,7 @@ class IndexDeleteByQueryRequest extends IndexReplicationOperationRequest<IndexDe
 
     IndexDeleteByQueryRequest(DeleteByQueryRequest request, String index, @Nullable Set<String> routing, @Nullable String[] filteringAliases,
                               long nowInMillis) {
-        super(index, request.timeout(), request.replicationType(), request.consistencyLevel());
+        super(index, request.timeout(), request.replicationType(), request.consistencyLevel(), request.validateWriteConsistency());
         this.source = request.source();
         this.types = request.types();
         this.routing = routing;

--- a/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/ShardDeleteByQueryRequest.java
@@ -58,6 +58,7 @@ public class ShardDeleteByQueryRequest extends ShardReplicationOperationRequest<
         this.shardId = shardId;
         replicationType(request.replicationType());
         consistencyLevel(request.consistencyLevel());
+        validateWriteConsistency(request.validateWriteConsistency());
         timeout = request.timeout();
         this.routing = request.routing();
         filteringAliases = request.filteringAliases();

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
@@ -64,8 +65,9 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
     public TransportShardDeleteByQueryAction(Settings settings, TransportService transportService,
                                              ClusterService clusterService, IndicesService indicesService, ThreadPool threadPool,
                                              ShardStateAction shardStateAction, ScriptService scriptService, CacheRecycler cacheRecycler,
-                                             PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
+                                             PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, ActionFilters actionFilters,
+                                             TransportShardActive transportShardActive) {
+        super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters, transportShardActive);
         this.scriptService = scriptService;
         this.cacheRecycler = cacheRecycler;
         this.pageCacheRecycler = pageCacheRecycler;

--- a/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -70,8 +71,9 @@ public class TransportIndexAction extends TransportShardReplicationOperationActi
     @Inject
     public TransportIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                 IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction, ActionFilters actionFilters) {
-        super(settings, IndexAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters);
+                                TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction, 
+                                ActionFilters actionFilters, TransportShardActive transportShardActive) {
+        super(settings, IndexAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters, transportShardActive);
         this.createIndexAction = createIndexAction;
         this.mappingUpdatedAction = mappingUpdatedAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);

--- a/src/main/java/org/elasticsearch/action/support/replication/IndexReplicationOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndexReplicationOperationRequest.java
@@ -41,12 +41,14 @@ public abstract class IndexReplicationOperationRequest<T extends IndexReplicatio
     private final String index;
     private final ReplicationType replicationType;
     private final WriteConsistencyLevel consistencyLevel;
+    private final Boolean validateWriteConsistency;
 
-    protected IndexReplicationOperationRequest(String index, TimeValue timeout, ReplicationType replicationType, WriteConsistencyLevel consistencyLevel) {
+    protected IndexReplicationOperationRequest(String index, TimeValue timeout, ReplicationType replicationType, WriteConsistencyLevel consistencyLevel, Boolean validateWriteConsistency) {
         this.index = index;
         this.timeout = timeout;
         this.replicationType = replicationType;
         this.consistencyLevel = consistencyLevel;
+        this.validateWriteConsistency = validateWriteConsistency;
     }
 
     @Override
@@ -78,6 +80,10 @@ public abstract class IndexReplicationOperationRequest<T extends IndexReplicatio
 
     public WriteConsistencyLevel consistencyLevel() {
         return this.consistencyLevel;
+    }
+
+    public Boolean validateWriteConsistency() {
+        return validateWriteConsistency;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.support.replication;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -41,6 +42,7 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
 
     protected ReplicationType replicationType = ReplicationType.DEFAULT;
     protected WriteConsistencyLevel consistencyLevel = WriteConsistencyLevel.DEFAULT;
+    protected Boolean validateWriteConsistency;
 
     public TimeValue timeout() {
         return timeout;
@@ -130,6 +132,16 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
         return (T) this;
     }
 
+    public Boolean validateWriteConsistency() {
+        return validateWriteConsistency;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T validateWriteConsistency(Boolean validateWriteConsistencyLevel) {
+        this.validateWriteConsistency = validateWriteConsistencyLevel;
+        return (T) this;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         return null;
@@ -143,6 +155,9 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
         timeout = TimeValue.readTimeValue(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            validateWriteConsistency = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -153,5 +168,8 @@ public class IndicesReplicationOperationRequest<T extends IndicesReplicationOper
         timeout.writeTo(out);
         out.writeStringArrayNullable(indices);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeOptionalBoolean(validateWriteConsistency);
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/IndicesReplicationOperationRequestBuilder.java
@@ -95,4 +95,13 @@ public abstract class IndicesReplicationOperationRequestBuilder<Request extends 
         request.consistencyLevel(consistencyLevel);
         return (RequestBuilder) this;
     }
+
+    /**
+     * Sets whether the write consistency should be validated
+     */
+    @SuppressWarnings("unchecked")
+    public RequestBuilder setValidateWriteConsistency(boolean validateWriteConsistency) {
+        request.validateWriteConsistency(validateWriteConsistency);
+        return (RequestBuilder) this;
+    }
 }

--- a/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequest.java
@@ -48,6 +48,7 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
     private boolean threadedOperation = true;
     private ReplicationType replicationType = ReplicationType.DEFAULT;
     private WriteConsistencyLevel consistencyLevel = WriteConsistencyLevel.DEFAULT;
+    private Boolean validateWriteConsistency;
     private boolean canHaveDuplicates = false;
 
     protected ShardReplicationOperationRequest() {
@@ -65,6 +66,7 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
         this.threadedOperation = request.operationThreaded();
         this.replicationType = request.replicationType();
         this.consistencyLevel = request.consistencyLevel();
+        this.validateWriteConsistency = request.validateWriteConsistency();
     }
 
     void setCanHaveDuplicates() {
@@ -171,6 +173,16 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
         return (T) this;
     }
 
+    public Boolean validateWriteConsistency() {
+        return validateWriteConsistency;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T validateWriteConsistency(Boolean validateWriteConsistency) {
+        this.validateWriteConsistency = validateWriteConsistency;
+        return (T) this;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -190,6 +202,9 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
         if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
             canHaveDuplicates = in.readBoolean();
         }
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            validateWriteConsistency = in.readOptionalBoolean();
+        }
         // no need to serialize threaded* parameters, since they only matter locally
     }
 
@@ -202,6 +217,9 @@ public abstract class ShardReplicationOperationRequest<T extends ShardReplicatio
         out.writeSharedString(index);
         if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
             out.writeBoolean(canHaveDuplicates);
+        }
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeOptionalBoolean(validateWriteConsistency);
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/ShardReplicationOperationRequestBuilder.java
@@ -94,4 +94,13 @@ public abstract class ShardReplicationOperationRequestBuilder<Request extends Sh
         request.consistencyLevel(consistencyLevel);
         return (RequestBuilder) this;
     }
+
+    /**
+     * Sets whether the write consistency should be validated
+     */
+    @SuppressWarnings("unchecked")
+    public RequestBuilder setValidateWriteConsistency(boolean validateWriteConsistency) {
+        request.validateWriteConsistency(validateWriteConsistency);
+        return (RequestBuilder) this;
+    }
 }

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -135,6 +135,7 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
                 throw blockException;
             }
 
+            logger.trace("resolving shards based on cluster state version [{}]", clusterState.version());
             this.shardIt = shards(clusterState, internalRequest);
         }
 

--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -125,7 +125,9 @@ public class UpdateHelper extends AbstractComponent {
                     .routing(request.routing())
                     .ttl(ttl)
                     .refresh(request.refresh())
-                    .replicationType(request.replicationType()).consistencyLevel(request.consistencyLevel());
+                    .replicationType(request.replicationType())
+                    .consistencyLevel(request.consistencyLevel())
+                    .validateWriteConsistency(request.validateWriteConsistency());
             indexRequest.operationThreaded(false);
             if (request.versionType() != VersionType.INTERNAL) {
                 // in all but the internal versioning mode, we want to create the new document using the given version.
@@ -210,7 +212,9 @@ public class UpdateHelper extends AbstractComponent {
             final IndexRequest indexRequest = Requests.indexRequest(request.index()).type(request.type()).id(request.id()).routing(routing).parent(parent)
                     .source(updatedSourceAsMap, updateSourceContentType)
                     .version(updateVersion).versionType(request.versionType())
-                    .replicationType(request.replicationType()).consistencyLevel(request.consistencyLevel())
+                    .replicationType(request.replicationType())
+                    .consistencyLevel(request.consistencyLevel())
+                    .validateWriteConsistency(request.validateWriteConsistency())
                     .timestamp(timestamp).ttl(ttl)
                     .refresh(request.refresh());
             indexRequest.operationThreaded(false);
@@ -218,7 +222,9 @@ public class UpdateHelper extends AbstractComponent {
         } else if ("delete".equals(operation)) {
             DeleteRequest deleteRequest = Requests.deleteRequest(request.index()).type(request.type()).id(request.id()).routing(routing).parent(parent)
                     .version(updateVersion).versionType(request.versionType())
-                    .replicationType(request.replicationType()).consistencyLevel(request.consistencyLevel());
+                    .replicationType(request.replicationType())
+                    .consistencyLevel(request.consistencyLevel())
+                    .validateWriteConsistency(request.validateWriteConsistency());
             deleteRequest.operationThreaded(false);
             return new Result(deleteRequest, Operation.DELETE, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -73,6 +73,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
 
     private ReplicationType replicationType = ReplicationType.DEFAULT;
     private WriteConsistencyLevel consistencyLevel = WriteConsistencyLevel.DEFAULT;
+    private Boolean validateWriteConsistency;
 
     private IndexRequest upsertRequest;
 
@@ -390,6 +391,15 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         return this;
     }
 
+    public Boolean validateWriteConsistency() {
+        return validateWriteConsistency;
+    }
+
+    public UpdateRequest validateWriteConsistency(Boolean validateWriteConsistency) {
+        this.validateWriteConsistency = validateWriteConsistency;
+        return this;
+    }
+
     /**
      * Sets the doc to use for updates when a script is not specified.
      */
@@ -676,6 +686,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
             detectNoop = in.readBoolean();
             scriptedUpsert = in.readBoolean();
         }
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            validateWriteConsistency = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -728,6 +741,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
             out.writeBoolean(detectNoop);
             out.writeBoolean(scriptedUpsert);
+        }
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeOptionalBoolean(validateWriteConsistency);
         }
     }
 

--- a/src/main/java/org/elasticsearch/cluster/ClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterService.java
@@ -110,4 +110,16 @@ public interface ClusterService extends LifecycleComponent<ClusterService> {
      * Returns the tasks that are pending.
      */
     List<PendingClusterTask> pendingTasks();
+
+    /**
+     * an exception to indicate a {@link org.elasticsearch.cluster.ClusterStateUpdateTask} was not executed as
+     * the current node is no longer master
+     */
+    public static class NoLongerMasterException extends ElasticsearchIllegalStateException {
+
+        public NoLongerMasterException(String msg) {
+            super(msg);
+        }
+
+    }
 }

--- a/src/main/java/org/elasticsearch/cluster/ClusterStateNonMasterUpdateTask.java
+++ b/src/main/java/org/elasticsearch/cluster/ClusterStateNonMasterUpdateTask.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+/**
+ * This is a marker interface to indicate that the task should be executed
+ * even if the current node is not a master.
+ */
+public interface ClusterStateNonMasterUpdateTask extends ClusterStateUpdateTask {
+}

--- a/src/main/java/org/elasticsearch/cluster/ProcessedClusterStateNonMasterUpdateTask.java
+++ b/src/main/java/org/elasticsearch/cluster/ProcessedClusterStateNonMasterUpdateTask.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster;
+
+/**
+ * A combination interface between {@link org.elasticsearch.cluster.ProcessedClusterStateUpdateTask} and
+ * {@link org.elasticsearch.cluster.ClusterStateNonMasterUpdateTask} to allow easy creation of anonymous classes
+ */
+public interface ProcessedClusterStateNonMasterUpdateTask extends ProcessedClusterStateUpdateTask, ClusterStateNonMasterUpdateTask {
+}

--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -108,6 +108,15 @@ public class ClusterBlocks {
         return global.contains(block);
     }
 
+    public boolean hasGlobalBlock(int blockId) {
+        for (ClusterBlock clusterBlock : global) {
+            if (clusterBlock.id() == blockId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Is there a global block with the provided status?
      */

--- a/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -117,6 +117,10 @@ public class ClusterBlocks {
         return false;
     }
 
+    public boolean hasGlobalBlock(ClusterBlockLevel level) {
+        return !global(level).isEmpty();
+    }
+
     /**
      * Is there a global block with the provided status?
      */

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
@@ -141,6 +141,11 @@ public class RoutingService extends AbstractLifecycleComponent<RoutingService> i
             clusterService.submitStateUpdateTask(CLUSTER_UPDATE_TASK_SOURCE, Priority.HIGH, new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
+                    // double check we are still master, this may have changed.
+                    if (!currentState.nodes().localNodeMaster()) {
+                        return currentState;
+                    }
+
                     RoutingAllocation.Result routingResult = allocationService.reroute(currentState);
                     if (!routingResult.changed()) {
                         // no state changed

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
@@ -141,10 +141,6 @@ public class RoutingService extends AbstractLifecycleComponent<RoutingService> i
             clusterService.submitStateUpdateTask(CLUSTER_UPDATE_TASK_SOURCE, Priority.HIGH, new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    // double check we are still master, this may have changed.
-                    if (!currentState.nodes().localNodeMaster()) {
-                        return currentState;
-                    }
 
                     RoutingAllocation.Result routingResult = allocationService.reroute(currentState);
                     if (!routingResult.changed()) {

--- a/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
@@ -152,8 +152,10 @@ public class RoutingService extends AbstractLifecycleComponent<RoutingService> i
 
                 @Override
                 public void onFailure(String source, Throwable t) {
-                    ClusterState state = clusterService.state();
-                    logger.error("unexpected failure during [{}], current state:\n{}", t, source, state.prettyPrint());
+                    if (!(t instanceof ClusterService.NoLongerMasterException)) {
+                        ClusterState state = clusterService.state();
+                        logger.error("unexpected failure during [{}], current state:\n{}", t, source, state.prettyPrint());
+                    }
                 }
             });
             routingTableDirty = false;

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -84,7 +84,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
 
     private volatile ClusterState clusterState;
 
-    private final ClusterBlocks.Builder initialBlocks = ClusterBlocks.builder().addGlobalBlock(Discovery.NO_MASTER_BLOCK);
+    private final ClusterBlocks.Builder initialBlocks;
 
     private volatile ScheduledFuture reconnectToNodes;
 
@@ -104,6 +104,8 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
         this.reconnectInterval = componentSettings.getAsTime("reconnect_interval", TimeValue.timeValueSeconds(10));
 
         localNodeMasterListeners = new LocalNodeMasterListeners(threadPool);
+
+        initialBlocks = ClusterBlocks.builder().addGlobalBlock(discoveryService.getNoMasterBlock());
     }
 
     public NodeSettingsService settingsService() {
@@ -380,7 +382,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                         }
                     }
                 } else {
-                    if (previousClusterState.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK) && !newClusterState.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK)) {
+                    if (previousClusterState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock()) && !newClusterState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock())) {
                         // force an update, its a fresh update from the master as we transition from a start of not having a master to having one
                         // have a fresh instances of routing and metadata to remove the chance that version might be the same
                         Builder builder = ClusterState.builder(newClusterState);

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -136,7 +136,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
         discoveryService.addLifecycleListener(new LifecycleListener() {
             @Override
             public void afterStart() {
-                submitStateUpdateTask("update local node", Priority.IMMEDIATE, new ClusterStateUpdateTask() {
+                submitStateUpdateTask("update local node", Priority.IMMEDIATE, new ClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         return ClusterState.builder(currentState)
@@ -146,7 +146,7 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
 
                     @Override
                     public void onFailure(String source, Throwable t) {
-                        logger.warn("failed ot update local node", t);
+                        logger.warn("failed to update local node", t);
                     }
                 });
             }

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -325,6 +325,11 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
             }
             logger.debug("processing [{}]: execute", source);
             ClusterState previousClusterState = clusterState;
+            if (!previousClusterState.nodes().localNodeMaster() && !(updateTask instanceof ClusterStateNonMasterUpdateTask)) {
+                logger.debug("failing [{}]: local node is no longer master", source);
+                updateTask.onFailure(source, new NoLongerMasterException("source: " + source));
+                return;
+            }
             ClusterState newClusterState;
             try {
                 newClusterState = updateTask.execute(previousClusterState);
@@ -722,5 +727,4 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
             }
         }
     }
-
 }

--- a/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -386,20 +386,6 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                             }
                         }
                     }
-                } else {
-                    if (previousClusterState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock()) && !newClusterState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock())) {
-                        // force an update, its a fresh update from the master as we transition from a start of not having a master to having one
-                        // have a fresh instances of routing and metadata to remove the chance that version might be the same
-                        Builder builder = ClusterState.builder(newClusterState);
-                        builder.routingTable(RoutingTable.builder(newClusterState.routingTable()));
-                        builder.metaData(MetaData.builder(newClusterState.metaData()));
-                        newClusterState = builder.build();
-                        logger.debug("got first state from fresh master [{}]", newClusterState.nodes().masterNodeId());
-                    } else if (newClusterState.version() < previousClusterState.version()) {
-                        // we got a cluster state with older version, when we are *not* the master, let it in since it might be valid
-                        // we check on version where applicable, like at ZenDiscovery#handleNewClusterStateFromMaster
-                        logger.debug("got smaller cluster state when not master [" + newClusterState.version() + "<" + previousClusterState.version() + "] from source [" + source + "]");
-                    }
                 }
 
                 newClusterState.status(ClusterState.ClusterStateStatus.BEING_APPLIED);

--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllo
 import org.elasticsearch.cluster.routing.allocation.decider.*;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.cache.filter.IndicesFilterCache;
@@ -57,6 +58,7 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION);
         clusterDynamicSettings.addDynamicSetting(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION);
         clusterDynamicSettings.addDynamicSetting(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, Validator.INTEGER);
+        clusterDynamicSettings.addDynamicSetting(ZenDiscovery.REJOIN_ON_MASTER_GONE, Validator.BOOLEAN);
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_INCLUDE_GROUP + "*");
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_EXCLUDE_GROUP + "*");
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_REQUIRE_GROUP + "*");

--- a/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
+++ b/src/main/java/org/elasticsearch/cluster/settings/ClusterDynamicSettingsModule.java
@@ -59,6 +59,7 @@ public class ClusterDynamicSettingsModule extends AbstractModule {
         clusterDynamicSettings.addDynamicSetting(DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_REPLICA_ALLOCATION);
         clusterDynamicSettings.addDynamicSetting(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, Validator.INTEGER);
         clusterDynamicSettings.addDynamicSetting(ZenDiscovery.REJOIN_ON_MASTER_GONE, Validator.BOOLEAN);
+        clusterDynamicSettings.addDynamicSetting(DiscoverySettings.NO_MASTER_BLOCK);
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_INCLUDE_GROUP + "*");
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_EXCLUDE_GROUP + "*");
         clusterDynamicSettings.addDynamicSetting(FilterAllocationDecider.CLUSTER_ROUTING_REQUIRE_GROUP + "*");

--- a/src/main/java/org/elasticsearch/discovery/Discovery.java
+++ b/src/main/java/org/elasticsearch/discovery/Discovery.java
@@ -36,8 +36,6 @@ import org.elasticsearch.rest.RestStatus;
  */
 public interface Discovery extends LifecycleComponent<Discovery> {
 
-    final ClusterBlock NO_MASTER_BLOCK = new ClusterBlock(2, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
-
     DiscoveryNode localNode();
 
     void addListener(InitialStateDiscoveryListener listener);

--- a/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
@@ -22,6 +22,7 @@ package org.elasticsearch.discovery;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -60,12 +61,18 @@ public class DiscoveryService extends AbstractLifecycleComponent<DiscoveryServic
     private final TimeValue initialStateTimeout;
     private final Discovery discovery;
     private InitialStateListener initialStateListener;
+    private final DiscoverySettings discoverySettings;
 
     @Inject
-    public DiscoveryService(Settings settings, Discovery discovery) {
+    public DiscoveryService(Settings settings, DiscoverySettings discoverySettings, Discovery discovery) {
         super(settings);
+        this.discoverySettings = discoverySettings;
         this.discovery = discovery;
         this.initialStateTimeout = componentSettings.getAsTime("initial_state_timeout", TimeValue.timeValueSeconds(30));
+    }
+
+    public ClusterBlock getNoMasterBlock() {
+        return discoverySettings.getNoMasterBlock();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -19,11 +19,14 @@
 
 package org.elasticsearch.discovery;
 
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.node.settings.NodeSettingsService;
+import org.elasticsearch.rest.RestStatus;
 
 /**
  * Exposes common discovery settings that may be supported by all the different discovery implementations
@@ -31,15 +34,18 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 public class DiscoverySettings extends AbstractComponent {
 
     public static final String PUBLISH_TIMEOUT = "discovery.zen.publish_timeout";
-
     public static final TimeValue DEFAULT_PUBLISH_TIMEOUT = TimeValue.timeValueSeconds(30);
-
     private volatile TimeValue publishTimeout = DEFAULT_PUBLISH_TIMEOUT;
+
+    public final static int NO_MASTER_BLOCK_ID = 2;
+
+    private final ClusterBlock noMasterBlock;
 
     @Inject
     public DiscoverySettings(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
         nodeSettingsService.addListener(new ApplySettings());
+        this.noMasterBlock = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
     }
 
     /**
@@ -47,6 +53,10 @@ public class DiscoverySettings extends AbstractComponent {
      */
     public TimeValue getPublishTimeout() {
         return publishTimeout;
+    }
+
+    public ClusterBlock getNoMasterBlock() {
+        return noMasterBlock;
     }
 
     private class ApplySettings implements NodeSettingsService.Listener {

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -43,8 +43,8 @@ public class DiscoverySettings extends AbstractComponent {
     public static final String DEFAULT_NO_MASTER_BLOCK = "write";
     public final static int NO_MASTER_BLOCK_ID = 2;
 
-    private final static ClusterBlock ALL = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
-    private final static ClusterBlock WRITE = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA));
+    public final static ClusterBlock NO_MASTER_BLOCK_ALL = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
+    public final static ClusterBlock NO_MASTER_BLOCK_WRITES = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA));
 
     private volatile ClusterBlock noMasterBlock;
     private volatile TimeValue publishTimeout = DEFAULT_PUBLISH_TIMEOUT;
@@ -90,9 +90,9 @@ public class DiscoverySettings extends AbstractComponent {
 
     private ClusterBlock parseNoMasterBlock(String value) {
         if ("all".equals(value)) {
-            return ALL;
+            return NO_MASTER_BLOCK_ALL;
         } else if ("write".equals(value)) {
-            return WRITE;
+            return NO_MASTER_BLOCK_WRITES;
         } else {
             throw new ElasticsearchIllegalArgumentException("invalid master block [" + value + "]");
         }

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -45,7 +45,6 @@ public class DiscoverySettings extends AbstractComponent {
 
     private final static ClusterBlock ALL = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
     private final static ClusterBlock WRITE = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA));
-    private final static ClusterBlock METADATA = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.METADATA));
 
     private volatile ClusterBlock noMasterBlock;
     private volatile TimeValue publishTimeout = DEFAULT_PUBLISH_TIMEOUT;
@@ -93,8 +92,6 @@ public class DiscoverySettings extends AbstractComponent {
             return ALL;
         } else if ("write".equals(value)) {
             return WRITE;
-        } else if ("metadata".equals(value)) {
-            return METADATA;
         } else {
             throw new ElasticsearchIllegalArgumentException("invalid master block [" + value + "]");
         }

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -29,6 +29,8 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.rest.RestStatus;
 
+import java.util.EnumSet;
+
 /**
  * Exposes common discovery settings that may be supported by all the different discovery implementations
  */
@@ -42,8 +44,8 @@ public class DiscoverySettings extends AbstractComponent {
     public final static int NO_MASTER_BLOCK_ID = 2;
 
     private final static ClusterBlock ALL = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL);
-    private final static ClusterBlock WRITE = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA);
-    private final static ClusterBlock METADATA = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.METADATA);
+    private final static ClusterBlock WRITE = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA));
+    private final static ClusterBlock METADATA = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.METADATA));
 
     private volatile ClusterBlock noMasterBlock;
     private volatile TimeValue publishTimeout = DEFAULT_PUBLISH_TIMEOUT;

--- a/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -54,6 +54,7 @@ public class DiscoverySettings extends AbstractComponent {
         super(settings);
         nodeSettingsService.addListener(new ApplySettings());
         this.noMasterBlock = parseNoMasterBlock(settings.get(NO_MASTER_BLOCK, DEFAULT_NO_MASTER_BLOCK));
+        this.publishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, publishTimeout);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
@@ -132,7 +132,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                         }
                         nodesBuilder.localNodeId(master.localNode().id()).masterNodeId(master.localNode().id());
                         // remove the NO_MASTER block in this case
-                        ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(Discovery.NO_MASTER_BLOCK);
+                        ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(discoverySettings.getNoMasterBlock());
                         return ClusterState.builder(currentState).nodes(nodesBuilder).blocks(blocks).build();
                     }
 

--- a/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
@@ -123,7 +123,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                 // we are the first master (and the master)
                 master = true;
                 final LocalDiscovery master = firstMaster;
-                clusterService.submitStateUpdateTask("local-disco-initial_connect(master)", new ProcessedClusterStateUpdateTask() {
+                clusterService.submitStateUpdateTask("local-disco-initial_connect(master)", new ProcessedClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
@@ -149,7 +149,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
             } else if (firstMaster != null) {
                 // update as fast as we can the local node state with the new metadata (so we create indices for example)
                 final ClusterState masterState = firstMaster.clusterService.state();
-                clusterService.submitStateUpdateTask("local-disco(detected_master)", new ClusterStateUpdateTask() {
+                clusterService.submitStateUpdateTask("local-disco(detected_master)", new ClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         // make sure we have the local node id set, we might need it as a result of the new metadata
@@ -165,7 +165,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
 
                 // tell the master to send the fact that we are here
                 final LocalDiscovery master = firstMaster;
-                firstMaster.clusterService.submitStateUpdateTask("local-disco-receive(from node[" + localNode + "])", new ProcessedClusterStateUpdateTask() {
+                firstMaster.clusterService.submitStateUpdateTask("local-disco-receive(from node[" + localNode + "])", new ProcessedClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
@@ -225,7 +225,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                 }
 
                 final LocalDiscovery master = firstMaster;
-                master.clusterService.submitStateUpdateTask("local-disco-update", new ClusterStateUpdateTask() {
+                master.clusterService.submitStateUpdateTask("local-disco-update", new ClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         DiscoveryNodes newNodes = currentState.nodes().removeDeadMembers(newMembers, master.localNode.id());
@@ -305,7 +305,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                 nodeSpecificClusterState.status(ClusterState.ClusterStateStatus.RECEIVED);
                 // ignore cluster state messages that do not include "me", not in the game yet...
                 if (nodeSpecificClusterState.nodes().localNode() != null) {
-                    discovery.clusterService.submitStateUpdateTask("local-disco-receive(from master)", new ProcessedClusterStateUpdateTask() {
+                    discovery.clusterService.submitStateUpdateTask("local-disco-receive(from master)", new ProcessedClusterStateNonMasterUpdateTask() {
                         @Override
                         public ClusterState execute(ClusterState currentState) {
                             if (nodeSpecificClusterState.version() < currentState.version() && Objects.equal(nodeSpecificClusterState.nodes().masterNodeId(), currentState.nodes().masterNodeId())) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -364,6 +364,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     continue;
                 }
 
+                if (latestDiscoNodes.masterNode() == null) {
+                    logger.debug("no master node is set, despite of join request completing. retrying pings");
+                    retry = true;
+                    continue;
+                }
+
                 masterFD.start(masterNode, "initial_join");
                 // no need to submit the received cluster state, we will get it from the master when it publishes
                 // the fact that we joined

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -86,7 +86,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     private final ClusterService clusterService;
     private AllocationService allocationService;
     private final ClusterName clusterName;
-    private final DiscoveryService discoveryService;
     private final DiscoveryNodeService discoveryNodeService;
     private final DiscoverySettings discoverySettings;
     private final ZenPingService pingService;
@@ -130,14 +129,13 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     @Inject
     public ZenDiscovery(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                         TransportService transportService, ClusterService clusterService, NodeSettingsService nodeSettingsService,
-                        DiscoveryNodeService discoveryNodeService, ZenPingService pingService, Version version, DiscoverySettings discoverySettings,
-                        DiscoveryService discoveryService) {
+                        DiscoveryNodeService discoveryNodeService, ZenPingService pingService, Version version,
+                        DiscoverySettings discoverySettings) {
         super(settings);
         this.clusterName = clusterName;
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.transportService = transportService;
-        this.discoveryService = discoveryService;
         this.discoveryNodeService = discoveryNodeService;
         this.discoverySettings = discoverySettings;
         this.pingService = pingService;
@@ -649,7 +647,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
 
                 assert newClusterState.nodes().masterNode() != null : "received a cluster state without a master";
-                assert !newClusterState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock()) : "received a cluster state with a master block";
+                assert !newClusterState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock()) : "received a cluster state with a master block";
 
                 clusterService.submitStateUpdateTask("zen-disco-receive(from master [" + newClusterState.nodes().masterNode() + "])", Priority.URGENT, new ProcessedClusterStateNonMasterUpdateTask() {
                     @Override
@@ -716,7 +714,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                             masterFD.restart(latestDiscoNodes.masterNode(), "new cluster state received and we are monitoring the wrong master [" + masterFD.masterNode() + "]");
                         }
 
-                        if (currentState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock())) {
+                        if (currentState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock())) {
                             // its a fresh update from the master as we transition from a start of not having a master to having one
                             logger.debug("got first state from fresh master [{}]", updatedState.nodes().masterNodeId());
                             return updatedState;

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -61,6 +61,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -524,6 +525,11 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                         .masterNodeId(null).build();
                 latestDiscoNodes = discoveryNodes;
 
+                // flush any pending cluster states from old master, so it will not be set as master again
+                ArrayList<ProcessClusterState> pendingNewClusterStates = new ArrayList<>();
+                processNewClusterStates.drainTo(pendingNewClusterStates);
+                logger.trace("removed [{}] pending cluster states", pendingNewClusterStates.size());
+
                 if (rejoinOnMasterGone) {
                     return rejoin(ClusterState.builder(currentState).nodes(discoveryNodes).build(), "master left (reason = " + reason + ")");
                 }
@@ -680,6 +686,11 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
                             // we are going to use it for sure, poll (remove) it
                             potentialState = processNewClusterStates.poll();
+                            if (potentialState == null) {
+                                // might happen if the queue is drained
+                                break;
+                            }
+
                             potentialState.processed = true;
 
                             if (potentialState.clusterState.version() > stateToProcess.clusterState.version()) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -166,10 +166,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         this.electMaster = new ElectMasterService(settings);
         nodeSettingsService.addListener(new ApplySettings());
 
-        this.masterFD = new MasterFaultDetection(settings, threadPool, transportService, this);
+        this.masterFD = new MasterFaultDetection(settings, threadPool, transportService, this, clusterName);
         this.masterFD.addListener(new MasterNodeFailureListener());
 
-        this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService);
+        this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService, clusterName);
         this.nodesFD.addListener(new NodeFailureListener());
 
         this.publishClusterState = new PublishClusterStateAction(settings, transportService, this, new NewClusterStateListener(), discoverySettings);

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -317,7 +317,9 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 clusterService.submitStateUpdateTask("zen-disco-join (elected_as_master)", Priority.URGENT, new ProcessedClusterStateUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
-                        DiscoveryNodes.Builder builder = new DiscoveryNodes.Builder()
+                        // Take into account the previous known nodes, if they happen not to be available
+                        // then fault detection will remove these nodes.
+                        DiscoveryNodes.Builder builder = new DiscoveryNodes.Builder(latestDiscoNodes)
                                 .localNodeId(localNode.id())
                                 .masterNodeId(localNode.id())
                                         // put our local node

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -869,7 +869,9 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         }
 
         Set<DiscoveryNode> possibleMasterNodes = Sets.newHashSet();
-        possibleMasterNodes.add(localNode);
+        if (localNode.masterNode()) {
+            possibleMasterNodes.add(localNode);
+        }
         for (ZenPing.PingResponse pingResponse : pingResponses) {
             possibleMasterNodes.add(pingResponse.target());
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -76,6 +76,8 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  */
 public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implements Discovery, DiscoveryNodesProvider {
 
+    private final static String REJOIN_ON_MASTER_GONE = "discovery.zen.rejoin_on_master_gone";
+
     public static final String DISCOVERY_REJOIN_ACTION_NAME = "internal:discovery/zen/rejoin";
 
     private final ThreadPool threadPool;
@@ -117,7 +119,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
     private final AtomicBoolean initialStateSent = new AtomicBoolean();
 
-    private final boolean rejoinOnMasterGone;
+    private volatile boolean rejoinOnMasterGone;
 
 
     @Nullable
@@ -144,7 +146,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
         this.masterElectionFilterClientNodes = settings.getAsBoolean("discovery.zen.master_election.filter_client", true);
         this.masterElectionFilterDataNodes = settings.getAsBoolean("discovery.zen.master_election.filter_data", false);
-        this.rejoinOnMasterGone = settings.getAsBoolean("discovery.zen.rejoin_on_master_gone", true);
+        this.rejoinOnMasterGone = settings.getAsBoolean(REJOIN_ON_MASTER_GONE, true);
 
         logger.debug("using ping.timeout [{}], join.timeout [{}], master_election.filter_client [{}], master_election.filter_data [{}]", pingTimeout, joinTimeout, masterElectionFilterClientNodes, masterElectionFilterDataNodes);
 
@@ -1014,6 +1016,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 logger.info("updating {} from [{}] to [{}]", ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES,
                         ZenDiscovery.this.electMaster.minimumMasterNodes(), minimumMasterNodes);
                 handleMinimumMasterNodesChanged(minimumMasterNodes);
+            }
+
+            boolean rejoinOnMasterGone = settings.getAsBoolean(REJOIN_ON_MASTER_GONE, ZenDiscovery.this.rejoinOnMasterGone);
+            if (rejoinOnMasterGone != ZenDiscovery.this.rejoinOnMasterGone) {
+                logger.info("updating {} from [{}] to [{}]", REJOIN_ON_MASTER_GONE, ZenDiscovery.this.rejoinOnMasterGone, rejoinOnMasterGone);
+                ZenDiscovery.this.rejoinOnMasterGone = rejoinOnMasterGone;
             }
         }
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.inject.Inject;
@@ -129,9 +130,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
     private volatile boolean rejoinOnMasterGone;
 
-
     @Nullable
     private NodeService nodeService;
+
+    private final BlockingQueue<Tuple<DiscoveryNode, MembershipAction.JoinCallback>> processJoinRequests = ConcurrentCollections.newBlockingQueue();
 
     @Inject
     public ZenDiscovery(Settings settings, ClusterName clusterName, ThreadPool threadPool,
@@ -822,26 +824,42 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             // validate the join request, will throw a failure if it fails, which will get back to the
             // node calling the join request
             membership.sendValidateJoinRequestBlocking(node, joinTimeout);
-
+            processJoinRequests.add(new Tuple<>(node, callback));
             clusterService.submitStateUpdateTask("zen-disco-receive(join from node[" + node + "])", Priority.IMMEDIATE, new ProcessedClusterStateUpdateTask() {
+
+                private final List<Tuple<DiscoveryNode, MembershipAction.JoinCallback>> drainedTasks = new ArrayList<>();
+
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    if (currentState.nodes().nodeExists(node.id())) {
-                        // the node already exists in the cluster
-                        logger.info("received a join request for an existing node [{}]", node);
-                        // still send a new cluster state, so it will be re published and possibly update the other node
-                        return ClusterState.builder(currentState).build();
+                    processJoinRequests.drainTo(drainedTasks);
+                    if (drainedTasks.isEmpty()) {
+                        return currentState;
                     }
-                    DiscoveryNodes.Builder builder = DiscoveryNodes.builder(currentState.nodes());
-                    for (DiscoveryNode existingNode : currentState.nodes()) {
-                        if (node.address().equals(existingNode.address())) {
-                            builder.remove(existingNode.id());
-                            logger.warn("received join request from node [{}], but found existing node {} with same address, removing existing node", node, existingNode);
+
+                    boolean modified = false;
+                    DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentState.nodes());
+                    for (Tuple<DiscoveryNode, MembershipAction.JoinCallback> task : drainedTasks) {
+                        DiscoveryNode node = task.v1();
+                        if (currentState.nodes().nodeExists(node.id())) {
+                            logger.debug("received a join request for an existing node [{}]", node);
+                        } else {
+                            modified = true;
+                            nodesBuilder.put(node);
+                            for (DiscoveryNode existingNode : currentState.nodes()) {
+                                if (node.address().equals(existingNode.address())) {
+                                    nodesBuilder.remove(existingNode.id());
+                                    logger.warn("received join request from node [{}], but found existing node {} with same address, removing existing node", node, existingNode);
+                                }
+                            }
                         }
                     }
-                    latestDiscoNodes = builder.build();
-                    // add the new node now (will update latestDiscoNodes on publish)
-                    return ClusterState.builder(currentState).nodes(latestDiscoNodes.newNode(node)).build();
+
+                    ClusterState.Builder stateBuilder = ClusterState.builder(currentState);
+                    if (modified) {
+                        latestDiscoNodes = nodesBuilder.build();
+                        stateBuilder.nodes(latestDiscoNodes);
+                    }
+                    return stateBuilder.build();
                 }
 
                 @Override
@@ -851,12 +869,16 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     } else {
                         logger.error("unexpected failure during [{}]", t, source);
                     }
-                    callback.onFailure(t);
+                    for (Tuple<DiscoveryNode, MembershipAction.JoinCallback> drainedTask : drainedTasks) {
+                        drainedTask.v2().onFailure(t);
+                    }
                 }
 
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    callback.onSuccess();
+                    for (Tuple<DiscoveryNode, MembershipAction.JoinCallback> drainedTask : drainedTasks) {
+                        drainedTask.v2().onSuccess();
+                    }
                 }
             });
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -846,24 +846,16 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
         ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(clusterState.blocks())
                 .addGlobalBlock(NO_MASTER_BLOCK)
-                .addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)
                 .build();
 
-        // clear the routing table, we have no master, so we need to recreate the routing when we reform the cluster
-        RoutingTable routingTable = RoutingTable.builder().build();
-        // we also clean the metadata, since we are going to recover it if we become master
-        MetaData metaData = MetaData.builder().build();
-
         // clean the nodes, we are now not connected to anybody, since we try and reform the cluster
-        latestDiscoNodes = new DiscoveryNodes.Builder().put(localNode).localNodeId(localNode.id()).build();
+        latestDiscoNodes = new DiscoveryNodes.Builder(latestDiscoNodes).masterNodeId(null).build();
 
         asyncJoinCluster();
 
         return ClusterState.builder(clusterState)
                 .blocks(clusterBlocks)
                 .nodes(latestDiscoNodes)
-                .routingTable(routingTable)
-                .metaData(metaData)
                 .build();
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -119,6 +119,8 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
     private final AtomicBoolean initialStateSent = new AtomicBoolean();
 
+    private final boolean rejoinOnMasterGone;
+
 
     @Nullable
     private NodeService nodeService;
@@ -144,6 +146,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
         this.masterElectionFilterClientNodes = settings.getAsBoolean("discovery.zen.master_election.filter_client", true);
         this.masterElectionFilterDataNodes = settings.getAsBoolean("discovery.zen.master_election.filter_data", false);
+        this.rejoinOnMasterGone = settings.getAsBoolean("discovery.zen.rejoin_on_master_gone", false);
 
         logger.debug("using ping.timeout [{}], join.timeout [{}], master_election.filter_client [{}], master_election.filter_data [{}]", pingTimeout, joinTimeout, masterElectionFilterClientNodes, masterElectionFilterDataNodes);
 
@@ -495,6 +498,11 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                         // make sure the old master node, which has failed, is not part of the nodes we publish
                         .remove(masterNode.id())
                         .masterNodeId(null).build();
+                latestDiscoNodes = discoveryNodes;
+
+                if (rejoinOnMasterGone) {
+                    return rejoin(ClusterState.builder(currentState).nodes(discoveryNodes).build(), "master left (reason = " + reason + ")");
+                }
 
                 if (!electMaster.hasEnoughMasterNodes(discoveryNodes)) {
                     return rejoin(ClusterState.builder(currentState).nodes(discoveryNodes).build(), "not enough master nodes after master left (reason = " + reason + ")");

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -85,6 +85,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     private final ClusterService clusterService;
     private AllocationService allocationService;
     private final ClusterName clusterName;
+    private final DiscoveryService discoveryService;
     private final DiscoveryNodeService discoveryNodeService;
     private final DiscoverySettings discoverySettings;
     private final ZenPingService pingService;
@@ -128,12 +129,14 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     @Inject
     public ZenDiscovery(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                         TransportService transportService, ClusterService clusterService, NodeSettingsService nodeSettingsService,
-                        DiscoveryNodeService discoveryNodeService, ZenPingService pingService, Version version, DiscoverySettings discoverySettings) {
+                        DiscoveryNodeService discoveryNodeService, ZenPingService pingService, Version version, DiscoverySettings discoverySettings,
+                        DiscoveryService discoveryService) {
         super(settings);
         this.clusterName = clusterName;
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.transportService = transportService;
+        this.discoveryService = discoveryService;
         this.discoveryNodeService = discoveryNodeService;
         this.discoverySettings = discoverySettings;
         this.pingService = pingService;
@@ -641,6 +644,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 final ProcessClusterState processClusterState = new ProcessClusterState(newClusterState, newStateProcessed);
                 processNewClusterStates.add(processClusterState);
 
+
+                assert newClusterState.nodes().masterNode() != null : "received a cluster state without a master";
+                assert !newClusterState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock()) : "received a cluster state with a master block";
+
                 clusterService.submitStateUpdateTask("zen-disco-receive(from master [" + newClusterState.nodes().masterNode() + "])", Priority.URGENT, new ProcessedClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
@@ -701,7 +708,16 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                             masterFD.restart(latestDiscoNodes.masterNode(), "new cluster state received and we are monitoring the wrong master [" + masterFD.masterNode() + "]");
                         }
 
+                        if (currentState.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock())) {
+                            // its a fresh update from the master as we transition from a start of not having a master to having one
+                            logger.debug("got first state from fresh master [{}]", updatedState.nodes().masterNodeId());
+                            return updatedState;
+                        }
+
+
+                        // some optimizations to make sure we keep old objects where possible
                         ClusterState.Builder builder = ClusterState.builder(updatedState);
+
                         // if the routing table did not change, use the original one
                         if (updatedState.routingTable().version() == currentState.routingTable().version()) {
                             builder.routingTable(currentState.routingTable());

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -388,6 +388,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             try {
                 logger.trace("joining master {}", masterNode);
                 membership.sendJoinRequestBlocking(masterNode, localNode, joinTimeout);
+                return true;
             } catch (ElasticsearchIllegalStateException e) {
                 if (joinAttempt >= this.joinRetryAttempts) {
                     logger.info("failed to send join request to master [{}], reason [{}]. Tried [{}] times",

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -342,7 +342,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
                     @Override
                     public void onFailure(String source, Throwable t) {
-                            logger.error("unexpected failure during [{}]", t, source);
+                        logger.error("unexpected failure during [{}]", t, source);
                     }
 
                     @Override
@@ -408,8 +408,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 public void onFailure(String source, Throwable t) {
                     if (t instanceof ClusterService.NoLongerMasterException) {
                         logger.debug("not processing {} leave request as we are no longer master", node);
-                    }
-                    else {
+                    } else {
                         logger.error("unexpected failure during [{}]", t, source);
                     }
                 }
@@ -448,8 +447,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             public void onFailure(String source, Throwable t) {
                 if (t instanceof ClusterService.NoLongerMasterException) {
                     logger.debug("not processing [{}] as we are no longer master", source);
-                }
-                else {
+                } else {
                     logger.error("unexpected failure during [{}]", t, source);
                 }
             }
@@ -486,8 +484,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             public void onFailure(String source, Throwable t) {
                 if (t instanceof ClusterService.NoLongerMasterException) {
                     logger.debug("not processing [{}] as we are no longer master", source);
-                }
-                else {
+                } else {
                     logger.error("unexpected failure during [{}]", t, source);
                 }
             }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -99,6 +99,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     private final TimeValue pingTimeout;
     private final TimeValue joinTimeout;
 
+    /** how many retry attempts to perform if join request failed with an retriable error */
+    private final int joinRetryAttempts;
+    /** how long to wait before performing another join attempt after a join request failed with an retriable error */
+    private final TimeValue joinRetryDelay;
+
+
     // a flag that should be used only for testing
     private final boolean sendLeaveRequest;
 
@@ -144,6 +150,8 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         // also support direct discovery.zen settings, for cases when it gets extended
         this.pingTimeout = settings.getAsTime("discovery.zen.ping.timeout", settings.getAsTime("discovery.zen.ping_timeout", componentSettings.getAsTime("ping_timeout", componentSettings.getAsTime("initial_ping_timeout", timeValueSeconds(3)))));
         this.joinTimeout = settings.getAsTime("discovery.zen.join_timeout", TimeValue.timeValueMillis(pingTimeout.millis() * 20));
+        this.joinRetryAttempts = settings.getAsInt("discovery.zen.join_retry_attempts", 3);
+        this.joinRetryDelay = settings.getAsTime("discovery.zen.join_retry_delay", TimeValue.timeValueMillis(100));
         this.sendLeaveRequest = componentSettings.getAsBoolean("send_leave_request", true);
 
         this.masterElectionFilterClientNodes = settings.getAsBoolean("discovery.zen.master_election.filter_client", true);
@@ -350,35 +358,62 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 });
             } else {
                 this.master = false;
-                try {
-                    // first, make sure we can connect to the master
-                    transportService.connectToNode(masterNode);
-                } catch (Exception e) {
-                    logger.warn("failed to connect to master [{}], retrying...", e, masterNode);
-                    retry = true;
-                    continue;
-                }
                 // send join request
-                try {
-                    membership.sendJoinRequestBlocking(masterNode, localNode, joinTimeout);
-                } catch (Exception e) {
-                    if (e instanceof ElasticsearchException) {
-                        logger.info("failed to send join request to master [{}], reason [{}]", masterNode, ((ElasticsearchException) e).getDetailedMessage());
-                    } else {
-                        logger.info("failed to send join request to master [{}], reason [{}]", masterNode, e.getMessage());
-                    }
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("detailed failed reason", e);
-                    }
-                    // failed to send the join request, retry
-                    retry = true;
+                retry = !joinElectedMaster(masterNode);
+                if (retry) {
                     continue;
                 }
+
                 masterFD.start(masterNode, "initial_join");
                 // no need to submit the received cluster state, we will get it from the master when it publishes
                 // the fact that we joined
             }
         }
+    }
+
+    /**
+     * Join a newly elected master.
+     *
+     * @return true if successful
+     */
+    private boolean joinElectedMaster(DiscoveryNode masterNode) {
+        try {
+            // first, make sure we can connect to the master
+            transportService.connectToNode(masterNode);
+        } catch (Exception e) {
+            logger.warn("failed to connect to master [{}], retrying...", e, masterNode);
+            return false;
+        }
+        for (int joinAttempt = 0; joinAttempt < this.joinRetryAttempts; joinAttempt++) {
+            try {
+                logger.trace("joining master {}", masterNode);
+                membership.sendJoinRequestBlocking(masterNode, localNode, joinTimeout);
+            } catch (ElasticsearchIllegalStateException e) {
+                if (joinAttempt >= this.joinRetryAttempts) {
+                    logger.info("failed to send join request to master [{}], reason [{}]. Tried [{}] times",
+                            masterNode, e.getDetailedMessage(), joinAttempt + 1);
+                    return false;
+                } else {
+                    logger.trace("master {} failed with [{}]. retrying... (attempts done: [{}])", masterNode, e.getDetailedMessage(), joinAttempt + 1);
+                }
+            } catch (Exception e) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("failed to send join request to master [{}]", e);
+                } else if (e instanceof ElasticsearchException) {
+                    logger.info("failed to send join request to master [{}], reason [{}]", masterNode, ((ElasticsearchException) e).getDetailedMessage());
+                } else {
+                    logger.info("failed to send join request to master [{}], reason [{}]", masterNode, e.getMessage());
+                }
+                return false;
+            }
+
+            try {
+                Thread.sleep(this.joinRetryDelay.millis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return false;
     }
 
     private void handleLeaveRequest(final DiscoveryNode node) {
@@ -887,17 +922,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 return null;
             }
             // lets tie break between discovered nodes
-            DiscoveryNode electedMaster = electMaster.electMaster(possibleMasterNodes);
-            if (localNode.equals(electedMaster)) {
-                return localNode;
-            }
+            return electMaster.electMaster(possibleMasterNodes);
         } else {
-            DiscoveryNode electedMaster = electMaster.electMaster(pingMasters);
-            if (electedMaster != null) {
-                return electedMaster;
-            }
+            return electMaster.electMaster(pingMasters);
         }
-        return null;
     }
 
     private ClusterState rejoin(ClusterState clusterState, String reason) {
@@ -1028,8 +1056,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 public void onFailure(String source, Throwable t) {
                     if (t instanceof ClusterService.NoLongerMasterException) {
                         logger.debug("not processing [{}] as we are no longer master", source);
-                    }
-                    else {
+                    } else {
                         logger.error("unexpected failure during [{}]", t, source);
                     }
                 }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -864,7 +864,11 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         List<DiscoveryNode> pingMasters = newArrayList();
         for (ZenPing.PingResponse pingResponse : pingResponses) {
             if (pingResponse.master() != null) {
-                pingMasters.add(pingResponse.master());
+                // We can't include the local node in pingMasters list, otherwise we may up electing ourselves without
+                // any check / verifications from other nodes in ZenDiscover#innerJoinCluster()
+                if (!localNode.equals(pingResponse.master())) {
+                    pingMasters.add(pingResponse.master());
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Priority;
@@ -56,7 +55,6 @@ import org.elasticsearch.discovery.zen.membership.MembershipAction;
 import org.elasticsearch.discovery.zen.ping.ZenPing;
 import org.elasticsearch.discovery.zen.ping.ZenPingService;
 import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
-import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -146,7 +144,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
         this.masterElectionFilterClientNodes = settings.getAsBoolean("discovery.zen.master_election.filter_client", true);
         this.masterElectionFilterDataNodes = settings.getAsBoolean("discovery.zen.master_election.filter_data", false);
-        this.rejoinOnMasterGone = settings.getAsBoolean("discovery.zen.rejoin_on_master_gone", false);
+        this.rejoinOnMasterGone = settings.getAsBoolean("discovery.zen.rejoin_on_master_gone", true);
 
         logger.debug("using ping.timeout [{}], join.timeout [{}], master_election.filter_client [{}], master_election.filter_data [{}]", pingTimeout, joinTimeout, masterElectionFilterClientNodes, masterElectionFilterDataNodes);
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -32,9 +32,6 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.MutableShardRouting;
-import org.elasticsearch.cluster.routing.RoutingNode;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Priority;
@@ -64,7 +61,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -331,17 +327,11 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                         // update the fact that we are the master...
                         latestDiscoNodes = builder.build();
                         ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
+                        currentState = ClusterState.builder(currentState).nodes(latestDiscoNodes).blocks(clusterBlocks).build();
 
-                        List<ShardRouting> failedShardRoutings = new ArrayList<>();
-                        for (RoutingNode routingNode : currentState.getRoutingNodes()) {
-                            if (!latestDiscoNodes.nodeExists(routingNode.nodeId())) {
-                                for (MutableShardRouting shardRouting : routingNode) {
-                                    failedShardRoutings.add(shardRouting);
-                                }
-                            }
-                        }
-                        RoutingAllocation.Result result = allocationService.applyFailedShards(currentState, failedShardRoutings);
-                        return ClusterState.builder(currentState).routingResult(result).nodes(latestDiscoNodes).blocks(clusterBlocks).build();
+                        // eagerly run reroute to remove dead nodes from routing table
+                        RoutingAllocation.Result result = allocationService.reroute(currentState);
+                        return ClusterState.builder(currentState).routingResult(result).build();
                     }
 
                     @Override

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -390,28 +391,29 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             logger.warn("failed to connect to master [{}], retrying...", e, masterNode);
             return false;
         }
-        for (int joinAttempt = 0; joinAttempt < this.joinRetryAttempts; joinAttempt++) {
+        int joinAttempt = 0; // we retry on illegal state if the master is not yet ready
+        while (true) {
             try {
                 logger.trace("joining master {}", masterNode);
                 membership.sendJoinRequestBlocking(masterNode, localNode, joinTimeout);
                 return true;
-            } catch (ElasticsearchIllegalStateException e) {
-                if (joinAttempt >= this.joinRetryAttempts) {
-                    logger.info("failed to send join request to master [{}], reason [{}]. Tried [{}] times",
-                            masterNode, e.getDetailedMessage(), joinAttempt + 1);
+            } catch (Throwable t) {
+                Throwable unwrap = ExceptionsHelper.unwrapCause(t);
+                if (unwrap instanceof ElasticsearchIllegalStateException) {
+                    if (++joinAttempt == this.joinRetryAttempts) {
+                        logger.info("failed to send join request to master [{}], reason [{}], tried [{}] times", masterNode, ExceptionsHelper.detailedMessage(t), joinAttempt);
+                        return false;
+                    } else {
+                        logger.trace("master {} failed with [{}]. retrying... (attempts done: [{}])", masterNode, ExceptionsHelper.detailedMessage(t), joinAttempt);
+                    }
+                } else {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("failed to send join request to master [{}]", t);
+                    } else {
+                        logger.info("failed to send join request to master [{}], reason [{}]", masterNode, ExceptionsHelper.detailedMessage(t));
+                    }
                     return false;
-                } else {
-                    logger.trace("master {} failed with [{}]. retrying... (attempts done: [{}])", masterNode, e.getDetailedMessage(), joinAttempt + 1);
                 }
-            } catch (Exception e) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("failed to send join request to master [{}]", e);
-                } else if (e instanceof ElasticsearchException) {
-                    logger.info("failed to send join request to master [{}], reason [{}]", masterNode, ((ElasticsearchException) e).getDetailedMessage());
-                } else {
-                    logger.info("failed to send join request to master [{}], reason [{}]", masterNode, e.getMessage());
-                }
-                return false;
             }
 
             try {
@@ -420,7 +422,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 Thread.currentThread().interrupt();
             }
         }
-        return false;
     }
 
     private void handleLeaveRequest(final DiscoveryNode node) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -873,14 +873,13 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         for (ZenPing.PingResponse pingResponse : pingResponses) {
             possibleMasterNodes.add(pingResponse.target());
         }
-        // if we don't have enough master nodes, we bail, even if we get a response that indicates
-        // there is a master by other node, we don't see enough...
-        if (!electMaster.hasEnoughMasterNodes(possibleMasterNodes)) {
-            logger.trace("not enough master nodes [{}]", possibleMasterNodes);
-            return null;
-        }
 
         if (pingMasters.isEmpty()) {
+            // if we don't have enough master nodes, we bail, because there are not enough master to elect from
+            if (!electMaster.hasEnoughMasterNodes(possibleMasterNodes)) {
+                logger.trace("not enough master nodes [{}]", possibleMasterNodes);
+                return null;
+            }
             // lets tie break between discovered nodes
             DiscoveryNode electedMaster = electMaster.electMaster(possibleMasterNodes);
             if (localNode.equals(electedMaster)) {

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
@@ -106,6 +107,8 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     /** how long to wait before performing another join attempt after a join request failed with an retriable error */
     private final TimeValue joinRetryDelay;
 
+    /** how many pings from *another* master to tolerate before forcing a rejoin on other or local master */
+    private final int maxPingsFromAnotherMaster;
 
     // a flag that should be used only for testing
     private final boolean sendLeaveRequest;
@@ -155,6 +158,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         this.joinTimeout = settings.getAsTime("discovery.zen.join_timeout", TimeValue.timeValueMillis(pingTimeout.millis() * 20));
         this.joinRetryAttempts = settings.getAsInt("discovery.zen.join_retry_attempts", 3);
         this.joinRetryDelay = settings.getAsTime("discovery.zen.join_retry_delay", TimeValue.timeValueMillis(100));
+        this.maxPingsFromAnotherMaster = settings.getAsInt("discovery.zen.max_pings_from_another_master", 3);
         this.sendLeaveRequest = componentSettings.getAsBoolean("send_leave_request", true);
 
         this.masterElectionFilterClientNodes = settings.getAsBoolean("discovery.zen.master_election.filter_client", true);
@@ -170,7 +174,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         this.masterFD.addListener(new MasterNodeFailureListener());
 
         this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService, clusterName);
-        this.nodesFD.addListener(new NodeFailureListener());
+        this.nodesFD.addListener(new NodeFaultDetectionListener());
 
         this.publishClusterState = new PublishClusterStateAction(settings, transportService, this, new NewClusterStateListener(), discoverySettings);
         this.pingService.setNodesProvider(this);
@@ -196,7 +200,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         final String nodeId = DiscoveryService.generateNodeId(settings);
         localNode = new DiscoveryNode(settings.get("name"), nodeId, transportService.boundAddress().publishAddress(), nodeAttributes, version);
         latestDiscoNodes = new DiscoveryNodes.Builder().put(localNode).localNodeId(localNode.id()).build();
-        nodesFD.updateNodes(latestDiscoNodes);
+        nodesFD.updateNodes(latestDiscoNodes, -1);
         pingService.start();
 
         // do the join on a different thread, the DiscoveryService waits for 30s anyhow till it is discovered
@@ -290,7 +294,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             throw new ElasticsearchIllegalStateException("Shouldn't publish state when not master");
         }
         latestDiscoNodes = clusterState.nodes();
-        nodesFD.updateNodes(clusterState.nodes());
+        nodesFD.updateNodes(clusterState.nodes(), clusterState.version());
         publishClusterState.publish(clusterState, ackListener);
     }
 
@@ -650,29 +654,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             clusterService.submitStateUpdateTask("zen-disco-master_receive_cluster_state_from_another_master [" + newState.nodes().masterNode() + "]", Priority.URGENT, new ProcessedClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    if (newState.version() > currentState.version()) {
-                        logger.warn("received cluster state from [{}] which is also master but with a newer cluster_state, rejoining to cluster...", newState.nodes().masterNode());
-                        return rejoin(currentState, "zen-disco-master_receive_cluster_state_from_another_master [" + newState.nodes().masterNode() + "]");
-                    } else {
-                        logger.warn("received cluster state from [{}] which is also master but with an older cluster_state, telling [{}] to rejoin the cluster", newState.nodes().masterNode(), newState.nodes().masterNode());
-
-                        try {
-                            // make sure we're connected to this node (connect to node does nothing if we're already connected)
-                            // since the network connections are asymmetric, it may be that we received a state but have disconnected from the node
-                            // in the past (after a master failure, for example)
-                            transportService.connectToNode(newState.nodes().masterNode());
-                            transportService.sendRequest(newState.nodes().masterNode(), DISCOVERY_REJOIN_ACTION_NAME, new RejoinClusterRequest(currentState.nodes().localNodeId()), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
-                                @Override
-                                public void handleException(TransportException exp) {
-                                    logger.warn("failed to send rejoin request to [{}]", exp, newState.nodes().masterNode());
-                                }
-                            });
-                        } catch (Exception e) {
-                            logger.warn("failed to send rejoin request to [{}]", e, newState.nodes().masterNode());
-                        }
-
-                        return currentState;
-                    }
+                    return handleAnotherMaster(currentState, newState.nodes().masterNode(), newState.version(), "via a new cluster state");
                 }
 
                 @Override
@@ -988,6 +970,31 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 .build();
     }
 
+    private ClusterState handleAnotherMaster(ClusterState localClusterState, final DiscoveryNode otherMaster, long otherClusterStateVersion, String reason) {
+        assert master : "handleAnotherMaster called but current node is not a master";
+        if (otherClusterStateVersion > localClusterState.version()) {
+            return rejoin(localClusterState, "zen-disco-discovered another master with a new cluster_state [" + otherMaster + "][" + reason + "]");
+        } else {
+            logger.warn("discovered [{}] which is also master but with an older cluster_state, telling [{}] to rejoin the cluster ([{}])", otherMaster, otherMaster, reason);
+            try {
+                // make sure we're connected to this node (connect to node does nothing if we're already connected)
+                // since the network connections are asymmetric, it may be that we received a state but have disconnected from the node
+                // in the past (after a master failure, for example)
+                transportService.connectToNode(otherMaster);
+                transportService.sendRequest(otherMaster, DISCOVERY_REJOIN_ACTION_NAME, new RejoinClusterRequest(localClusterState.nodes().localNodeId()), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+
+                    @Override
+                    public void handleException(TransportException exp) {
+                        logger.warn("failed to send rejoin request to [{}]", exp, otherMaster);
+                    }
+                });
+            } catch (Exception e) {
+                logger.warn("failed to send rejoin request to [{}]", e, otherMaster);
+            }
+            return localClusterState;
+        }
+    }
+
     private void sendInitialStateEventIfNeeded() {
         if (initialStateSent.compareAndSet(false, true)) {
             for (InitialStateDiscoveryListener listener : initialStateListeners) {
@@ -1016,11 +1023,47 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         }
     }
 
-    private class NodeFailureListener implements NodesFaultDetection.Listener {
+    private class NodeFaultDetectionListener extends NodesFaultDetection.Listener {
+
+        private final AtomicInteger pingsWhileMaster = new AtomicInteger(0);
 
         @Override
         public void onNodeFailure(DiscoveryNode node, String reason) {
             handleNodeFailure(node, reason);
+        }
+
+        @Override
+        public void onPingReceived(final NodesFaultDetection.PingRequest pingRequest) {
+            // if we are master, we don't expect any fault detection from another node. If we get it
+            // means we potentially have two masters in the cluster.
+            if (!master) {
+                pingsWhileMaster.set(0);
+                return;
+            }
+
+            // nodes pre 1.4.0 do not send this information
+            if (pingRequest.masterNode() == null) {
+                return;
+            }
+
+            if (pingsWhileMaster.incrementAndGet() < maxPingsFromAnotherMaster) {
+                logger.trace("got a ping from another master {}. current ping count: [{}]", pingRequest.masterNode(), pingsWhileMaster.get());
+                return;
+            }
+            logger.debug("got a ping from another master {}. resolving who should rejoin. current ping count: [{}]", pingRequest.masterNode(), pingsWhileMaster.get());
+            clusterService.submitStateUpdateTask("ping from another master", Priority.URGENT, new ClusterStateUpdateTask() {
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    pingsWhileMaster.set(0);
+                    return handleAnotherMaster(currentState, pingRequest.masterNode(), pingRequest.clusterStateVersion(), "node fd ping");
+                }
+
+                @Override
+                public void onFailure(String source, Throwable t) {
+                    logger.debug("unexpected error during cluster state update task after pings from another master", t);
+                }
+            });
         }
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -797,7 +797,11 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
                 @Override
                 public void onFailure(String source, Throwable t) {
-                    logger.error("unexpected failure during [{}]", t, source);
+                    if (t instanceof ClusterService.NoLongerMasterException) {
+                        logger.debug("not processing [{}] as we are no longer master", source);
+                    } else {
+                        logger.error("unexpected failure during [{}]", t, source);
+                    }
                     callback.onFailure(t);
                 }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -314,7 +314,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             if (localNode.equals(masterNode)) {
                 this.master = true;
                 nodesFD.start(); // start the nodes FD
-                clusterService.submitStateUpdateTask("zen-disco-join (elected_as_master)", Priority.URGENT, new ProcessedClusterStateUpdateTask() {
+                clusterService.submitStateUpdateTask("zen-disco-join (elected_as_master)", Priority.URGENT, new ProcessedClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         // Take into account the previous known nodes, if they happen not to be available
@@ -336,7 +336,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
                     @Override
                     public void onFailure(String source, Throwable t) {
-                        logger.error("unexpected failure during [{}]", t, source);
+                            logger.error("unexpected failure during [{}]", t, source);
                     }
 
                     @Override
@@ -400,7 +400,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
                 @Override
                 public void onFailure(String source, Throwable t) {
-                    logger.error("unexpected failure during [{}]", t, source);
+                    if (t instanceof ClusterService.NoLongerMasterException) {
+                        logger.debug("not processing {} leave request as we are no longer master", node);
+                    }
+                    else {
+                        logger.error("unexpected failure during [{}]", t, source);
+                    }
                 }
             });
         } else {
@@ -435,7 +440,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
             @Override
             public void onFailure(String source, Throwable t) {
-                logger.error("unexpected failure during [{}]", t, source);
+                if (t instanceof ClusterService.NoLongerMasterException) {
+                    logger.debug("not processing [{}] as we are no longer master", source);
+                }
+                else {
+                    logger.error("unexpected failure during [{}]", t, source);
+                }
             }
 
             @Override
@@ -468,7 +478,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
             @Override
             public void onFailure(String source, Throwable t) {
-                logger.error("unexpected failure during [{}]", t, source);
+                if (t instanceof ClusterService.NoLongerMasterException) {
+                    logger.debug("not processing [{}] as we are no longer master", source);
+                }
+                else {
+                    logger.error("unexpected failure during [{}]", t, source);
+                }
             }
 
             @Override
@@ -490,7 +505,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
         logger.info("master_left [{}], reason [{}]", masterNode, reason);
 
-        clusterService.submitStateUpdateTask("zen-disco-master_failed (" + masterNode + ")", Priority.IMMEDIATE, new ProcessedClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("zen-disco-master_failed (" + masterNode + ")", Priority.IMMEDIATE, new ProcessedClusterStateNonMasterUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 if (!masterNode.id().equals(currentState.nodes().masterNodeId())) {
@@ -624,7 +639,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 final ProcessClusterState processClusterState = new ProcessClusterState(newClusterState, newStateProcessed);
                 processNewClusterStates.add(processClusterState);
 
-                clusterService.submitStateUpdateTask("zen-disco-receive(from master [" + newClusterState.nodes().masterNode() + "])", Priority.URGENT, new ProcessedClusterStateUpdateTask() {
+                clusterService.submitStateUpdateTask("zen-disco-receive(from master [" + newClusterState.nodes().masterNode() + "])", Priority.URGENT, new ProcessedClusterStateNonMasterUpdateTask() {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         // we already processed it in a previous event
@@ -961,7 +976,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
         @Override
         public void messageReceived(final RejoinClusterRequest request, final TransportChannel channel) throws Exception {
-            clusterService.submitStateUpdateTask("received a request to rejoin the cluster from [" + request.fromNodeId + "]", Priority.URGENT, new ClusterStateUpdateTask() {
+            clusterService.submitStateUpdateTask("received a request to rejoin the cluster from [" + request.fromNodeId + "]", Priority.URGENT, new ClusterStateNonMasterUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     try {
@@ -974,7 +989,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
                 @Override
                 public void onFailure(String source, Throwable t) {
-                    logger.error("unexpected failure during [{}]", t, source);
+                    if (t instanceof ClusterService.NoLongerMasterException) {
+                        logger.debug("not processing [{}] as we are no longer master", source);
+                    }
+                    else {
+                        logger.error("unexpected failure during [{}]", t, source);
+                    }
                 }
             });
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -313,6 +313,15 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         });
     }
 
+
+    /**
+     * returns true if there is a currently a background thread active for (re)joining the cluster
+     * used for testing.
+     */
+    public boolean joiningCluster() {
+        return currentJoinThread != null;
+    }
+
     private void innerJoinCluster() {
         boolean retry = true;
         while (retry) {
@@ -410,7 +419,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     }
                 } else {
                     if (logger.isTraceEnabled()) {
-                        logger.trace("failed to send join request to master [{}]", t);
+                        logger.trace("failed to send join request to master [{}]", t, masterNode);
                     } else {
                         logger.info("failed to send join request to master [{}], reason [{}]", masterNode, ExceptionsHelper.detailedMessage(t));
                     }

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -32,6 +32,9 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.MutableShardRouting;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Priority;
@@ -61,6 +64,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -327,7 +331,17 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                         // update the fact that we are the master...
                         latestDiscoNodes = builder.build();
                         ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
-                        return ClusterState.builder(currentState).nodes(latestDiscoNodes).blocks(clusterBlocks).build();
+
+                        List<ShardRouting> failedShardRoutings = new ArrayList<>();
+                        for (RoutingNode routingNode : currentState.getRoutingNodes()) {
+                            if (!latestDiscoNodes.nodeExists(routingNode.nodeId())) {
+                                for (MutableShardRouting shardRouting : routingNode) {
+                                    failedShardRoutings.add(shardRouting);
+                                }
+                            }
+                        }
+                        RoutingAllocation.Result result = allocationService.applyFailedShards(currentState, failedShardRoutings);
+                        return ClusterState.builder(currentState).routingResult(result).nodes(latestDiscoNodes).blocks(clusterBlocks).build();
                     }
 
                     @Override

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -86,6 +86,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
     private AllocationService allocationService;
     private final ClusterName clusterName;
     private final DiscoveryNodeService discoveryNodeService;
+    private final DiscoverySettings discoverySettings;
     private final ZenPingService pingService;
     private final MasterFaultDetection masterFD;
     private final NodesFaultDetection nodesFD;
@@ -132,6 +133,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.discoveryNodeService = discoveryNodeService;
+        this.discoverySettings = discoverySettings;
         this.pingService = pingService;
         this.version = version;
 
@@ -321,7 +323,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                                 .put(localNode);
                         // update the fact that we are the master...
                         latestDiscoNodes = builder.build();
-                        ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(NO_MASTER_BLOCK).build();
+                        ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
                         return ClusterState.builder(currentState).nodes(latestDiscoNodes).blocks(clusterBlocks).build();
                     }
 
@@ -845,7 +847,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         master = false;
 
         ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(clusterState.blocks())
-                .addGlobalBlock(NO_MASTER_BLOCK)
+                .addGlobalBlock(discoverySettings.getNoMasterBlock())
                 .build();
 
         // clean the nodes, we are now not connected to anybody, since we try and reform the cluster

--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -77,7 +77,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  */
 public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implements Discovery, DiscoveryNodesProvider {
 
-    private final static String REJOIN_ON_MASTER_GONE = "discovery.zen.rejoin_on_master_gone";
+    public final static String REJOIN_ON_MASTER_GONE = "discovery.zen.rejoin_on_master_gone";
 
     public static final String DISCOVERY_REJOIN_ACTION_NAME = "internal:discovery/zen/rejoin";
 
@@ -971,6 +971,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 logger.warn("failed to send join request on disconnection from master [{}]", masterNode);
             }
         }
+    }
+
+    boolean isRejoinOnMasterGone() {
+        return rejoinOnMasterGone;
     }
 
     static class RejoinClusterRequest extends TransportRequest {

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -155,8 +155,9 @@ public class MasterFaultDetection extends AbstractComponent {
             masterPinger.stop();
         }
         this.masterPinger = new MasterPinger();
-        // start the ping process
-        threadPool.schedule(pingInterval, ThreadPool.Names.SAME, masterPinger);
+
+        // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
+        threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, masterPinger);
     }
 
     public void stop(String reason) {
@@ -200,7 +201,8 @@ public class MasterFaultDetection extends AbstractComponent {
                         masterPinger.stop();
                     }
                     this.masterPinger = new MasterPinger();
-                    threadPool.schedule(pingInterval, ThreadPool.Names.SAME, masterPinger);
+                    // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
+                    threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, masterPinger);
                 } catch (Exception e) {
                     logger.trace("[master] [{}] transport disconnected (with verified connect)", masterNode);
                     notifyMasterFailure(masterNode, "transport disconnected (with verified connect)");

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -91,7 +91,7 @@ public class MasterFaultDetection extends AbstractComponent {
         this.transportService = transportService;
         this.nodesProvider = nodesProvider;
 
-        this.connectOnNetworkDisconnect = componentSettings.getAsBoolean("connect_on_network_disconnect", true);
+        this.connectOnNetworkDisconnect = componentSettings.getAsBoolean("connect_on_network_disconnect", false);
         this.pingInterval = componentSettings.getAsTime("ping_interval", timeValueSeconds(1));
         this.pingRetryTimeout = componentSettings.getAsTime("ping_timeout", timeValueSeconds(30));
         this.pingRetryCount = componentSettings.getAsInt("ping_retries", 3);

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -156,8 +156,8 @@ public class MasterFaultDetection extends AbstractComponent {
         }
         this.masterPinger = new MasterPinger();
 
-        // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
-        threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, masterPinger);
+        // we start pinging slightly later to allow the chosen master to complete it's own master election
+        threadPool.schedule(pingInterval, ThreadPool.Names.SAME, masterPinger);
     }
 
     public void stop(String reason) {

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.discovery.zen.fd;
 
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -58,6 +60,8 @@ public class MasterFaultDetection extends AbstractComponent {
 
     private final DiscoveryNodesProvider nodesProvider;
 
+    private final ClusterName clusterName;
+
     private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
 
 
@@ -85,11 +89,13 @@ public class MasterFaultDetection extends AbstractComponent {
 
     private final AtomicBoolean notifiedMasterFailure = new AtomicBoolean();
 
-    public MasterFaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService, DiscoveryNodesProvider nodesProvider) {
+    public MasterFaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService,
+                                DiscoveryNodesProvider nodesProvider, ClusterName clusterName) {
         super(settings);
         this.threadPool = threadPool;
         this.transportService = transportService;
         this.nodesProvider = nodesProvider;
+        this.clusterName = clusterName;
 
         this.connectOnNetworkDisconnect = componentSettings.getAsBoolean("connect_on_network_disconnect", false);
         this.pingInterval = componentSettings.getAsTime("ping_interval", timeValueSeconds(1));
@@ -270,8 +276,10 @@ public class MasterFaultDetection extends AbstractComponent {
                 threadPool.schedule(pingInterval, ThreadPool.Names.SAME, MasterPinger.this);
                 return;
             }
-            transportService.sendRequest(masterToPing, MASTER_PING_ACTION_NAME, new MasterPingRequest(nodesProvider.nodes().localNode().id(), masterToPing.id()), options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout),
-                    new BaseTransportResponseHandler<MasterPingResponseResponse>() {
+            final MasterPingRequest request = new MasterPingRequest(nodesProvider.nodes().localNode().id(), masterToPing.id(), clusterName);
+            final TransportRequestOptions options = options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout);
+            transportService.sendRequest(masterToPing, MASTER_PING_ACTION_NAME, request, options, new BaseTransportResponseHandler<MasterPingResponseResponse>() {
+
                         @Override
                         public MasterPingResponseResponse newInstance() {
                             return new MasterPingResponseResponse();
@@ -328,7 +336,7 @@ public class MasterFaultDetection extends AbstractComponent {
                                         notifyMasterFailure(masterToPing, "failed to ping, tried [" + pingRetryCount + "] times, each with  maximum [" + pingRetryTimeout + "] timeout");
                                     } else {
                                         // resend the request, not reschedule, rely on send timeout
-                                        transportService.sendRequest(masterToPing, MASTER_PING_ACTION_NAME, new MasterPingRequest(nodesProvider.nodes().localNode().id(), masterToPing.id()), options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout), this);
+                                        transportService.sendRequest(masterToPing, MASTER_PING_ACTION_NAME, request, options, this);
                                     }
                                 }
                             }
@@ -351,6 +359,14 @@ public class MasterFaultDetection extends AbstractComponent {
     }
 
     static class NotMasterException extends ElasticsearchIllegalStateException {
+
+        NotMasterException(String msg) {
+            super(msg);
+        }
+
+        NotMasterException() {
+        }
+
         @Override
         public Throwable fillInStackTrace() {
             return null;
@@ -379,6 +395,12 @@ public class MasterFaultDetection extends AbstractComponent {
             if (!request.masterNodeId.equals(nodes.localNodeId())) {
                 throw new NotMasterException();
             }
+
+            if (request.clusterName != null && !request.clusterName.equals(clusterName)) {
+                logger.trace("master fault detection ping request is targeted for a different [{}] cluster then us [{}]", request.clusterName, clusterName);
+                throw new NotMasterException("master fault detection ping request is targeted for a different [" + request.clusterName + "] cluster then us [" + clusterName + "]");
+            }
+
             // if we are no longer master, fail...
             if (!nodes.localNodeMaster()) {
                 throw new NoLongerMasterException();
@@ -402,13 +424,15 @@ public class MasterFaultDetection extends AbstractComponent {
         private String nodeId;
 
         private String masterNodeId;
+        private ClusterName clusterName;
 
         private MasterPingRequest() {
         }
 
-        private MasterPingRequest(String nodeId, String masterNodeId) {
+        private MasterPingRequest(String nodeId, String masterNodeId, ClusterName clusterName) {
             this.nodeId = nodeId;
             this.masterNodeId = masterNodeId;
+            this.clusterName = clusterName;
         }
 
         @Override
@@ -416,6 +440,9 @@ public class MasterFaultDetection extends AbstractComponent {
             super.readFrom(in);
             nodeId = in.readString();
             masterNodeId = in.readString();
+            if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+                clusterName = ClusterName.readClusterName(in);
+            }
         }
 
         @Override
@@ -423,6 +450,9 @@ public class MasterFaultDetection extends AbstractComponent {
             super.writeTo(out);
             out.writeString(nodeId);
             out.writeString(masterNodeId);
+            if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+                clusterName.writeTo(out);
+            }
         }
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -201,7 +201,7 @@ public class NodesFaultDetection extends AbstractComponent {
         });
     }
 
-    private void notifyPingRecieved(final PingRequest pingRequest) {
+    private void notifyPingReceived(final PingRequest pingRequest) {
         threadPool.generic().execute(new Runnable() {
 
             @Override
@@ -326,7 +326,7 @@ public class NodesFaultDetection extends AbstractComponent {
                 throw new ElasticsearchIllegalStateException("Got pinged with cluster name [" + request.clusterName + "], but I'm part of cluster [" + clusterName + "]");
             }
 
-            notifyPingRecieved(request);
+            notifyPingReceived(request);
 
             channel.sendResponse(new PingResponse());
         }

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.discovery.zen.fd;
 
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -54,6 +56,7 @@ public class NodesFaultDetection extends AbstractComponent {
     private final ThreadPool threadPool;
 
     private final TransportService transportService;
+    private final ClusterName clusterName;
 
 
     private final boolean connectOnNetworkDisconnect;
@@ -78,10 +81,11 @@ public class NodesFaultDetection extends AbstractComponent {
 
     private volatile boolean running = false;
 
-    public NodesFaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService) {
+    public NodesFaultDetection(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterName clusterName) {
         super(settings);
         this.threadPool = threadPool;
         this.transportService = transportService;
+        this.clusterName = clusterName;
 
         this.connectOnNetworkDisconnect = componentSettings.getAsBoolean("connect_on_network_disconnect", false);
         this.pingInterval = componentSettings.getAsTime("ping_interval", timeValueSeconds(1));
@@ -204,8 +208,9 @@ public class NodesFaultDetection extends AbstractComponent {
             if (!running) {
                 return;
             }
-            transportService.sendRequest(node, PING_ACTION_NAME, new PingRequest(node.id()), options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout),
-                    new BaseTransportResponseHandler<PingResponse>() {
+            final PingRequest pingRequest = new PingRequest(node.id(), clusterName);
+            final TransportRequestOptions options = options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout);
+            transportService.sendRequest(node, PING_ACTION_NAME, pingRequest, options, new BaseTransportResponseHandler<PingResponse>() {
                         @Override
                         public PingResponse newInstance() {
                             return new PingResponse();
@@ -252,8 +257,7 @@ public class NodesFaultDetection extends AbstractComponent {
                                     }
                                 } else {
                                     // resend the request, not reschedule, rely on send timeout
-                                    transportService.sendRequest(node, PING_ACTION_NAME, new PingRequest(node.id()),
-                                            options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout), this);
+                                    transportService.sendRequest(node, PING_ACTION_NAME, pingRequest, options, this);
                                 }
                             }
                         }
@@ -298,6 +302,10 @@ public class NodesFaultDetection extends AbstractComponent {
             if (!latestNodes.localNodeId().equals(request.nodeId)) {
                 throw new ElasticsearchIllegalStateException("Got pinged as node [" + request.nodeId + "], but I am node [" + latestNodes.localNodeId() + "]");
             }
+            if (request.clusterName != null && !request.clusterName.equals(clusterName)) {
+                // Don't introduce new exception for bwc reasons
+                throw new ElasticsearchIllegalStateException("Got pinged with cluster name [" + request.clusterName + "], but I'm part of cluster [" + clusterName + "]");
+            }
             channel.sendResponse(new PingResponse());
         }
 
@@ -308,28 +316,45 @@ public class NodesFaultDetection extends AbstractComponent {
     }
 
 
-    static class PingRequest extends TransportRequest {
+    public static class PingRequest extends TransportRequest {
 
         // the (assumed) node id we are pinging
         private String nodeId;
 
+        private ClusterName clusterName;
+
         PingRequest() {
         }
 
-        PingRequest(String nodeId) {
+        PingRequest(String nodeId, ClusterName clusterName) {
             this.nodeId = nodeId;
+            this.clusterName = clusterName;
+        }
+
+        public String nodeId() {
+            return nodeId;
+        }
+
+        public ClusterName clusterName() {
+            return clusterName;
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             nodeId = in.readString();
+            if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+                clusterName = ClusterName.readClusterName(in);
+            }
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(nodeId);
+            if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+                clusterName.writeTo(out);
+            }
         }
     }
 

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -83,7 +83,7 @@ public class NodesFaultDetection extends AbstractComponent {
         this.threadPool = threadPool;
         this.transportService = transportService;
 
-        this.connectOnNetworkDisconnect = componentSettings.getAsBoolean("connect_on_network_disconnect", true);
+        this.connectOnNetworkDisconnect = componentSettings.getAsBoolean("connect_on_network_disconnect", false);
         this.pingInterval = componentSettings.getAsTime("ping_interval", timeValueSeconds(1));
         this.pingRetryTimeout = componentSettings.getAsTime("ping_timeout", timeValueSeconds(30));
         this.pingRetryCount = componentSettings.getAsInt("ping_retries", 3);

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -47,10 +47,13 @@ import static org.elasticsearch.transport.TransportRequestOptions.options;
 public class NodesFaultDetection extends AbstractComponent {
 
     public static final String PING_ACTION_NAME = "internal:discovery/zen/fd/ping";
+    
+    public abstract static class Listener {
 
-    public static interface Listener {
+        public void onNodeFailure(DiscoveryNode node, String reason) {}
 
-        void onNodeFailure(DiscoveryNode node, String reason);
+        public void onPingReceived(PingRequest pingRequest) {}
+
     }
 
     private final ThreadPool threadPool;
@@ -78,6 +81,8 @@ public class NodesFaultDetection extends AbstractComponent {
     private final FDConnectionListener connectionListener;
 
     private volatile DiscoveryNodes latestNodes = EMPTY_NODES;
+
+    private volatile long clusterStateVersion = -1;
 
     private volatile boolean running = false;
 
@@ -111,9 +116,10 @@ public class NodesFaultDetection extends AbstractComponent {
         listeners.remove(listener);
     }
 
-    public void updateNodes(DiscoveryNodes nodes) {
+    public void updateNodes(DiscoveryNodes nodes, long clusterStateVersion) {
         DiscoveryNodes prevNodes = latestNodes;
         this.latestNodes = nodes;
+        this.clusterStateVersion = clusterStateVersion;
         if (!running) {
             return;
         }
@@ -195,6 +201,19 @@ public class NodesFaultDetection extends AbstractComponent {
         });
     }
 
+    private void notifyPingRecieved(final PingRequest pingRequest) {
+        threadPool.generic().execute(new Runnable() {
+
+            @Override
+            public void run() {
+                for (Listener listener : listeners) {
+                    listener.onPingReceived(pingRequest);
+                }
+            }
+
+        });
+    }
+
     private class SendPingRequest implements Runnable {
 
         private final DiscoveryNode node;
@@ -208,7 +227,7 @@ public class NodesFaultDetection extends AbstractComponent {
             if (!running) {
                 return;
             }
-            final PingRequest pingRequest = new PingRequest(node.id(), clusterName);
+            final PingRequest pingRequest = new PingRequest(node.id(), clusterName, latestNodes.localNode(), clusterStateVersion);
             final TransportRequestOptions options = options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout);
             transportService.sendRequest(node, PING_ACTION_NAME, pingRequest, options, new BaseTransportResponseHandler<PingResponse>() {
                         @Override
@@ -306,6 +325,9 @@ public class NodesFaultDetection extends AbstractComponent {
                 // Don't introduce new exception for bwc reasons
                 throw new ElasticsearchIllegalStateException("Got pinged with cluster name [" + request.clusterName + "], but I'm part of cluster [" + clusterName + "]");
             }
+
+            notifyPingRecieved(request);
+
             channel.sendResponse(new PingResponse());
         }
 
@@ -323,12 +345,18 @@ public class NodesFaultDetection extends AbstractComponent {
 
         private ClusterName clusterName;
 
+        private DiscoveryNode masterNode;
+
+        private long clusterStateVersion = -1;
+
         PingRequest() {
         }
 
-        PingRequest(String nodeId, ClusterName clusterName) {
+        PingRequest(String nodeId, ClusterName clusterName, DiscoveryNode masterNode, long clusterStateVersion) {
             this.nodeId = nodeId;
             this.clusterName = clusterName;
+            this.masterNode = masterNode;
+            this.clusterStateVersion = clusterStateVersion;
         }
 
         public String nodeId() {
@@ -339,12 +367,22 @@ public class NodesFaultDetection extends AbstractComponent {
             return clusterName;
         }
 
+        public DiscoveryNode masterNode() {
+            return masterNode;
+        }
+
+        public long clusterStateVersion() {
+            return clusterStateVersion;
+        }
+
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             nodeId = in.readString();
             if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
                 clusterName = ClusterName.readClusterName(in);
+                masterNode = DiscoveryNode.readNode(in);
+                clusterStateVersion = in.readLong();
             }
         }
 
@@ -354,6 +392,8 @@ public class NodesFaultDetection extends AbstractComponent {
             out.writeString(nodeId);
             if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
                 clusterName.writeTo(out);
+                masterNode.writeTo(out);
+                out.writeLong(clusterStateVersion);
             }
         }
     }

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -121,7 +121,8 @@ public class NodesFaultDetection extends AbstractComponent {
             }
             if (!nodesFD.containsKey(newNode)) {
                 nodesFD.put(newNode, new NodeFD());
-                threadPool.schedule(pingInterval, ThreadPool.Names.SAME, new SendPingRequest(newNode));
+                // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
+                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, new SendPingRequest(newNode));
             }
         }
         for (DiscoveryNode removedNode : delta.removedNodes()) {
@@ -167,7 +168,8 @@ public class NodesFaultDetection extends AbstractComponent {
             try {
                 transportService.connectToNode(node);
                 nodesFD.put(node, new NodeFD());
-                threadPool.schedule(pingInterval, ThreadPool.Names.SAME, new SendPingRequest(node));
+                // we use schedule with a 0 time value to run the pinger on the pool as it will run on later
+                threadPool.schedule(TimeValue.timeValueMillis(0), ThreadPool.Names.SAME, new SendPingRequest(node));
             } catch (Exception e) {
                 logger.trace("[node  ] [{}] transport disconnected (with verified connect)", node);
                 notifyNodeFailure(node, "transport disconnected (with verified connect)");

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -143,6 +143,13 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         this.nodesProvider = nodesProvider;
     }
 
+    /**
+     * Clears the list of cached ping responses.
+     */
+    public void clearTemporalReponses() {
+        temporalResponses.clear();
+    }
+
     public PingResponse[] pingAndWait(TimeValue timeout) {
         final AtomicReference<PingResponse[]> response = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -134,12 +134,6 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
         if (lifecycle.stoppedOrClosed()) {
             return;
         }
-        if (event.state().blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK)) {
-            // we need to clear those flags, since we might need to recover again in case we disconnect
-            // from the cluster and then reconnect
-            recovered.set(false);
-            scheduledRecovery.set(false);
-        }
         if (event.localNodeMaster() && event.state().blocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK)) {
             checkStateMeetsSettingsAndMaybeRecover(event.state(), true);
         }

--- a/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -141,7 +141,7 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
 
     protected void checkStateMeetsSettingsAndMaybeRecover(ClusterState state, boolean asyncRecovery) {
         DiscoveryNodes nodes = state.nodes();
-        if (state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK)) {
+        if (state.blocks().hasGlobalBlock(discoveryService.getNoMasterBlock())) {
             logger.debug("not recovering from gateway, no master elected yet");
         } else if (recoverAfterNodes != -1 && (nodes.masterAndDataNodes().size()) < recoverAfterNodes) {
             logger.debug("not recovering from gateway, nodes_size (data+master) [" + nodes.masterAndDataNodes().size() + "] < recover_after_nodes [" + recoverAfterNodes + "]");

--- a/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -39,6 +39,7 @@ import org.elasticsearch.indices.recovery.RecoverySource;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.indices.ttl.IndicesTTLService;
 import org.elasticsearch.indices.warmer.IndicesWarmer;
 import org.elasticsearch.indices.warmer.InternalIndicesWarmer;
@@ -80,6 +81,7 @@ public class IndicesModule extends AbstractModule implements SpawnModules {
         bind(IndicesTTLService.class).asEagerSingleton();
         bind(IndicesWarmer.class).to(InternalIndicesWarmer.class).asEagerSingleton();
         bind(UpdateHelper.class).asEagerSingleton();
+        bind(TransportShardActive.class).asEagerSingleton();
 
         bind(IndicesFieldDataCacheListener.class).asEagerSingleton();
     }

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -307,7 +307,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                 return;
             }
 
-            clusterService.submitStateUpdateTask("indices_store", new ClusterStateUpdateTask() {
+            clusterService.submitStateUpdateTask("indices_store", new ClusterStateNonMasterUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     if (clusterState.getVersion() != currentState.getVersion()) {

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -21,37 +21,26 @@ package org.elasticsearch.indices.store;
 
 import org.apache.lucene.store.StoreRateLimiting;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.service.IndexService;
-import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.settings.NodeSettingsService;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.*;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
@@ -60,10 +49,6 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
 
     public static final String INDICES_STORE_THROTTLE_TYPE = "indices.store.throttle.type";
     public static final String INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = "indices.store.throttle.max_bytes_per_sec";
-
-    public static final String ACTION_SHARD_EXISTS = "internal:index/shard/exists";
-
-    private static final EnumSet<IndexShardState> ACTIVE_STATES = EnumSet.of(IndexShardState.STARTED, IndexShardState.RELOCATED);
 
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
@@ -94,7 +79,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
     private final IndicesService indicesService;
 
     private final ClusterService clusterService;
-    private final TransportService transportService;
+    private final TransportShardActive transportShardActive;
 
     private volatile String rateLimitingType;
     private volatile ByteSizeValue rateLimitingThrottle;
@@ -104,14 +89,13 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
 
     @Inject
     public IndicesStore(Settings settings, NodeEnvironment nodeEnv, NodeSettingsService nodeSettingsService, IndicesService indicesService,
-                        ClusterService clusterService, TransportService transportService) {
+                        ClusterService clusterService, TransportShardActive transportShardActive) {
         super(settings);
         this.nodeEnv = nodeEnv;
         this.nodeSettingsService = nodeSettingsService;
         this.indicesService = indicesService;
         this.clusterService = clusterService;
-        this.transportService = transportService;
-        transportService.registerHandler(ACTION_SHARD_EXISTS, new ShardActiveRequestHandler());
+        this.transportShardActive = transportShardActive;
 
         // we limit with 20MB / sec by default with a default type set to merge sice 0.90.1
         this.rateLimitingType = componentSettings.get("throttle.type", StoreRateLimiting.Type.MERGE.name());
@@ -131,7 +115,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         nodeSettingsService = null;
         indicesService = null;
         this.clusterService = null;
-        this.transportService = null;
+        this.transportShardActive = null;
     }
 
     public StoreRateLimiting rateLimiting() {
@@ -149,27 +133,28 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             return;
         }
 
-        if (event.state().blocks().disableStatePersistence()) {
+        final ClusterState state = event.state();
+        if (state.blocks().disableStatePersistence()) {
             return;
         }
 
-        for (IndexRoutingTable indexRoutingTable : event.state().routingTable()) {
+        for (IndexRoutingTable indexRoutingTable : state.routingTable()) {
             // Note, closed indices will not have any routing information, so won't be deleted
-            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
-                if (shardCanBeDeleted(event.state(), indexShardRoutingTable)) {
+            for (final IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                if (shardCanBeDeleted(state, indexShardRoutingTable)) {
                     ShardId shardId = indexShardRoutingTable.shardId();
                     IndexService indexService = indicesService.indexService(shardId.getIndex());
                     if (indexService == null) {
                         if (nodeEnv.hasNodeFile()) {
                             File[] shardLocations = nodeEnv.shardLocations(shardId);
                             if (FileSystemUtils.exists(shardLocations)) {
-                                deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
+                                deleteShardIfExistElseWhere(event.state(), shardId, indexShardRoutingTable);
                             }
                         }
                     } else {
                         if (!indexService.hasShard(shardId.id())) {
                             if (indexService.store().canDeleteUnallocated(shardId)) {
-                                deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
+                                deleteShardIfExistElseWhere(event.state(), shardId, indexShardRoutingTable);
                             }
                         }
                     }
@@ -226,227 +211,71 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         return true;
     }
 
-    private void deleteShardIfExistElseWhere(ClusterState state, IndexShardRoutingTable indexShardRoutingTable) {
-        List<Tuple<DiscoveryNode, ShardActiveRequest>> requests = new ArrayList<>(indexShardRoutingTable.size());
-        String indexUUID = state.getMetaData().index(indexShardRoutingTable.shardId().getIndex()).getUUID();
-        ClusterName clusterName = state.getClusterName();
-        for (ShardRouting shardRouting : indexShardRoutingTable) {
-            // Node can't be null, because otherwise shardCanBeDeleted() would have returned false
-            DiscoveryNode currentNode = state.nodes().get(shardRouting.currentNodeId());
-            assert currentNode != null;
+    private void deleteShardIfExistElseWhere(final ClusterState state, final ShardId shardId, final IndexShardRoutingTable indexShardRoutingTable) {
+        transportShardActive.shardActiveCount(state, shardId, indexShardRoutingTable, new ActionListener<TransportShardActive.Result>() {
+            @Override
+            public void onResponse(TransportShardActive.Result result) {
+                if (indexShardRoutingTable.size() != result.getActiveShards()) {
+                    logger.trace("not deleting shard [{}], expected {} active copies, but only {} found active copies", shardId, result.getTargetedShards(), result.getActiveShards());
+                    return;
+                }
 
-            requests.add(new Tuple<>(currentNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId())));
-            if (shardRouting.relocatingNodeId() != null) {
-                DiscoveryNode relocatingNode = state.nodes().get(shardRouting.relocatingNodeId());
-                assert relocatingNode != null;
-                requests.add(new Tuple<>(relocatingNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId())));
-            }
-        }
+                ClusterState latestClusterState = clusterService.state();
+                if (state.getVersion() != latestClusterState.getVersion()) {
+                    logger.trace("not deleting shard [{}], the latest cluster state version[{}] is not equal to cluster state before shard active api call [{}]", shardId, latestClusterState.getVersion(), state.getVersion());
+                    return;
+                }
 
-        ShardActiveResponseHandler responseHandler = new ShardActiveResponseHandler(indexShardRoutingTable.shardId(), state, requests.size());
-        for (Tuple<DiscoveryNode, ShardActiveRequest> request : requests) {
-            transportService.sendRequest(request.v1(), ACTION_SHARD_EXISTS, request.v2(), responseHandler);
-        }
-    }
-
-    private class ShardActiveResponseHandler implements TransportResponseHandler<ShardActiveResponse> {
-
-        private final ShardId shardId;
-        private final int expectedActiveCopies;
-        private final ClusterState clusterState;
-        private final AtomicInteger awaitingResponses;
-        private final AtomicInteger activeCopies;
-
-        public ShardActiveResponseHandler(ShardId shardId, ClusterState clusterState, int expectedActiveCopies) {
-            this.shardId = shardId;
-            this.expectedActiveCopies = expectedActiveCopies;
-            this.clusterState = clusterState;
-            this.awaitingResponses = new AtomicInteger(expectedActiveCopies);
-            this.activeCopies = new AtomicInteger();
-        }
-
-        @Override
-        public ShardActiveResponse newInstance() {
-            return new ShardActiveResponse();
-        }
-
-        @Override
-        public void handleResponse(ShardActiveResponse response) {
-            if (response.shardActive) {
-                logger.trace("[{}] exists on node [{}]", shardId, response.node);
-                activeCopies.incrementAndGet();
-            }
-
-            if (awaitingResponses.decrementAndGet() == 0) {
-                allNodesResponded();
-            }
-        }
-
-        @Override
-        public void handleException(TransportException exp) {
-            logger.debug("shards active request failed for {}", exp, shardId);
-            if (awaitingResponses.decrementAndGet() == 0) {
-                allNodesResponded();
-            }
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
-
-        private void allNodesResponded() {
-            if (activeCopies.get() != expectedActiveCopies) {
-                logger.trace("not deleting shard {}, expected {} active copies, but only {} found active copies", shardId, expectedActiveCopies, activeCopies.get());
-                return;
-            }
-
-            ClusterState latestClusterState = clusterService.state();
-            if (clusterState.getVersion() != latestClusterState.getVersion()) {
-                logger.trace("not deleting shard {}, the latest cluster state version[{}] is not equal to cluster state before shard active api call [{}]", shardId, latestClusterState.getVersion(), clusterState.getVersion());
-                return;
-            }
-
-            clusterService.submitStateUpdateTask("indices_store", new ClusterStateNonMasterUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) throws Exception {
-                    if (clusterState.getVersion() != currentState.getVersion()) {
-                        logger.trace("not deleting shard {}, the update task state version[{}] is not equal to cluster state before shard active api call [{}]", shardId, currentState.getVersion(), clusterState.getVersion());
-                        return currentState;
-                    }
-
-                    IndexService indexService = indicesService.indexService(shardId.getIndex());
-                    if (indexService == null) {
-                        // not physical allocation of the index, delete it from the file system if applicable
-                        if (nodeEnv.hasNodeFile()) {
-                            File[] shardLocations = nodeEnv.shardLocations(shardId);
-                            if (FileSystemUtils.exists(shardLocations)) {
-                                logger.debug("{} deleting shard that is no longer used", shardId);
-                                FileSystemUtils.deleteRecursively(shardLocations);
-                            }
+                clusterService.submitStateUpdateTask("indices_store", new ClusterStateNonMasterUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) throws Exception {
+                        if (state.getVersion() != currentState.getVersion()) {
+                            logger.trace("not deleting shard {}, the update task state version[{}] is not equal to cluster state before shard active api call [{}]", shardId, currentState.getVersion(), state.getVersion());
+                            return currentState;
                         }
-                    } else {
-                        if (!indexService.hasShard(shardId.id())) {
-                            if (indexService.store().canDeleteUnallocated(shardId)) {
-                                logger.debug("{} deleting shard that is no longer used", shardId);
-                                try {
-                                    indexService.store().deleteUnallocated(shardId);
-                                } catch (Exception e) {
-                                    logger.debug("{} failed to delete unallocated shard, ignoring", e, shardId);
+
+                        IndexService indexService = indicesService.indexService(shardId.getIndex());
+                        if (indexService == null) {
+                            // not physical allocation of the index, delete it from the file system if applicable
+                            if (nodeEnv.hasNodeFile()) {
+                                File[] shardLocations = nodeEnv.shardLocations(shardId);
+                                if (FileSystemUtils.exists(shardLocations)) {
+                                    logger.debug("{} deleting shard that is no longer used", shardId);
+                                    FileSystemUtils.deleteRecursively(shardLocations);
                                 }
                             }
                         } else {
-                            // this state is weird, should we log?
-                            // basically, it means that the shard is not allocated on this node using the routing
-                            // but its still physically exists on an IndexService
-                            // Note, this listener should run after IndicesClusterStateService...
+                            if (!indexService.hasShard(shardId.id())) {
+                                if (indexService.store().canDeleteUnallocated(shardId)) {
+                                    logger.debug("{} deleting shard that is no longer used", shardId);
+                                    try {
+                                        indexService.store().deleteUnallocated(shardId);
+                                    } catch (Exception e) {
+                                        logger.debug("{} failed to delete unallocated shard, ignoring", e, shardId);
+                                    }
+                                }
+                            } else {
+                                // this state is weird, should we log?
+                                // basically, it means that the shard is not allocated on this node using the routing
+                                // but its still physically exists on an IndexService
+                                // Note, this listener should run after IndicesClusterStateService...
+                            }
                         }
+                        return currentState;
                     }
-                    return currentState;
-                }
 
-                @Override
-                public void onFailure(String source, Throwable t) {
-                    logger.error("{} unexpected error during deletion of unallocated shard", t, shardId);
-                }
-            });
-        }
-
-    }
-
-    private class ShardActiveRequestHandler extends BaseTransportRequestHandler<ShardActiveRequest> {
-
-        @Override
-        public ShardActiveRequest newInstance() {
-            return new ShardActiveRequest();
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
-
-        @Override
-        public void messageReceived(ShardActiveRequest request, TransportChannel channel) throws Exception {
-            channel.sendResponse(new ShardActiveResponse(shardActive(request), clusterService.localNode()));
-        }
-
-        private boolean shardActive(ShardActiveRequest request) {
-            ClusterName thisClusterName = clusterService.state().getClusterName();
-            if (!thisClusterName.equals(request.clusterName)) {
-                logger.trace("shard exists request meant for cluster[{}], but this is cluster[{}], ignoring request", request.clusterName, thisClusterName);
-                return false;
+                    @Override
+                    public void onFailure(String source, Throwable t) {
+                        logger.error("{} unexpected error during deletion of unallocated shard", t, shardId);
+                    }
+                });
             }
 
-            ShardId shardId = request.shardId;
-            IndexService indexService = indicesService.indexService(shardId.index().getName());
-            if (indexService != null && indexService.indexUUID().equals(request.indexUUID)) {
-                IndexShard indexShard = indexService.shard(shardId.getId());
-                if (indexShard != null) {
-                    return ACTIVE_STATES.contains(indexShard.state());
-                }
+            @Override
+            public void onFailure(Throwable e) {
+                logger.debug("shard copy count failed", e);
             }
-            return false;
-        }
+        });
     }
 
-    private static class ShardActiveRequest extends TransportRequest {
-
-        private ClusterName clusterName;
-        private String indexUUID;
-        private ShardId shardId;
-
-        ShardActiveRequest() {
-        }
-
-        ShardActiveRequest(ClusterName clusterName, String indexUUID, ShardId shardId) {
-            this.shardId = shardId;
-            this.indexUUID = indexUUID;
-            this.clusterName = clusterName;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            clusterName = ClusterName.readClusterName(in);
-            indexUUID = in.readString();
-            shardId = ShardId.readShardId(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            clusterName.writeTo(out);
-            out.writeString(indexUUID);
-            shardId.writeTo(out);
-        }
-    }
-
-    private static class ShardActiveResponse extends TransportResponse {
-
-        private boolean shardActive;
-        private DiscoveryNode node;
-
-        ShardActiveResponse() {
-        }
-
-        ShardActiveResponse(boolean shardActive, DiscoveryNode node) {
-            this.shardActive = shardActive;
-            this.node = node;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardActive = in.readBoolean();
-            node = DiscoveryNode.readNode(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            out.writeBoolean(shardActive);
-            node.writeTo(out);
-        }
-    }
 }

--- a/src/main/java/org/elasticsearch/indices/store/TransportShardActive.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportShardActive.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.store;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.service.IndexShard;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ */
+public class TransportShardActive extends AbstractComponent {
+
+    public static final String ACTION_SHARD_EXISTS = "internal:index/shard/exists";
+    private static final EnumSet<IndexShardState> ACTIVE_STATES = EnumSet.of(IndexShardState.STARTED, IndexShardState.RELOCATED);
+
+    private final ClusterService clusterService;
+    private final IndicesService indicesService;
+    private final TransportService transportService;
+
+    @Inject
+    public TransportShardActive(Settings settings, ClusterService clusterService, IndicesService indicesService, TransportService transportService) {
+        super(settings);
+        this.clusterService = clusterService;
+        this.indicesService = indicesService;
+        this.transportService = transportService;
+        transportService.registerHandler(ACTION_SHARD_EXISTS, new ShardActiveRequestHandler());
+    }
+
+    public void shardActiveCount(ClusterState state, ShardId shardId, Iterable<ShardRouting> indexShardRoutingTable, ActionListener<Result> listener) {
+        List<Tuple<DiscoveryNode, ShardActiveRequest>> requests = new ArrayList<>(4);
+        String indexUUID = state.getMetaData().index(shardId.getIndex()).getUUID();
+        ClusterName clusterName = state.getClusterName();
+        for (ShardRouting shardRouting : indexShardRoutingTable) {
+            DiscoveryNode currentNode = state.nodes().get(shardRouting.currentNodeId());
+            if (currentNode != null) {
+                requests.add(new Tuple<>(currentNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId())));
+            }
+            if (shardRouting.relocatingNodeId() != null) {
+                DiscoveryNode relocatingNode = state.nodes().get(shardRouting.relocatingNodeId());
+                if (relocatingNode != null) {
+                    requests.add(new Tuple<>(relocatingNode, new ShardActiveRequest(clusterName, indexUUID, shardRouting.shardId())));
+                }
+            }
+        }
+
+        ShardActiveResponseHandler responseHandler = new ShardActiveResponseHandler(shardId, requests.size(), listener);
+        for (Tuple<DiscoveryNode, ShardActiveRequest> request : requests) {
+            DiscoveryNode target = request.v1();
+            if (clusterService.localNode().equals(target)) {
+                responseHandler.handleResponse(new ShardActiveResponse(shardActive(request.v2()), target));
+            } else {
+                logger.trace("Sending shard exists request to node [{}] for shard [{}]", target, shardId);
+                transportService.sendRequest(target, ACTION_SHARD_EXISTS, request.v2(), responseHandler);
+            }
+        }
+    }
+
+    private boolean shardActive(ShardActiveRequest request) {
+        ClusterName thisClusterName = clusterService.state().getClusterName();
+        if (!thisClusterName.equals(request.clusterName)) {
+            logger.trace("shard exists request meant for cluster[{}], but this is cluster[{}], ignoring request", request.clusterName, thisClusterName);
+            return false;
+        }
+
+        ShardId shardId = request.shardId;
+        IndexService indexService = indicesService.indexService(shardId.index().getName());
+        if (indexService != null && indexService.indexUUID().equals(request.indexUUID)) {
+            IndexShard indexShard = indexService.shard(shardId.getId());
+            if (indexShard != null) {
+                return ACTIVE_STATES.contains(indexShard.state());
+            }
+        }
+        return false;
+    }
+
+    public static class Result {
+
+        private final int targetedShards;
+        private final int activeShards;
+
+        public Result(int targetedShards, int activeShards) {
+            this.targetedShards = targetedShards;
+            this.activeShards = activeShards;
+        }
+
+        public int getTargetedShards() {
+            return targetedShards;
+        }
+
+        public int getActiveShards() {
+            return activeShards;
+        }
+    }
+
+    private static class ShardActiveRequest extends TransportRequest {
+
+        private ClusterName clusterName;
+        private String indexUUID;
+        private ShardId shardId;
+
+        ShardActiveRequest() {
+        }
+
+        ShardActiveRequest(ClusterName clusterName, String indexUUID, ShardId shardId) {
+            this.shardId = shardId;
+            this.indexUUID = indexUUID;
+            this.clusterName = clusterName;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            clusterName = ClusterName.readClusterName(in);
+            indexUUID = in.readString();
+            shardId = ShardId.readShardId(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            clusterName.writeTo(out);
+            out.writeString(indexUUID);
+            shardId.writeTo(out);
+        }
+    }
+
+    private static class ShardActiveResponse extends TransportResponse {
+
+        private boolean shardActive;
+        private DiscoveryNode node;
+
+        ShardActiveResponse() {
+        }
+
+        ShardActiveResponse(boolean shardActive, DiscoveryNode node) {
+            this.shardActive = shardActive;
+            this.node = node;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            shardActive = in.readBoolean();
+            node = DiscoveryNode.readNode(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeBoolean(shardActive);
+            node.writeTo(out);
+        }
+    }
+
+    private class ShardActiveRequestHandler extends BaseTransportRequestHandler<ShardActiveRequest> {
+
+        @Override
+        public ShardActiveRequest newInstance() {
+            return new ShardActiveRequest();
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.SAME;
+        }
+
+        @Override
+        public void messageReceived(ShardActiveRequest request, TransportChannel channel) throws Exception {
+            channel.sendResponse(new ShardActiveResponse(shardActive(request), clusterService.localNode()));
+        }
+    }
+
+    private class ShardActiveResponseHandler implements TransportResponseHandler<ShardActiveResponse> {
+
+        private final ShardId shardId;
+        private final int expectedActiveCopies;
+        private final ActionListener<Result> listener;
+
+        private final AtomicInteger awaitingResponses;
+        private final AtomicInteger activeCopies;
+
+        public ShardActiveResponseHandler(ShardId shardId, int expectedActiveCopies, ActionListener<Result> listener) {
+            this.shardId = shardId;
+            this.expectedActiveCopies = expectedActiveCopies;
+            this.listener = listener;
+            this.awaitingResponses = new AtomicInteger(expectedActiveCopies);
+            this.activeCopies = new AtomicInteger();
+        }
+
+        @Override
+        public ShardActiveResponse newInstance() {
+            return new ShardActiveResponse();
+        }
+
+        @Override
+        public void handleResponse(ShardActiveResponse response) {
+            if (response.shardActive) {
+                logger.trace("[{}] exists on node [{}]", shardId, response.node);
+                activeCopies.incrementAndGet();
+            }
+            countDownAndFinish();
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            logger.debug("shards active request failed for {}", exp, shardId);
+            countDownAndFinish();
+        }
+
+        private void countDownAndFinish() {
+            if (awaitingResponses.decrementAndGet() == 0) {
+                listener.onResponse(new Result(expectedActiveCopies, activeCopies.get()));
+            }
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.SAME;
+        }
+
+    }
+
+}

--- a/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -84,6 +84,10 @@ public class RestBulkAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             bulkRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
+        Boolean validateWriteConsistency = request.paramAsBoolean("validate_consistency", null);
+        if (validateWriteConsistency != null) {
+            bulkRequest.validateWriteConsistency(validateWriteConsistency);
+        }
         bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
         bulkRequest.refresh(request.paramAsBoolean("refresh", bulkRequest.refresh()));
         bulkRequest.add(request.content(), request.contentUnsafe(), defaultIndex, defaultType, defaultRouting, null, allowExplicitIndex);

--- a/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -70,6 +70,10 @@ public class RestDeleteAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             deleteRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
+        Boolean validateWriteConsistency = request.paramAsBoolean("validate_consistency", null);
+        if (validateWriteConsistency != null) {
+            deleteRequest.validateWriteConsistency(validateWriteConsistency);
+        }
 
         client.delete(deleteRequest, new RestBuilderListener<DeleteResponse>(channel) {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/deletebyquery/RestDeleteByQueryAction.java
@@ -81,6 +81,10 @@ public class RestDeleteByQueryAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             deleteByQueryRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
+        Boolean validateWriteConsistency = request.paramAsBoolean("validate_consistency", null);
+        if (validateWriteConsistency != null) {
+            deleteByQueryRequest.validateWriteConsistency(validateWriteConsistency);
+        }
         deleteByQueryRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteByQueryRequest.indicesOptions()));
         client.deleteByQuery(deleteByQueryRequest, new RestBuilderListener<DeleteByQueryResponse>(channel) {
             @Override

--- a/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -106,6 +106,10 @@ public class RestIndexAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             indexRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
+        Boolean validateWriteConsistency = request.paramAsBoolean("validate_consistency", null);
+        if (validateWriteConsistency != null) {
+            indexRequest.validateWriteConsistency(validateWriteConsistency);
+        }
         client.index(indexRequest, new RestBuilderListener<IndexResponse>(channel) {
             @Override
             public RestResponse buildResponse(IndexResponse response, XContentBuilder builder) throws Exception {

--- a/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -68,6 +68,10 @@ public class RestUpdateAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             updateRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
+        Boolean validateWriteConsistency = request.paramAsBoolean("validate_consistency", null);
+        if (validateWriteConsistency != null) {
+            updateRequest.validateWriteConsistency(validateWriteConsistency);
+        }
         updateRequest.docAsUpsert(request.paramAsBoolean("doc_as_upsert", updateRequest.docAsUpsert()));
         if( request.hasParam("script") ) {
             updateRequest.script(request.param("script"), ScriptService.ScriptType.INLINE);

--- a/src/main/java/org/elasticsearch/transport/ActionNames.java
+++ b/src/main/java/org/elasticsearch/transport/ActionNames.java
@@ -111,8 +111,8 @@ import org.elasticsearch.gateway.local.state.meta.TransportNodesListGatewayMetaS
 import org.elasticsearch.gateway.local.state.shards.TransportNodesListGatewayStartedShards;
 import org.elasticsearch.indices.recovery.RecoverySource;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
-import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.river.cluster.PublishRiverClusterStateAction;
 import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.snapshots.RestoreService;
@@ -322,7 +322,7 @@ final class ActionNames {
         builder.put(RecoveryTarget.Actions.TRANSLOG_OPS, "index/shard/recovery/translogOps");
         builder.put(RecoverySource.Actions.START_RECOVERY, "index/shard/recovery/startRecovery");
 
-        builder.put(IndicesStore.ACTION_SHARD_EXISTS, "index/shard/exists");
+        builder.put(TransportShardActive.ACTION_SHARD_EXISTS, "index/shard/exists");
 
         builder.put(PublishRiverClusterStateAction.ACTION_NAME, "river/state/publish");
 

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -245,6 +245,10 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         }
     }
 
+    protected TransportRequestHandler getHandler(String action) {
+        return serverHandlers.get(action);
+    }
+
     class Adapter implements TransportServiceAdapter {
 
         final MeanMetric rxMetric = new MeanMetric();

--- a/src/main/java/org/elasticsearch/transport/local/LocalTransportChannel.java
+++ b/src/main/java/org/elasticsearch/transport/local/LocalTransportChannel.java
@@ -72,7 +72,7 @@ public class LocalTransportChannel implements TransportChannel {
         response.writeTo(stream);
         stream.close();
         final byte[] data = bStream.bytes().toBytes();
-        targetTransport.threadPool().generic().execute(new Runnable() {
+        targetTransport.workers().execute(new Runnable() {
             @Override
             public void run() {
                 targetTransport.messageReceived(data, action, sourceTransport, version, null);
@@ -98,7 +98,7 @@ public class LocalTransportChannel implements TransportChannel {
             too.close();
         }
         final byte[] data = stream.bytes().toBytes();
-        targetTransport.threadPool().generic().execute(new Runnable() {
+        targetTransport.workers().execute(new Runnable() {
             @Override
             public void run() {
                 targetTransport.messageReceived(data, action, sourceTransport, version, null);

--- a/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.node.internal.InternalNode;
@@ -121,7 +122,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
     private final List<InternalNode> nodes = Lists.newCopyOnWriteArrayList();
 
     @Inject
-    public TribeService(Settings settings, ClusterService clusterService) {
+    public TribeService(Settings settings, ClusterService clusterService, DiscoveryService discoveryService) {
         super(settings);
         this.clusterService = clusterService;
         Map<String, Settings> nodesSettings = Maps.newHashMap(settings.getGroups("tribe", true));
@@ -143,7 +144,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
         if (!nodes.isEmpty()) {
             // remove the initial election / recovery blocks since we are not going to have a
             // master elected in this single tribe  node local "cluster"
-            clusterService.removeInitialStateBlock(Discovery.NO_MASTER_BLOCK);
+            clusterService.removeInitialStateBlock(discoveryService.getNoMasterBlock());
             clusterService.removeInitialStateBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK);
             if (settings.getAsBoolean("tribe.blocks.write", false)) {
                 clusterService.addInitialStateBlock(TRIBE_WRITE_BLOCK);

--- a/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.node.NodeBuilder;
@@ -223,7 +222,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
         @Override
         public void clusterChanged(final ClusterChangedEvent event) {
             logger.debug("[{}] received cluster event, [{}]", tribeName, event.source());
-            clusterService.submitStateUpdateTask("cluster event from " + tribeName + ", " + event.source(), new ClusterStateUpdateTask() {
+            clusterService.submitStateUpdateTask("cluster event from " + tribeName + ", " + event.source(), new ClusterStateNonMasterUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     ClusterState tribeState = event.state();

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -263,12 +263,12 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
                 .put("discovery.type", "local")
                 .build();
 
-        ListenableFuture<String> master = cluster().startNodeAsync(settings);
-        ListenableFuture<String> nonMaster = cluster().startNodeAsync(settingsBuilder().put(settings).put("node.master", false).build());
+        ListenableFuture<String> master = internalCluster().startNodeAsync(settings);
+        ListenableFuture<String> nonMaster = internalCluster().startNodeAsync(settingsBuilder().put(settings).put("node.master", false).build());
         master.get();
         ensureGreen(); // make sure we have a cluster
 
-        ClusterService clusterService = cluster().getInstance(ClusterService.class, nonMaster.get());
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class, nonMaster.get());
 
         final boolean[] taskFailed = {false};
         final CountDownLatch latch1 = new CountDownLatch(1);

--- a/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
+++ b/src/test/java/org/elasticsearch/cluster/ClusterServiceTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.cluster;
 
 import com.google.common.base.Predicate;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
@@ -254,6 +255,58 @@ public class ClusterServiceTests extends ElasticsearchIntegrationTest {
         assertThat(onFailure.get(), equalTo(false));
 
         assertThat(processedLatch.await(1, TimeUnit.SECONDS), equalTo(true));
+    }
+
+    @Test
+    public void testMasterAwareExecution() throws Exception {
+        Settings settings = settingsBuilder()
+                .put("discovery.type", "local")
+                .build();
+
+        ListenableFuture<String> master = cluster().startNodeAsync(settings);
+        ListenableFuture<String> nonMaster = cluster().startNodeAsync(settingsBuilder().put(settings).put("node.master", false).build());
+        master.get();
+        ensureGreen(); // make sure we have a cluster
+
+        ClusterService clusterService = cluster().getInstance(ClusterService.class, nonMaster.get());
+
+        final boolean[] taskFailed = {false};
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        clusterService.submitStateUpdateTask("test", new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                latch1.countDown();
+                return currentState;
+            }
+
+            @Override
+            public void onFailure(String source, Throwable t) {
+                taskFailed[0] = true;
+                latch1.countDown();
+            }
+        });
+
+        latch1.await();
+        assertTrue("cluster state update task was executed on a non-master", taskFailed[0]);
+
+        taskFailed[0] = true;
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        clusterService.submitStateUpdateTask("test", new ClusterStateNonMasterUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                taskFailed[0] = false;
+                latch2.countDown();
+                return currentState;
+            }
+
+            @Override
+            public void onFailure(String source, Throwable t) {
+                taskFailed[0] = true;
+                latch2.countDown();
+            }
+        });
+        latch2.await();
+        assertFalse("non-master cluster state update task was not executed", taskFailed[0]);
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.index.query.QueryBuilders;

--- a/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
+++ b/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -60,7 +61,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> should be blocked, no master...");
         ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().size(), equalTo(1)); // verify that we still see the local node in the cluster state
 
         logger.info("--> start second node, cluster should be formed");
@@ -70,9 +71,9 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().size(), equalTo(2));
@@ -98,11 +99,11 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         awaitBusy(new Predicate<Object>() {
             public boolean apply(Object obj) {
                 ClusterState  state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                return state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK);
+                return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
             }
         });
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().size(), equalTo(1)); // verify that we still see the local node in the cluster state
 
         logger.info("--> starting the previous master node again...");
@@ -112,9 +113,9 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().size(), equalTo(2));
@@ -135,7 +136,7 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         assertThat(awaitBusy(new Predicate<Object>() {
             public boolean apply(Object obj) {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                return state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK);
+                return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
             }
         }), equalTo(true));
 
@@ -146,9 +147,9 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().size(), equalTo(2));
@@ -183,21 +184,21 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
         awaitBusy(new Predicate<Object>() {
             public boolean apply(Object obj) {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                return state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK);
+                return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
             }
         });
         
         awaitBusy(new Predicate<Object>() {
             public boolean apply(Object obj) {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                return state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK);
+                return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
             }
         });
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID), equalTo(true));
 
         logger.info("--> start two more nodes");
         internalCluster().startNode(settings);
@@ -298,9 +299,9 @@ public class MinimumMasterNodesTests extends ElasticsearchIntegrationTest {
                 boolean success = true;
                 for (Client client : internalCluster()) {
                     ClusterState state = client.admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                    success &= state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK);
+                    success &= state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Checking for NO_MASTER_BLOCK on client: {} NO_MASTER_BLOCK: [{}]", client, state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK));
+                        logger.debug("Checking for NO_MASTER_BLOCK on client: {} NO_MASTER_BLOCK: [{}]", client, state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID));
                     }
                 }
                 return success;

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.ScriptService;
@@ -72,7 +73,7 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
             @Override
             public void run() {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                assertTrue(state.blocks().hasGlobalBlock(Discovery.NO_MASTER_BLOCK));
+                assertTrue(state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID));
             }
         });
 

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -19,13 +19,17 @@
 
 package org.elasticsearch.cluster;
 
+import com.google.common.base.Predicate;
+import org.elasticsearch.action.count.CountResponse;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.percolate.PercolateSourceBuilder;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.rest.RestStatus;
@@ -59,6 +63,7 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put("discovery.zen.ping_timeout", "200ms")
                 .put("discovery.initial_state_timeout", "500ms")
+                .put(DiscoverySettings.NO_MASTER_BLOCK, "all")
                 .build();
 
         TimeValue timeout = TimeValue.timeValueMillis(200);
@@ -233,5 +238,71 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
 
         internalCluster().startNode(settings);
         client().admin().cluster().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").execute().actionGet();
+    }
+
+    @Test
+    public void testNoMasterActions_writeMasterBlock() throws Exception {
+        Settings settings = settingsBuilder()
+                .put("discovery.type", "zen")
+                .put("action.auto_create_index", false)
+                .put("discovery.zen.minimum_master_nodes", 2)
+                .put("discovery.zen.ping_timeout", "200ms")
+                .put("discovery.initial_state_timeout", "500ms")
+                .put(DiscoverySettings.NO_MASTER_BLOCK, "write")
+                .build();
+
+        cluster().startNode(settings);
+        // start a second node, create an index, and then shut it down so we have no master block
+        cluster().startNode(settings);
+        prepareCreate("test1").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).get();
+        prepareCreate("test2").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).get();
+        client().admin().cluster().prepareHealth("_all").setWaitForGreenStatus().get();
+        client().prepareIndex("test1", "type1", "1").setSource("field", "value1").get();
+        client().prepareIndex("test2", "type1", "1").setSource("field", "value1").get();
+        refresh();
+
+        cluster().stopRandomNode();
+        assertThat(awaitBusy(new Predicate<Object>() {
+            public boolean apply(Object o) {
+                ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
+                return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+            }
+        }), equalTo(true));
+
+
+        GetResponse getResponse = client().prepareGet("test1", "type1", "1").get();
+        assertExists(getResponse);
+
+        CountResponse countResponse = client().prepareCount("test1").get();
+        assertHitCount(countResponse, 1l);
+
+        SearchResponse searchResponse = client().prepareSearch("test1").get();
+        assertHitCount(searchResponse, 1l);
+
+        countResponse = client().prepareCount("test2").get();
+        assertThat(countResponse.getTotalShards(), equalTo(2));
+        assertThat(countResponse.getSuccessfulShards(), equalTo(1));
+
+        TimeValue timeout = TimeValue.timeValueMillis(200);
+        long now = System.currentTimeMillis();
+        try {
+            client().prepareUpdate("test1", "type1", "1").setDoc("field", "value2").setTimeout(timeout).get();
+            fail("Expected ClusterBlockException");
+        } catch (ClusterBlockException e) {
+            assertThat(System.currentTimeMillis() - now, greaterThan(timeout.millis() - 50));
+            assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
+        }
+
+        now = System.currentTimeMillis();
+        try {
+            client().prepareIndex("test1", "type1", "1").setSource(XContentFactory.jsonBuilder().startObject().endObject()).setTimeout(timeout).get();
+            fail("Expected ClusterBlockException");
+        } catch (ClusterBlockException e) {
+            assertThat(System.currentTimeMillis() - now, greaterThan(timeout.millis() - 50));
+            assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
+        }
+
+        cluster().startNode(settings);
+        client().admin().cluster().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
     }
 }

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster;
 
 import com.google.common.base.Predicate;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -262,6 +263,11 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test1", "type1", "1").setSource("field", "value1").get();
         client().prepareIndex("test2", "type1", "1").setSource("field", "value1").get();
         refresh();
+
+        ensureSearchable("test1", "test2");
+
+        ClusterStateResponse clusterState = client().admin().cluster().prepareState().get();
+        logger.info("Cluster state:\n" + clusterState.getState().prettyPrint());
 
         internalCluster().stopRandomDataNode();
         assertThat(awaitBusy(new Predicate<Object>() {

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -44,6 +44,11 @@ import java.util.HashMap;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.hamcrest.Matchers.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertExists;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  */
@@ -261,7 +266,7 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test2", "type1", "1").setSource("field", "value1").get();
         refresh();
 
-        cluster().stopRandomNode();
+        cluster().stopRandomDataNode();
         assertThat(awaitBusy(new Predicate<Object>() {
             public boolean apply(Object o) {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();

--- a/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
+++ b/src/test/java/org/elasticsearch/cluster/NoMasterNodeTests.java
@@ -20,9 +20,9 @@
 package org.elasticsearch.cluster;
 
 import com.google.common.base.Predicate;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.percolate.PercolateSourceBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -43,12 +43,9 @@ import java.util.HashMap;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
-import static org.hamcrest.Matchers.*;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertExists;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.*;
 
 /**
  */
@@ -256,9 +253,9 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
                 .put(DiscoverySettings.NO_MASTER_BLOCK, "write")
                 .build();
 
-        cluster().startNode(settings);
+        internalCluster().startNode(settings);
         // start a second node, create an index, and then shut it down so we have no master block
-        cluster().startNode(settings);
+        internalCluster().startNode(settings);
         prepareCreate("test1").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).get();
         prepareCreate("test2").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).get();
         client().admin().cluster().prepareHealth("_all").setWaitForGreenStatus().get();
@@ -266,7 +263,7 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test2", "type1", "1").setSource("field", "value1").get();
         refresh();
 
-        cluster().stopRandomDataNode();
+        internalCluster().stopRandomDataNode();
         assertThat(awaitBusy(new Predicate<Object>() {
             public boolean apply(Object o) {
                 ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
@@ -307,7 +304,7 @@ public class NoMasterNodeTests extends ElasticsearchIntegrationTest {
             assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
         }
 
-        cluster().startNode(settings);
+        internalCluster().startNode(settings);
         client().admin().cluster().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
     }
 }

--- a/src/test/java/org/elasticsearch/discovery/ClusterDiscoveryConfiguration.java
+++ b/src/test/java/org/elasticsearch/discovery/ClusterDiscoveryConfiguration.java
@@ -72,6 +72,10 @@ public class ClusterDiscoveryConfiguration extends SettingsSource {
             this(numOfNodes, numOfNodes);
         }
 
+        public UnicastZen(int numOfNodes, Settings extraSettings) {
+            this(numOfNodes, numOfNodes, extraSettings);
+        }
+
         public UnicastZen(int numOfNodes, int numOfUnicastHosts) {
             this(numOfNodes, numOfUnicastHosts, ImmutableSettings.EMPTY);
         }

--- a/src/test/java/org/elasticsearch/discovery/ClusterDiscoveryConfiguration.java
+++ b/src/test/java/org/elasticsearch/discovery/ClusterDiscoveryConfiguration.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.discovery;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.google.common.primitives.Ints;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.SettingsSource;
+import org.elasticsearch.transport.local.LocalTransport;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ClusterDiscoveryConfiguration extends SettingsSource {
+
+    public static Settings DEFAULT_SETTINGS = ImmutableSettings.settingsBuilder()
+            .put("gateway.type", "local")
+            .put("discovery.type", "zen")
+            .build();
+
+    final int numOfNodes;
+
+    final Settings baseSettings;
+
+    public ClusterDiscoveryConfiguration(int numOfNodes) {
+        this(numOfNodes, ImmutableSettings.EMPTY);
+    }
+
+    public ClusterDiscoveryConfiguration(int numOfNodes, Settings extraSettings) {
+        this.numOfNodes = numOfNodes;
+        this.baseSettings = ImmutableSettings.builder().put(DEFAULT_SETTINGS).put(extraSettings).build();
+    }
+
+    @Override
+    public Settings node(int nodeOrdinal) {
+        return baseSettings;
+    }
+
+    @Override
+    public Settings transportClient() {
+        return baseSettings;
+    }
+
+    public static class UnicastZen extends ClusterDiscoveryConfiguration {
+
+        private final static AtomicInteger portRangeCounter = new AtomicInteger();
+
+        private final int[] unicastHostOrdinals;
+        private final int basePort;
+
+        public UnicastZen(int numOfNodes) {
+            this(numOfNodes, numOfNodes);
+        }
+
+        public UnicastZen(int numOfNodes, int numOfUnicastHosts) {
+            this(numOfNodes, numOfUnicastHosts, ImmutableSettings.EMPTY);
+        }
+
+        public UnicastZen(int numOfNodes, int numOfUnicastHosts, Settings extraSettings) {
+            super(numOfNodes, extraSettings);
+            if (numOfUnicastHosts == numOfNodes) {
+                unicastHostOrdinals = new int[numOfNodes];
+                for (int i = 0; i < numOfNodes; i++) {
+                    unicastHostOrdinals[i] = i;
+                }
+            } else {
+                Set<Integer> ordinals = new HashSet<>(numOfUnicastHosts);
+                while (ordinals.size() != numOfUnicastHosts) {
+                    ordinals.add(RandomizedTest.randomInt(numOfNodes - 1));
+                }
+                unicastHostOrdinals = Ints.toArray(ordinals);
+            }
+            this.basePort = calcBasePort();
+        }
+
+        public UnicastZen(int numOfNodes, int[] unicastHostOrdinals) {
+            this(numOfNodes, ImmutableSettings.EMPTY, unicastHostOrdinals);
+        }
+
+        public UnicastZen(int numOfNodes, Settings extraSettings, int[] unicastHostOrdinals) {
+            super(numOfNodes, extraSettings);
+            this.unicastHostOrdinals = unicastHostOrdinals;
+            this.basePort = calcBasePort();
+        }
+
+        private final static int calcBasePort() {
+            return 10000 +
+                    1000 * (ElasticsearchIntegrationTest.CHILD_VM_ID.hashCode() % 60) + // up to 60 jvms
+                    100 * portRangeCounter.incrementAndGet(); // up to 100 nodes
+        }
+
+
+        @Override
+        public Settings node(int nodeOrdinal) {
+            ImmutableSettings.Builder builder = ImmutableSettings.builder()
+                    .put("discovery.zen.ping.multicast.enabled", false);
+
+            String[] unicastHosts = new String[unicastHostOrdinals.length];
+            if (InternalTestCluster.NODE_MODE.equals("local")) {
+                builder.put(LocalTransport.TRANSPORT_LOCAL_ADDRESS, "node_" + nodeOrdinal);
+                for (int i = 0; i < unicastHosts.length; i++) {
+                    unicastHosts[i] = "node_" + unicastHostOrdinals[i];
+                }
+            } else {
+                // we need to pin the node port & host so we'd know where to point things
+                builder.put("transport.tcp.port", basePort + nodeOrdinal);
+                builder.put("transport.host", "localhost");
+                for (int i = 0; i < unicastHosts.length; i++) {
+                    unicastHosts[i] = "localhost:" + (basePort + unicastHostOrdinals[i]);
+                }
+            }
+            builder.putArray("discovery.zen.ping.unicast.hosts", unicastHosts);
+            return builder.put(super.node(nodeOrdinal)).build();
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/discovery/ClusterDiscoveryConfiguration.java
+++ b/src/test/java/org/elasticsearch/discovery/ClusterDiscoveryConfiguration.java
@@ -120,7 +120,8 @@ public class ClusterDiscoveryConfiguration extends SettingsSource {
                     .put("discovery.zen.ping.multicast.enabled", false);
 
             String[] unicastHosts = new String[unicastHostOrdinals.length];
-            if (InternalTestCluster.NODE_MODE.equals("local")) {
+            String mode = baseSettings.get("node.mode", InternalTestCluster.NODE_MODE);
+            if (mode.equals("local")) {
                 builder.put(LocalTransport.TRANSPORT_LOCAL_ADDRESS, "node_" + nodeOrdinal);
                 for (int i = 0; i < unicastHosts.length; i++) {
                     unicastHosts[i] = "node_" + unicastHostOrdinals[i];

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.discovery;
 
 import com.google.common.base.Predicate;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -361,6 +362,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     }
 
     @Test
+    @LuceneTestCase.AwaitsFix(bugUrl = "MvG will fix")
     public void testAckedIndexing() throws Exception {
         final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
         ensureStableCluster(3);

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -35,10 +35,10 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
@@ -47,9 +47,10 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportModule;
 import org.elasticsearch.transport.TransportService;
-import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -61,13 +62,14 @@ import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ClusterScope(scope= Scope.TEST, numDataNodes =0)
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationTest {
 
     private static final Settings nodeSettings = ImmutableSettings.settingsBuilder()
             .put("discovery.type", "zen") // <-- To override the local setting if set externally
             .put("discovery.zen.fd.ping_timeout", "1s") // <-- for hitting simulated network failures quickly
             .put("discovery.zen.fd.ping_retries", "1") // <-- for hitting simulated network failures quickly
+            .put(DiscoverySettings.PUBLISH_TIMEOUT, "1s") // <-- for hitting simulated network failures quickly
             .put("discovery.zen.minimum_master_nodes", 2)
             .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
             .build();
@@ -97,12 +99,8 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
 
         List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
 
-        // Wait until a green status has been reaches and 3 nodes are part of the cluster
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("3")
-                .get();
-        assertThat(clusterHealthResponse.isTimedOut(), is(false));
+        // Wait until 3 nodes are part of the cluster
+        ensureStableCluster(3);
 
         // Figure out what is the elected master node
         DiscoveryNode masterDiscoNode = findMasterNode(nodes);
@@ -155,11 +153,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         }
 
         // Wait until the master node sees all 3 nodes again.
-        clusterHealthResponse = masterClient.admin().cluster().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("3")
-                .get();
-        assertThat(clusterHealthResponse.isTimedOut(), is(false));
+        ensureStableCluster(3);
 
         for (String node : nodes) {
             ClusterState state = internalCluster().client(node).admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
@@ -171,17 +165,12 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     }
 
     @Test
-    @Ignore
     @TestLogging("discovery.zen:TRACE,action:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
     public void testDataConsistency() throws Exception {
         List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
 
-        // Wait until a green status has been reaches and 3 nodes are part of the cluster
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("3")
-                .get();
-        assertThat(clusterHealthResponse.isTimedOut(), is(false));
+        // Wait until a 3 nodes are part of the cluster
+        ensureStableCluster(3);
 
         assertAcked(prepareCreate("test")
                 .addMapping("type", "field", "type=long")
@@ -216,35 +205,29 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         ensureGreen("test");
 
         // Pick a node that isn't the elected master.
-        String isolatedNode = nodes.get(0);
-        String nonIsolatedNode = nodes.get(1);
-        final Client nonIsolatedNodeClient = internalCluster().client(nonIsolatedNode);
+        final String isolatedNode = nodes.get(0);
+        final String nonIsolatedNode = nodes.get(1);
 
         // Simulate a network issue between the unlucky node and the rest of the cluster.
-        for (String nodeId : nodes) {
-            if (!nodeId.equals(isolatedNode)) {
-                addFailToSendNoConnectRule(nodeId, isolatedNode);
-                addFailToSendNoConnectRule(isolatedNode, nodeId);
-            }
-        }
+        randomIsolateNode(isolatedNode, nodes);
         try {
-            // Wait until elected master has removed that the unlucky node...
+            logger.info("wait until elected master has removed [{}]", isolatedNode);
             boolean applied = awaitBusy(new Predicate<Object>() {
                 @Override
                 public boolean apply(Object input) {
-                    return nonIsolatedNodeClient.admin().cluster().prepareState().setLocal(true).get().getState().nodes().size() == 2;
+                    return client(nonIsolatedNode).admin().cluster().prepareState().setLocal(true).get().getState().nodes().size() == 2;
                 }
             }, 1, TimeUnit.MINUTES);
             assertThat(applied, is(true));
 
             // The unlucky node must report *no* master node, since it can't connect to master and in fact it should
             // continuously ping until network failures have been resolved. However
-            final Client isolatedNodeClient = internalCluster().client(isolatedNode);
             // It may a take a bit before the node detects it has been cut off from the elected master
+            logger.info("waiting for isolated node [{}] to have no master", isolatedNode);
             applied = awaitBusy(new Predicate<Object>() {
                 @Override
                 public boolean apply(Object input) {
-                    ClusterState localClusterState = isolatedNodeClient.admin().cluster().prepareState().setLocal(true).get().getState();
+                    ClusterState localClusterState = client(isolatedNode).admin().cluster().prepareState().setLocal(true).get().getState();
                     DiscoveryNodes localDiscoveryNodes = localClusterState.nodes();
                     logger.info("localDiscoveryNodes=" + localDiscoveryNodes.prettyPrint());
                     return localDiscoveryNodes.masterNode() == null;
@@ -252,13 +235,14 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
             }, 10, TimeUnit.SECONDS);
             assertThat(applied, is(true));
 
-            ClusterHealthResponse healthResponse = nonIsolatedNodeClient.admin().cluster().prepareHealth("test")
+            ClusterHealthResponse healthResponse = client(nonIsolatedNode).admin().cluster().prepareHealth("test")
                     .setWaitForYellowStatus().get();
             assertThat(healthResponse.isTimedOut(), is(false));
             assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
 
             // Reads on the right side of the split must work
-            searchResponse = nonIsolatedNodeClient.prepareSearch("test").setTypes("type")
+            logger.info("verifying healthy part of cluster returns data");
+            searchResponse = client(nonIsolatedNode).prepareSearch("test").setTypes("type")
                     .addSort("field", SortOrder.ASC)
                     .get();
             assertHitCount(searchResponse, indexRequests.length);
@@ -269,20 +253,21 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
             }
 
             // Reads on the wrong side of the split are partial
-            searchResponse = isolatedNodeClient.prepareSearch("test").setTypes("type")
-                    .addSort("field", SortOrder.ASC)
+            logger.info("verifying isolated node [{}] returns partial data", isolatedNode);
+            searchResponse = client(isolatedNode).prepareSearch("test").setTypes("type")
+                    .addSort("field", SortOrder.ASC).setPreference("_only_local")
                     .get();
             assertThat(searchResponse.getSuccessfulShards(), lessThan(searchResponse.getTotalShards()));
             assertThat(searchResponse.getHits().totalHits(), lessThan((long) indexRequests.length));
 
-            // Writes on the right side of the split must work
-            UpdateResponse updateResponse = nonIsolatedNodeClient.prepareUpdate("test", "type", "0").setDoc("field2", 2).get();
+            logger.info("verifying writes on healthy cluster");
+            UpdateResponse updateResponse = client(nonIsolatedNode).prepareUpdate("test", "type", "0").setDoc("field2", 2).get();
             assertThat(updateResponse.getVersion(), equalTo(2l));
 
-            // Writes on the wrong side of the split fail
             try {
-                isolatedNodeClient.prepareUpdate("test", "type", "0").setDoc("field2", 2)
-                        .setTimeout(TimeValue.timeValueSeconds(5)) // Fail quick, otherwise we wait 60 seconds.
+                logger.info("verifying writes on isolated [{}] fail", isolatedNode);
+                client(isolatedNode).prepareUpdate("test", "type", "0").setDoc("field2", 2)
+                        .setTimeout("1s") // Fail quick, otherwise we wait 60 seconds.
                         .get();
                 fail();
             } catch (ClusterBlockException exception) {
@@ -294,23 +279,13 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         } finally {
             // stop simulating network failures, from this point on the unlucky node is able to rejoin
             // We also need to do this even if assertions fail, since otherwise the test framework can't work properly
-            for (String nodeId : nodes) {
-                if (!nodeId.equals(isolatedNode)) {
-                    clearNoConnectRule(nodeId, isolatedNode);
-                    clearNoConnectRule(isolatedNode, nodeId);
-                }
-            }
+            restoreIsolation(isolatedNode, nodes);
         }
 
         // Wait until the master node sees all 3 nodes again.
-        clusterHealthResponse = nonIsolatedNodeClient.admin().cluster().prepareHealth()
-                .setWaitForGreenStatus()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("3")
-                .get();
-        assertThat(clusterHealthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
-        assertThat(clusterHealthResponse.isTimedOut(), is(false));
+        ensureStableCluster(3);
 
+        logger.info("verifying all nodes return all data");
         for (Client client : clients()) {
             searchResponse = client.prepareSearch("test").setTypes("type")
                     .addSort("field", SortOrder.ASC)
@@ -334,16 +309,79 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         }
     }
 
+
     @Test
-    @Ignore
+    @TestLogging("discovery.zen:TRACE,action:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
+    public void voidIsolateMasterAndVerifyClusterStateConsensus() throws Exception {
+        final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
+        ensureStableCluster(3);
+
+        assertAcked(prepareCreate("test")
+                .setSettings(ImmutableSettings.builder()
+                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1 + randomInt(2))
+                                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomInt(2))
+                ));
+
+        ensureGreen();
+        String isolatedNode = findMasterNode(nodes).name();
+        String nonIsolatedNode = null;
+        for (String node : nodes) {
+            if (!node.equals(isolatedNode)) {
+                nonIsolatedNode = node;
+                break;
+            }
+        }
+        randomIsolateNode(isolatedNode, nodes);
+
+        // make sure cluster reforms
+        ensureStableCluster(2, nonIsolatedNode);
+
+        // restore isolation
+        restoreIsolation(isolatedNode, nodes);
+
+        ensureStableCluster(3);
+
+        logger.info("issue a reroute");
+        // trigger a reroute now, instead of waiting for the background reroute of RerouteService
+        assertAcked(client().admin().cluster().prepareReroute());
+        // and wait for it to finish.
+        assertFalse(client().admin().cluster().prepareHealth().setWaitForRelocatingShards(0).get().isTimedOut());
+
+
+        // verify all cluster states are the same
+        ClusterState state = null;
+        for (String node : nodes) {
+            ClusterState nodeState = client(node).admin().cluster().prepareState().setLocal(true).get().getState();
+            if (state == null) {
+                state = nodeState;
+                continue;
+            }
+            // assert nodes are identical
+            try {
+                assertEquals("unequal versions", state.version(), nodeState.version());
+                assertEquals("unequal node count", state.nodes().size(), nodeState.nodes().size());
+                assertEquals("different masters ", state.nodes().masterNodeId(), nodeState.nodes().masterNodeId());
+                assertEquals("different meta data version", state.metaData().version(), nodeState.metaData().version());
+                if (!state.routingTable().prettyPrint().equals(nodeState.routingTable().prettyPrint())) {
+                    fail("different routing");
+                }
+            } catch (AssertionError t) {
+                fail("failed comparing cluster state: " + t.getMessage() + "\n" +
+                        "--- cluster state of node [" + nodes.get(0) + "]: ---\n" + state.prettyPrint() +
+                        "\n--- cluster state [" + node + "]: ---\n" + nodeState.prettyPrint());
+            }
+
+        }
+
+    }
+
+
+    @Test
     @TestLogging("discovery.zen:TRACE,action:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
     public void testRejoinDocumentExistsInAllShardCopies() throws Exception {
-        final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
-        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("3")
-                .get();
-        assertThat(clusterHealthResponse.isTimedOut(), is(false));
+        List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
+        ensureStableCluster(3);
+
         assertAcked(prepareCreate("test")
                 .setSettings(ImmutableSettings.builder()
                                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
@@ -352,23 +390,15 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
                 .get());
         ensureGreen("test");
 
-        String isolatedNode = findMasterNode(nodes).getName();
-        String notIsolatedNode = null;
-        for (String node : nodes) {
-            if (!node.equals(isolatedNode)) {
-                notIsolatedNode = node;
-                break;
-            }
-        }
+        nodes = new ArrayList<>(nodes);
+        Collections.shuffle(nodes, getRandom());
+        String isolatedNode = nodes.get(0);
+        String notIsolatedNode = nodes.get(1);
 
-        logger.info("Isolating node[" + isolatedNode + "]");
-        for (String nodeId : nodes) {
-            if (!nodeId.equals(isolatedNode)) {
-                addFailToSendNoConnectRule(nodeId, isolatedNode);
-                addFailToSendNoConnectRule(isolatedNode, nodeId);
-            }
-        }
-        ensureYellow("test");
+        randomIsolateNode(isolatedNode, nodes);
+        ensureStableCluster(2, notIsolatedNode);
+        assertFalse(client(notIsolatedNode).admin().cluster().prepareHealth("test").setWaitForYellowStatus().get().isTimedOut());
+
 
         IndexResponse indexResponse = internalCluster().client(notIsolatedNode).prepareIndex("test", "type").setSource("field", "value").get();
         assertThat(indexResponse.getVersion(), equalTo(1l));
@@ -381,13 +411,9 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         assertThat(getResponse.getVersion(), equalTo(1l));
         assertThat(getResponse.getId(), equalTo(indexResponse.getId()));
 
-        for (String nodeId : nodes) {
-            if (!nodeId.equals(isolatedNode)) {
-                clearNoConnectRule(nodeId, isolatedNode);
-                clearNoConnectRule(isolatedNode, nodeId);
-            }
-        }
+        restoreIsolation(isolatedNode, nodes);
 
+        ensureStableCluster(3);
         ensureGreen("test");
 
         for (String node : nodes) {
@@ -398,6 +424,32 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
             assertThat(getResponse.isExists(), is(true));
             assertThat(getResponse.getVersion(), equalTo(1l));
             assertThat(getResponse.getId(), equalTo(indexResponse.getId()));
+        }
+    }
+
+    protected void restoreIsolation(String isolatedNode, List<String> nodes) {
+        logger.info("restoring isolation of [{}]", isolatedNode);
+        for (String nodeId : nodes) {
+            if (!nodeId.equals(isolatedNode)) {
+                clearNoConnectRule(nodeId, isolatedNode);
+                clearNoConnectRule(isolatedNode, nodeId);
+            }
+        }
+    }
+
+    protected void randomIsolateNode(String isolatedNode, List<String> nodes) {
+        boolean unresponsive = randomBoolean();
+        logger.info("isolating [{}] with unresponsive: [{}]", isolatedNode, unresponsive);
+        for (String nodeId : nodes) {
+            if (!nodeId.equals(isolatedNode)) {
+                if (unresponsive) {
+                    addUnresponsiveRule(nodeId, isolatedNode);
+                    addUnresponsiveRule(isolatedNode, nodeId);
+                } else {
+                    addFailToSendNoConnectRule(nodeId, isolatedNode);
+                    addFailToSendNoConnectRule(isolatedNode, nodeId);
+                }
+            }
         }
     }
 
@@ -421,9 +473,28 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         ((MockTransportService) mockTransportService).addFailToSendNoConnectRule(internalCluster().getInstance(Discovery.class, toNode).localNode());
     }
 
+    private void addUnresponsiveRule(String fromNode, String toNode) {
+        TransportService mockTransportService = internalCluster().getInstance(TransportService.class, fromNode);
+        ((MockTransportService) mockTransportService).addUnresponsiveRule(internalCluster().getInstance(Discovery.class, toNode).localNode());
+    }
+
     private void clearNoConnectRule(String fromNode, String toNode) {
         TransportService mockTransportService = internalCluster().getInstance(TransportService.class, fromNode);
         ((MockTransportService) mockTransportService).clearRule(internalCluster().getInstance(Discovery.class, toNode).localNode());
+    }
+
+
+    private void ensureStableCluster(int nodeCount) {
+        ensureStableCluster(nodeCount, null);
+    }
+
+    private void ensureStableCluster(int nodeCount, @Nullable String viaNode) {
+        ClusterHealthResponse clusterHealthResponse = client(viaNode).admin().cluster().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForNodes(Integer.toString(nodeCount))
+                .setWaitForRelocatingShards(0)
+                .get();
+        assertThat(clusterHealthResponse.isTimedOut(), is(false));
     }
 
 }

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -55,7 +55,6 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
                 .put("discovery.zen.fd.ping_timeout", "1s") // <-- for hitting simulated network failures quickly
                 .put("discovery.zen.minimum_master_nodes", 2)
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
-                .put("discovery.zen.rejoin_on_master_gone", true)
                 .build();
 
         List<String> nodes = internalCluster().startNodesAsync(3, settings).get();

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -161,7 +161,12 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         internalCluster().startNodesAsync(3, nodeSettings).get();
         // Wait until a 3 nodes are part of the cluster
         ensureStableCluster(3);
-        createIndex("test");
+
+        // Makes sure that the get request can be executed on each node locally:
+        assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)
+        ));
 
         // Everything is stable now, it is now time to simulate evil...
         // but first make sure we have no initializing shards and all is green

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -67,6 +67,7 @@ import static org.hamcrest.Matchers.is;
 public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationTest {
 
     private static final Settings nodeSettings = ImmutableSettings.settingsBuilder()
+            .put("gateway.type", "local")
             .put("discovery.type", "zen") // <-- To override the local setting if set externally
             .put("discovery.zen.fd.ping_timeout", "1s") // <-- for hitting simulated network failures quickly
             .put("discovery.zen.fd.ping_retries", "1") // <-- for hitting simulated network failures quickly

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -297,7 +297,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
 
     @Test
     @TestLogging("discovery.zen:TRACE,action:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
-    public void voidIsolateMasterAndVerifyClusterStateConsensus() throws Exception {
+    public void testIsolateMasterAndVerifyClusterStateConsensus() throws Exception {
         final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
         ensureStableCluster(3);
 
@@ -329,9 +329,8 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         logger.info("issue a reroute");
         // trigger a reroute now, instead of waiting for the background reroute of RerouteService
         assertAcked(client().admin().cluster().prepareReroute());
-        // and wait for it to finish.
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForRelocatingShards(0).get().isTimedOut());
-
+        // and wait for it to finish and for the cluster to stabilize
+        ensureGreen("test");
 
         // verify all cluster states are the same
         ClusterState state = null;

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.discovery;
 
 import com.google.common.base.Predicate;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -364,7 +365,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     }
 
     @Test
-//    @LuceneTestCase.AwaitsFix(bugUrl = "MvG will fix")
+    @LuceneTestCase.AwaitsFix(bugUrl = "MvG will fix")
     @TestLogging("action.index:TRACE,action.get:TRACE,discovery:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
     public void testAckedIndexing() throws Exception {
         final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.discovery;
 
 import com.google.common.base.Predicate;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -30,13 +29,14 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportModule;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
@@ -44,21 +44,23 @@ import static org.hamcrest.Matchers.*;
 
 /**
  */
-@ClusterScope(scope= Scope.SUITE, numDataNodes =0)
+@ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationTest {
 
     @Test
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/2488")
+    @TestLogging("discovery.zen:TRACE")
     public void failWithMinimumMasterNodesConfigured() throws Exception {
         final Settings settings = ImmutableSettings.settingsBuilder()
-                .put("discovery.zen.minimum_master_nodes", 2)
+                .put("discovery.type", "zen") // <-- To override the local setting if set externally
                 .put("discovery.zen.fd.ping_timeout", "1s") // <-- for hitting simulated network failures quickly
+                .put("discovery.zen.minimum_master_nodes", 2)
                 .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
+                .put("discovery.zen.rejoin_on_master_gone", true)
                 .build();
-        List<String>nodes = internalCluster().startNodesAsync(3, settings).get();
+
+        List<String> nodes = internalCluster().startNodesAsync(3, settings).get();
 
         // Wait until a green status has been reaches and 3 nodes are part of the cluster
-        List<String> nodesList = Arrays.asList(nodes.toArray(new String[3]));
         ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes("3")
@@ -67,7 +69,8 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
 
         // Figure out what is the elected master node
         DiscoveryNode masterDiscoNode = null;
-        for (String node : nodesList) {
+
+        for (String node : nodes) {
             ClusterState state = internalCluster().client(node).admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
             assertThat(state.nodes().size(), equalTo(3));
             if (masterDiscoNode == null) {
@@ -84,7 +87,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
 
         // Pick a node that isn't the elected master.
         String unluckyNode = null;
-        for (String node : nodesList) {
+        for (String node : nodes) {
             if (!node.equals(masterDiscoNode.getName())) {
                 unluckyNode = node;
             }
@@ -96,12 +99,13 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         addFailToSendNoConnectRule(unluckyNode, masterDiscoNode.getName());
         try {
             // Wait until elected master has removed that the unlucky node...
-            awaitBusy(new Predicate<Object>() {
+            boolean applied = awaitBusy(new Predicate<Object>() {
                 @Override
                 public boolean apply(Object input) {
                     return masterClient.admin().cluster().prepareState().setLocal(true).get().getState().nodes().size() == 2;
                 }
-            });
+            }, 1, TimeUnit.MINUTES);
+            assertThat(applied, is(true));
 
             // The unlucky node must report *no* master node, since it can't connect to master and in fact it should
             // continuously ping until network failures have been resolved.
@@ -123,7 +127,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
                 .get();
         assertThat(clusterHealthResponse.isTimedOut(), is(false));
 
-        for (String node : nodesList) {
+        for (String node : nodes) {
             ClusterState state = internalCluster().client(node).admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
             assertThat(state.nodes().size(), equalTo(3));
             // The elected master shouldn't have changed, since the unlucky node never could have elected himself as

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -117,7 +117,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
                 public boolean apply(Object input) {
                     ClusterState localClusterState = isolatedNodeClient.admin().cluster().prepareState().setLocal(true).get().getState();
                     DiscoveryNodes localDiscoveryNodes = localClusterState.nodes();
-                    logger.info("localDiscoveryNodes=" + localDiscoveryNodes.toString());
+                    logger.info("localDiscoveryNodes=" + localDiscoveryNodes.prettyPrint());
                     return localDiscoveryNodes.masterNode() == null;
                 }
             }, 10, TimeUnit.SECONDS);

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -176,7 +176,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         NetworkPartition networkPartition = addRandomPartition();
 
         final String isolatedNode = networkPartition.getMinoritySide().get(0);
-        final String nonIsolatedNode = networkPartition.getMjaoritySide().get(0);
+        final String nonIsolatedNode = networkPartition.getMajoritySide().get(0);
 
         // Simulate a network issue between the unlucky node and the rest of the cluster.
         networkPartition.startDisrupting();

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithNetworkFailuresTests.java
@@ -37,19 +37,18 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.*;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportModule;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -68,15 +67,18 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
 
     private static final TimeValue DISRUPTION_HEALING_OVERHEAD = TimeValue.timeValueSeconds(40); // we use 30s as timeout in many places.
 
-    private static final Settings nodeSettings = ImmutableSettings.settingsBuilder()
-            .put("gateway.type", "local")
-            .put("discovery.type", "zen") // <-- To override the local setting if set externally
-            .put("discovery.zen.fd.ping_timeout", "1s") // <-- for hitting simulated network failures quickly
-            .put("discovery.zen.fd.ping_retries", "1") // <-- for hitting simulated network failures quickly
-            .put(DiscoverySettings.PUBLISH_TIMEOUT, "1s") // <-- for hitting simulated network failures quickly
-            .put("discovery.zen.minimum_master_nodes", 2)
-            .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
-            .build();
+    private ClusterDiscoveryConfiguration discoveryConfig;
+
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return discoveryConfig.node(nodeOrdinal);
+    }
+
+    @Before
+    public void clearConfig() {
+        discoveryConfig = null;
+    }
 
     @Override
     protected int numberOfShards() {
@@ -88,6 +90,31 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
         return 1;
     }
 
+    private List<String> startCluster(int numberOfNodes) throws ExecutionException, InterruptedException {
+        Settings settings = ImmutableSettings.builder()
+                // TODO: this is a temporary solution so that nodes will not base their reaction to a partition based on previous successful results
+                .put("discovery.zen.ping_timeout", "0.5s")
+                        // end of temporary solution
+                .put("discovery.zen.fd.ping_timeout", "1s") // <-- for hitting simulated network failures quickly
+                .put("discovery.zen.fd.ping_retries", "1") // <-- for hitting simulated network failures quickly
+                .put(DiscoverySettings.PUBLISH_TIMEOUT, "1s") // <-- for hitting simulated network failures quickly
+                .put("http.enabled", false) // just to make test quicker
+                .put(TransportModule.TRANSPORT_SERVICE_TYPE_KEY, MockTransportService.class.getName())
+                .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, numberOfNodes / 2 + 1).build();
+
+        if (discoveryConfig == null) {
+            if (randomBoolean()) {
+                discoveryConfig = new ClusterDiscoveryConfiguration.UnicastZen(numberOfNodes, numberOfNodes, settings);
+            } else {
+                discoveryConfig = new ClusterDiscoveryConfiguration(numberOfNodes, settings);
+            }
+        }
+        List<String> nodes = internalCluster().startNodesAsync(numberOfNodes).get();
+        ensureStableCluster(numberOfNodes);
+
+        return nodes;
+    }
+
     /**
      * Test that no split brain occurs under partial network partition. See https://github.com/elasticsearch/elasticsearch/issues/2488
      *
@@ -96,10 +123,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     @Test
     public void failWithMinimumMasterNodesConfigured() throws Exception {
 
-        List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
-
-        // Wait until 3 nodes are part of the cluster
-        ensureStableCluster(3);
+        List<String> nodes = startCluster(3);
 
         // Figure out what is the elected master node
         final String masterNode = internalCluster().getMasterName();
@@ -154,9 +178,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     @Test
     @TestLogging(value = "cluster.service:TRACE,indices.recovery:TRACE")
     public void testVerifyApiBlocksDuringPartition() throws Exception {
-        internalCluster().startNodesAsync(3, nodeSettings).get();
-        // Wait until a 3 nodes are part of the cluster
-        ensureStableCluster(3);
+        startCluster(3);
 
         // Makes sure that the get request can be executed on each node locally:
         assertAcked(prepareCreate("test").setSettings(ImmutableSettings.builder()
@@ -276,8 +298,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     @Test
     @TestLogging("discovery.zen:TRACE,action:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
     public void testIsolateMasterAndVerifyClusterStateConsensus() throws Exception {
-        final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
-        ensureStableCluster(3);
+        final List<String> nodes = startCluster(3);
 
         assertAcked(prepareCreate("test")
                 .setSettings(ImmutableSettings.builder()
@@ -340,8 +361,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     @LuceneTestCase.AwaitsFix(bugUrl = "MvG will fix")
     @TestLogging("action.index:TRACE,action.get:TRACE,discovery:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
     public void testAckedIndexing() throws Exception {
-        final List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
-        ensureStableCluster(3);
+        final List<String> nodes = startCluster(3);
 
         assertAcked(prepareCreate("test")
                 .setSettings(ImmutableSettings.builder()
@@ -478,8 +498,7 @@ public class DiscoveryWithNetworkFailuresTests extends ElasticsearchIntegrationT
     @Test
     @TestLogging("discovery.zen:TRACE,action:TRACE,cluster.service:TRACE,indices.recovery:TRACE,indices.cluster:TRACE")
     public void testRejoinDocumentExistsInAllShardCopies() throws Exception {
-        List<String> nodes = internalCluster().startNodesAsync(3, nodeSettings).get();
-        ensureStableCluster(3);
+        List<String> nodes = startCluster(3);
 
         assertAcked(prepareCreate("test")
                 .setSettings(ImmutableSettings.builder()

--- a/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
+++ b/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptions.java
@@ -141,17 +141,12 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
     }
 
     private List<String> startUnicastCluster(int numberOfNodes, @Nullable int[] unicastHostsOrdinals, int minimumMasterNode) throws ExecutionException, InterruptedException {
-        return startUnicastCluster(numberOfNodes, unicastHostsOrdinals, minimumMasterNode, ImmutableSettings.EMPTY);
-    }
-
-    private List<String> startUnicastCluster(int numberOfNodes, @Nullable int[] unicastHostsOrdinals, int minimumMasterNode, Settings settings) throws ExecutionException, InterruptedException {
         if (minimumMasterNode < 0) {
             minimumMasterNode = numberOfNodes / 2 + 1;
         }
         // TODO: Rarely use default settings form some of these
         Settings nodeSettings = ImmutableSettings.builder()
                 .put(DEFAULT_SETTINGS)
-                .put(settings)
                 .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, minimumMasterNode)
                 .build();
 
@@ -511,9 +506,7 @@ public class DiscoveryWithServiceDisruptions extends ElasticsearchIntegrationTes
     public void testMasterNodeGCs() throws Exception {
         // TODO: on mac OS multicast threads are shared between nodes and we therefore we can't simulate GC and stop pinging for just one node
         // find a way to block thread creation in the generic thread pool to avoid this.
-        // TODO: with local transport the threads of the source node enter the target node, since everything is local and like above we can't simulate GC on one node
-        // with netty transport the threads of different nodes don't touch each other due to the network threading Netty uses
-        List<String> nodes = startUnicastCluster(3, null, -1, ImmutableSettings.builder().put("node.mode", "network").build());
+        List<String> nodes = startUnicastCluster(3, null, -1);
 
         String oldMasterNode = internalCluster().getMasterName();
         // a very long GC, but it's OK as we remove the disruption when it has had an effect

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -134,7 +134,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
         settings.put("discovery.zen.fd.connect_on_network_disconnect", shouldRetry).put("discovery.zen.fd.ping_interval", "5m");
         NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, new ClusterName("test"));
         nodesFD.start();
-        nodesFD.updateNodes(buildNodesForA(true));
+        nodesFD.updateNodes(buildNodesForA(true), -1);
         final String[] failureReason = new String[1];
         final DiscoveryNode[] failureNode = new DiscoveryNode[1];
         final CountDownLatch notified = new CountDownLatch(1);

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.discovery;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -131,7 +132,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
         boolean shouldRetry = randomBoolean();
         // make sure we don't ping
         settings.put("discovery.zen.fd.connect_on_network_disconnect", shouldRetry).put("discovery.zen.fd.ping_interval", "5m");
-        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA);
+        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA, new ClusterName("test"));
         nodesFD.start();
         nodesFD.updateNodes(buildNodesForA(true));
         final String[] failureReason = new String[1];
@@ -165,6 +166,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
         boolean shouldRetry = randomBoolean();
         // make sure we don't ping
         settings.put("discovery.zen.fd.connect_on_network_disconnect", shouldRetry).put("discovery.zen.fd.ping_interval", "5m");
+        ClusterName clusterName = new ClusterName(randomAsciiOfLengthBetween(3, 20));
         final DiscoveryNodes nodes = buildNodesForA(false);
         MasterFaultDetection masterFD = new MasterFaultDetection(settings.build(), threadPool, serviceA,
                 new DiscoveryNodesProvider() {
@@ -177,7 +179,8 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
                     public NodeService nodeService() {
                         return null;
                     }
-                }
+                },
+                clusterName
         );
         masterFD.start(nodeB, "test");
 

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
+import org.elasticsearch.discovery.zen.fd.MasterFaultDetection;
+import org.elasticsearch.discovery.zen.fd.NodesFaultDetection;
+import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportConnectionListener;
+import org.elasticsearch.transport.local.LocalTransport;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ZenFaultDetectionTests extends ElasticsearchTestCase {
+
+    protected ThreadPool threadPool;
+
+    protected static final Version version0 = Version.fromId(/*0*/99);
+    protected DiscoveryNode nodeA;
+    protected MockTransportService serviceA;
+
+    protected static final Version version1 = Version.fromId(199);
+    protected DiscoveryNode nodeB;
+    protected MockTransportService serviceB;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new ThreadPool();
+        serviceA = build(ImmutableSettings.builder().put("name", "TS_A").build(), version0);
+        nodeA = new DiscoveryNode("TS_A", "TS_A", serviceA.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), version0);
+        serviceB = build(ImmutableSettings.builder().put("name", "TS_B").build(), version1);
+        nodeB = new DiscoveryNode("TS_B", "TS_B", serviceB.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), version1);
+
+        // wait till all nodes are properly connected and the event has been sent, so tests in this class
+        // will not get this callback called on the connections done in this setup
+        final CountDownLatch latch = new CountDownLatch(4);
+        TransportConnectionListener waitForConnection = new TransportConnectionListener() {
+            @Override
+            public void onNodeConnected(DiscoveryNode node) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onNodeDisconnected(DiscoveryNode node) {
+                fail("disconnect should not be called " + node);
+            }
+        };
+        serviceA.addConnectionListener(waitForConnection);
+        serviceB.addConnectionListener(waitForConnection);
+
+        serviceA.connectToNode(nodeB);
+        serviceA.connectToNode(nodeA);
+        serviceB.connectToNode(nodeA);
+        serviceB.connectToNode(nodeB);
+
+        assertThat("failed to wait for all nodes to connect", latch.await(5, TimeUnit.SECONDS), equalTo(true));
+        serviceA.removeConnectionListener(waitForConnection);
+        serviceB.removeConnectionListener(waitForConnection);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        serviceA.close();
+        serviceB.close();
+        threadPool.shutdown();
+    }
+
+    protected MockTransportService build(Settings settings, Version version) {
+        MockTransportService transportService = new MockTransportService(ImmutableSettings.EMPTY, new LocalTransport(settings, threadPool, version), threadPool);
+        transportService.start();
+        return transportService;
+    }
+
+    private DiscoveryNodes buildNodesForA(boolean master) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        builder.put(nodeA);
+        builder.put(nodeB);
+        builder.localNodeId(nodeA.id());
+        builder.masterNodeId(master ? nodeA.id() : nodeB.id());
+        return builder.build();
+    }
+
+    private DiscoveryNodes buildNodesForB(boolean master) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        builder.put(nodeA);
+        builder.put(nodeB);
+        builder.localNodeId(nodeB.id());
+        builder.masterNodeId(master ? nodeB.id() : nodeA.id());
+        return builder.build();
+    }
+
+    @Test
+    public void testNodesFaultDetectionConnectOnDisconnect() throws InterruptedException {
+        ImmutableSettings.Builder settings = ImmutableSettings.builder();
+        boolean shouldRetry = randomBoolean();
+        // make sure we don't ping
+        settings.put("discovery.zen.fd.connect_on_network_disconnect", shouldRetry).put("discovery.zen.fd.ping_interval", "5m");
+        NodesFaultDetection nodesFD = new NodesFaultDetection(settings.build(), threadPool, serviceA);
+        nodesFD.start();
+        nodesFD.updateNodes(buildNodesForA(true));
+        final String[] failureReason = new String[1];
+        final DiscoveryNode[] failureNode = new DiscoveryNode[1];
+        final CountDownLatch notified = new CountDownLatch(1);
+        nodesFD.addListener(new NodesFaultDetection.Listener() {
+            @Override
+            public void onNodeFailure(DiscoveryNode node, String reason) {
+                failureNode[0] = node;
+                failureReason[0] = reason;
+                notified.countDown();
+            }
+        });
+        // will raise a disconnect on A
+        serviceB.stop();
+        notified.await(30, TimeUnit.SECONDS);
+
+        assertEquals(nodeB, failureNode[0]);
+        Matcher<String> matcher = Matchers.containsString("verified");
+        if (!shouldRetry) {
+            matcher = Matchers.not(matcher);
+        }
+
+        assertThat(failureReason[0], matcher);
+    }
+
+    @Test
+    public void testMasterFaultDetectionConnectOnDisconnect() throws InterruptedException {
+
+        ImmutableSettings.Builder settings = ImmutableSettings.builder();
+        boolean shouldRetry = randomBoolean();
+        // make sure we don't ping
+        settings.put("discovery.zen.fd.connect_on_network_disconnect", shouldRetry).put("discovery.zen.fd.ping_interval", "5m");
+        final DiscoveryNodes nodes = buildNodesForA(false);
+        MasterFaultDetection masterFD = new MasterFaultDetection(settings.build(), threadPool, serviceA,
+                new DiscoveryNodesProvider() {
+                    @Override
+                    public DiscoveryNodes nodes() {
+                        return nodes;
+                    }
+
+                    @Override
+                    public NodeService nodeService() {
+                        return null;
+                    }
+                }
+        );
+        masterFD.start(nodeB, "test");
+
+        final String[] failureReason = new String[1];
+        final DiscoveryNode[] failureNode = new DiscoveryNode[1];
+        final CountDownLatch notified = new CountDownLatch(1);
+        masterFD.addListener(new MasterFaultDetection.Listener() {
+
+            @Override
+            public void onMasterFailure(DiscoveryNode masterNode, String reason) {
+                failureNode[0] = masterNode;
+                failureReason[0] = reason;
+                notified.countDown();
+            }
+
+            @Override
+            public void onDisconnectedFromMaster() {
+
+            }
+        });
+        // will raise a disconnect on A
+        serviceB.stop();
+        notified.await(30, TimeUnit.SECONDS);
+
+        assertEquals(nodeB, failureNode[0]);
+        Matcher<String> matcher = Matchers.containsString("verified");
+        if (!shouldRetry) {
+            matcher = Matchers.not(matcher);
+        }
+
+        assertThat(failureReason[0], matcher);
+    }
+}

--- a/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -60,7 +60,7 @@ public class ZenFaultDetectionTests extends ElasticsearchTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        threadPool = new ThreadPool();
+        threadPool = new ThreadPool(getClass().getName());
         serviceA = build(ImmutableSettings.builder().put("name", "TS_A").build(), version0);
         nodeA = new DiscoveryNode("TS_A", "TS_A", serviceA.boundAddress().publishAddress(), ImmutableMap.<String, String>of(), version0);
         serviceB = build(ImmutableSettings.builder().put("name", "TS_B").build(), version1);

--- a/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTests.java
+++ b/src/test/java/org/elasticsearch/discovery/ZenUnicastDiscoveryTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
-import org.elasticsearch.transport.local.LocalTransport;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,46 +37,24 @@ import static org.hamcrest.Matchers.equalTo;
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class ZenUnicastDiscoveryTests extends ElasticsearchIntegrationTest {
 
-    private static int currentNumNodes = -1;
-
-    static int currentBaseHttpPort = -1;
-    static int currentNumOfUnicastHosts = -1;
-
-    @Before
-    public void setUP() throws Exception {
-        ElasticsearchIntegrationTest.beforeClass();
-        currentNumNodes = randomIntBetween(3, 5);
-        currentNumOfUnicastHosts = randomIntBetween(1, currentNumNodes);
-        currentBaseHttpPort = 25000 + randomInt(100);
-    }
+    private ClusterDiscoveryConfiguration discoveryConfig;
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        ImmutableSettings.Builder builder = ImmutableSettings.settingsBuilder()
-                .put("discovery.type", "zen")
-                .put("discovery.zen.ping.multicast.enabled", false)
-                .put("http.enabled", false) // just to make test quicker
-                .put(super.nodeSettings(nodeOrdinal));
+        return discoveryConfig.node(nodeOrdinal);
+    }
 
-        String[] unicastHosts = new String[currentNumOfUnicastHosts];
-        if (internalCluster().getDefaultSettings().get("node.mode").equals("local")) {
-            builder.put(LocalTransport.TRANSPORT_LOCAL_ADDRESS, "unicast_test_" + nodeOrdinal);
-            for (int i = 0; i < unicastHosts.length; i++) {
-                unicastHosts[i] = "unicast_test_" + i;
-            }
-        } else {
-            // we need to pin the node ports so we'd know where to point things
-            builder.put("transport.tcp.port", currentBaseHttpPort + nodeOrdinal);
-            for (int i = 0; i < unicastHosts.length; i++) {
-                unicastHosts[i] = "localhost:" + (currentBaseHttpPort + i);
-            }
-        }
-        builder.putArray("discovery.zen.ping.unicast.hosts", unicastHosts);
-        return builder.build();
+    @Before
+    public void clearConfig() {
+        discoveryConfig = null;
     }
 
     @Test
     public void testNormalClusterForming() throws ExecutionException, InterruptedException {
+        int currentNumNodes = randomIntBetween(3, 5);
+        int currentNumOfUnicastHosts = randomIntBetween(1, currentNumNodes);
+        discoveryConfig = new ClusterDiscoveryConfiguration.UnicastZen(currentNumNodes, currentNumOfUnicastHosts);
+
         internalCluster().startNodesAsync(currentNumNodes).get();
 
         if (client().admin().cluster().prepareHealth().setWaitForNodes("" + currentNumNodes).get().isTimedOut()) {
@@ -91,9 +68,12 @@ public class ZenUnicastDiscoveryTests extends ElasticsearchIntegrationTest {
     // test fails, because 2 nodes elect themselves as master and the health request times out b/c waiting_for_nodes=N
     // can't be satisfied.
     public void testMinimumMasterNodes() throws Exception {
+        int currentNumNodes = randomIntBetween(3, 5);
+        int currentNumOfUnicastHosts = randomIntBetween(1, currentNumNodes);
         final Settings settings = ImmutableSettings.settingsBuilder().put("discovery.zen.minimum_master_nodes", currentNumNodes / 2 + 1).build();
+        discoveryConfig = new ClusterDiscoveryConfiguration.UnicastZen(currentNumNodes, currentNumOfUnicastHosts, settings);
 
-        List<String> nodes = internalCluster().startNodesAsync(currentNumNodes, settings).get();
+        List<String> nodes = internalCluster().startNodesAsync(currentNumNodes).get();
 
         ensureGreen();
 

--- a/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryRejoinOnMaster.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryRejoinOnMaster.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.zen;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ */
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
+public class ZenDiscoveryRejoinOnMaster extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testChangeRejoinOnMaster() throws Exception {
+        Settings nodeSettings = ImmutableSettings.settingsBuilder()
+                .put("discovery.type", "zen") // <-- To override the local setting if set externally
+                .build();
+        String nodeName = internalCluster().startNode(nodeSettings);
+        ZenDiscovery zenDiscovery = (ZenDiscovery) internalCluster().getInstance(Discovery.class, nodeName);
+        assertThat(zenDiscovery.isRejoinOnMasterGone(), is(true));
+
+        client().admin().cluster().prepareUpdateSettings()
+                .setTransientSettings(ImmutableSettings.builder().put(ZenDiscovery.REJOIN_ON_MASTER_GONE, false))
+                .get();
+
+        assertThat(zenDiscovery.isRejoinOnMasterGone(), is(false));
+    }
+
+}

--- a/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryRejoinOnMaster.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryRejoinOnMaster.java
@@ -19,12 +19,17 @@
 
 package org.elasticsearch.discovery.zen;
 
+import com.google.common.base.Predicate;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -33,7 +38,7 @@ import static org.hamcrest.Matchers.is;
 public class ZenDiscoveryRejoinOnMaster extends ElasticsearchIntegrationTest {
 
     @Test
-    public void testChangeRejoinOnMaster() throws Exception {
+    public void testChangeRejoinOnMasterOptionIsDynamic() throws Exception {
         Settings nodeSettings = ImmutableSettings.settingsBuilder()
                 .put("discovery.type", "zen") // <-- To override the local setting if set externally
                 .build();
@@ -46,6 +51,53 @@ public class ZenDiscoveryRejoinOnMaster extends ElasticsearchIntegrationTest {
                 .get();
 
         assertThat(zenDiscovery.isRejoinOnMasterGone(), is(false));
+    }
+
+    @Test
+    public void testNoShardRelocationsOccurWhenElectedMasterNodeFails() throws Exception {
+        Settings defaultSettings = ImmutableSettings.builder()
+                .put("discovery.zen.fd.ping_timeout", "1s")
+                .put("discovery.zen.fd.ping_retries", "1")
+                .put("discovery.type", "zen")
+                .build();
+
+        Settings masterNodeSettings = ImmutableSettings.builder()
+                .put("node.data", false)
+                .put(defaultSettings)
+                .build();
+        internalCluster().startNodesAsync(2, masterNodeSettings).get();
+        Settings dateNodeSettings = ImmutableSettings.builder()
+                .put("node.master", false)
+                .put(defaultSettings)
+                .build();
+        internalCluster().startNodesAsync(2, dateNodeSettings).get();
+        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForNodes("4")
+                .setWaitForRelocatingShards(0)
+                .get();
+        assertThat(clusterHealthResponse.isTimedOut(), is(false));
+
+        createIndex("test");
+        ensureSearchable("test");
+        RecoveryResponse r = client().admin().indices().prepareRecoveries("test").get();
+        int numRecoveriesBeforeNewMaster = r.shardResponses().get("test").size();
+
+        final String oldMaster = internalCluster().getMasterName();
+        internalCluster().stopCurrentMasterNode();
+        boolean result = awaitBusy(new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                String current = internalCluster().getMasterName();
+                return current != null && !current.equals(oldMaster);
+            }
+        });
+        assertTrue(result);
+        ensureSearchable("test");
+
+        r = client().admin().indices().prepareRecoveries("test").get();
+        int numRecoveriesAfterNewMaster = r.shardResponses().get("test").size();
+        assertThat(numRecoveriesAfterNewMaster, equalTo(numRecoveriesBeforeNewMaster));
     }
 
 }

--- a/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryRejoinOnMaster.java
+++ b/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryRejoinOnMaster.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.discovery.zen;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.common.Priority;
@@ -29,8 +28,7 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 /**
  */
@@ -85,14 +83,14 @@ public class ZenDiscoveryRejoinOnMaster extends ElasticsearchIntegrationTest {
 
         final String oldMaster = internalCluster().getMasterName();
         internalCluster().stopCurrentMasterNode();
-        boolean result = awaitBusy(new Predicate<Object>() {
+        assertBusy(new Runnable() {
             @Override
-            public boolean apply(Object input) {
+            public void run() {
                 String current = internalCluster().getMasterName();
-                return current != null && !current.equals(oldMaster);
+                assertThat(current, notNullValue());
+                assertThat(current, not(equalTo(oldMaster)));
             }
         });
-        assertTrue(result);
         ensureSearchable("test");
 
         r = client().admin().indices().prepareRecoveries("test").get();

--- a/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
+++ b/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.recovery;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -55,6 +56,7 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
     @Test
     @Slow
     @TestLogging("indices.cluster:TRACE,cluster.service:TRACE")
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/tree/feature/improve_zen")
     public void testFullRollingRestart() throws Exception {
         internalCluster().startNode();
         createIndex("test");

--- a/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
+++ b/src/test/java/org/elasticsearch/recovery/FullRollingRestartTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.recovery;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -31,7 +30,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.test.ElasticsearchIntegrationTest.*;
+import static org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 /**
@@ -55,8 +54,7 @@ public class FullRollingRestartTests extends ElasticsearchIntegrationTest {
 
     @Test
     @Slow
-    @TestLogging("indices.cluster:TRACE,cluster.service:TRACE")
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/tree/feature/improve_zen")
+    @TestLogging("indices.cluster:TRACE,cluster.service:TRACE,action.search:TRACE,indices.recovery:TRACE")
     public void testFullRollingRestart() throws Exception {
         internalCluster().startNode();
         createIndex("test");

--- a/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadTests.java
+++ b/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadTests.java
@@ -43,7 +43,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RecoveryWhileUnderLoadTests extends ElasticsearchIntegrationTest {

--- a/src/test/java/org/elasticsearch/test/BackgroundIndexer.java
+++ b/src/test/java/org/elasticsearch/test/BackgroundIndexer.java
@@ -217,7 +217,7 @@ public class BackgroundIndexer implements AutoCloseable {
         setBudget(numOfDocs);
     }
 
-    /** Stop all background threads **/
+    /** Stop all background threads * */
     public void stop() throws InterruptedException {
         if (stop.get()) {
             return;

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -859,7 +859,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
      * It is useful to ensure that all action on the cluster have finished and all shards that were currently relocating
      * are now allocated and started.
      */
-    public ClusterHealthStatus ensureGreen(String... indices) {
+    public ClusterHealthStatus  ensureGreen(String... indices) {
         ClusterHealthResponse actionGet = client().admin().cluster()
                 .health(Requests.clusterHealthRequest(indices).waitForGreenStatus().waitForEvents(Priority.LANGUID).waitForRelocatingShards(0)).actionGet();
         if (actionGet.isTimedOut()) {

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -97,6 +97,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.client.RandomizingClient;
 import org.hamcrest.Matchers;
+import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.junit.*;
 
 import java.io.IOException;
@@ -535,6 +536,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         boolean success = false;
         try {
             logger.info("[{}#{}]: cleaning up after test", getTestClass().getSimpleName(), getTestName());
+            clearDisruptionScheme();
             final Scope currentClusterScope = getCurrentClusterScope();
             try {
                 if (currentClusterScope != Scope.TEST) {
@@ -646,6 +648,15 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
     protected int numberOfReplicas() {
         return between(minimumNumberOfReplicas(), maximumNumberOfReplicas());
+    }
+
+
+    public void setDisruptionScheme(ServiceDisruptionScheme scheme) {
+        internalCluster().setDisruptionScheme(scheme);
+    }
+
+    public void clearDisruptionScheme() {
+        internalCluster().clearDisruptionScheme();
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -598,6 +598,13 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
     }
 
     public static Client client() {
+        return client(null);
+    }
+
+    public static Client client(@Nullable String node) {
+        if (node != null) {
+            return internalCluster().client(node);
+        }
         Client client = cluster().client();
         if (frequently()) {
             client = new RandomizingClient(client, getRandom());

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -77,6 +77,7 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.cache.recycler.MockBigArraysModule;
 import org.elasticsearch.test.cache.recycler.MockPageCacheRecyclerModule;
+import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.engine.MockEngineModule;
 import org.elasticsearch.test.store.MockFSIndexStoreModule;
 import org.elasticsearch.test.transport.AssertingLocalTransportModule;
@@ -185,6 +186,8 @@ public final class InternalTestCluster extends TestCluster {
 
     private final boolean hasFilterCache;
 
+    private ServiceDisruptionScheme activeDisruptionScheme;
+
     public InternalTestCluster(long clusterSeed, String clusterName) {
         this(clusterSeed, DEFAULT_MIN_NUM_DATA_NODES, DEFAULT_MAX_NUM_DATA_NODES, clusterName, SettingsSource.EMPTY, DEFAULT_NUM_CLIENT_NODES, DEFAULT_ENABLE_RANDOM_BENCH_NODES);
     }
@@ -286,6 +289,10 @@ public final class InternalTestCluster extends TestCluster {
     @Override
     public String getClusterName() {
         return clusterName;
+    }
+
+    public String[] getNodeNames() {
+        return nodes.keySet().toArray(Strings.EMPTY_ARRAY);
     }
 
     private static boolean isLocalTransportConfigured() {
@@ -487,6 +494,7 @@ public final class InternalTestCluster extends TestCluster {
         while (limit.hasNext()) {
             NodeAndClient next = limit.next();
             nodesToRemove.add(next);
+            removeDistruptionSchemeFromNode(next);
             next.close();
         }
         for (NodeAndClient toRemove : nodesToRemove) {
@@ -661,6 +669,10 @@ public final class InternalTestCluster extends TestCluster {
     @Override
     public void close() {
         if (this.open.compareAndSet(true, false)) {
+            if (activeDisruptionScheme != null) {
+                activeDisruptionScheme.testClusterClosed();
+                activeDisruptionScheme = null;
+            }
             IOUtils.closeWhileHandlingException(nodes.values());
             nodes.clear();
             executor.shutdownNow();
@@ -858,6 +870,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     private synchronized void reset(boolean wipeData) throws IOException {
+        clearDisruptionScheme();
         resetClients(); /* reset all clients - each test gets its own client based on the Random instance created above. */
         if (wipeData) {
             wipeDataDirectories();
@@ -1054,6 +1067,7 @@ public final class InternalTestCluster extends TestCluster {
         NodeAndClient nodeAndClient = getRandomNodeAndClient(new DataNodePredicate());
         if (nodeAndClient != null) {
             logger.info("Closing random node [{}] ", nodeAndClient.name);
+            removeDistruptionSchemeFromNode(nodeAndClient);
             nodes.remove(nodeAndClient.name);
             nodeAndClient.close();
         }
@@ -1073,6 +1087,7 @@ public final class InternalTestCluster extends TestCluster {
         });
         if (nodeAndClient != null) {
             logger.info("Closing filtered random node [{}] ", nodeAndClient.name);
+            removeDistruptionSchemeFromNode(nodeAndClient);
             nodes.remove(nodeAndClient.name);
             nodeAndClient.close();
         }
@@ -1087,6 +1102,7 @@ public final class InternalTestCluster extends TestCluster {
         String masterNodeName = getMasterName();
         assert nodes.containsKey(masterNodeName);
         logger.info("Closing master node [{}] ", masterNodeName);
+        removeDistruptionSchemeFromNode(nodes.get(masterNodeName));
         NodeAndClient remove = nodes.remove(masterNodeName);
         remove.close();
     }
@@ -1098,6 +1114,7 @@ public final class InternalTestCluster extends TestCluster {
         NodeAndClient nodeAndClient = getRandomNodeAndClient(Predicates.not(new MasterNodePredicate(getMasterName())));
         if (nodeAndClient != null) {
             logger.info("Closing random non master node [{}] current master [{}] ", nodeAndClient.name, getMasterName());
+            removeDistruptionSchemeFromNode(nodeAndClient);
             nodes.remove(nodeAndClient.name);
             nodeAndClient.close();
         }
@@ -1151,6 +1168,9 @@ public final class InternalTestCluster extends TestCluster {
                 if (!callback.doRestart(nodeAndClient.name)) {
                     logger.info("Closing node [{}] during restart", nodeAndClient.name);
                     toRemove.add(nodeAndClient);
+                    if (activeDisruptionScheme != null) {
+                        activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
+                    }
                     nodeAndClient.close();
                 }
             }
@@ -1165,18 +1185,33 @@ public final class InternalTestCluster extends TestCluster {
             for (NodeAndClient nodeAndClient : nodes.values()) {
                 callback.doAfterNodes(numNodesRestarted++, nodeAndClient.nodeClient());
                 logger.info("Restarting node [{}] ", nodeAndClient.name);
+                if (activeDisruptionScheme != null) {
+                    activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
+                }
                 nodeAndClient.restart(callback);
+                if (activeDisruptionScheme != null) {
+                    activeDisruptionScheme.applyToNode(nodeAndClient.name, this);
+                }
             }
         } else {
             int numNodesRestarted = 0;
             for (NodeAndClient nodeAndClient : nodes.values()) {
                 callback.doAfterNodes(numNodesRestarted++, nodeAndClient.nodeClient());
                 logger.info("Stopping node [{}] ", nodeAndClient.name);
+                if (activeDisruptionScheme != null) {
+                    activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
+                }
                 nodeAndClient.node.close();
             }
             for (NodeAndClient nodeAndClient : nodes.values()) {
                 logger.info("Starting node [{}] ", nodeAndClient.name);
+                if (activeDisruptionScheme != null) {
+                    activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
+                }
                 nodeAndClient.restart(callback);
+                if (activeDisruptionScheme != null) {
+                    activeDisruptionScheme.applyToNode(nodeAndClient.name, this);
+                }
             }
         }
     }
@@ -1374,6 +1409,7 @@ public final class InternalTestCluster extends TestCluster {
             dataDirToClean.addAll(Arrays.asList(nodeEnv.nodeDataLocations()));
         }
         nodes.put(nodeAndClient.name, nodeAndClient);
+        applyDisruptionSchemeToNode(nodeAndClient);
     }
 
     public void closeNonSharedNodes(boolean wipeData) throws IOException {
@@ -1393,6 +1429,33 @@ public final class InternalTestCluster extends TestCluster {
     @Override
     public boolean hasFilterCache() {
         return hasFilterCache;
+    }
+
+    public void setDisruptionScheme(ServiceDisruptionScheme scheme) {
+        clearDisruptionScheme();
+        scheme.applyToCluster(this);
+        activeDisruptionScheme = scheme;
+    }
+
+    public void clearDisruptionScheme() {
+        if (activeDisruptionScheme != null) {
+            activeDisruptionScheme.removeFromCluster(this);
+        }
+        activeDisruptionScheme = null;
+    }
+
+    private void applyDisruptionSchemeToNode(NodeAndClient nodeAndClient) {
+        if (activeDisruptionScheme != null) {
+            assert nodes.containsKey(nodeAndClient.name);
+            activeDisruptionScheme.applyToNode(nodeAndClient.name, this);
+        }
+    }
+
+    private void removeDistruptionSchemeFromNode(NodeAndClient nodeAndClient) {
+        if (activeDisruptionScheme != null) {
+            assert nodes.containsKey(nodeAndClient.name);
+            activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
+        }
     }
 
     private synchronized Collection<NodeAndClient> dataNodeAndClients() {

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -104,14 +104,13 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAs
 import static junit.framework.Assert.fail;
 import static org.apache.lucene.util.LuceneTestCase.rarely;
 import static org.apache.lucene.util.LuceneTestCase.usually;
-import static org.elasticsearch.common.settings.ImmutableSettings.EMPTY;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 import static org.elasticsearch.test.ElasticsearchTestCase.assertBusy;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 
 /**
  * InternalTestCluster manages a set of JVM private nodes and allows convenient access to them.
@@ -155,7 +154,7 @@ public final class InternalTestCluster extends TestCluster {
 
     static final boolean DEFAULT_ENABLE_RANDOM_BENCH_NODES = true;
 
-    static final String NODE_MODE = nodeMode();
+    public static final String NODE_MODE = nodeMode();
 
     /* sorted map to make traverse order reproducible, concurrent since we do checks on it not within a sync block */
     private final NavigableMap<String, NodeAndClient> nodes = new TreeMap<>();

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -870,7 +870,15 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     private synchronized void reset(boolean wipeData) throws IOException {
+        TimeValue expectedHealingTime = activeDisruptionScheme != null ? activeDisruptionScheme.expectedTimeToHeal() : null;
         clearDisruptionScheme();
+        if (expectedHealingTime != null && expectedHealingTime.millis() > 0) {
+            try {
+                Thread.sleep(expectedHealingTime.millis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
         resetClients(); /* reset all clients - each test gets its own client based on the Random instance created above. */
         if (wipeData) {
             wipeDataDirectories();

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -34,6 +34,7 @@ import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
+import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecyclerModule;
 import org.elasticsearch.client.Client;
@@ -99,6 +100,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.frequently;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsBoolean;
 import static junit.framework.Assert.fail;
@@ -261,6 +263,9 @@ public final class InternalTestCluster extends TestCluster {
         }
         if (Strings.hasLength(System.getProperty("es.logger.prefix"))) {
             builder.put("logger.prefix", System.getProperty("es.logger.level"));
+        }
+        if (randomBoolean()) {
+            builder.put(TransportShardReplicationOperationAction.VALIDATE_WRITE_CONSISTENCY, randomBoolean());
         }
         defaultSettings = builder.build();
         executor = EsExecutors.newCached(1, TimeUnit.MINUTES, EsExecutors.daemonThreadFactory("test_" + clusterName));

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -871,25 +871,28 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     private synchronized void reset(boolean wipeData) throws IOException {
-        TimeValue expectedHealingTime = activeDisruptionScheme != null ? activeDisruptionScheme.expectedTimeToHeal() : null;
-        clearDisruptionScheme();
-        if (expectedHealingTime != null && expectedHealingTime.millis() > 0) {
-            try {
-                Thread.sleep(expectedHealingTime.millis());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-        resetClients(); /* reset all clients - each test gets its own client based on the Random instance created above. */
-        if (wipeData) {
-            wipeDataDirectories();
-        }
         // clear all rules for mock transport services
         for (NodeAndClient nodeAndClient : nodes.values()) {
             TransportService transportService = nodeAndClient.node.injector().getInstance(TransportService.class);
             if (transportService instanceof MockTransportService) {
                 ((MockTransportService) transportService).clearAllRules();
             }
+        }
+        if (activeDisruptionScheme != null) {
+            TimeValue expectedHealingTime = activeDisruptionScheme.expectedTimeToHeal();
+            clearDisruptionScheme();
+            if (expectedHealingTime != null && expectedHealingTime.millis() > 0) {
+                try {
+                    Thread.sleep(expectedHealingTime.millis());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            assert !client().admin().cluster().prepareHealth().setWaitForNodes("" + nodes.size()).get().isTimedOut() : "cluster failed to form after disruption was healed";
+        }
+        resetClients(); /* reset all clients - each test gets its own client based on the Random instance created above. */
+        if (wipeData) {
+            wipeDataDirectories();
         }
         if (nextNodeId.get() == sharedNodesSeeds.length && nodes.size() == sharedNodesSeeds.length) {
             logger.debug("Cluster hasn't changed - moving out - nodes: [{}] nextNodeId: [{}] numSharedNodes: [{}]", nodes.keySet(), nextNodeId.get(), sharedNodesSeeds.length);

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -222,7 +222,7 @@ public final class InternalTestCluster extends TestCluster {
                 this.numSharedClientNodes = numClientNodes;
             }
         }
-        assert this.numSharedClientNodes >=0;
+        assert this.numSharedClientNodes >= 0;
 
         this.enableRandomBenchNodes = enableRandomBenchNodes;
 
@@ -247,7 +247,7 @@ public final class InternalTestCluster extends TestCluster {
             if (numOfDataPaths > 0) {
                 StringBuilder dataPath = new StringBuilder();
                 for (int i = 0; i < numOfDataPaths; i++) {
-                    dataPath.append(new File("data/d"+i).getAbsolutePath()).append(',');
+                    dataPath.append(new File("data/d" + i).getAbsolutePath()).append(',');
                 }
                 builder.put("path.data", dataPath.toString());
             }
@@ -270,7 +270,7 @@ public final class InternalTestCluster extends TestCluster {
 
     public static String nodeMode() {
         Builder builder = ImmutableSettings.builder();
-        if (Strings.isEmpty(System.getProperty("es.node.mode"))&& Strings.isEmpty(System.getProperty("es.node.local"))) {
+        if (Strings.isEmpty(System.getProperty("es.node.mode")) && Strings.isEmpty(System.getProperty("es.node.local"))) {
             return "local"; // default if nothing is specified
         }
         if (Strings.hasLength(System.getProperty("es.node.mode"))) {
@@ -327,7 +327,7 @@ public final class InternalTestCluster extends TestCluster {
                 //.put("index.store.type", random.nextInt(10) == 0 ? MockRamIndexStoreModule.class.getName() : MockFSIndexStoreModule.class.getName())
                 // decrease the routing schedule so new nodes will be added quickly - some random value between 30 and 80 ms
                 .put("cluster.routing.schedule", (30 + random.nextInt(50)) + "ms")
-                // default to non gateway
+                        // default to non gateway
                 .put("gateway.type", "none")
                 .put(SETTING_CLUSTER_NODE_SEED, seed);
         if (ENABLE_MOCK_MODULES && usually(random)) {
@@ -352,7 +352,7 @@ public final class InternalTestCluster extends TestCluster {
             builder.put(SearchService.KEEPALIVE_INTERVAL_KEY, TimeValue.timeValueSeconds(10 + random.nextInt(5 * 60)));
         }
         if (random.nextBoolean()) { // sometimes set a
-            builder.put(SearchService.DEFAUTL_KEEPALIVE_KEY, TimeValue.timeValueSeconds(100 + random.nextInt(5*60)));
+            builder.put(SearchService.DEFAUTL_KEEPALIVE_KEY, TimeValue.timeValueSeconds(100 + random.nextInt(5 * 60)));
         }
         if (random.nextBoolean()) {
             // change threadpool types to make sure we don't have components that rely on the type of thread pools
@@ -789,6 +789,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     public static final String TRANSPORT_CLIENT_PREFIX = "transport_client_";
+
     static class TransportClientFactory extends ClientFactory {
 
         private static TransportClientFactory NO_SNIFF_CLIENT_FACTORY = new TransportClientFactory(false, ImmutableSettings.EMPTY);
@@ -1260,7 +1261,10 @@ public final class InternalTestCluster extends TestCluster {
     }
 
 
-    private String getMasterName() {
+    /**
+     * get the name of the current master node
+     */
+    public String getMasterName() {
         try {
             ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
             return state.nodes().masterNode().name();

--- a/src/test/java/org/elasticsearch/test/SettingsSource.java
+++ b/src/test/java/org/elasticsearch/test/SettingsSource.java
@@ -20,7 +20,7 @@ package org.elasticsearch.test;
 
 import org.elasticsearch.common.settings.Settings;
 
-abstract class SettingsSource {
+public abstract class SettingsSource {
 
     public static final SettingsSource EMPTY = new SettingsSource() {
         @Override
@@ -35,7 +35,7 @@ abstract class SettingsSource {
     };
 
     /**
-     * @return  the settings for the node represented by the given ordinal, or {@code null} if there are no settings defined
+     * @return the settings for the node represented by the given ordinal, or {@code null} if there are no settings defined
      */
     public abstract Settings node(int nodeOrdinal);
 

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.indices.IndexMissingException;

--- a/src/test/java/org/elasticsearch/test/disruption/LongGCDisruption.java
+++ b/src/test/java/org/elasticsearch/test/disruption/LongGCDisruption.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+public class LongGCDisruption extends SingleNodeDisruption {
+
+    volatile boolean disrupting;
+    volatile Thread worker;
+
+    final long intervalBetweenDelaysMin;
+    final long intervalBetweenDelaysMax;
+    final long delayDurationMin;
+    final long delayDurationMax;
+
+
+    public LongGCDisruption(Random random) {
+        this(null, random);
+    }
+
+    public LongGCDisruption(String disruptedNode, Random random) {
+        this(disruptedNode, random, 100, 200, 300, 20000);
+    }
+
+    public LongGCDisruption(String disruptedNode, Random random, long intervalBetweenDelaysMin,
+                            long intervalBetweenDelaysMax, long delayDurationMin, long delayDurationMax) {
+        this(random, intervalBetweenDelaysMin, intervalBetweenDelaysMax, delayDurationMin, delayDurationMax);
+        this.disruptedNode = disruptedNode;
+    }
+
+    public LongGCDisruption(Random random,
+                            long intervalBetweenDelaysMin, long intervalBetweenDelaysMax, long delayDurationMin,
+                            long delayDurationMax) {
+        super(random);
+        this.intervalBetweenDelaysMin = intervalBetweenDelaysMin;
+        this.intervalBetweenDelaysMax = intervalBetweenDelaysMax;
+        this.delayDurationMin = delayDurationMin;
+        this.delayDurationMax = delayDurationMax;
+    }
+
+    final static AtomicInteger thread_ids = new AtomicInteger();
+
+    @Override
+    public void startDisrupting() {
+        disrupting = true;
+        worker = new Thread(new BackgroundWorker(), "long_gc_simulation_" + thread_ids.incrementAndGet());
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    @Override
+    public void stopDisrupting() {
+        if (worker == null) {
+            return;
+        }
+        logger.info("stopping long GCs on [{}]", disruptedNode);
+        disrupting = false;
+        worker.interrupt();
+        try {
+            worker.join(2 * (intervalBetweenDelaysMax + delayDurationMax));
+        } catch (InterruptedException e) {
+            logger.info("background thread failed to stop");
+        }
+        worker = null;
+    }
+
+    final static Pattern[] unsafeClasses = new Pattern[]{
+            // logging has shared JVM locks - we may suspend a thread and block other nodes from doing their thing
+            Pattern.compile("Logger")
+    };
+
+    private boolean stopNodeThreads(String node, Set<Thread> nodeThreads) {
+        Set<Thread> allThreadsSet = Thread.getAllStackTraces().keySet();
+        boolean stopped = false;
+        final String nodeThreadNamePart = "[" + node + "]";
+        for (Thread thread : allThreadsSet) {
+            String name = thread.getName();
+            if (name.contains(nodeThreadNamePart)) {
+                if (thread.isAlive() && nodeThreads.add(thread)) {
+                    stopped = true;
+                    thread.suspend();
+                    // double check the thread is not in a shared resource like logging. If so, let it go and come back..
+                    boolean safe = true;
+                    safe:
+                    for (StackTraceElement stackElement : thread.getStackTrace()) {
+                        String className = stackElement.getClassName();
+                        for (Pattern unsafePattern : unsafeClasses) {
+                            if (unsafePattern.matcher(className).find()) {
+                                safe = false;
+                                break safe;
+                            }
+                        }
+                    }
+                    if (!safe) {
+                        thread.resume();
+                        nodeThreads.remove(thread);
+                    }
+                }
+            }
+        }
+        return stopped;
+    }
+
+    private void resumeThreads(Set<Thread> threads) {
+        for (Thread thread : threads) {
+            thread.resume();
+        }
+    }
+
+    private void simulateLongGC(final TimeValue duration) throws InterruptedException {
+        final String disruptionNodeCopy = disruptedNode;
+        if (disruptionNodeCopy == null) {
+            return;
+        }
+        logger.info("node [{}] goes into GC for for [{}]", disruptionNodeCopy, duration);
+        final Set<Thread> nodeThreads = new HashSet<>();
+        try {
+            while (stopNodeThreads(disruptionNodeCopy, nodeThreads)) ;
+            if (!nodeThreads.isEmpty()) {
+                Thread.sleep(duration.millis());
+            }
+        } finally {
+            logger.info("node [{}] resumes from GC", disruptionNodeCopy);
+            resumeThreads(nodeThreads);
+        }
+    }
+
+    @Override
+    public TimeValue expectedTimeToHeal() {
+        return TimeValue.timeValueMillis(0);
+    }
+
+    class BackgroundWorker implements Runnable {
+
+        @Override
+        public void run() {
+            while (disrupting && disruptedNode != null) {
+                try {
+                    TimeValue duration = new TimeValue(delayDurationMin + random.nextInt((int) (delayDurationMax - delayDurationMin)));
+                    simulateLongGC(duration);
+
+                    duration = new TimeValue(intervalBetweenDelaysMin + random.nextInt((int) (intervalBetweenDelaysMax - intervalBetweenDelaysMin)));
+                    if (disrupting && disruptedNode != null) {
+                        Thread.sleep(duration.millis());
+                    }
+                } catch (InterruptedException e) {
+                } catch (Exception e) {
+                    logger.error("error in background worker", e);
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
@@ -86,7 +86,7 @@ public class NetworkDelaysPartition extends NetworkPartition {
     }
 
     @Override
-    public TimeValue afterDisruptionTimeOut() {
-        return TimeValue.timeValueMillis(delayMax + super.afterDisruptionTimeOut().millis());
+    public TimeValue expectedTimeToHeal() {
+        return TimeValue.timeValueMillis(delayMax);
     }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.transport.MockTransportService;
+
+import java.util.Random;
+import java.util.Set;
+
+public class NetworkDelaysPartition extends NetworkPartition {
+
+    static long DEFAULT_DELAY_MIN = 10000;
+    static long DEFAULT_DELAY_MAX = 90000;
+
+
+    final long delayMin;
+    final long delayMax;
+
+    TimeValue duration;
+
+    public NetworkDelaysPartition(Random random) {
+        this(random, DEFAULT_DELAY_MIN, DEFAULT_DELAY_MAX);
+    }
+
+    public NetworkDelaysPartition(Random random, long delayMin, long delayMax) {
+        super(random);
+        this.delayMin = delayMin;
+        this.delayMax = delayMax;
+    }
+
+    public NetworkDelaysPartition(String node1, String node2, Random random) {
+        this(node1, node2, DEFAULT_DELAY_MIN, DEFAULT_DELAY_MAX, random);
+    }
+
+    public NetworkDelaysPartition(String node1, String node2, long delayMin, long delayMax, Random random) {
+        super(node1, node2, random);
+        this.delayMin = delayMin;
+        this.delayMax = delayMax;
+    }
+
+    public NetworkDelaysPartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, Random random) {
+        this(nodesSideOne, nodesSideTwo, DEFAULT_DELAY_MIN, DEFAULT_DELAY_MAX, random);
+    }
+
+    public NetworkDelaysPartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, long delayMin, long delayMax, Random random) {
+        super(nodesSideOne, nodesSideTwo, random);
+        this.delayMin = delayMin;
+        this.delayMax = delayMax;
+
+    }
+
+    @Override
+    public synchronized void startDisrupting() {
+        duration = new TimeValue(delayMin + random.nextInt((int) (delayMax - delayMin)));
+        super.startDisrupting();
+    }
+
+    @Override
+    void applyDisruption(DiscoveryNode node1, MockTransportService transportService1,
+                         DiscoveryNode node2, MockTransportService transportService2) {
+        transportService1.addUnresponsiveRule(node1, duration);
+        transportService1.addUnresponsiveRule(node2, duration);
+    }
+
+    @Override
+    protected String getPartitionDescription() {
+        return "network delays for [" + duration + "]";
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
@@ -85,4 +85,8 @@ public class NetworkDelaysPartition extends NetworkPartition {
         return "network delays for [" + duration + "]";
     }
 
+    @Override
+    public TimeValue afterDisruptionTimeOut() {
+        return TimeValue.timeValueMillis(delayMax + super.afterDisruptionTimeOut().millis());
+    }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkDisconnectPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkDisconnectPartition.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.test.transport.MockTransportService;
+
+import java.util.Random;
+import java.util.Set;
+
+public class NetworkDisconnectPartition extends NetworkPartition {
+
+
+    public NetworkDisconnectPartition(Random random) {
+        super(random);
+    }
+
+    public NetworkDisconnectPartition(String node1, String node2, Random random) {
+        super(node1, node2, random);
+    }
+
+    public NetworkDisconnectPartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, Random random) {
+        super(nodesSideOne, nodesSideTwo, random);
+    }
+
+    @Override
+    protected String getPartitionDescription() {
+        return "disconnected";
+    }
+
+    @Override
+    void applyDisruption(DiscoveryNode node1, MockTransportService transportService1,
+                         DiscoveryNode node2, MockTransportService transportService2) {
+        transportService1.addFailToSendNoConnectRule(node2);
+        transportService2.addFailToSendNoConnectRule(node1);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkDisconnectPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkDisconnectPartition.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.Random;
@@ -49,5 +50,10 @@ public class NetworkDisconnectPartition extends NetworkPartition {
                          DiscoveryNode node2, MockTransportService transportService2) {
         transportService1.addFailToSendNoConnectRule(node2);
         transportService2.addFailToSendNoConnectRule(node1);
+    }
+
+    @Override
+    public TimeValue expectedTimeToHeal() {
+        return TimeValue.timeValueSeconds(0);
     }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.TestCluster;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+public abstract class NetworkPartition implements ServiceDisruptionScheme {
+
+    protected final ESLogger logger = Loggers.getLogger(getClass());
+
+    final Set<String> nodesSideOne;
+    final Set<String> nodesSideTwo;
+    volatile boolean autoExpand;
+    protected final Random random;
+    protected volatile InternalTestCluster cluster;
+
+
+    public NetworkPartition(Random random) {
+        this.random = new Random(random.nextLong());
+        nodesSideOne = new HashSet<>();
+        nodesSideTwo = new HashSet<>();
+        autoExpand = true;
+    }
+
+    public NetworkPartition(String node1, String node2, Random random) {
+        this(random);
+        nodesSideOne.add(node1);
+        nodesSideTwo.add(node2);
+        autoExpand = false;
+    }
+
+    public NetworkPartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, Random random) {
+        this(random);
+        this.nodesSideOne.addAll(nodesSideOne);
+        this.nodesSideTwo.addAll(nodesSideTwo);
+        autoExpand = false;
+    }
+
+
+    public List<String> getNodesSideOne() {
+        return ImmutableList.copyOf(nodesSideOne);
+    }
+
+    public List<String> getNodesSideTwo() {
+        return ImmutableList.copyOf(nodesSideTwo);
+    }
+
+    public List<String> getMjaoritySide() {
+        if (nodesSideOne.size() >= nodesSideTwo.size()) {
+            return getNodesSideOne();
+        } else {
+            return getNodesSideTwo();
+        }
+    }
+
+    public List<String> getMinoritySide() {
+        if (nodesSideOne.size() >= nodesSideTwo.size()) {
+            return getNodesSideTwo();
+        } else {
+            return getNodesSideOne();
+        }
+    }
+
+    @Override
+    public void applyToCluster(InternalTestCluster cluster) {
+        this.cluster = cluster;
+        if (autoExpand) {
+            for (String node : cluster.getNodeNames()) {
+                applyToNode(node, cluster);
+            }
+        }
+    }
+
+    @Override
+    public void removeFromCluster(InternalTestCluster cluster) {
+        stopDisrupting();
+    }
+
+    @Override
+    public synchronized void applyToNode(String node, InternalTestCluster cluster) {
+        if (!autoExpand || nodesSideOne.contains(node) || nodesSideTwo.contains(node)) {
+            return;
+        }
+        if (nodesSideOne.isEmpty()) {
+            nodesSideOne.add(node);
+        } else if (nodesSideTwo.isEmpty()) {
+            nodesSideTwo.add(node);
+        } else if (random.nextBoolean()) {
+            nodesSideOne.add(node);
+        } else {
+            nodesSideTwo.add(node);
+        }
+    }
+
+    @Override
+    public synchronized void removeFromNode(String node, InternalTestCluster cluster) {
+        MockTransportService transportService = (MockTransportService) cluster.getInstance(TransportService.class, node);
+        DiscoveryNode discoveryNode = discoveryNode(node);
+        Set<String> otherSideNodes;
+        if (nodesSideOne.contains(node)) {
+            otherSideNodes = nodesSideTwo;
+        } else if (nodesSideTwo.contains(node)) {
+            otherSideNodes = nodesSideOne;
+        } else {
+            return;
+        }
+        for (String node2 : otherSideNodes) {
+            MockTransportService transportService2 = (MockTransportService) cluster.getInstance(TransportService.class, node2);
+            DiscoveryNode discoveryNode2 = discoveryNode(node2);
+            removeDisruption(discoveryNode, transportService, discoveryNode2, transportService2);
+        }
+    }
+
+    @Override
+    public synchronized void testClusterClosed() {
+
+    }
+
+    protected abstract String getPartitionDescription();
+
+
+    protected DiscoveryNode discoveryNode(String node) {
+        return cluster.getInstance(Discovery.class, node).localNode();
+    }
+
+    @Override
+    public synchronized void startDisrupting() {
+        if (nodesSideOne.size() == 0 || nodesSideTwo.size() == 0) {
+            return;
+        }
+        logger.info("nodes {} will be partitioned from {}. partition type [{}]", nodesSideOne, nodesSideTwo, getPartitionDescription());
+        for (String node1 : nodesSideOne) {
+            MockTransportService transportService1 = (MockTransportService) cluster.getInstance(TransportService.class, node1);
+            DiscoveryNode discoveryNode1 = discoveryNode(node1);
+            for (String node2 : nodesSideTwo) {
+                DiscoveryNode discoveryNode2 = discoveryNode(node2);
+                MockTransportService transportService2 = (MockTransportService) cluster.getInstance(TransportService.class, node2);
+                applyDisruption(discoveryNode1, transportService1, discoveryNode2, transportService2);
+            }
+        }
+    }
+
+
+    @Override
+    public void stopDisrupting() {
+        if (nodesSideOne.size() == 0 || nodesSideTwo.size() == 0) {
+            return;
+        }
+        logger.info("restoring partition between nodes {} & nodes {}", nodesSideOne, nodesSideTwo);
+        for (String node1 : nodesSideOne) {
+            MockTransportService transportService1 = (MockTransportService) cluster.getInstance(TransportService.class, node1);
+            DiscoveryNode discoveryNode1 = discoveryNode(node1);
+            for (String node2 : nodesSideTwo) {
+                DiscoveryNode discoveryNode2 = discoveryNode(node2);
+                MockTransportService transportService2 = (MockTransportService) cluster.getInstance(TransportService.class, node2);
+                removeDisruption(discoveryNode1, transportService1, discoveryNode2, transportService2);
+            }
+        }
+    }
+
+    abstract void applyDisruption(DiscoveryNode node1, MockTransportService transportService1,
+                                  DiscoveryNode node2, MockTransportService transportService2);
+
+
+    protected void removeDisruption(DiscoveryNode node1, MockTransportService transportService1,
+                                    DiscoveryNode node2, MockTransportService transportService2) {
+        transportService1.clearRule(node2);
+        transportService2.clearRule(node1);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
@@ -22,9 +22,9 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.TestCluster;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportService;
 
@@ -195,5 +195,10 @@ public abstract class NetworkPartition implements ServiceDisruptionScheme {
                                     DiscoveryNode node2, MockTransportService transportService2) {
         transportService1.clearRule(node2);
         transportService2.clearRule(node1);
+    }
+
+    @Override
+    public TimeValue afterDisruptionTimeOut() {
+        return TimeValue.timeValueSeconds(30);
     }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -197,8 +196,4 @@ public abstract class NetworkPartition implements ServiceDisruptionScheme {
         transportService2.clearRule(node1);
     }
 
-    @Override
-    public TimeValue afterDisruptionTimeOut() {
-        return TimeValue.timeValueSeconds(30);
-    }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkPartition.java
@@ -73,7 +73,7 @@ public abstract class NetworkPartition implements ServiceDisruptionScheme {
         return ImmutableList.copyOf(nodesSideTwo);
     }
 
-    public List<String> getMjaoritySide() {
+    public List<String> getMajoritySide() {
         if (nodesSideOne.size() >= nodesSideTwo.size()) {
             return getNodesSideOne();
         } else {

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkUnresponsivePartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkUnresponsivePartition.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.Random;
@@ -48,5 +49,10 @@ public class NetworkUnresponsivePartition extends NetworkPartition {
                          DiscoveryNode node2, MockTransportService transportService2) {
         transportService1.addUnresponsiveRule(node2);
         transportService2.addUnresponsiveRule(node1);
+    }
+
+    @Override
+    public TimeValue expectedTimeToHeal() {
+        return TimeValue.timeValueSeconds(0);
     }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NetworkUnresponsivePartition.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NetworkUnresponsivePartition.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.test.transport.MockTransportService;
+
+import java.util.Random;
+import java.util.Set;
+
+public class NetworkUnresponsivePartition extends NetworkPartition {
+
+    public NetworkUnresponsivePartition(Random random) {
+        super(random);
+    }
+
+    public NetworkUnresponsivePartition(String node1, String node2, Random random) {
+        super(node1, node2, random);
+    }
+
+    public NetworkUnresponsivePartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, Random random) {
+        super(nodesSideOne, nodesSideTwo, random);
+    }
+
+    @Override
+    protected String getPartitionDescription() {
+        return "unresponsive";
+    }
+
+    @Override
+    void applyDisruption(DiscoveryNode node1, MockTransportService transportService1,
+                         DiscoveryNode node2, MockTransportService transportService2) {
+        transportService1.addUnresponsiveRule(node2);
+        transportService2.addUnresponsiveRule(node1);
+    }
+}

--- a/src/test/java/org/elasticsearch/test/disruption/NoOpDisruptionScheme.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NoOpDisruptionScheme.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test.disruption;
 
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.InternalTestCluster;
 
 public class NoOpDisruptionScheme implements ServiceDisruptionScheme {
@@ -56,5 +57,10 @@ public class NoOpDisruptionScheme implements ServiceDisruptionScheme {
     @Override
     public void testClusterClosed() {
 
+    }
+
+    @Override
+    public TimeValue afterDisruptionTimeOut() {
+        return TimeValue.timeValueSeconds(30);
     }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NoOpDisruptionScheme.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NoOpDisruptionScheme.java
@@ -60,7 +60,7 @@ public class NoOpDisruptionScheme implements ServiceDisruptionScheme {
     }
 
     @Override
-    public TimeValue afterDisruptionTimeOut() {
-        return TimeValue.timeValueSeconds(30);
+    public TimeValue expectedTimeToHeal() {
+        return TimeValue.timeValueSeconds(0);
     }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/NoOpDisruptionScheme.java
+++ b/src/test/java/org/elasticsearch/test/disruption/NoOpDisruptionScheme.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.test.InternalTestCluster;
+
+public class NoOpDisruptionScheme implements ServiceDisruptionScheme {
+
+    @Override
+    public void applyToCluster(InternalTestCluster cluster) {
+
+    }
+
+    @Override
+    public void removeFromCluster(InternalTestCluster cluster) {
+
+    }
+
+    @Override
+    public void applyToNode(String node, InternalTestCluster cluster) {
+
+    }
+
+    @Override
+    public void removeFromNode(String node, InternalTestCluster cluster) {
+
+    }
+
+    @Override
+    public void startDisrupting() {
+
+    }
+
+    @Override
+    public void stopDisrupting() {
+
+    }
+
+    @Override
+    public void testClusterClosed() {
+
+    }
+}

--- a/src/test/java/org/elasticsearch/test/disruption/ServiceDisruptionScheme.java
+++ b/src/test/java/org/elasticsearch/test/disruption/ServiceDisruptionScheme.java
@@ -37,6 +37,6 @@ public interface ServiceDisruptionScheme {
 
     public void testClusterClosed();
 
-    public TimeValue afterDisruptionTimeOut();
+    public TimeValue expectedTimeToHeal();
 
 }

--- a/src/test/java/org/elasticsearch/test/disruption/ServiceDisruptionScheme.java
+++ b/src/test/java/org/elasticsearch/test/disruption/ServiceDisruptionScheme.java
@@ -18,8 +18,8 @@
  */
 package org.elasticsearch.test.disruption;
 
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.TestCluster;
 
 public interface ServiceDisruptionScheme {
 
@@ -36,5 +36,7 @@ public interface ServiceDisruptionScheme {
     public void stopDisrupting();
 
     public void testClusterClosed();
+
+    public TimeValue afterDisruptionTimeOut();
 
 }

--- a/src/test/java/org/elasticsearch/test/disruption/ServiceDisruptionScheme.java
+++ b/src/test/java/org/elasticsearch/test/disruption/ServiceDisruptionScheme.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.TestCluster;
+
+public interface ServiceDisruptionScheme {
+
+    public void applyToCluster(InternalTestCluster cluster);
+
+    public void removeFromCluster(InternalTestCluster cluster);
+
+    public void applyToNode(String node, InternalTestCluster cluster);
+
+    public void removeFromNode(String node, InternalTestCluster cluster);
+
+    public void startDisrupting();
+
+    public void stopDisrupting();
+
+    public void testClusterClosed();
+
+}

--- a/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
@@ -20,6 +20,7 @@ package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.Random;
@@ -80,4 +81,8 @@ public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
         disruptedNode = null;
     }
 
+    @Override
+    public TimeValue afterDisruptionTimeOut() {
+        return TimeValue.timeValueSeconds(30);
+    }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
@@ -21,7 +21,6 @@ package org.elasticsearch.test.disruption;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.TestCluster;
 
 import java.util.Random;
 
@@ -30,7 +29,7 @@ public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
     protected final ESLogger logger = Loggers.getLogger(getClass());
 
     protected volatile String disruptedNode;
-    protected volatile TestCluster cluster;
+    protected volatile InternalTestCluster cluster;
     protected final Random random;
 
 

--- a/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
@@ -20,7 +20,6 @@ package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.Random;
@@ -81,8 +80,4 @@ public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
         disruptedNode = null;
     }
 
-    @Override
-    public TimeValue afterDisruptionTimeOut() {
-        return TimeValue.timeValueSeconds(30);
-    }
 }

--- a/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.TestCluster;
+
+import java.util.Random;
+
+public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
+
+    protected final ESLogger logger = Loggers.getLogger(getClass());
+
+    protected volatile String disruptedNode;
+    protected volatile TestCluster cluster;
+    protected final Random random;
+
+
+    public SingleNodeDisruption(String disruptedNode, Random random) {
+        this(random);
+        this.disruptedNode = disruptedNode;
+    }
+
+    public SingleNodeDisruption(Random random) {
+        this.random = new Random(random.nextLong());
+    }
+
+    @Override
+    public void applyToCluster(InternalTestCluster cluster) {
+        this.cluster = cluster;
+        if (disruptedNode == null) {
+            String[] nodes = cluster.getNodeNames();
+            disruptedNode = nodes[random.nextInt(nodes.length)];
+        }
+    }
+
+    @Override
+    public void removeFromCluster(InternalTestCluster cluster) {
+        if (disruptedNode != null) {
+            removeFromNode(disruptedNode, cluster);
+        }
+    }
+
+    @Override
+    public synchronized void applyToNode(String node, InternalTestCluster cluster) {
+
+    }
+
+    @Override
+    public synchronized void removeFromNode(String node, InternalTestCluster cluster) {
+        if (disruptedNode == null) {
+            return;
+        }
+        if (!node.equals(disruptedNode)) {
+            return;
+        }
+        stopDisrupting();
+        disruptedNode = null;
+    }
+
+    @Override
+    public synchronized void testClusterClosed() {
+        disruptedNode = null;
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.test.disruption;
+
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateNonMasterUpdateTask;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.Random;
+
+public class SlowClusterStateProcessing extends SingleNodeDisruption {
+
+    volatile boolean disrupting;
+    volatile Thread worker;
+
+    final long intervalBetweenDelaysMin;
+    final long intervalBetweenDelaysMax;
+    final long delayDurationMin;
+    final long delayDurationMax;
+
+
+    public SlowClusterStateProcessing(Random random) {
+        this(null, random);
+    }
+
+    public SlowClusterStateProcessing(String disruptedNode, Random random) {
+        this(disruptedNode, random, 100, 200, 300, 20000);
+    }
+
+    public SlowClusterStateProcessing(String disruptedNode, Random random, long intervalBetweenDelaysMin,
+                                      long intervalBetweenDelaysMax, long delayDurationMin, long delayDurationMax) {
+        this(random, intervalBetweenDelaysMin, intervalBetweenDelaysMax, delayDurationMin, delayDurationMax);
+        this.disruptedNode = disruptedNode;
+    }
+
+    public SlowClusterStateProcessing(Random random,
+                                      long intervalBetweenDelaysMin, long intervalBetweenDelaysMax, long delayDurationMin,
+                                      long delayDurationMax) {
+        super(random);
+        this.intervalBetweenDelaysMin = intervalBetweenDelaysMin;
+        this.intervalBetweenDelaysMax = intervalBetweenDelaysMax;
+        this.delayDurationMin = delayDurationMin;
+        this.delayDurationMax = delayDurationMax;
+    }
+
+
+    @Override
+    public void startDisrupting() {
+        disrupting = true;
+        worker = new Thread(new BackgroundWorker());
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    @Override
+    public void stopDisrupting() {
+        disrupting = false;
+        try {
+            worker.join(2 * (intervalBetweenDelaysMax + delayDurationMax));
+        } catch (InterruptedException e) {
+            logger.info("background thread failed to stop");
+        }
+        worker = null;
+    }
+
+
+    private synchronized boolean interruptClusterStateProcessing(final TimeValue duration) {
+        if (disruptedNode == null) {
+            return false;
+        }
+        logger.info("delaying cluster state updates on node [{}] for [{}]", disruptedNode, duration);
+        ClusterService clusterService = cluster.getInstance(ClusterService.class, disruptedNode);
+        clusterService.submitStateUpdateTask("service_disruption_delay", Priority.IMMEDIATE, new ClusterStateNonMasterUpdateTask() {
+
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                Thread.sleep(duration.millis());
+                return currentState;
+            }
+
+            @Override
+            public void onFailure(String source, Throwable t) {
+
+            }
+        });
+        return true;
+    }
+
+    class BackgroundWorker implements Runnable {
+
+        @Override
+        public void run() {
+            while (disrupting) {
+                try {
+                    TimeValue duration = new TimeValue(delayDurationMin + random.nextInt((int) (delayDurationMax - delayDurationMin)));
+                    if (!interruptClusterStateProcessing(duration)) {
+                        continue;
+                    }
+                    Thread.sleep(duration.millis());
+
+                    if (disruptedNode == null) {
+                        return;
+                    }
+
+                } catch (Exception e) {
+                    logger.error("error in background worker", e);
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
@@ -107,6 +107,11 @@ public class SlowClusterStateProcessing extends SingleNodeDisruption {
         return true;
     }
 
+    @Override
+    public TimeValue expectedTimeToHeal() {
+        return TimeValue.timeValueSeconds(delayDurationMax + intervalBetweenDelaysMax);
+    }
+
     class BackgroundWorker implements Runnable {
 
         @Override

--- a/src/test/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
+++ b/src/test/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
@@ -72,6 +72,9 @@ public class SlowClusterStateProcessing extends SingleNodeDisruption {
 
     @Override
     public void stopDisrupting() {
+        if (worker == null) {
+            return;
+        }
         disrupting = false;
         try {
             worker.join(2 * (intervalBetweenDelaysMax + delayDurationMax));

--- a/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -37,6 +37,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
@@ -96,6 +98,13 @@ public class MockTransportService extends TransportService {
                 throw new ConnectTransportException(node, "DISCONNECT: simulated");
             }
         });
+    }
+
+    /**
+     * Adds a rule that will cause matching operations to throw ConnectTransportExceptions
+     */
+    public void addFailToSendNoConnectRule(DiscoveryNode node, final String... blockedActions) {
+        addFailToSendNoConnectRule(node, new HashSet<>(Arrays.asList(blockedActions)));
     }
 
     /**
@@ -307,10 +316,10 @@ public class MockTransportService extends TransportService {
 
         protected final Transport transport;
 
+
         public DelegateTransport(Transport transport) {
             this.transport = transport;
         }
-
 
         @Override
         public void transportServiceAdapter(TransportServiceAdapter service) {

--- a/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -168,6 +168,7 @@ public class MockTransportService extends TransportService {
                 TimeValue delay = getDelay();
                 if (delay.millis() <= 0) {
                     original.connectToNode(node);
+                    return;
                 }
 
                 // TODO: Replace with proper setting
@@ -190,6 +191,7 @@ public class MockTransportService extends TransportService {
                 TimeValue delay = getDelay();
                 if (delay.millis() <= 0) {
                     original.connectToNodeLight(node);
+                    return;
                 }
 
                 // TODO: Replace with proper setting
@@ -214,6 +216,7 @@ public class MockTransportService extends TransportService {
                 TimeValue delay = getDelay();
                 if (delay.millis() <= 0) {
                     original.sendRequest(node, requestId, action, request, options);
+                    return;
                 }
 
                 // poor mans request cloning...

--- a/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/src/test/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -24,9 +24,14 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
@@ -46,6 +51,7 @@ public class MockTransportService extends TransportService {
     public MockTransportService(Settings settings, Transport transport, ThreadPool threadPool) {
         super(settings, new LookupTestTransport(transport), threadPool);
         this.original = transport;
+
     }
 
     /**
@@ -97,7 +103,7 @@ public class MockTransportService extends TransportService {
      */
     public void addFailToSendNoConnectRule(DiscoveryNode node, final Set<String> blockedActions) {
 
-        ((LookupTestTransport) transport).transports.put(node.getAddress(), new DelegateTransport(original) {
+        addDelegate(node, new DelegateTransport(original) {
             @Override
             public void connectToNode(DiscoveryNode node) throws ConnectTransportException {
                 original.connectToNode(node);
@@ -124,7 +130,6 @@ public class MockTransportService extends TransportService {
      * and failing to connect once the rule was added.
      */
     public void addUnresponsiveRule(DiscoveryNode node) {
-        // TODO add a parameter to delay the connect timeout?
         addDelegate(node, new DelegateTransport(original) {
             @Override
             public void connectToNode(DiscoveryNode node) throws ConnectTransportException {
@@ -144,7 +149,97 @@ public class MockTransportService extends TransportService {
     }
 
     /**
+     * Adds a rule that will cause ignores each send request, simulating an unresponsive node
+     * and failing to connect once the rule was added.
+     *
+     * @param duration the amount of time to delay sending and connecting.
+     */
+    public void addUnresponsiveRule(DiscoveryNode node, final TimeValue duration) {
+        final long startTime = System.currentTimeMillis();
+
+        addDelegate(node, new DelegateTransport(original) {
+
+            TimeValue getDelay() {
+                return new TimeValue(duration.millis() - (System.currentTimeMillis() - startTime));
+            }
+
+            @Override
+            public void connectToNode(DiscoveryNode node) throws ConnectTransportException {
+                TimeValue delay = getDelay();
+                if (delay.millis() <= 0) {
+                    original.connectToNode(node);
+                }
+
+                // TODO: Replace with proper setting
+                TimeValue connectingTimeout = NetworkService.TcpSettings.TCP_DEFAULT_CONNECT_TIMEOUT;
+                try {
+                    if (delay.millis() < connectingTimeout.millis()) {
+                        Thread.sleep(delay.millis());
+                        original.connectToNode(node);
+                    } else {
+                        Thread.sleep(connectingTimeout.millis());
+                        throw new ConnectTransportException(node, "UNRESPONSIVE: simulated");
+                    }
+                } catch (InterruptedException e) {
+                    throw new ConnectTransportException(node, "UNRESPONSIVE: interrupted while sleeping", e);
+                }
+            }
+
+            @Override
+            public void connectToNodeLight(DiscoveryNode node) throws ConnectTransportException {
+                TimeValue delay = getDelay();
+                if (delay.millis() <= 0) {
+                    original.connectToNodeLight(node);
+                }
+
+                // TODO: Replace with proper setting
+                TimeValue connectingTimeout = NetworkService.TcpSettings.TCP_DEFAULT_CONNECT_TIMEOUT;
+                try {
+                    if (delay.millis() < connectingTimeout.millis()) {
+                        Thread.sleep(delay.millis());
+                        original.connectToNodeLight(node);
+                    } else {
+                        Thread.sleep(connectingTimeout.millis());
+                        throw new ConnectTransportException(node, "UNRESPONSIVE: simulated");
+                    }
+                } catch (InterruptedException e) {
+                    throw new ConnectTransportException(node, "UNRESPONSIVE: interrupted while sleeping", e);
+                }
+            }
+
+            @Override
+            public void sendRequest(final DiscoveryNode node, final long requestId, final String action, TransportRequest request, final TransportRequestOptions options) throws IOException, TransportException {
+                // delayed sending - even if larger then the request timeout to simulated a potential late response from target node
+
+                TimeValue delay = getDelay();
+                if (delay.millis() <= 0) {
+                    original.sendRequest(node, requestId, action, request, options);
+                }
+
+                // poor mans request cloning...
+                TransportRequestHandler handler = MockTransportService.this.getHandler(action);
+                BytesStreamOutput bStream = new BytesStreamOutput();
+                request.writeTo(bStream);
+                final TransportRequest clonedRequest = handler.newInstance();
+                clonedRequest.readFrom(new BytesStreamInput(bStream.bytes()));
+
+                threadPool.schedule(delay, ThreadPool.Names.GENERIC, new AbstractRunnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            original.sendRequest(node, requestId, action, clonedRequest, options);
+                        } catch (Throwable e) {
+                            logger.debug("failed to send delayed request", e);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    /**
      * Adds a new delegate transport that is used for communication with the given node.
+     *
      * @return <tt>true</tt> iff no other delegate was registered for this node before, otherwise <tt>false</tt>
      */
     public boolean addDelegate(DiscoveryNode node, DelegateTransport transport) {
@@ -212,7 +307,6 @@ public class MockTransportService extends TransportService {
         public DelegateTransport(Transport transport) {
             this.transport = transport;
         }
-
 
 
         @Override

--- a/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
@@ -31,7 +31,7 @@ import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptAction;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.indices.store.IndicesStore;
+import org.elasticsearch.indices.store.TransportShardActive;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -127,7 +127,7 @@ public class ActionNamesBackwardsCompatibilityTest extends ElasticsearchBackward
         actionsVersions.put(ExistsAction.NAME, Version.V_1_4_0);
         actionsVersions.put(ExistsAction.NAME + "[s]", Version.V_1_4_0);
 
-        actionsVersions.put(IndicesStore.ACTION_SHARD_EXISTS, Version.V_1_3_0);
+        actionsVersions.put(TransportShardActive.ACTION_SHARD_EXISTS, Version.V_1_3_0);
 
         actionsVersions.put(GetIndexedScriptAction.NAME, Version.V_1_3_0);
         actionsVersions.put(DeleteIndexedScriptAction.NAME, Version.V_1_3_0);


### PR DESCRIPTION
Add additional optional validation on top of the write consistency check. After the cluster state write validation check we have today, an optional extra write consistency validation may happens that actually goes the nodes containing the shard copies and verifies if that nodes are in a started state.

Note: this PR is based on improve_zen branch
