### PR TITLE
Refactor TransportActions

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -38,17 +39,16 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  */
-public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMappingsRequest, GetFieldMappingsResponse> {
+public class TransportGetFieldMappingsAction extends HandledTransportAction<GetFieldMappingsRequest, GetFieldMappingsResponse> {
 
     private final ClusterService clusterService;
     private final TransportGetFieldMappingsIndexAction shardAction;
 
     @Inject
     public TransportGetFieldMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, TransportGetFieldMappingsIndexAction shardAction, ActionFilters actionFilters) {
-        super(settings, GetFieldMappingsAction.NAME, threadPool, actionFilters);
+        super(settings, GetFieldMappingsAction.NAME, threadPool, transportService, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
-        transportService.registerHandler(actionName, new TransportHandler());
     }
 
     @Override
@@ -101,41 +101,8 @@ public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMap
         return new GetFieldMappingsResponse(mergedResponses.immutableMap());
     }
 
-    private class TransportHandler extends BaseTransportRequestHandler<GetFieldMappingsRequest> {
-
-        @Override
-        public GetFieldMappingsRequest newInstance() {
-            return new GetFieldMappingsRequest();
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
-
-        @Override
-        public void messageReceived(final GetFieldMappingsRequest request, final TransportChannel channel) throws Exception {
-            // no need for a threaded listener, since we just send a response
-            request.listenerThreaded(false);
-            execute(request, new ActionListener<GetFieldMappingsResponse>() {
-                @Override
-                public void onResponse(GetFieldMappingsResponse result) {
-                    try {
-                        channel.sendResponse(result);
-                    } catch (Throwable e) {
-                        onFailure(e);
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Exception e1) {
-                        logger.warn("Failed to send error response for action [" + actionName + "] and request [" + request + "]", e1);
-                    }
-                }
-            });
-        }
+    @Override
+    public GetFieldMappingsRequest newRequestInstance() {
+        return new GetFieldMappingsRequest();
     }
 }

--- a/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.get;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,7 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class TransportMultiGetAction extends TransportAction<MultiGetRequest, MultiGetResponse> {
+public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequest, MultiGetResponse> {
 
     private final ClusterService clusterService;
 
@@ -47,11 +48,14 @@ public class TransportMultiGetAction extends TransportAction<MultiGetRequest, Mu
 
     @Inject
     public TransportMultiGetAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportShardMultiGetAction shardAction, ActionFilters actionFilters) {
-        super(settings, MultiGetAction.NAME, threadPool, actionFilters);
+        super(settings, MultiGetAction.NAME, threadPool, transportService, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
+    }
 
-        transportService.registerHandler(MultiGetAction.NAME, new TransportHandler());
+    @Override
+    public MultiGetRequest newRequestInstance(){
+        return new MultiGetRequest();
     }
 
     @Override
@@ -126,44 +130,6 @@ public class TransportMultiGetAction extends TransportAction<MultiGetRequest, Mu
                     listener.onResponse(new MultiGetResponse(responses.toArray(new MultiGetItemResponse[responses.length()])));
                 }
             });
-        }
-    }
-
-    class TransportHandler extends BaseTransportRequestHandler<MultiGetRequest> {
-
-        @Override
-        public MultiGetRequest newInstance() {
-            return new MultiGetRequest();
-        }
-
-        @Override
-        public void messageReceived(final MultiGetRequest request, final TransportChannel channel) throws Exception {
-            // no need to use threaded listener, since we just send a response
-            request.listenerThreaded(false);
-            execute(request, new ActionListener<MultiGetResponse>() {
-                @Override
-                public void onResponse(MultiGetResponse response) {
-                    try {
-                        channel.sendResponse(response);
-                    } catch (Throwable e) {
-                        onFailure(e);
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Exception e1) {
-                        logger.warn("Failed to send error response for action [" + MultiGetAction.NAME + "] and request [" + request + "]", e1);
-                    }
-                }
-            });
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/TransportMoreLikeThisAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -65,7 +66,7 @@ import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 /**
  * The more like this action.
  */
-public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisRequest, SearchResponse> {
+public class TransportMoreLikeThisAction extends HandledTransportAction<MoreLikeThisRequest, SearchResponse> {
 
     private final TransportSearchAction searchAction;
 
@@ -80,14 +81,17 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
     @Inject
     public TransportMoreLikeThisAction(Settings settings, ThreadPool threadPool, TransportSearchAction searchAction, TransportGetAction getAction,
                                        ClusterService clusterService, IndicesService indicesService, TransportService transportService, ActionFilters actionFilters) {
-        super(settings, MoreLikeThisAction.NAME, threadPool, actionFilters);
+        super(settings, MoreLikeThisAction.NAME, threadPool, transportService, actionFilters);
         this.searchAction = searchAction;
         this.getAction = getAction;
         this.indicesService = indicesService;
         this.clusterService = clusterService;
         this.transportService = transportService;
+    }
 
-        transportService.registerHandler(MoreLikeThisAction.NAME, new TransportHandler());
+    @Override
+    public MoreLikeThisRequest newRequestInstance(){
+        return new MoreLikeThisRequest();
     }
 
     @Override
@@ -330,43 +334,5 @@ public class TransportMoreLikeThisAction extends TransportAction<MoreLikeThisReq
                 .stopWords(request.stopWords())
                 .failOnUnsupportedField(failOnUnsupportedField);
         boolBuilder.should(mlt);
-    }
-
-    private class TransportHandler extends BaseTransportRequestHandler<MoreLikeThisRequest> {
-
-        @Override
-        public MoreLikeThisRequest newInstance() {
-            return new MoreLikeThisRequest();
-        }
-
-        @Override
-        public void messageReceived(MoreLikeThisRequest request, final TransportChannel channel) throws Exception {
-            // no need to have a threaded listener since we just send back a response
-            request.listenerThreaded(false);
-            execute(request, new ActionListener<SearchResponse>() {
-                @Override
-                public void onResponse(SearchResponse result) {
-                    try {
-                        channel.sendResponse(result);
-                    } catch (Throwable e) {
-                        onFailure(e);
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Exception e1) {
-                        logger.warn("Failed to send response for get", e1);
-                    }
-                }
-            });
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -38,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
-public class TransportMultiSearchAction extends TransportAction<MultiSearchRequest, MultiSearchResponse> {
+public class TransportMultiSearchAction extends HandledTransportAction<MultiSearchRequest, MultiSearchResponse> {
 
     private final ClusterService clusterService;
 
@@ -46,11 +47,9 @@ public class TransportMultiSearchAction extends TransportAction<MultiSearchReque
 
     @Inject
     public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportSearchAction searchAction, ActionFilters actionFilters) {
-        super(settings, MultiSearchAction.NAME, threadPool, actionFilters);
+        super(settings, MultiSearchAction.NAME, threadPool, transportService, actionFilters);
         this.clusterService = clusterService;
         this.searchAction = searchAction;
-
-        transportService.registerHandler(MultiSearchAction.NAME, new TransportHandler());
     }
 
     @Override
@@ -86,41 +85,8 @@ public class TransportMultiSearchAction extends TransportAction<MultiSearchReque
         }
     }
 
-    class TransportHandler extends BaseTransportRequestHandler<MultiSearchRequest> {
-
-        @Override
-        public MultiSearchRequest newInstance() {
-            return new MultiSearchRequest();
-        }
-
-        @Override
-        public void messageReceived(final MultiSearchRequest request, final TransportChannel channel) throws Exception {
-            // no need to use threaded listener, since we just send a response
-            request.listenerThreaded(false);
-            execute(request, new ActionListener<MultiSearchResponse>() {
-                @Override
-                public void onResponse(MultiSearchResponse response) {
-                    try {
-                        channel.sendResponse(response);
-                    } catch (Throwable e) {
-                        onFailure(e);
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Exception e1) {
-                        logger.warn("Failed to send error response for action [msearch] and request [" + request + "]", e1);
-                    }
-                }
-            });
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
+    @Override
+    public MultiSearchRequest newRequestInstance() {
+        return new MultiSearchRequest();
     }
 }

--- a/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportMultiTermVectorsAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.termvector;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,7 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVectorsRequest, MultiTermVectorsResponse> {
+public class TransportMultiTermVectorsAction extends HandledTransportAction<MultiTermVectorsRequest, MultiTermVectorsResponse> {
 
     private final ClusterService clusterService;
 
@@ -48,11 +49,9 @@ public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVe
     @Inject
     public TransportMultiTermVectorsAction(Settings settings, ThreadPool threadPool, TransportService transportService,
                                            ClusterService clusterService, TransportSingleShardMultiTermsVectorAction shardAction, ActionFilters actionFilters) {
-        super(settings, MultiTermVectorsAction.NAME, threadPool, actionFilters);
+        super(settings, MultiTermVectorsAction.NAME, threadPool, transportService, actionFilters);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
-
-        transportService.registerHandler(MultiTermVectorsAction.NAME, new TransportHandler());
     }
 
     @Override
@@ -134,42 +133,8 @@ public class TransportMultiTermVectorsAction extends TransportAction<MultiTermVe
         }
     }
 
-    class TransportHandler extends BaseTransportRequestHandler<MultiTermVectorsRequest> {
-
-        @Override
-        public MultiTermVectorsRequest newInstance() {
-            return new MultiTermVectorsRequest();
-        }
-
-        @Override
-        public void messageReceived(final MultiTermVectorsRequest request, final TransportChannel channel) throws Exception {
-            // no need to use threaded listener, since we just send a response
-            request.listenerThreaded(false);
-            execute(request, new ActionListener<MultiTermVectorsResponse>() {
-                @Override
-                public void onResponse(MultiTermVectorsResponse response) {
-                    try {
-                        channel.sendResponse(response);
-                    } catch (Throwable t) {
-                        onFailure(t);
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Throwable t) {
-                        logger.warn("Failed to send error response for action [" + MultiTermVectorsAction.NAME + "] and request ["
-                                + request + "]", t);
-                    }
-                }
-            });
-        }
-
-        @Override
-        public String executor() {
-            return ThreadPool.Names.SAME;
-        }
+    @Override
+    public MultiTermVectorsRequest newRequestInstance() {
+        return new MultiTermVectorsRequest();
     }
 }


### PR DESCRIPTION
Get rid of boilerplate code for handling transport actions.
Make these transport actions extend HandledTransportAction where this code
now lives.
