### PR TITLE
Don't remove ancestors on deb removal

### DIFF
--- a/src/deb/control/postrm
+++ b/src/deb/control/postrm
@@ -7,7 +7,7 @@ case "$1" in
         rm -rf /var/log/elasticsearch
         
         # remove **only** empty data dir
-        rmdir -p --ignore-fail-on-non-empty /var/lib/elasticsearch
+        rmdir --ignore-fail-on-non-empty /var/lib/elasticsearch
     ;;
 
     purge)


### PR DESCRIPTION
The used -p option could result in accidentally deleting more directories
than /var/lib/elasticsearch - so this option was removed. 

Note: This only happens if the directories, but still isnt needed.

Relates #5770
