### PR TITLE
Lucene version checker should use `Lucene.parseVersionLenient`

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -568,12 +568,8 @@ public class PluginsService extends AbstractComponent {
             }
 
             if (luceneVersion != null) {
-                // We only keep the first two parts
-                String parts[] = luceneVersion.split("\\.");
-
                 // Should fail if the running node is too old!
-                org.apache.lucene.util.Version luceneExpectedVersion = Lucene.parseVersionLenient(parts[0] + "." + parts[1], null);
-
+                org.apache.lucene.util.Version luceneExpectedVersion = Lucene.parseVersionLenient(luceneVersion, null);
                 if (Version.CURRENT.luceneVersion.equals(luceneExpectedVersion)) {
                     logger.debug("starting analysis plugin for Lucene [{}].", luceneExpectedVersion);
                     return true;


### PR DESCRIPTION
With commit 07c632a2d4dbefe44e8f25dc4ded6cf143d60e41, we now have a new Lucene.parseVersionLenient(String, Version) method which tries to find an existing Lucene version based on the two first digits X.Y of X.Y.Z String.
