### PR TITLE
Prefer private networking for HTTP by default, avoiding public IP bind

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -219,6 +219,11 @@
 #
 #transport.tcp.compress: true
 
+# Default is allowing HTTP for on-site IPs only (localhost, private network IPs).
+# Public access for HTTP must be explicitly enabled (disabled by default):
+#
+#http.public_access: true
+
 # Set a custom port to listen for HTTP traffic:
 #
 #http.port: 9200


### PR DESCRIPTION
This change breaks with current behavior of ES HTTP server socket binding.

The new default should be to bind HTTP only to private internet addresses
(localhost, link-local, private network RFC 1918) and to avoid
automatic public IP binds.

This change can no longer use the `null` host name for socket binding as
default. Instead, it looks up the host name by a reverse IP check and uses
`localhost` if this fails. For success, DNS must be working and configured correctly.
The IP of the host name is used for binding and for the check if the IP is
public. If the IP is public, an exception is thrown, and the HTTP socket is not
available.

A new parameter `http.public_access` must be enabled explicitly to allow
binding the HTTP port against a public IP. The default is `false`.
