### PR TITLE
Stops direct subclassing of InternalNumericMetricsAggregation

### DIFF
--- a/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -50,9 +50,9 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
     }
 
-    protected InternalNumericMetricsAggregation() {} // for serialization
+    private InternalNumericMetricsAggregation() {} // for serialization
 
-    protected InternalNumericMetricsAggregation(String name) {
+    private InternalNumericMetricsAggregation(String name) {
         super(name);
     }
 


### PR DESCRIPTION
Must subclass either InternalNumericMetricsAggregation.SingleValue or InternalNumericMetricsAggregation.MultiValue
