### PR TITLE
Streamline use of IndexClosedException introduced with #6475

### DIFF
--- a/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -42,6 +42,12 @@ public class IndicesOptions {
     private static final byte FORBID_ALIASES_TO_MULTIPLE_INDICES = 16;
     private static final byte FORBID_CLOSED_INDICES = 32;
 
+    private static final byte STRICT_EXPAND_OPEN = 6;
+    private static final byte LENIENT_EXPAND_OPEN = 7;
+    private static final byte STRICT_EXPAND_OPEN_CLOSED = 14;
+    private static final byte STRICT_EXPAND_OPEN_FORBID_CLOSED = 38;
+    private static final byte STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED = 48;
+
     static {
         byte max = 1 << 6;
         VALUES = new IndicesOptions[max];
@@ -177,7 +183,7 @@ public class IndicesOptions {
      *         allows that no indices are resolved from wildcard expressions (not returning an error).
      */
     public static IndicesOptions strictExpandOpen() {
-        return VALUES[6];
+        return VALUES[STRICT_EXPAND_OPEN];
     }
 
     /**
@@ -186,7 +192,7 @@ public class IndicesOptions {
      *         use of closed indices by throwing an error.
      */
     public static IndicesOptions strictExpandOpenAndForbidClosed() {
-        return VALUES[38];
+        return VALUES[STRICT_EXPAND_OPEN_FORBID_CLOSED];
     }
 
     /**
@@ -194,15 +200,15 @@ public class IndicesOptions {
      * indices and allows that no indices are resolved from wildcard expressions (not returning an error).
      */
     public static IndicesOptions strictExpand() {
-        return VALUES[14];
+        return VALUES[STRICT_EXPAND_OPEN_CLOSED];
     }
 
     /**
      * @return indices option that requires each specified index or alias to exist, doesn't expand wildcards and
      * throws error if any of the aliases resolves to multiple indices
      */
-    public static IndicesOptions strictSingleIndexNoExpand() {
-        return VALUES[FORBID_ALIASES_TO_MULTIPLE_INDICES];
+    public static IndicesOptions strictSingleIndexNoExpandForbidClosed() {
+        return VALUES[STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED];
     }
 
     /**
@@ -210,7 +216,7 @@ public class IndicesOptions {
      *         allows that no indices are resolved from wildcard expressions (not returning an error).
      */
     public static IndicesOptions lenientExpandOpen() {
-        return VALUES[7];
+        return VALUES[LENIENT_EXPAND_OPEN];
     }
 
     private static byte toByte(boolean ignoreUnavailable, boolean allowNoIndices, boolean wildcardExpandToOpen,

--- a/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -705,7 +705,7 @@ public class MetaData implements Iterable<IndexMetaData> {
     }
 
     public String concreteSingleIndex(String indexOrAlias) throws IndexMissingException, ElasticsearchIllegalArgumentException {
-        String[] indices = concreteIndices(IndicesOptions.strictSingleIndexNoExpand(), indexOrAlias);
+        String[] indices = concreteIndices(IndicesOptions.strictSingleIndexNoExpandForbidClosed(), indexOrAlias);
         assert indices.length == 1 : "expected an exception to be thrown otherwise";
         return indices[0];
     }

--- a/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/gateway/local/LocalGatewayIndexStateTests.java
@@ -21,10 +21,8 @@ package org.elasticsearch.gateway.local;
 
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -35,11 +33,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.gateway.Gateway;
+import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.InternalTestCluster.RestartCallback;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -123,7 +121,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         try {
             client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setTimeout("1s").execute().actionGet();
             fail();
-        } catch (ClusterBlockException e) {
+        } catch (IndexClosedException e) {
             // all is well
         }
 
@@ -166,7 +164,7 @@ public class LocalGatewayIndexStateTests extends ElasticsearchIntegrationTest {
         try {
             client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setTimeout("1s").execute().actionGet();
             fail();
-        } catch (ClusterBlockException e) {
+        } catch (IndexClosedException e) {
             // all is well
         }
 

--- a/src/test/java/org/elasticsearch/indices/state/SimpleIndexStateTests.java
+++ b/src/test/java/org/elasticsearch/indices/state/SimpleIndexStateTests.java
@@ -25,13 +25,13 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
-import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndexPrimaryShardNotAllocatedException;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -78,7 +78,7 @@ public class SimpleIndexStateTests extends ElasticsearchIntegrationTest {
         try {
             client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
             fail();
-        } catch (ClusterBlockException e) {
+        } catch (IndexClosedException e) {
             // all is well
         }
 


### PR DESCRIPTION
Single index operations to use the newly added IndexClosedException introduced with #6475. This way we can also fail faster when we are trying to execute operations on closed indices and their use is not allowed (depending on indices options). Indices blocks are still checked but we can throw error earlier on while resolving indices (MetaData#concreteIndices).

Effectively this change also affects what we return when using one of the following apis: analyze, bulk, index, update, delete, explain, get, multi_get, mlt, term vector, multi_term vector. We now return: 

```
{"error":"IndexClosedException[[test] closed]","status":403}
```

instead of 

```
{"error":"ClusterBlockException[blocked by: [FORBIDDEN/4/index closed];]","status":403}
```

Closes #6988
