### PR TITLE
[Discovery] join master after first election

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -382,26 +382,25 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             logger.warn("failed to connect to master [{}], retrying...", e, masterNode);
             return false;
         }
-        for (int joinAttempt = 1; joinAttempt <= this.joinRetryAttempts; joinAttempt++) {
+        for (int joinAttempt = 0; joinAttempt < this.joinRetryAttempts; joinAttempt++) {
             try {
                 logger.trace("joining master {}", masterNode);
                 membership.sendJoinRequestBlocking(masterNode, localNode, joinTimeout);
             } catch (ElasticsearchIllegalStateException e) {
                 if (joinAttempt >= this.joinRetryAttempts) {
                     logger.info("failed to send join request to master [{}], reason [{}]. Tried [{}] times",
-                            masterNode, e.getDetailedMessage(), joinAttempt);
+                            masterNode, e.getDetailedMessage(), joinAttempt + 1);
                     return false;
                 } else {
-                    logger.trace("master {} failed with [{}]. retrying... (attempts done: [{}])", masterNode, e.getDetailedMessage(), joinAttempt);
+                    logger.trace("master {} failed with [{}]. retrying... (attempts done: [{}])", masterNode, e.getDetailedMessage(), joinAttempt + 1);
                 }
             } catch (Exception e) {
-                if (e instanceof ElasticsearchException) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("failed to send join request to master [{}]", e);
+                } else if (e instanceof ElasticsearchException) {
                     logger.info("failed to send join request to master [{}], reason [{}]", masterNode, ((ElasticsearchException) e).getDetailedMessage());
                 } else {
                     logger.info("failed to send join request to master [{}], reason [{}]", masterNode, e.getMessage());
-                }
-                if (logger.isTraceEnabled()) {
-                    logger.trace("detailed failed reason", e);
                 }
                 return false;
             }


### PR DESCRIPTION
Currently, pinging results are only used if the local node is elected master or if they detect another _already_ active master. This has the effect that master election requires two pinging rounds - one for the elected master to take is role and another for the other nodes to detect it and join the cluster. We can be smarter and use the election of the first round on other nodes as well. Those nodes can try to join the elected master immediately. There is a catch though - the elected master node may still be processing the election and may reject the join request if not ready yet. To compensate a retry mechanism is introduced to try again (up to 3 times by default) if this happens.

Note: this is against the improve zen branch
