### PR TITLE
Switch to using the multi-termvectors API

### DIFF
--- a/docs/reference/query-dsl/queries/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/queries/mlt-query.asciidoc
@@ -119,7 +119,7 @@ boost factor.
 
 |`boost` |Sets the boost value of the query. Defaults to `1.0`.
 
-|`analyzer` |The analyzer that will be used to analyze the text.
-Defaults to the analyzer associated with the field.
+|`analyzer` |The analyzer that will be used to analyze the `like text`.
+Defaults to the analyzer associated with the first field in `fields`.
 |=======================================================================
 

--- a/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.termvector;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.*;
+import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -49,6 +50,11 @@ public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsReque
 
     public MultiTermVectorsRequest add(String index, @Nullable String type, String id) {
         requests.add(new TermVectorRequest(index, type, id));
+        return this;
+    }
+
+    public MultiTermVectorsRequest add(MultiGetRequest.Item item) {
+        requests.add(new TermVectorRequest(item));
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorRequest.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -68,7 +69,7 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         this.id = id;
         this.type = type;
     }
-    
+
     /**
      * Constructs a new term vector request for a document that will be fetch
      * from the provided index. Use {@link #type(String)} and
@@ -84,6 +85,14 @@ public class TermVectorRequest extends SingleShardOperationRequest<TermVectorReq
         if (other.selectedFields != null) {
             this.selectedFields = new HashSet<>(other.selectedFields);
         }
+    }
+
+    public TermVectorRequest(MultiGetRequest.Item item) {
+        super(item.index());
+        this.id = item.id();
+        this.type = item.type();
+        this.selectedFields(item.fields());
+        this.routing(item.routing());
     }
 
     public EnumSet<Flag> getFlags() {

--- a/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -53,11 +53,7 @@ import org.elasticsearch.common.io.FastStringReader;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 
 /**
@@ -619,6 +615,49 @@ public final class XMoreLikeThis {
     }
 
     /**
+     * Return a query that will return docs like the passed Terms.
+     *
+     * @return a query that will return docs like the passed Terms.
+     */
+    public Query like(Terms... likeTerms) throws IOException {
+        Map<String, Int> termFreqMap = new HashMap<>();
+        for (Terms vector : likeTerms) {
+            addTermFrequencies(termFreqMap, vector);
+        }
+        return createQuery(createQueue(termFreqMap));
+    }
+
+    /**
+     * Return a query that will return docs like the passed Fields.
+     *
+     * @return a query that will return docs like the passed Fields.
+     */
+    public Query like(Fields... likeFields) throws IOException {
+        // get all field names
+        Set<String> fieldNames = new HashSet<>();
+        for (Fields fields : likeFields) {
+            for (String fieldName : fields) {
+                fieldNames.add(fieldName);
+            }
+        }
+        // to create one query per field name only
+        BooleanQuery bq = new BooleanQuery();
+        for (String fieldName : fieldNames) {
+            Map<String, Int> termFreqMap = new HashMap<>();
+            this.setFieldNames(new String[]{fieldName});
+            for (Fields fields : likeFields) {
+                Terms vector = fields.terms(fieldName);
+                if (vector != null) {
+                    addTermFrequencies(termFreqMap, vector);
+                }
+            }
+            Query query = createQuery(createQueue(termFreqMap));
+            bq.add(query, BooleanClause.Occur.SHOULD);
+        }
+        return bq;
+    }
+
+    /**
      * Create the More like query from a PriorityQueue
      */
     private Query createQuery(PriorityQueue<ScoreTerm> q) {
@@ -773,7 +812,9 @@ public final class XMoreLikeThis {
             if (isNoiseWord(term)) {
                 continue;
             }
-            final int freq = (int) termsEnum.totalTermFreq();
+
+            DocsEnum docs = termsEnum.docs(null, null);
+            final int freq = docs.freq();
 
             // increment frequency
             Int cnt = termFreqMap.get(term);

--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queries.TermsFilter;
@@ -40,10 +39,12 @@ import org.elasticsearch.index.analysis.Analysis;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
-import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService.LikeText;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -201,52 +202,23 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 }
                 if (item.fields() == null && item.fetchSourceContext() == null) {
                     item.fields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
-                } else {
-                    // TODO how about fields content fetched from _source?
-                    removeUnsupportedFields(item, analyzer, failOnUnsupportedField);
                 }
             }
-            // fetching the items with multi-get
-            List<LikeText> likeTexts = fetchService.fetch(items);
-            // collapse the text onto the same field name
-            Collection<LikeText> likeTextsCollapsed = collapseTextOnField(likeTexts);
-            // right now we are just building a boolean query
+            // fetching the items with multi-termvectors API
             BooleanQuery boolQuery = new BooleanQuery();
