### PR TITLE
Docs: Reflect that 'field_value_factor' is only in 1.2.x

### DIFF
--- a/docs/reference/mapping/fields/boost-field.asciidoc
+++ b/docs/reference/mapping/fields/boost-field.asciidoc
@@ -68,3 +68,5 @@ any field the document:
 <1> The original query, now wrapped in a `function_score` query.
 <2> This function returns the value in `my_boost_field`, which is then
     multiplied by the query `_score` for each document.
+
+Note, that `field_value_factor` is a 1.2.x feature.

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -151,6 +151,9 @@ that is initialized with a `seed`.
 --------------------------------------------------
 
 ===== Field Value factor
+
+added[1.2.0]
+
 The `field_value_factor` function allows you to use a field from a document to
 influence the score. It's similar to using the `script_score` function, however,
 it avoids the overhead of scripting. If used on a multi-valued field, only the


### PR DESCRIPTION
While the blogpost http://www.elasticsearch.org/blog/2014-04-02-this-week-in-elasticsearch/ states, that feature #5519 was added to 1.x, the release notes for, e.g. v1.1.2, however tell otherwise.
Only the release notes for 1.2.0 list #5519 as a new feature.

Since the 1.x docs deprecate/discourage from using `_boost`, and seemingly give a migration example at
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-boost-field.html#function-score-instead-of-boost
users of 1.1.x should be warned.
