### PR TITLE
Make `ignore_unmapped` work for sorting cross-index queries.

### DIFF
--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -131,22 +131,31 @@ the `nested_filter` then a missing value is used.
 
 ==== Ignoring Unmapped Fields
 
+coming[1.4.0] Before 1.4.0 this parameter accepted a boolean, which was not
+enough information to decide on the sort values to emit, and didn't work for
+cross-index search.
+
 By default, the search request will fail if there is no mapping
 associated with a field. The `ignore_unmapped` option allows to ignore
-fields that have no mapping and not sort by them. Here is an example of
-how it can be used:
+fields that have no mapping and not sort by them. The value of this
+parameter is used to determine what sort values to emit. Here is an
+example of how it can be used:
 
 [source,js]
 --------------------------------------------------
 {
     "sort" : [
-        { "price" : {"ignore_unmapped" : true} },
+        { "price" : {"ignore_unmapped" : "long"} },
     ],
     "query" : {
         "term" : { "user" : "kimchy" }
     }
 }
 --------------------------------------------------
+
+If any of the indices that are queried doesn't have a mapping for `price`
+then Elasticsearch will handle it as if there was a mapping of type
+`long`, with all documents in this index having no value for this field.
 
 ==== Geo Distance Sorting
 

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -131,12 +131,14 @@ the `nested_filter` then a missing value is used.
 
 ==== Ignoring Unmapped Fields
 
-coming[1.4.0] Before 1.4.0 this parameter accepted a boolean, which was not
-enough information to decide on the sort values to emit, and didn't work for
-cross-index search.
+coming[1.4.0] Before 1.4.0 there was the `ignore_unmapped` boolean
+parameter, which was not enough information to decide on the sort
+values to emit, and didn't work for cross-index search. It is still
+supported but users are encouraged to migrate to the new
+`unmapped_type` instead.
 
 By default, the search request will fail if there is no mapping
-associated with a field. The `ignore_unmapped` option allows to ignore
+associated with a field. The `unmapped_type` option allows to ignore
 fields that have no mapping and not sort by them. The value of this
 parameter is used to determine what sort values to emit. Here is an
 example of how it can be used:
@@ -145,7 +147,7 @@ example of how it can be used:
 --------------------------------------------------
 {
     "sort" : [
-        { "price" : {"ignore_unmapped" : "long"} },
+        { "price" : {"unmapped_type" : "long"} },
     ],
     "query" : {
         "term" : { "user" : "kimchy" }

--- a/src/main/java/org/elasticsearch/common/text/StringAndBytesText.java
+++ b/src/main/java/org/elasticsearch/common/text/StringAndBytesText.java
@@ -98,6 +98,9 @@ public class StringAndBytesText implements Text {
 
     @Override
     public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
         return bytes().equals(((Text) obj).bytes());
     }
 

--- a/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -36,7 +36,9 @@ public class FieldSortBuilder extends SortBuilder {
 
     private Object missing;
 
-    private Object ignoreUnmapped;
+    private Boolean ignoreUnmapped;
+
+    private String unmappedType;
 
     private String sortMode;
 
@@ -78,19 +80,23 @@ public class FieldSortBuilder extends SortBuilder {
     /**
      * Sets if the field does not exists in the index, it should be ignored and not sorted by or not. Defaults
      * to <tt>false</tt> (not ignoring).
+     * @deprecated Use {@link #unmappedType(String)} instead. <code>ignoreUnmapped
      */
+    @Deprecated
     public FieldSortBuilder ignoreUnmapped(boolean ignoreUnmapped) {
         this.ignoreUnmapped = ignoreUnmapped;
         return this;
     }
 
     /**
-     * Sets if the field does not exists in the index, it should be ignored and not sorted by or not.
+     * Set the type to use in case the current field is not mapped in an index.
      * Specifying a type tells Elasticsearch what type the sort values should have, which is important
      * for cross-index search, if there are sort fields that exist on some indices only.
+     * If the unmapped type is <tt>null</tt> then query execution will fail if one or more indices
+     * don't have a mapping for the current field.
      */
-    public FieldSortBuilder ignoreUnmapped(String type) {
-        this.ignoreUnmapped = type;
+    public FieldSortBuilder unmappedType(String type) {
+        this.unmappedType = type;
         return this;
     }
 
@@ -134,7 +140,10 @@ public class FieldSortBuilder extends SortBuilder {
             builder.field("missing", missing);
         }
         if (ignoreUnmapped != null) {
-            builder.field("ignore_unmapped", ignoreUnmapped);
+            builder.field(SortParseElement.IGNORE_UNMAPPED.getPreferredName(), ignoreUnmapped);
+        }
+        if (unmappedType != null) {
+            builder.field(SortParseElement.UNMAPPED_TYPE.getPreferredName(), unmappedType);
         }
         if (sortMode != null) {
             builder.field("mode", sortMode);

--- a/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -80,7 +80,7 @@ public class FieldSortBuilder extends SortBuilder {
     /**
      * Sets if the field does not exists in the index, it should be ignored and not sorted by or not. Defaults
      * to <tt>false</tt> (not ignoring).
-     * @deprecated Use {@link #unmappedType(String)} instead. <code>ignoreUnmapped
+     * @deprecated Use {@link #unmappedType(String)} instead.
      */
     @Deprecated
     public FieldSortBuilder ignoreUnmapped(boolean ignoreUnmapped) {

--- a/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.search.sort;
 
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.FilterBuilder;
-import org.elasticsearch.ElasticsearchIllegalArgumentException;
 
 import java.io.IOException;
 
@@ -36,7 +36,7 @@ public class FieldSortBuilder extends SortBuilder {
 
     private Object missing;
 
-    private Boolean ignoreUnmapped;
+    private Object ignoreUnmapped;
 
     private String sortMode;
 
@@ -81,6 +81,16 @@ public class FieldSortBuilder extends SortBuilder {
      */
     public FieldSortBuilder ignoreUnmapped(boolean ignoreUnmapped) {
         this.ignoreUnmapped = ignoreUnmapped;
+        return this;
+    }
+
+    /**
+     * Sets if the field does not exists in the index, it should be ignored and not sorted by or not.
+     * Specifying a type tells Elasticsearch what type the sort values should have, which is important
+     * for cross-index search, if there are sort fields that exist on some indices only.
+     */
+    public FieldSortBuilder ignoreUnmapped(String type) {
+        this.ignoreUnmapped = type;
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -158,7 +158,10 @@ public class SortParseElement implements SearchParseElement {
                                     missing = parser.textOrNull();
                                 } else if (IGNORE_UNMAPPED.match(innerJsonName)) {
                                     // backward compatibility: ignore_unmapped has been replaced with unmapped_type
-                                    unmappedType = parser.booleanValue() ? LongFieldMapper.CONTENT_TYPE : null;
+                                    if (unmappedType == null // don't override if unmapped_type has been provided too
+                                            && parser.booleanValue()) {
+                                        unmappedType = LongFieldMapper.CONTENT_TYPE;
+                                    }
                                 } else if (UNMAPPED_TYPE.match(innerJsonName)) {
                                     unmappedType = parser.textOrNull();
                                 } else if ("mode".equals(innerJsonName)) {

--- a/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -52,6 +53,7 @@ import java.util.concurrent.ExecutionException;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.scriptFunction;
+import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
@@ -1675,5 +1677,41 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
         }
     }
 
+    public void testCrossIndexIgnoreUnmapped() throws Exception {
+        assertAcked(prepareCreate("test1").addMapping(
+                "type", "str_field1", "type=string",
+                "long_field", "type=long",
+                "double_field", "type=double").get());
+        assertAcked(prepareCreate("test2").get());
+
+        indexRandom(true,
+                client().prepareIndex("test1", "type").setSource("str_field", "bcd", "long_field", 3, "double_field", 0.65),
+                client().prepareIndex("test2", "type").setSource());
+
+        ensureYellow("test1", "test2");
+
+        SearchResponse resp = client().prepareSearch("test1", "test2")
+                .addSort(fieldSort("str_field").order(SortOrder.ASC).ignoreUnmapped("string"))
+                .addSort(fieldSort("str_field2").order(SortOrder.DESC).ignoreUnmapped("string")).get();
+
+        final StringAndBytesText maxTerm = new StringAndBytesText(IndexFieldData.XFieldComparatorSource.MAX_TERM.utf8ToString());
+        assertSortValues(resp,
+                new Object[] {new StringAndBytesText("bcd"), null},
+                new Object[] {maxTerm, null});
+
+        resp = client().prepareSearch("test1", "test2")
+                .addSort(fieldSort("long_field").order(SortOrder.ASC).ignoreUnmapped("long"))
+                .addSort(fieldSort("long_field2").order(SortOrder.DESC).ignoreUnmapped("long")).get();
+        assertSortValues(resp,
+                new Object[] {3L, Long.MIN_VALUE},
+                new Object[] {Long.MAX_VALUE, Long.MIN_VALUE});
+
+        resp = client().prepareSearch("test1", "test2")
+                .addSort(fieldSort("double_field").order(SortOrder.ASC).ignoreUnmapped("double"))
+                .addSort(fieldSort("double_field2").order(SortOrder.DESC).ignoreUnmapped("double")).get();
+        assertSortValues(resp,
+                new Object[] {0.65, Double.NEGATIVE_INFINITY},
+                new Object[] {Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY});
+    }
 
 }

--- a/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -1691,8 +1691,8 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
         ensureYellow("test1", "test2");
 
         SearchResponse resp = client().prepareSearch("test1", "test2")
-                .addSort(fieldSort("str_field").order(SortOrder.ASC).ignoreUnmapped("string"))
-                .addSort(fieldSort("str_field2").order(SortOrder.DESC).ignoreUnmapped("string")).get();
+                .addSort(fieldSort("str_field").order(SortOrder.ASC).unmappedType("string"))
+                .addSort(fieldSort("str_field2").order(SortOrder.DESC).unmappedType("string")).get();
 
         final StringAndBytesText maxTerm = new StringAndBytesText(IndexFieldData.XFieldComparatorSource.MAX_TERM.utf8ToString());
         assertSortValues(resp,
@@ -1700,15 +1700,15 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                 new Object[] {maxTerm, null});
 
         resp = client().prepareSearch("test1", "test2")
-                .addSort(fieldSort("long_field").order(SortOrder.ASC).ignoreUnmapped("long"))
-                .addSort(fieldSort("long_field2").order(SortOrder.DESC).ignoreUnmapped("long")).get();
+                .addSort(fieldSort("long_field").order(SortOrder.ASC).unmappedType("long"))
+                .addSort(fieldSort("long_field2").order(SortOrder.DESC).unmappedType("long")).get();
         assertSortValues(resp,
                 new Object[] {3L, Long.MIN_VALUE},
                 new Object[] {Long.MAX_VALUE, Long.MIN_VALUE});
 
         resp = client().prepareSearch("test1", "test2")
-                .addSort(fieldSort("double_field").order(SortOrder.ASC).ignoreUnmapped("double"))
-                .addSort(fieldSort("double_field2").order(SortOrder.DESC).ignoreUnmapped("double")).get();
+                .addSort(fieldSort("double_field").order(SortOrder.ASC).unmappedType("double"))
+                .addSort(fieldSort("double_field2").order(SortOrder.DESC).unmappedType("double")).get();
         assertSortValues(resp,
                 new Object[] {0.65, Double.NEGATIVE_INFINITY},
                 new Object[] {Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY});

--- a/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -78,8 +78,7 @@ import static com.google.common.base.Predicates.isNull;
 import static org.elasticsearch.test.ElasticsearchTestCase.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -152,6 +151,17 @@ public class ElasticsearchAssertions {
         }
         assertThat("Expected ids: " + Arrays.toString(idsSet.toArray(new String[idsSet.size()])) + " in the result - result size differs."
                 + shardStatus, idsSet.size(), equalTo(0));
+        assertVersionSerializable(searchResponse);
+    }
+
+    public static void assertSortValues(SearchResponse searchResponse, Object[]... sortValues) {
+        assertSearchResponse(searchResponse);
+        SearchHit[] hits = searchResponse.getHits().getHits();
+        assertEquals(sortValues.length, hits.length);
+        for (int i = 0; i < sortValues.length; ++i) {
+            final Object[] hitsSortValues = hits[i].getSortValues();
+            assertArrayEquals("Offset " + Integer.toString(i) + ", id " + hits[i].getId(), sortValues[i], hitsSortValues);
+        }
         assertVersionSerializable(searchResponse);
     }
 


### PR DESCRIPTION
Close #2255