-            for (LikeText likeText : likeTextsCollapsed) {
-                addMoreLikeThis(boolQuery, mltQuery, likeText);
-            }
+            org.apache.lucene.index.Fields[] likeFields = fetchService.fetch(items);
+            mltQuery.setLikeText(likeFields);
+            boolQuery.add(mltQuery, BooleanClause.Occur.SHOULD);
             // exclude the items from the search
             if (!include) {
                 TermsFilter filter = new TermsFilter(UidFieldMapper.NAME, Uid.createUids(items));
                 ConstantScoreQuery query = new ConstantScoreQuery(filter);
                 boolQuery.add(query, BooleanClause.Occur.MUST_NOT);
             }
-            // add the possible mlt query with like_text
-            if (mltQuery.getLikeText() != null) {
-                boolQuery.add(mltQuery, BooleanClause.Occur.SHOULD);
-            }
             return boolQuery;
         }
 
         return mltQuery;
-    }
-
-    private void addMoreLikeThis(BooleanQuery boolQuery, MoreLikeThisQuery mltQuery, LikeText likeText) {
-        MoreLikeThisQuery mlt = new MoreLikeThisQuery();
-        mlt.setMoreLikeFields(new String[] {likeText.field});
-        mlt.setLikeText(likeText.text);
-        mlt.setAnalyzer(mltQuery.getAnalyzer());
-        mlt.setPercentTermsToMatch(mltQuery.getPercentTermsToMatch());
-        mlt.setBoostTerms(mltQuery.isBoostTerms());
-        mlt.setBoostTermsFactor(mltQuery.getBoostTermsFactor());
-        mlt.setMinDocFreq(mltQuery.getMinDocFreq());
-        mlt.setMaxDocFreq(mltQuery.getMaxDocFreq());
-        mlt.setMinWordLen(mltQuery.getMinWordLen());
-        mlt.setMaxWordLen(mltQuery.getMaxWordLen());
-        mlt.setMinTermFrequency(mltQuery.getMinTermFrequency());
-        mlt.setMaxQueryTerms(mltQuery.getMaxQueryTerms());
-        mlt.setStopWords(mltQuery.getStopWords());
-        boolQuery.add(mlt, BooleanClause.Occur.SHOULD);
     }
 
     private List<String> removeUnsupportedFields(List<String> moreLikeFields, Analyzer analyzer, boolean failOnUnsupportedField) throws IOException {
@@ -262,22 +234,4 @@ public class MoreLikeThisQueryParser implements QueryParser {
         }
         return moreLikeFields;
     }
-
-    public static Collection<LikeText> collapseTextOnField (Collection<LikeText> likeTexts) {
-        Map<String, LikeText> collapsedTexts = new HashMap<>();
-        for (LikeText likeText : likeTexts) {
-            String field = likeText.field;
-            String[] text = likeText.text;
-            if (collapsedTexts.containsKey(field)) {
-                text = ObjectArrays.concat(collapsedTexts.get(field).text, text, String.class);
-            }
-            collapsedTexts.put(field, new LikeText(field, text));
-        }
-        return collapsedTexts.values();
-    }
-
-    private void removeUnsupportedFields(MultiGetRequest.Item item, Analyzer analyzer, boolean failOnUnsupportedField) throws IOException {
-        item.fields((String[]) removeUnsupportedFields(Arrays.asList(item.fields()), analyzer, failOnUnsupportedField).toArray());
-    }
-
 }

--- a/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -21,18 +21,23 @@ package org.elasticsearch.index.query;
 
 
 import com.google.common.collect.Lists;
-import org.apache.lucene.index.Term;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.index.*;
+import org.apache.lucene.index.memory.MemoryIndex;
 import org.apache.lucene.queries.*;
 import org.apache.lucene.sandbox.queries.FuzzyLikeThisQuery;
 import org.apache.lucene.search.*;
 import org.apache.lucene.search.spans.*;
 import org.apache.lucene.spatial.prefix.IntersectsPrefixTreeFilter;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedString;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.*;
 import org.elasticsearch.common.lucene.search.function.BoostScoreFunction;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
@@ -48,7 +53,6 @@ import org.elasticsearch.index.search.geo.GeoDistanceFilter;
 import org.elasticsearch.index.search.geo.GeoPolygonFilter;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxFilter;
 import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService;
-import org.elasticsearch.index.search.morelikethis.MoreLikeThisFetchService.LikeText;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.hamcrest.Matchers;
@@ -1591,37 +1595,24 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         MoreLikeThisQueryParser parser = (MoreLikeThisQueryParser) queryParser.queryParser("more_like_this");
         parser.setFetchService(new MockMoreLikeThisFetchService());
 
