### PR TITLE
Internal: Add a future 1.5.0 Version constant

### DIFF
--- a/src/main/java/org/elasticsearch/Version.java
+++ b/src/main/java/org/elasticsearch/Version.java
@@ -194,6 +194,8 @@ public class Version implements Serializable {
     public static final Version V_1_3_1 = new Version(V_1_3_1_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
     public static final int V_1_4_0_ID = /*00*/1040099;
     public static final Version V_1_4_0 = new Version(V_1_4_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
+    public static final int V_1_5_0_ID = /*00*/1050099;
+    public static final Version V_1_5_0 = new Version(V_1_5_0_ID, false, org.apache.lucene.util.Version.LUCENE_4_9);
     public static final int V_2_0_0_ID = /*00*/2000099;
     public static final Version V_2_0_0 = new Version(V_2_0_0_ID, true, org.apache.lucene.util.Version.LUCENE_4_9);
 
@@ -211,6 +213,8 @@ public class Version implements Serializable {
         switch (id) {
             case V_2_0_0_ID:
                 return V_2_0_0;
+            case V_1_5_0_ID:
+                return V_1_5_0;
             case V_1_4_0_ID:
                 return V_1_4_0;
             case V_1_3_1_ID:


### PR DESCRIPTION
I'm not sure if this is something we want to do, but I think it makes it easier to plan PRs. I wanted to submit this and see if people had thoughts about it.

Since our git workflow includes not rebasing a branch once a PR has been submitted (rightly so!), this makes it possible to submit PRs during the 1.4.0 development cycle that target 1.5.0, without this all PRs have to target 2.0.0 and then fix-up their version checks once 1.4.0 is actually released since the new `Version` is not added until then.
