### PR TITLE
Aggregations: Fix JSON output of geo bounds aggregation

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBounds.java
@@ -105,6 +105,7 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
     
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
         GeoPoint topLeft = topLeft();
         GeoPoint bottomRight = bottomRight();
         if (topLeft != null) {
@@ -116,6 +117,7 @@ public class InternalGeoBounds extends InternalMetricsAggregation implements Geo
             builder.startObject("bottom_right");
             builder.field("lat", bottomRight.lat());
             builder.field("lon", bottomRight.lon());
+            builder.endObject();
             builder.endObject();
         }
         return builder.endObject();


### PR DESCRIPTION
The geo bounds aggregation was not outputting the aggregation name and in the case where there was no data would output malformed JSON (extra } )
