### PR TITLE
With unicast discovery, only disconnect from temporary connected nodes

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -270,7 +270,12 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
                 if (sendPingsHandler.isClosed()) {
                     return;
                 }
-                sendPingsHandler.nodeToDisconnect.add(nodeToSend);
+                // only disconnect from nodes that we will end up creating a light connection to, as they are temporal
+                // if we find on the disco nodes a matching node by address, we are going to restore the connection
+                // anyhow down the line if its not connected...
+                if (!nodeFoundByAddress) {
+                    sendPingsHandler.nodeToDisconnect.add(nodeToSend);
+                }
                 // fork the connection to another thread
                 sendPingsHandler.executor().execute(new Runnable() {
                     @Override


### PR DESCRIPTION
In unicast discovery, we try to reuse existing discovery nodes based on the node address they have. If we find an existing node based on its address, and for some reason its not connected, don't add it to the list of nodes to disconnect from, as that (full) connection is useful down the road
 Also, fixed a rogue count down on a latch in case the ping cycle has ended (in practice, it didn't do any harm, since the latch has timed out already by definition, but still cleaner)
