### PR TITLE
Fixes parse error with complex shapes

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -19,8 +19,12 @@
 
 package org.elasticsearch.common.geo.builders;
 
+import com.spatial4j.core.context.jts.JtsSpatialContext;
+import com.spatial4j.core.shape.Shape;
 import com.spatial4j.core.shape.jts.JtsGeometry;
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.logging.ESLogger;
@@ -32,10 +36,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
-import com.spatial4j.core.context.jts.JtsSpatialContext;
-import com.spatial4j.core.shape.Shape;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
 import java.io.IOException;
 import java.util.*;
 
@@ -296,9 +296,6 @@ public abstract class ShapeBuilder implements ToXContent {
                 if (position == 1) {
                     if (Double.compare(p1.x, dateline) == Double.compare(edges[i].next.next.coordinate.x, dateline)) {
                         // Ignore the ear
-                        continue;
-                    } else if (p2.x == dateline) {
-                        // Ignore Linesegment on dateline
                         continue;
                     }
                 }

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -30,8 +30,7 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchGeoAssertions.assertMultiLineString;
-import static org.elasticsearch.test.hamcrest.ElasticsearchGeoAssertions.assertMultiPolygon;
+import static org.elasticsearch.test.hamcrest.ElasticsearchGeoAssertions.*;
 /**
  * Tests for {@link ShapeBuilder}
  */
@@ -233,5 +232,80 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
         Shape shape = builder.close().build();
 
          assertMultiPolygon(shape);
+     }
+
+    @Test
+    public void testComplexShapeWithHole() {
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+            .point(-85.0018514,37.1311314)
+            .point(-85.0016645,37.1315293)
+            .point(-85.0016246,37.1317069)
+            .point(-85.0016526,37.1318183)
+            .point(-85.0017119,37.1319196)
+            .point(-85.0019371,37.1321182)
+            .point(-85.0019972,37.1322115)
+            .point(-85.0019942,37.1323234)
+            .point(-85.0019543,37.1324336)
+            .point(-85.001906,37.1324985)
+            .point(-85.001834,37.1325497)
+            .point(-85.0016965,37.1325907)
+            .point(-85.0016011,37.1325873)
+            .point(-85.0014816,37.1325353)
+            .point(-85.0011755,37.1323509)
+            .point(-85.000955,37.1322802)
+            .point(-85.0006241,37.1322529)
+            .point(-85.0000002,37.1322307)
+            .point(-84.9994,37.1323001)
+            .point(-84.999109,37.1322864)
+            .point(-84.998934,37.1322415)
+            .point(-84.9988639,37.1321888)
+            .point(-84.9987841,37.1320944)
+            .point(-84.9987208,37.131954)
+            .point(-84.998736,37.1316611)
+            .point(-84.9988091,37.131334)
+            .point(-84.9989283,37.1311337)
+            .point(-84.9991943,37.1309198)
+            .point(-84.9993573,37.1308459)
+            .point(-84.9995888,37.1307924)
+            .point(-84.9998746,37.130806)
+            .point(-85.0000002,37.1308358)
+            .point(-85.0004984,37.1310658)
+            .point(-85.0008008,37.1311625)
+            .point(-85.0009461,37.1311684)
+            .point(-85.0011373,37.1311515)
+            .point(-85.0016455,37.1310491)
+            .point(-85.0018514,37.1311314);
+
+        builder.hole()
+            .point(-85.0000002,37.1317672)
+            .point(-85.0001983,37.1317538)
+            .point(-85.0003378,37.1317582)
+            .point(-85.0004697,37.131792)
+            .point(-85.0008048,37.1319439)
+            .point(-85.0009342,37.1319838)
+            .point(-85.0010184,37.1319463)
+            .point(-85.0010618,37.13184)
+            .point(-85.0010057,37.1315102)
+            .point(-85.000977,37.1314403)
+            .point(-85.0009182,37.1313793)
+            .point(-85.0005366,37.1312209)
+            .point(-85.000224,37.1311466)
+            .point(-85.000087,37.1311356)
+            .point(-85.0000002,37.1311433)
+            .point(-84.9995021,37.1312336)
+            .point(-84.9993308,37.1312859)
+            .point(-84.9992567,37.1313252)
+            .point(-84.9991868,37.1314277)
+            .point(-84.9991593,37.1315381)
+            .point(-84.9991841,37.1316527)
+            .point(-84.9992329,37.1317117)
+            .point(-84.9993527,37.1317788)
+            .point(-84.9994931,37.1318061)
+            .point(-84.9996815,37.1317979)
+            .point(-85.0000002,37.1317672);
+
+        Shape shape = builder.close().build();
+
+         assertPolygon(shape);
      }
 }


### PR DESCRIPTION
The bug reproduces when the point under test for the placement of the hole of the polygon has an x coordinate which only intersects with the ends of edges in the main polygon. The previous code threw out these cases as not relevant but an intersect at 1.0 of the distance from the start to the end of an edge is just as valid as an intersect at any other point along the edge.  The fix corrects this and adds a test.

Closes #5773
