### PR TITLE
Transport client: Don't add listed nodes to connected nodes list in sniff mode

### DIFF
--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -456,7 +456,7 @@ public class TransportClientNodesService extends AbstractComponent {
                 return;
             }
 
-            HashSet<DiscoveryNode> newNodes = new HashSet<>(listedNodes);
+            HashSet<DiscoveryNode> newNodes = new HashSet<>();
             HashSet<DiscoveryNode> newFilteredNodes = new HashSet<>();
             for (Map.Entry<DiscoveryNode, ClusterStateResponse> entry : clusterStateResponses.entrySet()) {
                 if (!ignoreClusterName && !clusterName.equals(entry.getValue().getClusterName())) {


### PR DESCRIPTION
This commit effectively reverts e1aa91d , as it is not needed anymore to add the original listed nodes. The cluster state local call made will in fact always return at least the local node (see #6811).

There were a couple of downsides caused by putting the original listed nodes among the connected nodes:
1) in the following retries, they weren't seen as listed nodes anymore, thus the light connect wasn't used
2) among the connected nodes some were "bad" duplicates as they are already there and don't contain all needed info for each node. This was causing serialization problems for instance given that the node version was missing on the `DiscoveryNode` object (or `minCompatibilityVersion` after #6894).

(As a side note, the fact that nodes were appearing twice in the list was hiding #6829 in sniff mode, as more nodes than expected were in the list and then retried)

Next step is to enable transport client `sniff` mode in our tests, already in the work on a public branch: https://github.com/elasticsearch/elasticsearch/tree/enhancement/test-enable-transport-client-sniff .
