### PR TITLE
Sorting: Allow _geo_distance to handle many to many geo point distance

### DIFF
--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -263,6 +263,22 @@ conform with http://geojson.org/[GeoJSON].
 }
 --------------------------------------------------
 
+
+==== Multiple reference points
+
+Multiple geo points can be passed as an array containing any `geo_point` format, for example
+
+```
+"pin.location" : [[-70, 40], [-71, 42]]
+"pin.location" : [{"lat": -70, "lon": 40}, {"lat": -71, "lon": 42}]
+
+```
+and so forth.
+
+The final distance for a document will then be `min`/`max` distance of all points contained in the document to all points given in the sort request.
+
+
+
 ==== Script Based Sorting
 
 Allow to sort based on custom scripts, here is an example:

--- a/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -209,7 +209,7 @@ public class GeoDistanceParser implements Aggregator.Parser {
             public void setNextReader(AtomicReaderContext reader) {
                 final MultiGeoPointValues geoValues = source.geoPointValues();
                 final FixedSourceDistance distance = distanceType.fixedSourceDistance(origin.getLat(), origin.getLon(), unit);
-                distanceValues = GeoDistance.distanceValues(distance, geoValues);
+                distanceValues = GeoDistance.distanceValues(geoValues, distance);
             }
 
             @Override

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.query.FilterBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -73,15 +74,15 @@ public class GeoDistanceSortBuilder extends SortBuilder {
      * @param points reference points.
      */
     public GeoDistanceSortBuilder points(GeoPoint... points) {
-        this.points.addAll(Lists.newArrayList(points));
+        this.points.addAll(Arrays.asList(points));
         return this;
     }
 
     /**
      * The geohash of the geo point to create the range distance facets from.
      */
-    public GeoDistanceSortBuilder geohash(String... geohash) {
-        this.geohashes.addAll(Lists.newArrayList(geohash));
+    public GeoDistanceSortBuilder geohash(String... geohashes) {
+        this.geohashes.addAll(Arrays.asList(geohashes));
         return this;
     }
 

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.sort;
 
-import com.google.common.collect.Lists;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -82,7 +81,7 @@ public class GeoDistanceSortBuilder extends SortBuilder {
     /**
      * The geohash of the geo point to create the range distance facets from.
      */
-    public GeoDistanceSortBuilder geohash(String... geohashes) {
+    public GeoDistanceSortBuilder geohashes(String... geohashes) {
         this.geohashes.addAll(Arrays.asList(geohashes));
         return this;
     }

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -27,13 +27,12 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoDistance.FixedSourceDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.*;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -47,8 +46,6 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 /**
  *

--- a/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -1774,7 +1774,7 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
         for (int i = 0; i < 4; i++) {
             int at = randomInt(3 - i);
             if (randomBoolean()) {
-                geoDistanceSortBuilder.geohash(qHashes.get(at));
+                geoDistanceSortBuilder.geohashes(qHashes.get(at));
             } else {
                 geoDistanceSortBuilder.points(qPoints.get(at));
             }

--- a/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.search.sort;
+
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.service.IndexService;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.elasticsearch.test.TestSearchContext;
+import org.junit.Test;
+
+public class SortParserTests extends ElasticsearchSingleNodeTest {
+
+    @Test
+    public void testGeoDistanceSortParserManyPointsNoException() throws Exception {
+        String mapping = "{\"type\": {\"properties\": {\"location\": {\"type\": \"geo_point\"}}}}";
+        IndexService indexService = createIndex("testidx", ImmutableSettings.settingsBuilder().build(), "type", mapping);
+        TestSearchContext context = (TestSearchContext)createSearchContext(indexService);
+        context.setTypes("type");
+
+        String sortString = "{\n" +
+                "        \"location\": [\n" +
+                "          [\n" +
+                "            1.2,\n" +
+                "            3\n" +
+                "          ],\n" +
+                "          [\n" +
+                "            5,\n" +
+                "            6\n" +
+                "          ]\n" +
+                "        ],\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "      }\n" +
+                "    }";
+        XContentParser parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        GeoDistanceSortParser geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": [\n" +
+                "          {\n" +
+                "            \"lat\":1.2,\n" +
+                "            \"lon\":3\n" +
+                "          },\n" +
+                "          {\n" +
+                "             \"lat\":1.2,\n" +
+                "            \"lon\":3\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": [\n" +
+                "          \"1,2\",\n" +
+                "          \"3,4\"\n" +
+                "        ],\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": [\n" +
+                "          \"s3y0zh7w1z0g\",\n" +
+                "          \"s6wjr4et3f8v\"\n" +
+                "        ],\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": " +
+                "          [\n" +
+                "            1.2,\n" +
+                "            3\n" +
+                "          ],\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "      }\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": \n" +
+                "          {\n" +
+                "            \"lat\":1.2,\n" +
+                "            \"lon\":3\n" +
+                "          }," +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": \"1,2\"," +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+
+        sortString = "{\n" +
+                "        \"location\": \"s3y0zh7w1z0g\",\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "    }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
+    }
+}

--- a/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
@@ -21,8 +21,9 @@
 package org.elasticsearch.search.sort;
 
 
-import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.service.IndexService;
@@ -30,158 +31,119 @@ import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.elasticsearch.test.TestSearchContext;
 import org.junit.Test;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
 public class SortParserTests extends ElasticsearchSingleNodeTest {
 
     @Test
     public void testGeoDistanceSortParserManyPointsNoException() throws Exception {
-        String mapping = "{\"type\": {\"properties\": {\"location\": {\"type\": \"geo_point\"}}}}";
+        XContentBuilder mapping = jsonBuilder();
+        mapping.startObject().startObject("type").startObject("properties").startObject("location").field("type", "geo_point").endObject().endObject().endObject().endObject();
         IndexService indexService = createIndex("testidx", ImmutableSettings.settingsBuilder().build(), "type", mapping);
-        TestSearchContext context = (TestSearchContext)createSearchContext(indexService);
+        TestSearchContext context = (TestSearchContext) createSearchContext(indexService);
         context.setTypes("type");
 
-        String sortString = "{\n" +
-                "        \"location\": [\n" +
-                "          [\n" +
-                "            1.2,\n" +
-                "            3\n" +
-                "          ],\n" +
-                "          [\n" +
-                "            5,\n" +
-                "            6\n" +
-                "          ]\n" +
-                "        ],\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "      }\n" +
-                "    }";
-        XContentParser parser = XContentHelper.createParser(new BytesArray(sortString));
+        XContentBuilder sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.startArray("location");
+        sortBuilder.startArray().value(1.2).value(3).endArray().startArray().value(5).value(6).endArray();
+        sortBuilder.endArray();
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        XContentParser parser = XContentHelper.createParser(sortBuilder.bytes());
         parser.nextToken();
         GeoDistanceSortParser geoParser = new GeoDistanceSortParser();
         geoParser.parse(parser, context);
 
-        sortString = "{\n" +
-                "        \"location\": [\n" +
-                "          {\n" +
-                "            \"lat\":1.2,\n" +
-                "            \"lon\":3\n" +
-                "          },\n" +
-                "          {\n" +
-                "             \"lat\":1.2,\n" +
-                "            \"lon\":3\n" +
-                "          }\n" +
-                "        ],\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.startArray("location");
+        sortBuilder.value(new GeoPoint(1.2, 3)).value(new GeoPoint(1.2, 3));
+        sortBuilder.endArray();
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
-        sortString = "{\n" +
-                "        \"location\": [\n" +
-                "          \"1,2\",\n" +
-                "          \"3,4\"\n" +
-                "        ],\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.startArray("location");
+        sortBuilder.value("1,2").value("3,4");
+        sortBuilder.endArray();
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
-        sortString = "{\n" +
-                "        \"location\": [\n" +
-                "          \"s3y0zh7w1z0g\",\n" +
-                "          \"s6wjr4et3f8v\"\n" +
-                "        ],\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.startArray("location");
+        sortBuilder.value("s3y0zh7w1z0g").value("s6wjr4et3f8v");
+        sortBuilder.endArray();
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
-        sortString = "{\n" +
-                "        \"location\": " +
-                "          [\n" +
-                "            1.2,\n" +
-                "            3\n" +
-                "          ],\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "      }\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.startArray("location");
+        sortBuilder.value(1.2).value(3);
+        sortBuilder.endArray();
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
-        sortString = "{\n" +
-                "        \"location\": \n" +
-                "          {\n" +
-                "            \"lat\":1.2,\n" +
-                "            \"lon\":3\n" +
-                "          }," +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.field("location", new GeoPoint(1, 2));
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
-        sortString = "{\n" +
-                "        \"location\": \"1,2\"," +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.field("location", "1,2");
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
-        sortString = "{\n" +
-                "        \"location\": \"s3y0zh7w1z0g\",\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "    }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
-        parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
-        geoParser.parse(parser, context);
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.field("location", "s3y0zh7w1z0g");
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
 
+        sortBuilder = jsonBuilder();
+        sortBuilder.startObject();
+        sortBuilder.startArray("location");
+        sortBuilder.value(new GeoPoint(1, 2)).value("s3y0zh7w1z0g").startArray().value(1).value(2).endArray().value("1,2");
+        sortBuilder.endArray();
+        sortBuilder.field("order", "desc");
+        sortBuilder.field("unit", "km");
+        sortBuilder.field("sort_mode", "max");
+        sortBuilder.endObject();
+        parse(context, sortBuilder);
+    }
 
-        sortString = "{\n" +
-                "        \"location\": [\n" +
-                "          {\n" +
-                "            \"lat\": 1.2,\n" +
-                "            \"lon\": 3\n" +
-                "          },\n" +
-                "          \"s3y0zh7w1z0g\",\n" +
-                "          [\n" +
-                "            1,\n" +
-                "            2\n" +
-                "          ],\n" +
-                "          \"1,2\"\n" +
-                "        ],\n" +
-                "        \"order\": \"desc\",\n" +
-                "        \"unit\": \"km\",\n" +
-                "        \"sort_mode\": \"max\"\n" +
-                "      }";
-        parser = XContentHelper.createParser(new BytesArray(sortString));
+    protected void parse(TestSearchContext context, XContentBuilder sortBuilder) throws Exception {
+        XContentParser parser = XContentHelper.createParser(sortBuilder.bytes());
         parser.nextToken();
-        geoParser = new GeoDistanceSortParser();
+        GeoDistanceSortParser geoParser = new GeoDistanceSortParser();
         geoParser.parse(parser, context);
     }
 }

--- a/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
+++ b/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
@@ -160,5 +160,28 @@ public class SortParserTests extends ElasticsearchSingleNodeTest {
         parser.nextToken();
         geoParser = new GeoDistanceSortParser();
         geoParser.parse(parser, context);
+
+
+        sortString = "{\n" +
+                "        \"location\": [\n" +
+                "          {\n" +
+                "            \"lat\": 1.2,\n" +
+                "            \"lon\": 3\n" +
+                "          },\n" +
+                "          \"s3y0zh7w1z0g\",\n" +
+                "          [\n" +
+                "            1,\n" +
+                "            2\n" +
+                "          ],\n" +
+                "          \"1,2\"\n" +
+                "        ],\n" +
+                "        \"order\": \"desc\",\n" +
+                "        \"unit\": \"km\",\n" +
+                "        \"sort_mode\": \"max\"\n" +
+                "      }";
+        parser = XContentHelper.createParser(new BytesArray(sortString));
+        parser.nextToken();
+        geoParser = new GeoDistanceSortParser();
+        geoParser.parse(parser, context);
     }
 }

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -20,6 +20,7 @@ package org.elasticsearch.test;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.client.Requests;
@@ -126,7 +127,18 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
      * Create a new index on the singleton node with the provided index settings.
      */
     protected static IndexService createIndex(String index, Settings settings) {
-        assertAcked(Holder.NODE.client().admin().indices().prepareCreate(index).setSettings(settings).get());
+        return createIndex(index, settings, null, null);
+    }
+
+    /**
+     * Create a new index on the singleton node with the provided index settings.
+     */
+    protected static IndexService createIndex(String index, Settings settings, String type, String mappings) {
+        CreateIndexRequestBuilder createIndexRequestBuilder = Holder.NODE.client().admin().indices().prepareCreate(index).setSettings(settings);
+        if (type != null && mappings != null) {
+            createIndexRequestBuilder.addMapping(type, mappings);
+        }
+        assertAcked(createIndexRequestBuilder.get());
         // Wait for the index to be allocated so that cluster state updates don't override
         // changes that would have been done locally
         ClusterHealthResponse health = Holder.NODE.client().admin().cluster()

--- a/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchSingleNodeTest.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.Node;
@@ -133,7 +134,7 @@ public abstract class ElasticsearchSingleNodeTest extends ElasticsearchTestCase 
     /**
      * Create a new index on the singleton node with the provided index settings.
      */
-    protected static IndexService createIndex(String index, Settings settings, String type, String mappings) {
+    protected static IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = Holder.NODE.client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null && mappings != null) {
             createIndexRequestBuilder.addMapping(type, mappings);

--- a/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -77,6 +77,7 @@ public class TestSearchContext extends SearchContext {
     ContextIndexSearcher searcher;
     int size;
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
+    private String[] types;
 
     public TestSearchContext(ThreadPool threadPool, CacheRecycler cacheRecycler, PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService, FilterCache filterCache, IndexFieldDataService indexFieldDataService) {
         this.cacheRecycler = cacheRecycler;
@@ -96,6 +97,10 @@ public class TestSearchContext extends SearchContext {
         this.filterCache = null;
         this.indexFieldDataService = null;
         this.threadPool = null;
+    }
+
+    public void setTypes(String... types) {
+        this.types = types;
     }
 
     @Override
@@ -290,7 +295,10 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public MapperService mapperService() {
-        return indexService.mapperService();
+        if (indexService != null) {
+            return indexService.mapperService();
+        }
+        return null;
     }
 
     @Override
@@ -582,6 +590,9 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public FieldMapper<?> smartNameFieldMapper(String name) {
+        if (mapperService() != null) {
+            return mapperService().smartNameFieldMapper(name, types());
+        }
         return null;
     }
 


### PR DESCRIPTION
Add computation of disyance to many geo points. Example request:

```
{
  "sort": [
    {
      "_geo_distance": {
        "location": [
          {
            "lat":1.2,
            "lon":3
          },
          {
             "lat":1.2,
            "lon":3
          }
        ],
        "order": "desc",
        "unit": "km",
        "sort_mode": "max"
      }
    }
  ]
}
```

closes #3926
