### PR TITLE
Support parsing lucene minor version strings

### DIFF
--- a/core-signatures.txt
+++ b/core-signatures.txt
@@ -66,3 +66,6 @@ java.nio.channels.ReadableByteChannel#read(java.nio.ByteBuffer)
 java.nio.channels.ScatteringByteChannel#read(java.nio.ByteBuffer[])
 java.nio.channels.ScatteringByteChannel#read(java.nio.ByteBuffer[], int, int)
 java.nio.channels.FileChannel#read(java.nio.ByteBuffer, long)
+
+@defaultMessage Use Lucene.parseLenient instead it strips off minor version
+org.apache.lucene.util.Version#parseLeniently(java.lang.String)

--- a/pom.xml
+++ b/pom.xml
@@ -1169,6 +1169,9 @@
                                 <!-- start exclude for Channels utility class -->
                                 <exclude>org/elasticsearch/common/io/Channels.class</exclude>
                                 <!-- end exclude for Channels -->
+                                <!-- start exclude for Lucene utility class -->
+                                <exclude>org/elasticsearch/common/lucene/Lucene$LenientParser.class</exclude>
+                                <!-- end exclude for Lucene -->
                             </excludes>
                             <bundledSignatures>
                                 <!-- This will automatically choose the right signatures based on 'targetVersion': -->

--- a/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.Version;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -255,7 +256,7 @@ public class BlobStoreIndexShardSnapshot {
                             } else if ("part_size".equals(currentFieldName)) {
                                 partSize = new ByteSizeValue(parser.longValue());
                             } else if ("written_by".equals(currentFieldName)) {
-                                writtenBy = Version.parseLeniently(parser.text());
+                                writtenBy = Lucene.parseVersionLenient(parser.text(), null);
                             } else {
                                 throw new ElasticsearchParseException("unknown parameter [" + currentFieldName + "]");
                             }

--- a/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/src/main/java/org/elasticsearch/index/store/Store.java
@@ -448,7 +448,7 @@ public class Store extends AbstractIndexShardComponent implements CloseableIndex
                 Version maxVersion = Version.LUCENE_3_0; // we don't know which version was used to write so we take the max version.
                 Set<String> added = new HashSet<>();
                 for (SegmentCommitInfo info : segmentCommitInfos) {
-                    final Version version = Version.parseLeniently(info.info.getVersion());
+                    final Version version = Lucene.parseVersionLenient(info.info.getVersion(), Version.LUCENE_3_0);
                     if (version.onOrAfter(maxVersion)) {
                         maxVersion = version;
                     }

--- a/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
+++ b/src/main/java/org/elasticsearch/index/store/StoreFileMetaData.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.index.store;
 
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.lucene.Lucene;
 
 import java.io.IOException;
 
@@ -102,7 +102,7 @@ public class StoreFileMetaData implements Streamable {
         checksum = in.readOptionalString();
         if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_3_0)) {
             String versionString = in.readOptionalString();
-            writtenBy = versionString == null ? null : Version.parseLeniently(versionString);
+            writtenBy = Lucene.parseVersionLenient(versionString, null);
         }
     }
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -21,10 +21,10 @@ package org.elasticsearch.indices.recovery;
 
 import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.transport.TransportRequest;
@@ -101,7 +101,7 @@ public final class RecoveryFileChunkRequest extends TransportRequest {  // publi
         Version writtenBy = null;
         if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_1_3_0)) {
             String versionString = in.readOptionalString();
-            writtenBy = versionString == null ? null : Version.parseLeniently(versionString);
+            writtenBy = Lucene.parseVersionLenient(versionString, null);
         }
         metaData = new StoreFileMetaData(name, length, checksum, writtenBy);
     }

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -571,7 +572,7 @@ public class PluginsService extends AbstractComponent {
                 String parts[] = luceneVersion.split("\\.");
 
                 // Should fail if the running node is too old!
-                org.apache.lucene.util.Version luceneExpectedVersion = org.apache.lucene.util.Version.parseLeniently(parts[0]+"."+parts[1]);
+                org.apache.lucene.util.Version luceneExpectedVersion = Lucene.parseVersionLenient(parts[0] + "." + parts[1], null);
 
                 if (Version.CURRENT.luceneVersion.equals(luceneExpectedVersion)) {
                     logger.debug("starting analysis plugin for Lucene [{}].", luceneExpectedVersion);

--- a/src/test/java/org/elasticsearch/VersionTests.java
+++ b/src/test/java/org/elasticsearch/VersionTests.java
@@ -20,9 +20,13 @@
 package org.elasticsearch;
 
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.test.ElasticsearchTestCase;
+import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.Locale;
 
 import static org.elasticsearch.Version.V_0_20_0;
 import static org.elasticsearch.Version.V_0_90_0;
@@ -112,6 +116,21 @@ public class VersionTests extends ElasticsearchTestCase {
         assertThat(Version.V_1_2_0.minimumCompatibilityVersion(), equalTo(Version.V_1_0_0));
         assertThat(Version.V_1_2_3.minimumCompatibilityVersion(), equalTo(Version.V_1_0_0));
         assertThat(Version.V_1_0_0_RC2.minimumCompatibilityVersion(), equalTo(Version.V_1_0_0_RC2));
+    }
+
+    @Test
+    public void parseLenient() {
+        int numIters = randomIntBetween(10, 100);
+        for (int i = 0; i < numIters; i++) {
+            Version version = randomVersion(getRandom());
+            org.apache.lucene.util.Version luceneVersion = version.luceneVersion;
+            String string = luceneVersion.name().toUpperCase(Locale.ROOT)
+                    .replaceFirst("^LUCENE_(\\d+)_(\\d+)$", "$1.$2");
+            if (randomBoolean()) {
+                string = string + "." + randomIntBetween(0, 100);
+            }
+            assertThat(luceneVersion, Matchers.equalTo(Lucene.parseVersionLenient(string, null)));
+        }
     }
 
 }


### PR DESCRIPTION
We parse the version that is shipped with the Lucene segments in order
to find the version of lucene that wrote a particular segment. Yet, some lucene
version ie:
- 4.3.1 (Elasticsearch 0.90.2)
- 4.5.1 (Elasticsearch 0.90.7)
- 3.6.1 (pre Elasticsearch 0.90.0)

wrote illegal strings containing the minor version which causes IAE exceptions
being thrown from lucenes parsing method.

Note: this is a BWC issues that causes replication to fail if the segment was created with on of the broken version and the node is upgraded to `Elasticsearch 1.3.0`