-        List<LikeText> likeTexts = new ArrayList<>();
-        likeTexts.add(new LikeText("name.first", new String[]{
-                "test person 1 name.first", "test person 2 name.first", "test person 3 name.first", "test person 4 name.first"}));
-        likeTexts.add(new LikeText("name.last", new String[]{
-                "test person 1 name.last", "test person 2 name.last", "test person 3 name.last", "test person 4 name.last"}));
-
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/mlt-items.json");
         Query parsedQuery = queryParser.parse(query).query();
         assertThat(parsedQuery, instanceOf(BooleanQuery.class));
         BooleanQuery booleanQuery = (BooleanQuery) parsedQuery;
-        assertThat(booleanQuery.getClauses().length, is(likeTexts.size() + 1));
+        assertThat(booleanQuery.getClauses().length, is(1));
 
-        // check each clause is for each item
-        BooleanClause[] boolClauses = booleanQuery.getClauses();
-        for (int i = 0; i < likeTexts.size(); i++) {
-            BooleanClause booleanClause = booleanQuery.getClauses()[i];
-            assertThat(booleanClause.getOccur(), is(BooleanClause.Occur.SHOULD));
-            assertThat(booleanClause.getQuery(), instanceOf(MoreLikeThisQuery.class));
-            MoreLikeThisQuery mltQuery = (MoreLikeThisQuery) booleanClause.getQuery();
-            assertThat(mltQuery.getLikeTexts(), is(likeTexts.get(i).text));
-            assertThat(mltQuery.getMoreLikeFields()[0], equalTo(likeTexts.get(i).field));
+        BooleanClause itemClause = booleanQuery.getClauses()[0];
+        assertThat(itemClause.getOccur(), is(BooleanClause.Occur.SHOULD));
+        assertThat(itemClause.getQuery(), instanceOf(MoreLikeThisQuery.class));
+        MoreLikeThisQuery mltQuery = (MoreLikeThisQuery) itemClause.getQuery();
+
+        // check each Fields is for each item
+        for (int id = 1; id <= 4; id++) {
+            Fields fields = mltQuery.getLikeFields()[id - 1];
+            assertThat(termsToString(fields.terms("name.first")), is(String.valueOf(id)));
+            assertThat(termsToString(fields.terms("name.last")), is(String.valueOf(id)));
         }
-
-        // check last clause is for 'like_text'
-        BooleanClause boolClause = boolClauses[boolClauses.length - 1];
-        assertThat(boolClause.getOccur(), is(BooleanClause.Occur.SHOULD));
-        assertThat(boolClause.getQuery(), instanceOf(MoreLikeThisQuery.class));
-        MoreLikeThisQuery mltQuery = (MoreLikeThisQuery) boolClause.getQuery();
-        assertArrayEquals("Not the same more like this 'fields'", new String[] {"name.first", "name.last"}, mltQuery.getMoreLikeFields());
-        assertThat(mltQuery.getLikeText(), equalTo("Apache Lucene"));
     }
 
     private static class MockMoreLikeThisFetchService extends MoreLikeThisFetchService {
@@ -1630,17 +1621,34 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
             super(null, ImmutableSettings.Builder.EMPTY_SETTINGS);
         }
 
-        public List<LikeText> fetch(List<MultiGetRequest.Item> items) throws IOException {
-            List<LikeText> likeTexts = new ArrayList<>();
-            for (MultiGetRequest.Item item: items) {
-                for (String field : item.fields()) {
-                    LikeText likeText = new LikeText(
-                            field, item.index() + " " + item.type() + " " + item.id() + " " + field);
-                    likeTexts.add(likeText);
-                }
+        public Fields[] fetch(List<MultiGetRequest.Item> items) throws IOException {
+            List<Fields> likeTexts = new ArrayList<>();
+            for (MultiGetRequest.Item item : items) {
+                likeTexts.add(generateFields(item.fields(), item.id()));
             }
-            return likeTexts;
+            return likeTexts.toArray(Fields.EMPTY_ARRAY);
         }
+    }
+
+    private static Fields generateFields(String[] fieldNames, String text) throws IOException {
+        MemoryIndex index = new MemoryIndex();
+        for (String fieldName : fieldNames) {
+            index.addField(fieldName, text, new WhitespaceAnalyzer(Lucene.VERSION));
+        }
+        return MultiFields.getFields(index.createSearcher().getIndexReader());
+    }
+
+    private static String termsToString(Terms terms) throws IOException {
+        String strings = "";
+        TermsEnum termsEnum = terms.iterator(null);
+        CharsRef spare = new CharsRef();
+        BytesRef text;
+        while((text = termsEnum.next()) != null) {
+            UnicodeUtil.UTF8toUTF16(text, spare);
+            String term = spare.toString();
+            strings += term;
+        }
+        return strings;
     }
 
     @Test


### PR DESCRIPTION
The term vector API can now generate term vectors on the fly, if the terms are
not already stored in the index. This commit exploits this new functionality
for the MLT query. Now the terms are directly retrieved using multi-
termvectors API, instead of retrieving the texts using the multi-get API. The
terms are then directly passed to Lucene MLT.
