### PR TITLE
Better categorization for transport actions

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class ClusterHealthAction extends ClusterAction<ClusterHealthRequest, ClusterHealthResponse, ClusterHealthRequestBuilder> {
 
     public static final ClusterHealthAction INSTANCE = new ClusterHealthAction();
-    public static final String NAME = "cluster/health";
+    public static final String NAME = "cluster:monitor/health";
 
     private ClusterHealthAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class NodesHotThreadsAction extends ClusterAction<NodesHotThreadsRequest, NodesHotThreadsResponse, NodesHotThreadsRequestBuilder> {
 
     public static final NodesHotThreadsAction INSTANCE = new NodesHotThreadsAction();
-    public static final String NAME = "cluster/nodes/hot_threads";
+    public static final String NAME = "cluster:monitor/nodes/hot_threads";
 
     private NodesHotThreadsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class NodesInfoAction extends ClusterAction<NodesInfoRequest, NodesInfoResponse, NodesInfoRequestBuilder> {
 
     public static final NodesInfoAction INSTANCE = new NodesInfoAction();
-    public static final String NAME = "cluster/nodes/info";
+    public static final String NAME = "cluster:monitor/nodes/info";
 
     private NodesInfoAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/NodesRestartAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/restart/NodesRestartAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class NodesRestartAction extends ClusterAction<NodesRestartRequest, NodesRestartResponse, NodesRestartRequestBuilder> {
 
     public static final NodesRestartAction INSTANCE = new NodesRestartAction();
-    public static final String NAME = "cluster/nodes/restart";
+    public static final String NAME = "cluster:admin/nodes/restart";
 
     private NodesRestartAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodesShutdownAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class NodesShutdownAction extends ClusterAction<NodesShutdownRequest, NodesShutdownResponse, NodesShutdownRequestBuilder> {
 
     public static final NodesShutdownAction INSTANCE = new NodesShutdownAction();
-    public static final String NAME = "cluster/nodes/shutdown";
+    public static final String NAME = "cluster:admin/nodes/shutdown";
 
     private NodesShutdownAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportNodesShutdownAction.java
@@ -47,6 +47,8 @@ import java.util.concurrent.CountDownLatch;
  */
 public class TransportNodesShutdownAction extends TransportMasterNodeOperationAction<NodesShutdownRequest, NodesShutdownResponse> {
 
+    public static final String SHUTDOWN_NODE_ACTION_NAME = NodesShutdownAction.NAME + "[n]";
+
     private final Node node;
     private final ClusterName clusterName;
     private final boolean disabled;
@@ -61,7 +63,7 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
         this.disabled = settings.getAsBoolean("action.disable_shutdown", componentSettings.getAsBoolean("disabled", false));
         this.delay = componentSettings.getAsTime("delay", TimeValue.timeValueMillis(200));
 
-        this.transportService.registerHandler(NodeShutdownRequestHandler.ACTION, new NodeShutdownRequestHandler());
+        this.transportService.registerHandler(SHUTDOWN_NODE_ACTION_NAME, new NodeShutdownRequestHandler());
     }
 
     @Override
@@ -122,7 +124,7 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
                             latch.countDown();
                         } else {
                             logger.trace("[cluster_shutdown]: sending shutdown request to [{}]", node);
-                            transportService.sendRequest(node, NodeShutdownRequestHandler.ACTION, new NodeShutdownRequest(request), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                            transportService.sendRequest(node, SHUTDOWN_NODE_ACTION_NAME, new NodeShutdownRequest(request), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                                 @Override
                                 public void handleResponse(TransportResponse.Empty response) {
                                     logger.trace("[cluster_shutdown]: received shutdown response from [{}]", node);
@@ -146,7 +148,7 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
 
                     // now, kill the master
                     logger.trace("[cluster_shutdown]: shutting down the master [{}]", state.nodes().masterNode());
-                    transportService.sendRequest(state.nodes().masterNode(), NodeShutdownRequestHandler.ACTION, new NodeShutdownRequest(request), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                    transportService.sendRequest(state.nodes().masterNode(), SHUTDOWN_NODE_ACTION_NAME, new NodeShutdownRequest(request), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                         @Override
                         public void handleResponse(TransportResponse.Empty response) {
                             logger.trace("[cluster_shutdown]: received shutdown response from master");
@@ -190,7 +192,7 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
                         }
 
                         logger.trace("[partial_cluster_shutdown]: sending shutdown request to [{}]", node);
-                        transportService.sendRequest(node, NodeShutdownRequestHandler.ACTION, new NodeShutdownRequest(request), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                        transportService.sendRequest(node, SHUTDOWN_NODE_ACTION_NAME, new NodeShutdownRequest(request), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                             @Override
                             public void handleResponse(TransportResponse.Empty response) {
                                 logger.trace("[partial_cluster_shutdown]: received shutdown response from [{}]", node);
@@ -220,8 +222,6 @@ public class TransportNodesShutdownAction extends TransportMasterNodeOperationAc
     }
 
     private class NodeShutdownRequestHandler extends BaseTransportRequestHandler<NodeShutdownRequest> {
-
-        static final String ACTION = "/cluster/nodes/shutdown/node";
 
         @Override
         public NodeShutdownRequest newInstance() {

--- a/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class NodesStatsAction extends ClusterAction<NodesStatsRequest, NodesStatsResponse, NodesStatsRequestBuilder> {
 
     public static final NodesStatsAction INSTANCE = new NodesStatsAction();
-    public static final String NAME = "cluster/nodes/stats";
+    public static final String NAME = "cluster:monitor/nodes/stats";
 
     private NodesStatsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class DeleteRepositoryAction extends ClusterAction<DeleteRepositoryRequest, DeleteRepositoryResponse, DeleteRepositoryRequestBuilder> {
 
     public static final DeleteRepositoryAction INSTANCE = new DeleteRepositoryAction();
-    public static final String NAME = "cluster/repository/delete";
+    public static final String NAME = "cluster:admin/repository/delete";
 
     private DeleteRepositoryAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class GetRepositoriesAction extends ClusterAction<GetRepositoriesRequest, GetRepositoriesResponse, GetRepositoriesRequestBuilder> {
 
     public static final GetRepositoriesAction INSTANCE = new GetRepositoriesAction();
-    public static final String NAME = "cluster/repository/get";
+    public static final String NAME = "cluster:admin/repository/get";
 
     private GetRepositoriesAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class PutRepositoryAction extends ClusterAction<PutRepositoryRequest, PutRepositoryResponse, PutRepositoryRequestBuilder> {
 
     public static final PutRepositoryAction INSTANCE = new PutRepositoryAction();
-    public static final String NAME = "cluster/repository/put";
+    public static final String NAME = "cluster:admin/repository/put";
 
     private PutRepositoryAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class ClusterRerouteAction extends ClusterAction<ClusterRerouteRequest, ClusterRerouteResponse, ClusterRerouteRequestBuilder> {
 
     public static final ClusterRerouteAction INSTANCE = new ClusterRerouteAction();
-    public static final String NAME = "cluster/reroute";
+    public static final String NAME = "cluster:admin/reroute";
 
     private ClusterRerouteAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class ClusterUpdateSettingsAction extends ClusterAction<ClusterUpdateSettingsRequest, ClusterUpdateSettingsResponse, ClusterUpdateSettingsRequestBuilder> {
 
     public static final ClusterUpdateSettingsAction INSTANCE = new ClusterUpdateSettingsAction();
-    public static final String NAME = "cluster/settings/update";
+    public static final String NAME = "cluster:admin/settings/update";
 
     private ClusterUpdateSettingsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class ClusterSearchShardsAction extends ClusterAction<ClusterSearchShardsRequest, ClusterSearchShardsResponse, ClusterSearchShardsRequestBuilder> {
 
     public static final ClusterSearchShardsAction INSTANCE = new ClusterSearchShardsAction();
-    public static final String NAME = "cluster/shards/search_shards";
+    public static final String NAME = "indices:admin/shards/search_shards";
 
     private ClusterSearchShardsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class CreateSnapshotAction extends ClusterAction<CreateSnapshotRequest, CreateSnapshotResponse, CreateSnapshotRequestBuilder> {
 
     public static final CreateSnapshotAction INSTANCE = new CreateSnapshotAction();
-    public static final String NAME = "cluster/snapshot/create";
+    public static final String NAME = "cluster:admin/snapshot/create";
 
     private CreateSnapshotAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class DeleteSnapshotAction extends ClusterAction<DeleteSnapshotRequest, DeleteSnapshotResponse, DeleteSnapshotRequestBuilder> {
 
     public static final DeleteSnapshotAction INSTANCE = new DeleteSnapshotAction();
-    public static final String NAME = "cluster/snapshot/delete";
+    public static final String NAME = "cluster:admin/snapshot/delete";
 
     private DeleteSnapshotAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class GetSnapshotsAction extends ClusterAction<GetSnapshotsRequest, GetSnapshotsResponse, GetSnapshotsRequestBuilder> {
 
     public static final GetSnapshotsAction INSTANCE = new GetSnapshotsAction();
-    public static final String NAME = "cluster/snapshot/get";
+    public static final String NAME = "cluster:admin/snapshot/get";
 
     private GetSnapshotsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class RestoreSnapshotAction extends ClusterAction<RestoreSnapshotRequest, RestoreSnapshotResponse, RestoreSnapshotRequestBuilder> {
 
     public static final RestoreSnapshotAction INSTANCE = new RestoreSnapshotAction();
-    public static final String NAME = "cluster/snapshot/restore";
+    public static final String NAME = "cluster:admin/snapshot/restore";
 
     private RestoreSnapshotAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class SnapshotsStatusAction extends ClusterAction<SnapshotsStatusRequest, SnapshotsStatusResponse, SnapshotsStatusRequestBuilder> {
 
     public static final SnapshotsStatusAction INSTANCE = new SnapshotsStatusAction();
-    public static final String NAME = "cluster/snapshot/status";
+    public static final String NAME = "cluster:admin/snapshot/status";
 
     private SnapshotsStatusAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesSnapshotsStatus extends TransportNodesOperationAction<TransportNodesSnapshotsStatus.Request, TransportNodesSnapshotsStatus.NodesSnapshotStatus, TransportNodesSnapshotsStatus.NodeRequest, TransportNodesSnapshotsStatus.NodeSnapshotStatus> {
 
-    private static final String ACTION_NAME = "cluster/snapshot/status/nodes";
+    public static final String ACTION_NAME = SnapshotsStatusAction.NAME + "[nodes]";
 
     private final SnapshotsService snapshotsService;
 

--- a/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class ClusterStateAction extends ClusterAction<ClusterStateRequest, ClusterStateResponse, ClusterStateRequestBuilder> {
 
     public static final ClusterStateAction INSTANCE = new ClusterStateAction();
-    public static final String NAME = "cluster/state";
+    public static final String NAME = "cluster:monitor/state";
 
     private ClusterStateAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class ClusterStatsAction extends ClusterAction<ClusterStatsRequest, ClusterStatsResponse, ClusterStatsRequestBuilder> {
 
     public static final ClusterStatsAction INSTANCE = new ClusterStatsAction();
-    public static final String NAME = "cluster/stats";
+    public static final String NAME = "cluster:monitor/stats";
 
     private ClusterStatsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ClusterAdminClient;
 public class PendingClusterTasksAction extends ClusterAction<PendingClusterTasksRequest, PendingClusterTasksResponse, PendingClusterTasksRequestBuilder> {
 
     public static final PendingClusterTasksAction INSTANCE = new PendingClusterTasksAction();
-    public static final String NAME = "cluster/task";
+    public static final String NAME = "cluster:monitor/task";
 
     private PendingClusterTasksAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class IndicesAliasesAction extends IndicesAction<IndicesAliasesRequest, IndicesAliasesResponse, IndicesAliasesRequestBuilder> {
 
     public static final IndicesAliasesAction INSTANCE = new IndicesAliasesAction();
-    public static final String NAME = "indices/aliases";
+    public static final String NAME = "indices:admin/aliases";
 
     private IndicesAliasesAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/AliasesExistAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/exists/AliasesExistAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class AliasesExistAction extends IndicesAction<GetAliasesRequest, AliasesExistResponse, AliasesExistRequestBuilder> {
 
     public static final AliasesExistAction INSTANCE = new AliasesExistAction();
-    public static final String NAME = "indices/exists/aliases";
+    public static final String NAME = "indices:admin/aliases/exists";
 
     private AliasesExistAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class GetAliasesAction extends IndicesAction<GetAliasesRequest, GetAliasesResponse, GetAliasesRequestBuilder> {
 
     public static final GetAliasesAction INSTANCE = new GetAliasesAction();
-    public static final String NAME = "indices/get/aliases";
+    public static final String NAME = "indices:admin/aliases/get";
 
     private GetAliasesAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class AnalyzeAction extends IndicesAction<AnalyzeRequest, AnalyzeResponse, AnalyzeRequestBuilder> {
 
     public static final AnalyzeAction INSTANCE = new AnalyzeAction();
-    public static final String NAME = "indices/analyze";
+    public static final String NAME = "indices:admin/analyze";
 
     private AnalyzeAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class ClearIndicesCacheAction extends IndicesAction<ClearIndicesCacheRequest, ClearIndicesCacheResponse, ClearIndicesCacheRequestBuilder> {
 
     public static final ClearIndicesCacheAction INSTANCE = new ClearIndicesCacheAction();
-    public static final String NAME = "indices/cache/clear";
+    public static final String NAME = "indices:admin/cache/clear";
 
     private ClearIndicesCacheAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class CloseIndexAction extends IndicesAction<CloseIndexRequest, CloseIndexResponse, CloseIndexRequestBuilder> {
 
     public static final CloseIndexAction INSTANCE = new CloseIndexAction();
-    public static final String NAME = "indices/close";
+    public static final String NAME = "indices:admin/close";
 
     private CloseIndexAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class CreateIndexAction extends IndicesAction<CreateIndexRequest, CreateIndexResponse, CreateIndexRequestBuilder> {
 
     public static final CreateIndexAction INSTANCE = new CreateIndexAction();
-    public static final String NAME = "indices/create";
+    public static final String NAME = "indices:admin/create";
 
     private CreateIndexAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class DeleteIndexAction extends IndicesAction<DeleteIndexRequest, DeleteIndexResponse, DeleteIndexRequestBuilder> {
 
     public static final DeleteIndexAction INSTANCE = new DeleteIndexAction();
-    public static final String NAME = "indices/delete";
+    public static final String NAME = "indices:admin/delete";
 
     private DeleteIndexAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class IndicesExistsAction extends IndicesAction<IndicesExistsRequest, IndicesExistsResponse, IndicesExistsRequestBuilder> {
 
     public static final IndicesExistsAction INSTANCE = new IndicesExistsAction();
-    public static final String NAME = "indices/exists";
+    public static final String NAME = "indices:admin/exists";
 
     private IndicesExistsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class TypesExistsAction extends IndicesAction<TypesExistsRequest, TypesExistsResponse, TypesExistsRequestBuilder> {
 
     public static final TypesExistsAction INSTANCE = new TypesExistsAction();
-    public static final String NAME = "indices/types/exists";
+    public static final String NAME = "indices:admin/types/exists";
 
     private TypesExistsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class FlushAction extends IndicesAction<FlushRequest, FlushResponse, FlushRequestBuilder> {
 
     public static final FlushAction INSTANCE = new FlushAction();
-    public static final String NAME = "indices/flush";
+    public static final String NAME = "indices:admin/flush";
 
     private FlushAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/delete/DeleteMappingAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class DeleteMappingAction extends IndicesAction<DeleteMappingRequest, DeleteMappingResponse, DeleteMappingRequestBuilder> {
 
     public static final DeleteMappingAction INSTANCE = new DeleteMappingAction();
-    public static final String NAME = "indices/mapping/delete";
+    public static final String NAME = "indices:admin/mapping/delete";
 
     private DeleteMappingAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class GetFieldMappingsAction extends IndicesAction<GetFieldMappingsRequest, GetFieldMappingsResponse, GetFieldMappingsRequestBuilder> {
 
     public static final GetFieldMappingsAction INSTANCE = new GetFieldMappingsAction();
-    public static final String NAME = "mappings/fields/get";
+    public static final String NAME = "indices:admin/mappings/fields/get";
 
     private GetFieldMappingsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class GetMappingsAction extends IndicesAction<GetMappingsRequest, GetMappingsResponse, GetMappingsRequestBuilder> {
 
     public static final GetMappingsAction INSTANCE = new GetMappingsAction();
-    public static final String NAME = "mappings/get";
+    public static final String NAME = "indices:admin/mappings/get";
 
     private GetMappingsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -56,7 +56,7 @@ import java.util.List;
  */
 public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomOperationAction<GetFieldMappingsIndexRequest, GetFieldMappingsResponse> {
 
-    private static final String ACTION_NAME = GetFieldMappingsAction.NAME + "/index";
+    private static final String ACTION_NAME = GetFieldMappingsAction.NAME + "[index]";
 
     protected final ClusterService clusterService;
     private final IndicesService indicesService;

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class PutMappingAction extends IndicesAction<PutMappingRequest, PutMappingResponse, PutMappingRequestBuilder> {
 
     public static final PutMappingAction INSTANCE = new PutMappingAction();
-    public static final String NAME = "indices/mapping/put";
+    public static final String NAME = "indices:admin/mapping/put";
 
     private PutMappingAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class OpenIndexAction extends IndicesAction<OpenIndexRequest, OpenIndexResponse, OpenIndexRequestBuilder> {
 
     public static final OpenIndexAction INSTANCE = new OpenIndexAction();
-    public static final String NAME = "indices/open";
+    public static final String NAME = "indices:admin/open";
 
     private OpenIndexAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/OptimizeAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class OptimizeAction extends IndicesAction<OptimizeRequest, OptimizeResponse, OptimizeRequestBuilder> {
 
     public static final OptimizeAction INSTANCE = new OptimizeAction();
-    public static final String NAME = "indices/optimize";
+    public static final String NAME = "indices:admin/optimize";
 
     private OptimizeAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.action.admin.indices.IndicesAction;
 public class RecoveryAction extends IndicesAction<RecoveryRequest, RecoveryResponse, RecoveryRequestBuilder> {
 
     public static final RecoveryAction INSTANCE = new RecoveryAction();
-    public static final String NAME = "indices/recovery";
+    public static final String NAME = "indices:monitor/recovery";
 
     private RecoveryAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class RefreshAction extends IndicesAction<RefreshRequest, RefreshResponse, RefreshRequestBuilder> {
 
     public static final RefreshAction INSTANCE = new RefreshAction();
-    public static final String NAME = "indices/refresh";
+    public static final String NAME = "indices:admin/refresh";
 
     private RefreshAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class IndicesSegmentsAction extends IndicesAction<IndicesSegmentsRequest, IndicesSegmentResponse, IndicesSegmentsRequestBuilder> {
 
     public static final IndicesSegmentsAction INSTANCE = new IndicesSegmentsAction();
-    public static final String NAME = "indices/segments";
+    public static final String NAME = "indices:monitor/segments";
 
     private IndicesSegmentsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class GetSettingsAction extends IndicesAction<GetSettingsRequest, GetSettingsResponse, GetSettingsRequestBuilder> {
 
     public static final GetSettingsAction INSTANCE = new GetSettingsAction();
-    public static final String NAME = "indices/settings/get";
+    public static final String NAME = "indices:monitor/settings/get";
 
     public GetSettingsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class UpdateSettingsAction extends IndicesAction<UpdateSettingsRequest, UpdateSettingsResponse, UpdateSettingsRequestBuilder> {
 
     public static final UpdateSettingsAction INSTANCE = new UpdateSettingsAction();
-    public static final String NAME = "indices/settings/update";
+    public static final String NAME = "indices:admin/settings/update";
 
     private UpdateSettingsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class IndicesStatsAction extends IndicesAction<IndicesStatsRequest, IndicesStatsResponse, IndicesStatsRequestBuilder> {
 
     public static final IndicesStatsAction INSTANCE = new IndicesStatsAction();
-    public static final String NAME = "indices/stats";
+    public static final String NAME = "indices:monitor/stats";
 
     private IndicesStatsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/status/IndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/IndicesStatusAction.java
@@ -30,7 +30,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class IndicesStatusAction extends IndicesAction<IndicesStatusRequest, IndicesStatusResponse, IndicesStatusRequestBuilder> {
 
     public static final IndicesStatusAction INSTANCE = new IndicesStatusAction();
-    public static final String NAME = "indices/status";
+    public static final String NAME = "indices:monitor/status";
 
     private IndicesStatusAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class DeleteIndexTemplateAction extends IndicesAction<DeleteIndexTemplateRequest, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestBuilder> {
 
     public static final DeleteIndexTemplateAction INSTANCE = new DeleteIndexTemplateAction();
-    public static final String NAME = "indices/template/delete";
+    public static final String NAME = "indices:admin/template/delete";
 
     private DeleteIndexTemplateAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class GetIndexTemplatesAction extends IndicesAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse, GetIndexTemplatesRequestBuilder> {
 
     public static final GetIndexTemplatesAction INSTANCE = new GetIndexTemplatesAction();
-    public static final String NAME = "indices/template/get";
+    public static final String NAME = "indices:admin/template/get";
 
     protected GetIndexTemplatesAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class PutIndexTemplateAction extends IndicesAction<PutIndexTemplateRequest, PutIndexTemplateResponse, PutIndexTemplateRequestBuilder> {
 
     public static final PutIndexTemplateAction INSTANCE = new PutIndexTemplateAction();
-    public static final String NAME = "indices/template/put";
+    public static final String NAME = "indices:admin/template/put";
 
     private PutIndexTemplateAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class ValidateQueryAction extends IndicesAction<ValidateQueryRequest, ValidateQueryResponse, ValidateQueryRequestBuilder> {
 
     public static final ValidateQueryAction INSTANCE = new ValidateQueryAction();
-    public static final String NAME = "indices/validate/query";
+    public static final String NAME = "indices:admin/validate/query";
 
     private ValidateQueryAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class DeleteWarmerAction extends IndicesAction<DeleteWarmerRequest, DeleteWarmerResponse, DeleteWarmerRequestBuilder> {
 
     public static final DeleteWarmerAction INSTANCE = new DeleteWarmerAction();
-    public static final String NAME = "indices/warmer/delete";
+    public static final String NAME = "indices:admin/warmers/delete";
 
     private DeleteWarmerAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/GetWarmersAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/GetWarmersAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class GetWarmersAction extends IndicesAction<GetWarmersRequest, GetWarmersResponse, GetWarmersRequestBuilder> {
 
     public static final GetWarmersAction INSTANCE = new GetWarmersAction();
-    public static final String NAME = "warmers/get";
+    public static final String NAME = "indices:admin/warmers/get";
 
     private GetWarmersAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 public class PutWarmerAction extends IndicesAction<PutWarmerRequest, PutWarmerResponse, PutWarmerRequestBuilder> {
 
     public static final PutWarmerAction INSTANCE = new PutWarmerAction();
-    public static final String NAME = "indices/warmer/put";
+    public static final String NAME = "indices:admin/warmers/put";
 
     private PutWarmerAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/AbortBenchmarkAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.Client;
 public class AbortBenchmarkAction extends ClientAction<AbortBenchmarkRequest, AbortBenchmarkResponse, AbortBenchmarkRequestBuilder> {
 
     public static final AbortBenchmarkAction INSTANCE = new AbortBenchmarkAction();
-    public static final String NAME = "benchmark/abort";
+    public static final String NAME = "indices:data/benchmark/abort";
 
     private AbortBenchmarkAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.Strings;
 public class BenchmarkAction extends ClientAction<BenchmarkRequest, BenchmarkResponse, BenchmarkRequestBuilder> {
 
     public static final BenchmarkAction INSTANCE = new BenchmarkAction();
-    public static final String NAME = "benchmark/start";
+    public static final String NAME = "indices:data/benchmark/start";
 
     private BenchmarkAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkService.java
@@ -59,6 +59,10 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
     private final TransportService transportService;
     protected final BenchmarkExecutor executor;
 
+    public static final String ABORT_ACTION_NAME = "indices:data/benchmark/executor/abort";
+    public static final String STATUS_ACTION_NAME = "indices:data/benchmark/executor/status";
+    public static final String START_ACTION_NAME = "indices:data/benchmark/executor/start";
+
     /**
      * Constructs a service component for running benchmarks
      *
@@ -76,9 +80,9 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
         this.executor = new BenchmarkExecutor(client, clusterService);
         this.clusterService = clusterService;
         this.transportService = transportService;
-        transportService.registerHandler(BenchExecutionHandler.ACTION, new BenchExecutionHandler());
-        transportService.registerHandler(AbortExecutionHandler.ACTION, new AbortExecutionHandler());
-        transportService.registerHandler(StatusExecutionHandler.ACTION, new StatusExecutionHandler());
+        transportService.registerHandler(START_ACTION_NAME, new BenchExecutionHandler());
+        transportService.registerHandler(ABORT_ACTION_NAME, new AbortExecutionHandler());
+        transportService.registerHandler(STATUS_ACTION_NAME, new StatusExecutionHandler());
     }
 
     @Override
@@ -105,7 +109,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
             BenchmarkStatusAsyncHandler async = new BenchmarkStatusAsyncHandler(nodes.size(), request, listener);
             for (DiscoveryNode node : nodes) {
                 assert isBenchmarkNode(node);
-                transportService.sendRequest(node, StatusExecutionHandler.ACTION, new NodeStatusRequest(request), async);
+                transportService.sendRequest(node, STATUS_ACTION_NAME, new NodeStatusRequest(request), async);
             }
         }
     }
@@ -142,7 +146,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
                                 for (String nodeId : nodeNames) {
                                     final DiscoveryNode node = nodes.get(nodeId);
                                     if (node != null) {
-                                        transportService.sendRequest(node, AbortExecutionHandler.ACTION, new NodeAbortRequest(benchmarkNames), asyncHandler);
+                                        transportService.sendRequest(node, ABORT_ACTION_NAME, new NodeAbortRequest(benchmarkNames), asyncHandler);
                                     } else {
                                         asyncHandler.countDown.countDown();
                                         logger.debug("Node for ID [" + nodeId + "] not found in cluster state - skipping");
@@ -194,7 +198,7 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
                                             new ElasticsearchIllegalStateException("Node for ID [" + nodeId + "] not found in cluster state - skipping"));
                                 } else {
                                     logger.debug("Starting benchmark [{}] node [{}]", request.benchmarkName(), node.name());
-                                    transportService.sendRequest(node, BenchExecutionHandler.ACTION, new NodeBenchRequest(request), async);
+                                    transportService.sendRequest(node, START_ACTION_NAME, new NodeBenchRequest(request), async);
                                 }
                             }
                         }
@@ -257,8 +261,6 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
 
     private class BenchExecutionHandler extends BaseTransportRequestHandler<NodeBenchRequest> {
 
-        static final String ACTION = "benchmark/executor/start";
-
         @Override
         public NodeBenchRequest newInstance() {
             return new NodeBenchRequest();
@@ -277,8 +279,6 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
     }
 
     private class StatusExecutionHandler extends BaseTransportRequestHandler<NodeStatusRequest> {
-
-        static final String ACTION = "benchmark/executor/status";
 
         @Override
         public NodeStatusRequest newInstance() {
@@ -300,8 +300,6 @@ public class BenchmarkService extends AbstractLifecycleComponent<BenchmarkServic
     }
 
     private class AbortExecutionHandler extends BaseTransportRequestHandler<NodeAbortRequest> {
-
-        static final String ACTION = "benchmark/executor/abort";
 
         @Override
         public NodeAbortRequest newInstance() {

--- a/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/bench/BenchmarkStatusAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.Client;
 public class BenchmarkStatusAction extends ClientAction<BenchmarkStatusRequest, BenchmarkStatusResponse, BenchmarkStatusRequestBuilder> {
 
     public static final BenchmarkStatusAction INSTANCE = new BenchmarkStatusAction();
-    public static final String NAME = "benchmark/status";
+    public static final String NAME = "indices:data/benchmark/status";
 
     public BenchmarkStatusAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
@@ -29,7 +29,7 @@ import org.elasticsearch.transport.TransportRequestOptions;
 public class BulkAction extends ClientAction<BulkRequest, BulkResponse, BulkRequestBuilder> {
 
     public static final BulkAction INSTANCE = new BulkAction();
-    public static final String NAME = "bulk";
+    public static final String NAME = "indices:data/write/bulk";
 
     private BulkAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -76,7 +76,7 @@ public class TransportShardBulkAction extends TransportShardReplicationOperation
     private final static String OP_TYPE_UPDATE = "update";
     private final static String OP_TYPE_DELETE = "delete";
 
-    private static final String ACTION_NAME = BulkAction.NAME + "/shard";
+    private static final String ACTION_NAME = BulkAction.NAME + "[s]";
 
     private final MappingUpdatedAction mappingUpdatedAction;
     private final UpdateHelper updateHelper;

--- a/src/main/java/org/elasticsearch/action/count/CountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/CountAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class CountAction extends ClientAction<CountRequest, CountResponse, CountRequestBuilder> {
 
     public static final CountAction INSTANCE = new CountAction();
-    public static final String NAME = "count";
+    public static final String NAME = "indices:data/read/count";
 
     private CountAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/delete/DeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/DeleteAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class DeleteAction extends ClientAction<DeleteRequest, DeleteResponse, DeleteRequestBuilder> {
 
     public static final DeleteAction INSTANCE = new DeleteAction();
-    public static final String NAME = "delete";
+    public static final String NAME = "indices:data/write/delete";
 
     private DeleteAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportIndexDeleteAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.delete.index;
 
 import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.action.delete.DeleteAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportIndexReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -39,7 +40,7 @@ import java.util.List;
  */
 public class TransportIndexDeleteAction extends TransportIndexReplicationOperationAction<IndexDeleteRequest, IndexDeleteResponse, ShardDeleteRequest, ShardDeleteRequest, ShardDeleteResponse> {
 
-    private static final String ACTION_NAME = "indices/index/delete";
+    private static final String ACTION_NAME = DeleteAction.NAME + "[index]";
 
     @Inject
     public TransportIndexDeleteAction(Settings settings, ClusterService clusterService, TransportService transportService,

--- a/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
+++ b/src/main/java/org/elasticsearch/action/delete/index/TransportShardDeleteAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.delete.index;
 
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.action.delete.DeleteAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -43,7 +44,7 @@ import org.elasticsearch.transport.TransportService;
  */
 public class TransportShardDeleteAction extends TransportShardReplicationOperationAction<ShardDeleteRequest, ShardDeleteRequest, ShardDeleteResponse> {
 
-    private static final String ACTION_NAME = "indices/index/b_shard/delete";
+    private static final String ACTION_NAME = DeleteAction.NAME + "[s]";
 
     @Inject
     public TransportShardDeleteAction(Settings settings, TransportService transportService,

--- a/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class DeleteByQueryAction extends ClientAction<DeleteByQueryRequest, DeleteByQueryResponse, DeleteByQueryRequestBuilder> {
 
     public static final DeleteByQueryAction INSTANCE = new DeleteByQueryAction();
-    public static final String NAME = "deleteByQuery";
+    public static final String NAME = "indices:data/write/delete/by_query";
 
     private DeleteByQueryAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportIndexDeleteByQueryAction.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class TransportIndexDeleteByQueryAction extends TransportIndexReplicationOperationAction<IndexDeleteByQueryRequest, IndexDeleteByQueryResponse, ShardDeleteByQueryRequest, ShardDeleteByQueryRequest, ShardDeleteByQueryResponse> {
 
-    private static final String ACTION_NAME = DeleteByQueryAction.NAME + "/index";
+    private static final String ACTION_NAME = DeleteByQueryAction.NAME + "[index]";
 
     @Inject
     public TransportIndexDeleteByQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,

--- a/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/deletebyquery/TransportShardDeleteByQueryAction.java
@@ -55,7 +55,7 @@ public class TransportShardDeleteByQueryAction extends TransportShardReplication
 
     public final static String DELETE_BY_QUERY_API = "delete_by_query";
 
-    private static final String ACTION_NAME = DeleteByQueryAction.NAME + "/shard";
+    private static final String ACTION_NAME = DeleteByQueryAction.NAME + "[s]";
 
     private final ScriptService scriptService;
     private final CacheRecycler cacheRecycler;

--- a/src/main/java/org/elasticsearch/action/explain/ExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.Client;
 public class ExplainAction extends ClientAction<ExplainRequest, ExplainResponse, ExplainRequestBuilder> {
 
     public static final ExplainAction INSTANCE = new ExplainAction();
-    public static final String NAME = "explain";
+    public static final String NAME = "indices:data/read/explain";
 
     private ExplainAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/get/GetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/GetAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class GetAction extends ClientAction<GetRequest, GetResponse, GetRequestBuilder> {
 
     public static final GetAction INSTANCE = new GetAction();
-    public static final String NAME = "get";
+    public static final String NAME = "indices:data/read/get";
 
     private GetAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/get/MultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/MultiGetAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class MultiGetAction extends ClientAction<MultiGetRequest, MultiGetResponse, MultiGetRequestBuilder> {
 
     public static final MultiGetAction INSTANCE = new MultiGetAction();
-    public static final String NAME = "mget";
+    public static final String NAME = "indices:data/read/mget";
 
     private MultiGetAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -43,7 +43,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportShardMultiGetAction extends TransportShardSingleOperationAction<MultiGetShardRequest, MultiGetShardResponse> {
 
-    private static final String ACTION_NAME = MultiGetAction.NAME + "/shard";
+    private static final String ACTION_NAME = MultiGetAction.NAME + "[shard]";
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/action/index/IndexAction.java
+++ b/src/main/java/org/elasticsearch/action/index/IndexAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class IndexAction extends ClientAction<IndexRequest, IndexResponse, IndexRequestBuilder> {
 
     public static final IndexAction INSTANCE = new IndexAction();
-    public static final String NAME = "index";
+    public static final String NAME = "indices:data/write/index";
 
     private IndexAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/indexedscripts/delete/DeleteIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/delete/DeleteIndexedScriptAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class DeleteIndexedScriptAction extends ClientAction<DeleteIndexedScriptRequest, DeleteIndexedScriptResponse, DeleteIndexedScriptRequestBuilder> {
 
     public static final DeleteIndexedScriptAction INSTANCE = new DeleteIndexedScriptAction();
-    public static final String NAME = "deleteIndexedScript";
+    public static final String NAME = "indices:data/write/script/delete";
 
     private DeleteIndexedScriptAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/get/GetIndexedScriptAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class GetIndexedScriptAction extends ClientAction<GetIndexedScriptRequest, GetIndexedScriptResponse, GetIndexedScriptRequestBuilder> {
 
     public static final GetIndexedScriptAction INSTANCE = new GetIndexedScriptAction();
-    public static final String NAME = "getIndexedScript";
+    public static final String NAME = "indices:data/read/script/get";
 
     private GetIndexedScriptAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/indexedscripts/put/PutIndexedScriptAction.java
+++ b/src/main/java/org/elasticsearch/action/indexedscripts/put/PutIndexedScriptAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.Client;
 public class PutIndexedScriptAction extends ClientAction<PutIndexedScriptRequest, PutIndexedScriptResponse, PutIndexedScriptRequestBuilder> {
 
     public static final PutIndexedScriptAction INSTANCE = new PutIndexedScriptAction();
-    public static final String NAME = "putIndexedScript";
+    public static final String NAME = "indices:data/write/script/put";
 
 
     private PutIndexedScriptAction() {

--- a/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisAction.java
+++ b/src/main/java/org/elasticsearch/action/mlt/MoreLikeThisAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.Client;
 public class MoreLikeThisAction extends ClientAction<MoreLikeThisRequest, SearchResponse, MoreLikeThisRequestBuilder> {
 
     public static final MoreLikeThisAction INSTANCE = new MoreLikeThisAction();
-    public static final String NAME = "mlt";
+    public static final String NAME = "indices:data/read/mlt";
 
     private MoreLikeThisAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/percolate/MultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/MultiPercolateAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.Client;
 public class MultiPercolateAction extends ClientAction<MultiPercolateRequest, MultiPercolateResponse, MultiPercolateRequestBuilder> {
 
     public static final MultiPercolateAction INSTANCE = new MultiPercolateAction();
-    public static final String NAME = "mpercolate";
+    public static final String NAME = "indices:data/read/mpercolate";
 
     private MultiPercolateAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class PercolateAction extends ClientAction<PercolateRequest, PercolateResponse, PercolateRequestBuilder> {
 
     public static final PercolateAction INSTANCE = new PercolateAction();
-    public static final String NAME = "percolate";
+    public static final String NAME = "indices:data/read/percolate";
 
     private PercolateAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -52,7 +52,7 @@ public class TransportShardMultiPercolateAction extends TransportShardSingleOper
 
     private final PercolatorService percolatorService;
 
-    private static final String ACTION_NAME = "mpercolate/shard";
+    private static final String ACTION_NAME = MultiPercolateAction.NAME + "[shard]";
 
     @Inject
     public TransportShardMultiPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, PercolatorService percolatorService, ActionFilters actionFilters) {

--- a/src/main/java/org/elasticsearch/action/search/ClearScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/ClearScrollAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class ClearScrollAction extends ClientAction<ClearScrollRequest, ClearScrollResponse, ClearScrollRequestBuilder> {
 
     public static final ClearScrollAction INSTANCE = new ClearScrollAction();
-    public static final String NAME = "clear_sc";
+    public static final String NAME = "indices:data/read/scroll/clear";
 
     private ClearScrollAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class MultiSearchAction extends ClientAction<MultiSearchRequest, MultiSearchResponse, MultiSearchRequestBuilder> {
 
     public static final MultiSearchAction INSTANCE = new MultiSearchAction();
-    public static final String NAME = "msearch";
+    public static final String NAME = "indices:data/read/msearch";
 
     private MultiSearchAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/search/SearchAction.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class SearchAction extends ClientAction<SearchRequest, SearchResponse, SearchRequestBuilder> {
 
     public static final SearchAction INSTANCE = new SearchAction();
-    public static final String NAME = "search";
+    public static final String NAME = "indices:data/read/search";
 
     private SearchAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/search/SearchScrollAction.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchScrollAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class SearchScrollAction extends ClientAction<SearchScrollRequest, SearchResponse, SearchScrollRequestBuilder> {
 
     public static final SearchScrollAction INSTANCE = new SearchScrollAction();
-    public static final String NAME = "search/scroll";
+    public static final String NAME = "indices:data/read/scroll";
 
     private SearchScrollAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/suggest/SuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.search.suggest.Suggest;
 public class SuggestAction extends ClientAction<SuggestRequest, SuggestResponse, SuggestRequestBuilder> {
 
     public static final SuggestAction INSTANCE = new SuggestAction();
-    public static final String NAME = "suggest";
+    public static final String NAME = "indices:data/read/suggest";
 
     private SuggestAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastOperationAction.java
@@ -59,7 +59,7 @@ public abstract class TransportBroadcastOperationAction<Request extends Broadcas
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.threadPool = threadPool;
-        this.transportShardAction = actionName + "/s";
+        this.transportShardAction = actionName + "[s]";
         this.executor = executor();
 
         transportService.registerHandler(actionName, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesOperationAction.java
@@ -58,7 +58,7 @@ public abstract class TransportNodesOperationAction<Request extends NodesOperati
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportNodeAction = actionName + "/n";
+        this.transportNodeAction = actionName + "[n]";
         this.executor = executor();
 
         transportService.registerHandler(actionName, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/replication/TransportShardReplicationOperationAction.java
@@ -152,7 +152,7 @@ public abstract class TransportShardReplicationOperationAction<Request extends S
     }
 
     private String transportReplicaAction() {
-        return actionName + "/replica";
+        return actionName + "[r]";
     }
 
     protected boolean retryPrimaryException(Throwable e) {

--- a/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
@@ -56,7 +56,7 @@ public abstract class TransportSingleCustomOperationAction<Request extends Singl
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportShardAction = actionName + "/s";
+        this.transportShardAction = actionName + "[s]";
         this.executor = executor();
 
         transportService.registerHandler(actionName, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
+++ b/src/main/java/org/elasticsearch/action/support/single/shard/TransportShardSingleOperationAction.java
@@ -61,7 +61,7 @@ public abstract class TransportShardSingleOperationAction<Request extends Single
         this.clusterService = clusterService;
         this.transportService = transportService;
 
-        this.transportShardAction = actionName + "/s";
+        this.transportShardAction = actionName + "[s]";
         this.executor = executor();
 
         transportService.registerHandler(actionName, new TransportHandler());

--- a/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/MultiTermVectorsAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class MultiTermVectorsAction extends ClientAction<MultiTermVectorsRequest, MultiTermVectorsResponse, MultiTermVectorsRequestBuilder> {
 
     public static final MultiTermVectorsAction INSTANCE = new MultiTermVectorsAction();
-    public static final String NAME = "mtv";
+    public static final String NAME = "indices:data/read/mtv";
 
     private MultiTermVectorsAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/termvector/TermVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TermVectorAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class TermVectorAction extends ClientAction<TermVectorRequest, TermVectorResponse, TermVectorRequestBuilder> {
 
     public static final TermVectorAction INSTANCE = new TermVectorAction();
-    public static final String NAME = "tv";
+    public static final String NAME = "indices:data/read/tv";
 
     private TermVectorAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
+++ b/src/main/java/org/elasticsearch/action/termvector/TransportSingleShardMultiTermsVectorAction.java
@@ -41,7 +41,7 @@ public class TransportSingleShardMultiTermsVectorAction extends TransportShardSi
 
     private final IndicesService indicesService;
 
-    private static final String ACTION_NAME = MultiTermVectorsAction.NAME + "/shard";
+    private static final String ACTION_NAME = MultiTermVectorsAction.NAME + "[shard]";
 
     @Inject
     public TransportSingleShardMultiTermsVectorAction(Settings settings, ClusterService clusterService, TransportService transportService,

--- a/src/main/java/org/elasticsearch/action/update/UpdateAction.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.Client;
 public class UpdateAction extends ClientAction<UpdateRequest, UpdateResponse, UpdateRequestBuilder> {
 
     public static final UpdateAction INSTANCE = new UpdateAction();
-    public static final String NAME = "update";
+    public static final String NAME = "indices:data/write/update";
 
     private UpdateAction() {
         super(NAME);

--- a/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -397,7 +397,7 @@ public class TransportClientNodesService extends AbstractComponent {
                             if (!transportService.nodeConnected(listedNode)) {
                                 try {
 
-                                    // if its one of hte actual nodes we will talk to, not to listed nodes, fully connect
+                                    // if its one of the actual nodes we will talk to, not to listed nodes, fully connect
                                     if (nodes.contains(listedNode)) {
                                         logger.trace("connecting to cluster node [{}]", listedNode);
                                         transportService.connectToNode(listedNode);

--- a/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -67,8 +67,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class MappingUpdatedAction extends TransportMasterNodeOperationAction<MappingUpdatedAction.MappingUpdatedRequest, MappingUpdatedAction.MappingUpdatedResponse> {
 
     public static final String INDICES_MAPPING_ADDITIONAL_MAPPING_CHANGE_TIME = "indices.mapping.additional_mapping_change_time";
-
-    private static final String ACTION_NAME = "cluster/mappingUpdated";
+    public static final String ACTION_NAME = "internal:cluster/mapping_updated";
 
     private final AtomicLong mappingUpdateOrderGen = new AtomicLong();
     private final MetaDataMappingService metaDataMappingService;

--- a/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
@@ -39,6 +39,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class NodeIndexDeletedAction extends AbstractComponent {
 
+    public static final String INDEX_DELETED_ACTION_NAME = "internal:cluster/node/index/deleted";
+    public static final String INDEX_STORE_DELETED_ACTION_NAME = "internal:cluster/node/index_store/deleted";
+
     private final ThreadPool threadPool;
     private final TransportService transportService;
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
@@ -48,8 +51,8 @@ public class NodeIndexDeletedAction extends AbstractComponent {
         super(settings);
         this.threadPool = threadPool;
         this.transportService = transportService;
-        transportService.registerHandler(NodeIndexDeletedTransportHandler.ACTION, new NodeIndexDeletedTransportHandler());
-        transportService.registerHandler(NodeIndexStoreDeletedTransportHandler.ACTION, new NodeIndexStoreDeletedTransportHandler());
+        transportService.registerHandler(INDEX_DELETED_ACTION_NAME, new NodeIndexDeletedTransportHandler());
+        transportService.registerHandler(INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedTransportHandler());
     }
 
     public void add(Listener listener) {
@@ -71,7 +74,7 @@ public class NodeIndexDeletedAction extends AbstractComponent {
             });
         } else {
             transportService.sendRequest(clusterState.nodes().masterNode(),
-                    NodeIndexDeletedTransportHandler.ACTION, new NodeIndexDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
+                    INDEX_DELETED_ACTION_NAME, new NodeIndexDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
         }
     }
 
@@ -86,7 +89,7 @@ public class NodeIndexDeletedAction extends AbstractComponent {
             });
         } else {
             transportService.sendRequest(clusterState.nodes().masterNode(),
-                    NodeIndexStoreDeletedTransportHandler.ACTION, new NodeIndexStoreDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
+                    INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
         }
     }
 
@@ -110,8 +113,6 @@ public class NodeIndexDeletedAction extends AbstractComponent {
 
     private class NodeIndexDeletedTransportHandler extends BaseTransportRequestHandler<NodeIndexDeletedMessage> {
 
-        static final String ACTION = "cluster/nodeIndexDeleted";
-
         @Override
         public NodeIndexDeletedMessage newInstance() {
             return new NodeIndexDeletedMessage();
@@ -130,8 +131,6 @@ public class NodeIndexDeletedAction extends AbstractComponent {
     }
 
     private class NodeIndexStoreDeletedTransportHandler extends BaseTransportRequestHandler<NodeIndexStoreDeletedMessage> {
-
-        static final String ACTION = "cluster/nodeIndexStoreDeleted";
 
         @Override
         public NodeIndexStoreDeletedMessage newInstance() {

--- a/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -41,6 +41,8 @@ import java.io.IOException;
  */
 public class NodeMappingRefreshAction extends AbstractComponent {
 
+    public static final String ACTION_NAME = "internal:cluster/node/mapping/refresh";
+
     private final TransportService transportService;
     private final MetaDataMappingService metaDataMappingService;
 
@@ -49,7 +51,7 @@ public class NodeMappingRefreshAction extends AbstractComponent {
         super(settings);
         this.transportService = transportService;
         this.metaDataMappingService = metaDataMappingService;
-        transportService.registerHandler(NodeMappingRefreshTransportHandler.ACTION, new NodeMappingRefreshTransportHandler());
+        transportService.registerHandler(ACTION_NAME, new NodeMappingRefreshTransportHandler());
     }
 
     public void nodeMappingRefresh(final ClusterState state, final NodeMappingRefreshRequest request) throws ElasticsearchException {
@@ -58,7 +60,7 @@ public class NodeMappingRefreshAction extends AbstractComponent {
             innerMappingRefresh(request);
         } else {
             transportService.sendRequest(state.nodes().masterNode(),
-                    NodeMappingRefreshTransportHandler.ACTION, request, EmptyTransportResponseHandler.INSTANCE_SAME);
+                    ACTION_NAME, request, EmptyTransportResponseHandler.INSTANCE_SAME);
         }
     }
 
@@ -67,8 +69,6 @@ public class NodeMappingRefreshAction extends AbstractComponent {
     }
 
     private class NodeMappingRefreshTransportHandler extends BaseTransportRequestHandler<NodeMappingRefreshRequest> {
-
-        static final String ACTION = "cluster/nodeMappingRefresh";
 
         @Override
         public NodeMappingRefreshRequest newInstance() {

--- a/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -44,6 +44,8 @@ import static org.elasticsearch.transport.TransportRequestOptions.options;
  */
 public class NodesFaultDetection extends AbstractComponent {
 
+    public static final String PING_ACTION_NAME = "internal:discovery/zen/fd/ping";
+
     public static interface Listener {
 
         void onNodeFailure(DiscoveryNode node, String reason);
@@ -89,7 +91,7 @@ public class NodesFaultDetection extends AbstractComponent {
 
         logger.debug("[node  ] uses ping_interval [{}], ping_timeout [{}], ping_retries [{}]", pingInterval, pingRetryTimeout, pingRetryCount);
 
-        transportService.registerHandler(PingRequestHandler.ACTION, new PingRequestHandler());
+        transportService.registerHandler(PING_ACTION_NAME, new PingRequestHandler());
 
         this.connectionListener = new FDConnectionListener();
         if (registerConnectionListener) {
@@ -145,7 +147,7 @@ public class NodesFaultDetection extends AbstractComponent {
 
     public void close() {
         stop();
-        transportService.removeHandler(PingRequestHandler.ACTION);
+        transportService.removeHandler(PING_ACTION_NAME);
         transportService.removeConnectionListener(connectionListener);
     }
 
@@ -200,7 +202,7 @@ public class NodesFaultDetection extends AbstractComponent {
             if (!running) {
                 return;
             }
-            transportService.sendRequest(node, PingRequestHandler.ACTION, new PingRequest(node.id()), options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout),
+            transportService.sendRequest(node, PING_ACTION_NAME, new PingRequest(node.id()), options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout),
                     new BaseTransportResponseHandler<PingResponse>() {
                         @Override
                         public PingResponse newInstance() {
@@ -248,7 +250,7 @@ public class NodesFaultDetection extends AbstractComponent {
                                     }
                                 } else {
                                     // resend the request, not reschedule, rely on send timeout
-                                    transportService.sendRequest(node, PingRequestHandler.ACTION, new PingRequest(node.id()),
+                                    transportService.sendRequest(node, PING_ACTION_NAME, new PingRequest(node.id()),
                                             options().withType(TransportRequestOptions.Type.PING).withTimeout(pingRetryTimeout), this);
                                 }
                             }
@@ -281,8 +283,6 @@ public class NodesFaultDetection extends AbstractComponent {
 
 
     class PingRequestHandler extends BaseTransportRequestHandler<PingRequest> {
-
-        public static final String ACTION = "discovery/zen/fd/ping";
 
         @Override
         public PingRequest newInstance() {

--- a/src/main/java/org/elasticsearch/discovery/zen/membership/MembershipAction.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/membership/MembershipAction.java
@@ -41,6 +41,10 @@ import java.util.concurrent.TimeUnit;
  */
 public class MembershipAction extends AbstractComponent {
 
+    public static final String DISCOVERY_JOIN_ACTION_NAME = "internal:discovery/zen/join";
+    public static final String DISCOVERY_JOIN_VALIDATE_ACTION_NAME = "internal:discovery/zen/join/validate";
+    public static final String DISCOVERY_LEAVE_ACTION_NAME = "internal:discovery/zen/leave";
+
     public static interface JoinCallback {
         void onSuccess();
 
@@ -68,31 +72,31 @@ public class MembershipAction extends AbstractComponent {
         this.listener = listener;
         this.clusterService = clusterService;
 
-        transportService.registerHandler(JoinRequestRequestHandler.ACTION, new JoinRequestRequestHandler());
-        transportService.registerHandler(ValidateJoinRequestRequestHandler.ACTION, new ValidateJoinRequestRequestHandler());
-        transportService.registerHandler(LeaveRequestRequestHandler.ACTION, new LeaveRequestRequestHandler());
+        transportService.registerHandler(DISCOVERY_JOIN_ACTION_NAME, new JoinRequestRequestHandler());
+        transportService.registerHandler(DISCOVERY_JOIN_VALIDATE_ACTION_NAME, new ValidateJoinRequestRequestHandler());
+        transportService.registerHandler(DISCOVERY_LEAVE_ACTION_NAME, new LeaveRequestRequestHandler());
     }
 
     public void close() {
-        transportService.removeHandler(JoinRequestRequestHandler.ACTION);
-        transportService.removeHandler(ValidateJoinRequestRequestHandler.ACTION);
-        transportService.removeHandler(LeaveRequestRequestHandler.ACTION);
+        transportService.removeHandler(DISCOVERY_JOIN_ACTION_NAME);
+        transportService.removeHandler(DISCOVERY_JOIN_VALIDATE_ACTION_NAME);
+        transportService.removeHandler(DISCOVERY_LEAVE_ACTION_NAME);
     }
 
     public void sendLeaveRequest(DiscoveryNode masterNode, DiscoveryNode node) {
-        transportService.sendRequest(node, LeaveRequestRequestHandler.ACTION, new LeaveRequest(masterNode), EmptyTransportResponseHandler.INSTANCE_SAME);
+        transportService.sendRequest(node, DISCOVERY_LEAVE_ACTION_NAME, new LeaveRequest(masterNode), EmptyTransportResponseHandler.INSTANCE_SAME);
     }
 
     public void sendLeaveRequestBlocking(DiscoveryNode masterNode, DiscoveryNode node, TimeValue timeout) throws ElasticsearchException {
-        transportService.submitRequest(masterNode, LeaveRequestRequestHandler.ACTION, new LeaveRequest(node), EmptyTransportResponseHandler.INSTANCE_SAME).txGet(timeout.millis(), TimeUnit.MILLISECONDS);
+        transportService.submitRequest(masterNode, DISCOVERY_LEAVE_ACTION_NAME, new LeaveRequest(node), EmptyTransportResponseHandler.INSTANCE_SAME).txGet(timeout.millis(), TimeUnit.MILLISECONDS);
     }
 
     public void sendJoinRequest(DiscoveryNode masterNode, DiscoveryNode node) {
-        transportService.sendRequest(masterNode, JoinRequestRequestHandler.ACTION, new JoinRequest(node), EmptyTransportResponseHandler.INSTANCE_SAME);
+        transportService.sendRequest(masterNode, DISCOVERY_JOIN_ACTION_NAME, new JoinRequest(node), EmptyTransportResponseHandler.INSTANCE_SAME);
     }
 
     public void sendJoinRequestBlocking(DiscoveryNode masterNode, DiscoveryNode node, TimeValue timeout) throws ElasticsearchException {
-        transportService.submitRequest(masterNode, JoinRequestRequestHandler.ACTION, new JoinRequest(node), EmptyTransportResponseHandler.INSTANCE_SAME)
+        transportService.submitRequest(masterNode, DISCOVERY_JOIN_ACTION_NAME, new JoinRequest(node), EmptyTransportResponseHandler.INSTANCE_SAME)
                 .txGet(timeout.millis(), TimeUnit.MILLISECONDS);
     }
 
@@ -100,7 +104,7 @@ public class MembershipAction extends AbstractComponent {
      * Validates the join request, throwing a failure if it failed.
      */
     public void sendValidateJoinRequestBlocking(DiscoveryNode node, TimeValue timeout) throws ElasticsearchException {
-        transportService.submitRequest(node, ValidateJoinRequestRequestHandler.ACTION, new ValidateJoinRequest(), EmptyTransportResponseHandler.INSTANCE_SAME)
+        transportService.submitRequest(node, DISCOVERY_JOIN_VALIDATE_ACTION_NAME, new ValidateJoinRequest(), EmptyTransportResponseHandler.INSTANCE_SAME)
                 .txGet(timeout.millis(), TimeUnit.MILLISECONDS);
     }
 
@@ -167,8 +171,6 @@ public class MembershipAction extends AbstractComponent {
 
     private class JoinRequestRequestHandler extends BaseTransportRequestHandler<JoinRequest> {
 
-        static final String ACTION = "discovery/zen/join";
-
         @Override
         public JoinRequest newInstance() {
             return new JoinRequest();
@@ -232,8 +234,6 @@ public class MembershipAction extends AbstractComponent {
 
     private class ValidateJoinRequestRequestHandler extends BaseTransportRequestHandler<ValidateJoinRequest> {
 
-        static final String ACTION = "discovery/zen/join/validate";
-
         @Override
         public ValidateJoinRequest newInstance() {
             return new ValidateJoinRequest();
@@ -276,8 +276,6 @@ public class MembershipAction extends AbstractComponent {
     }
 
     private class LeaveRequestRequestHandler extends BaseTransportRequestHandler<LeaveRequest> {
-
-        static final String ACTION = "discovery/zen/leave";
 
         @Override
         public LeaveRequest newInstance() {

--- a/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/ping/multicast/MulticastZenPing.java
@@ -62,6 +62,8 @@ import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.new
  */
 public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implements ZenPing {
 
+    public static final String ACTION_NAME = "internal:discovery/zen/multicast";
+
     private static final byte[] INTERNAL_HEADER = new byte[]{1, 9, 8, 4};
 
     private final String address;
@@ -106,7 +108,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
 
         logger.debug("using group [{}], with port [{}], ttl [{}], and address [{}]", group, port, ttl, address);
 
-        this.transportService.registerHandler(MulticastPingResponseRequestHandler.ACTION, new MulticastPingResponseRequestHandler());
+        this.transportService.registerHandler(ACTION_NAME, new MulticastPingResponseRequestHandler());
     }
 
     @Override
@@ -233,8 +235,6 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
     }
 
     class MulticastPingResponseRequestHandler extends BaseTransportRequestHandler<MulticastPingResponse> {
-
-        static final String ACTION = "discovery/zen/multicast";
 
         @Override
         public MulticastPingResponse newInstance() {
@@ -445,7 +445,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                         // connect to the node if possible
                         try {
                             transportService.connectToNode(requestingNode);
-                            transportService.sendRequest(requestingNode, MulticastPingResponseRequestHandler.ACTION, multicastPingResponse, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                            transportService.sendRequest(requestingNode, ACTION_NAME, multicastPingResponse, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                                 @Override
                                 public void handleException(TransportException exp) {
                                     logger.warn("failed to receive confirmation on sent ping response to [{}]", exp, requestingNode);
@@ -459,7 +459,7 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
                     }
                 });
             } else {
-                transportService.sendRequest(requestingNode, MulticastPingResponseRequestHandler.ACTION, multicastPingResponse, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                transportService.sendRequest(requestingNode, ACTION_NAME, multicastPingResponse, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                     @Override
                     public void handleException(TransportException exp) {
                         if (lifecycle.started()) {

--- a/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -45,6 +45,8 @@ import java.util.Map;
  */
 public class PublishClusterStateAction extends AbstractComponent {
 
+    public static final String ACTION_NAME = "internal:discovery/zen/publish";
+
     public static interface NewClusterStateListener {
 
         static interface NewStateProcessed {
@@ -69,11 +71,11 @@ public class PublishClusterStateAction extends AbstractComponent {
         this.nodesProvider = nodesProvider;
         this.listener = listener;
         this.discoverySettings = discoverySettings;
-        transportService.registerHandler(PublishClusterStateRequestHandler.ACTION, new PublishClusterStateRequestHandler());
+        transportService.registerHandler(ACTION_NAME, new PublishClusterStateRequestHandler());
     }
 
     public void close() {
-        transportService.removeHandler(PublishClusterStateRequestHandler.ACTION);
+        transportService.removeHandler(ACTION_NAME);
     }
 
     public void publish(ClusterState clusterState, final Discovery.AckListener ackListener) {
@@ -112,7 +114,7 @@ public class PublishClusterStateAction extends AbstractComponent {
                 TransportRequestOptions options = TransportRequestOptions.options().withType(TransportRequestOptions.Type.STATE).withCompress(false);
                 // no need to put a timeout on the options here, because we want the response to eventually be received
                 // and not log an error if it arrives after the timeout
-                transportService.sendRequest(node, PublishClusterStateRequestHandler.ACTION,
+                transportService.sendRequest(node, ACTION_NAME,
                         new BytesTransportRequest(bytes, node.version()),
                         options, // no need to compress, we already compressed the bytes
 
@@ -151,8 +153,6 @@ public class PublishClusterStateAction extends AbstractComponent {
     }
 
     private class PublishClusterStateRequestHandler extends BaseTransportRequestHandler<BytesTransportRequest> {
-
-        static final String ACTION = "discovery/zen/publish";
 
         @Override
         public BytesTransportRequest newInstance() {

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalAllocateDangledIndices.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/LocalAllocateDangledIndices.java
@@ -45,6 +45,8 @@ import java.util.Arrays;
  */
 public class LocalAllocateDangledIndices extends AbstractComponent {
 
+    public static final String ACTION_NAME = "internal:gateway/local/allocate_dangled";
+
     private final TransportService transportService;
 
     private final ClusterService clusterService;
@@ -57,7 +59,7 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.allocationService = allocationService;
-        transportService.registerHandler(AllocateDangledRequestHandler.ACTION, new AllocateDangledRequestHandler());
+        transportService.registerHandler(ACTION_NAME, new AllocateDangledRequestHandler());
     }
 
     public void allocateDangled(IndexMetaData[] indices, final Listener listener) {
@@ -68,7 +70,7 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
             return;
         }
         AllocateDangledRequest request = new AllocateDangledRequest(clusterService.localNode(), indices);
-        transportService.sendRequest(masterNode, AllocateDangledRequestHandler.ACTION, request, new TransportResponseHandler<AllocateDangledResponse>() {
+        transportService.sendRequest(masterNode, ACTION_NAME, request, new TransportResponseHandler<AllocateDangledResponse>() {
             @Override
             public AllocateDangledResponse newInstance() {
                 return new AllocateDangledResponse();
@@ -98,8 +100,6 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
     }
 
     class AllocateDangledRequestHandler extends BaseTransportRequestHandler<AllocateDangledRequest> {
-
-        public static final String ACTION = "/gateway/local/allocate_dangled";
 
         @Override
         public AllocateDangledRequest newInstance() {

--- a/src/main/java/org/elasticsearch/gateway/local/state/meta/TransportNodesListGatewayMetaState.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/meta/TransportNodesListGatewayMetaState.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesListGatewayMetaState extends TransportNodesOperationAction<TransportNodesListGatewayMetaState.Request, TransportNodesListGatewayMetaState.NodesLocalGatewayMetaState, TransportNodesListGatewayMetaState.NodeRequest, TransportNodesListGatewayMetaState.NodeLocalGatewayMetaState> {
 
-    private static final String ACTION_NAME = "/gateway/local/meta-state";
+    public static final String ACTION_NAME = "internal:gateway/local/meta_state";
 
     private LocalGatewayMetaState metaState;
 

--- a/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
+++ b/src/main/java/org/elasticsearch/gateway/local/state/shards/TransportNodesListGatewayStartedShards.java
@@ -48,8 +48,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesListGatewayStartedShards extends TransportNodesOperationAction<TransportNodesListGatewayStartedShards.Request, TransportNodesListGatewayStartedShards.NodesLocalGatewayStartedShards, TransportNodesListGatewayStartedShards.NodeRequest, TransportNodesListGatewayStartedShards.NodeLocalGatewayStartedShards> {
 
-    private static final String ACTION_NAME = "/gateway/local/started-shards";
-
+    public static final String ACTION_NAME = "internal:gateway/local/started_shards";
 
     private LocalGatewayShardsState shardsState;
 

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -72,7 +72,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class RecoverySource extends AbstractComponent {
 
     public static class Actions {
-        public static final String START_RECOVERY = "index/shard/recovery/startRecovery";
+        public static final String START_RECOVERY = "internal:index/shard/recovery/start_recovery";
     }
 
     private final TransportService transportService;

--- a/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -65,12 +65,12 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 public class RecoveryTarget extends AbstractComponent {
 
     public static class Actions {
-        public static final String FILES_INFO = "index/shard/recovery/filesInfo";
-        public static final String FILE_CHUNK = "index/shard/recovery/fileChunk";
-        public static final String CLEAN_FILES = "index/shard/recovery/cleanFiles";
-        public static final String TRANSLOG_OPS = "index/shard/recovery/translogOps";
-        public static final String PREPARE_TRANSLOG = "index/shard/recovery/prepareTranslog";
-        public static final String FINALIZE = "index/shard/recovery/finalize";
+        public static final String FILES_INFO = "internal:index/shard/recovery/filesInfo";
+        public static final String FILE_CHUNK = "internal:index/shard/recovery/file_chunk";
+        public static final String CLEAN_FILES = "internal:index/shard/recovery/clean_files";
+        public static final String TRANSLOG_OPS = "internal:index/shard/recovery/translog_ops";
+        public static final String PREPARE_TRANSLOG = "internal:index/shard/recovery/prepare_translog";
+        public static final String FINALIZE = "internal:index/shard/recovery/finalize";
     }
 
     private final ThreadPool threadPool;

--- a/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -61,7 +61,8 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
     public static final String INDICES_STORE_THROTTLE_TYPE = "indices.store.throttle.type";
     public static final String INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = "indices.store.throttle.max_bytes_per_sec";
 
-    private static final String ACTION_SHARD_EXISTS = "index/shard/exists";
+    public static final String ACTION_SHARD_EXISTS = "internal:index/shard/exists";
+
     private static final EnumSet<IndexShardState> ACTIVE_STATES = EnumSet.of(IndexShardState.STARTED, IndexShardState.RELOCATED);
 
     class ApplySettings implements NodeSettingsService.Listener {

--- a/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class TransportNodesListShardStoreMetaData extends TransportNodesOperationAction<TransportNodesListShardStoreMetaData.Request, TransportNodesListShardStoreMetaData.NodesStoreFilesMetaData, TransportNodesListShardStoreMetaData.NodeRequest, TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> {
 
-    private static final String ACTION_NAME = "/cluster/nodes/indices/shard/store";
+    public static final String ACTION_NAME = "internal:cluster/nodes/indices/shard/store";
 
     private final IndicesService indicesService;
 

--- a/src/main/java/org/elasticsearch/river/cluster/PublishRiverClusterStateAction.java
+++ b/src/main/java/org/elasticsearch/river/cluster/PublishRiverClusterStateAction.java
@@ -36,6 +36,8 @@ import java.io.IOException;
  */
 public class PublishRiverClusterStateAction extends AbstractComponent {
 
+    public static final String ACTION_NAME = "internal:river/state/publish";
+
     public static interface NewClusterStateListener {
         void onNewClusterState(RiverClusterState clusterState);
     }
@@ -52,11 +54,11 @@ public class PublishRiverClusterStateAction extends AbstractComponent {
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.listener = listener;
-        transportService.registerHandler(PublishClusterStateRequestHandler.ACTION, new PublishClusterStateRequestHandler());
+        transportService.registerHandler(ACTION_NAME, new PublishClusterStateRequestHandler());
     }
 
     public void close() {
-        transportService.removeHandler(PublishClusterStateRequestHandler.ACTION);
+        transportService.removeHandler(ACTION_NAME);
     }
 
     public void publish(RiverClusterState clusterState) {
@@ -76,7 +78,7 @@ public class PublishRiverClusterStateAction extends AbstractComponent {
                 continue;
             }
 
-            transportService.sendRequest(node, PublishClusterStateRequestHandler.ACTION, new PublishClusterStateRequest(clusterState), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+            transportService.sendRequest(node, ACTION_NAME, new PublishClusterStateRequest(clusterState), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                 @Override
                 public void handleException(TransportException exp) {
                     logger.debug("failed to send cluster state to [{}], should be detected as failed soon...", exp, node);
@@ -110,8 +112,6 @@ public class PublishRiverClusterStateAction extends AbstractComponent {
     }
 
     private class PublishClusterStateRequestHandler extends BaseTransportRequestHandler<PublishClusterStateRequest> {
-
-        static final String ACTION = "river/state/publish";
 
         @Override
         public PublishClusterStateRequest newInstance() {

--- a/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
+++ b/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
@@ -53,6 +53,19 @@ import java.util.concurrent.Callable;
  */
 public class SearchServiceTransportAction extends AbstractComponent {
 
+    public static final String FREE_CONTEXT_ACTION_NAME = "indices:data/read/search[free_context]";
+    public static final String CLEAR_SCROLL_CONTEXTS_ACTION_NAME = "indices:data/read/search[clear_scroll_contexts]";
+    public static final String DFS_ACTION_NAME = "indices:data/read/search[phase/dfs]";
+    public static final String QUERY_ACTION_NAME = "indices:data/read/search[phase/query]";
+    public static final String QUERY_ID_ACTION_NAME = "indices:data/read/search[phase/query/id]";
+    public static final String QUERY_SCROLL_ACTION_NAME = "indices:data/read/search[phase/query/scroll]";
+    public static final String QUERY_FETCH_ACTION_NAME = "indices:data/read/search[phase/query+fetch]";
+    public static final String QUERY_QUERY_FETCH_ACTION_NAME = "indices:data/read/search[phase/query/query+fetch]";
+    public static final String QUERY_FETCH_SCROLL_ACTION_NAME = "indices:data/read/search[phase/query+fetch/scroll]";
+    public static final String FETCH_ID_ACTION_NAME = "indices:data/read/search[phase/fetch/id]";
+    public static final String SCAN_ACTION_NAME = "indices:data/read/search[phase/scan]";
+    public static final String SCAN_SCROLL_ACTION_NAME = "indices:data/read/search[phase/scan/scroll]";
+
     static final class FreeContextResponseHandler implements TransportResponseHandler<SearchFreeContextResponse> {
 
         private final ActionListener<Boolean> listener;
@@ -104,25 +117,25 @@ public class SearchServiceTransportAction extends AbstractComponent {
         this.clusterService = clusterService;
         this.searchService = searchService;
 
-        transportService.registerHandler(SearchFreeContextTransportHandler.ACTION, new SearchFreeContextTransportHandler());
-        transportService.registerHandler(ClearScrollContextsTransportHandler.ACTION, new ClearScrollContextsTransportHandler());
-        transportService.registerHandler(SearchDfsTransportHandler.ACTION, new SearchDfsTransportHandler());
-        transportService.registerHandler(SearchQueryTransportHandler.ACTION, new SearchQueryTransportHandler());
-        transportService.registerHandler(SearchQueryByIdTransportHandler.ACTION, new SearchQueryByIdTransportHandler());
-        transportService.registerHandler(SearchQueryScrollTransportHandler.ACTION, new SearchQueryScrollTransportHandler());
-        transportService.registerHandler(SearchQueryFetchTransportHandler.ACTION, new SearchQueryFetchTransportHandler());
-        transportService.registerHandler(SearchQueryQueryFetchTransportHandler.ACTION, new SearchQueryQueryFetchTransportHandler());
-        transportService.registerHandler(SearchQueryFetchScrollTransportHandler.ACTION, new SearchQueryFetchScrollTransportHandler());
-        transportService.registerHandler(SearchFetchByIdTransportHandler.ACTION, new SearchFetchByIdTransportHandler());
-        transportService.registerHandler(SearchScanTransportHandler.ACTION, new SearchScanTransportHandler());
-        transportService.registerHandler(SearchScanScrollTransportHandler.ACTION, new SearchScanScrollTransportHandler());
+        transportService.registerHandler(FREE_CONTEXT_ACTION_NAME, new SearchFreeContextTransportHandler());
+        transportService.registerHandler(CLEAR_SCROLL_CONTEXTS_ACTION_NAME, new ClearScrollContextsTransportHandler());
+        transportService.registerHandler(DFS_ACTION_NAME, new SearchDfsTransportHandler());
+        transportService.registerHandler(QUERY_ACTION_NAME, new SearchQueryTransportHandler());
+        transportService.registerHandler(QUERY_ID_ACTION_NAME, new SearchQueryByIdTransportHandler());
+        transportService.registerHandler(QUERY_SCROLL_ACTION_NAME, new SearchQueryScrollTransportHandler());
+        transportService.registerHandler(QUERY_FETCH_ACTION_NAME, new SearchQueryFetchTransportHandler());
+        transportService.registerHandler(QUERY_QUERY_FETCH_ACTION_NAME, new SearchQueryQueryFetchTransportHandler());
+        transportService.registerHandler(QUERY_FETCH_SCROLL_ACTION_NAME, new SearchQueryFetchScrollTransportHandler());
+        transportService.registerHandler(FETCH_ID_ACTION_NAME, new SearchFetchByIdTransportHandler());
+        transportService.registerHandler(SCAN_ACTION_NAME, new SearchScanTransportHandler());
+        transportService.registerHandler(SCAN_SCROLL_ACTION_NAME, new SearchScanScrollTransportHandler());
     }
 
     public void sendFreeContext(DiscoveryNode node, final long contextId, SearchRequest request) {
         if (clusterService.state().nodes().localNodeId().equals(node.id())) {
             searchService.freeContext(contextId);
         } else {
-            transportService.sendRequest(node, SearchFreeContextTransportHandler.ACTION, new SearchFreeContextRequest(request, contextId), freeContextResponseHandler);
+            transportService.sendRequest(node, FREE_CONTEXT_ACTION_NAME, new SearchFreeContextRequest(request, contextId), freeContextResponseHandler);
         }
     }
 
@@ -131,7 +144,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
             boolean freed = searchService.freeContext(contextId);
             actionListener.onResponse(freed);
         } else {
-            transportService.sendRequest(node, SearchFreeContextTransportHandler.ACTION, new SearchFreeContextRequest(request, contextId), new FreeContextResponseHandler(actionListener));
+            transportService.sendRequest(node, FREE_CONTEXT_ACTION_NAME, new SearchFreeContextRequest(request, contextId), new FreeContextResponseHandler(actionListener));
         }
     }
 
@@ -140,7 +153,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
             searchService.freeAllScrollContexts();
             actionListener.onResponse(true);
         } else {
-            transportService.sendRequest(node, ClearScrollContextsTransportHandler.ACTION, new ClearScrollContextsRequest(request), new TransportResponseHandler<TransportResponse>() {
+            transportService.sendRequest(node, CLEAR_SCROLL_CONTEXTS_ACTION_NAME, new ClearScrollContextsRequest(request), new TransportResponseHandler<TransportResponse>() {
                 @Override
                 public TransportResponse newInstance() {
                     return TransportResponse.Empty.INSTANCE;
@@ -173,7 +186,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchDfsTransportHandler.ACTION, request, new BaseTransportResponseHandler<DfsSearchResult>() {
+            transportService.sendRequest(node, DFS_ACTION_NAME, request, new BaseTransportResponseHandler<DfsSearchResult>() {
 
                 @Override
                 public DfsSearchResult newInstance() {
@@ -207,7 +220,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchQueryTransportHandler.ACTION, request, new BaseTransportResponseHandler<QuerySearchResult>() {
+            transportService.sendRequest(node, QUERY_ACTION_NAME, request, new BaseTransportResponseHandler<QuerySearchResult>() {
 
                 @Override
                 public QuerySearchResult newInstance() {
@@ -241,7 +254,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchQueryByIdTransportHandler.ACTION, request, new BaseTransportResponseHandler<QuerySearchResult>() {
+            transportService.sendRequest(node, QUERY_ID_ACTION_NAME, request, new BaseTransportResponseHandler<QuerySearchResult>() {
 
                 @Override
                 public QuerySearchResult newInstance() {
@@ -275,7 +288,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchQueryScrollTransportHandler.ACTION, request, new BaseTransportResponseHandler<ScrollQuerySearchResult>() {
+            transportService.sendRequest(node, QUERY_SCROLL_ACTION_NAME, request, new BaseTransportResponseHandler<ScrollQuerySearchResult>() {
 
                 @Override
                 public ScrollQuerySearchResult newInstance() {
@@ -309,7 +322,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchQueryFetchTransportHandler.ACTION, request, new BaseTransportResponseHandler<QueryFetchSearchResult>() {
+            transportService.sendRequest(node, QUERY_FETCH_ACTION_NAME, request, new BaseTransportResponseHandler<QueryFetchSearchResult>() {
 
                 @Override
                 public QueryFetchSearchResult newInstance() {
@@ -343,7 +356,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchQueryQueryFetchTransportHandler.ACTION, request, new BaseTransportResponseHandler<QueryFetchSearchResult>() {
+            transportService.sendRequest(node, QUERY_QUERY_FETCH_ACTION_NAME, request, new BaseTransportResponseHandler<QueryFetchSearchResult>() {
 
                 @Override
                 public QueryFetchSearchResult newInstance() {
@@ -377,7 +390,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchQueryFetchScrollTransportHandler.ACTION, request, new BaseTransportResponseHandler<ScrollQueryFetchSearchResult>() {
+            transportService.sendRequest(node, QUERY_FETCH_SCROLL_ACTION_NAME, request, new BaseTransportResponseHandler<ScrollQueryFetchSearchResult>() {
 
                 @Override
                 public ScrollQueryFetchSearchResult newInstance() {
@@ -411,7 +424,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchFetchByIdTransportHandler.ACTION, request, new BaseTransportResponseHandler<FetchSearchResult>() {
+            transportService.sendRequest(node, FETCH_ID_ACTION_NAME, request, new BaseTransportResponseHandler<FetchSearchResult>() {
 
                 @Override
                 public FetchSearchResult newInstance() {
@@ -445,7 +458,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchScanTransportHandler.ACTION, request, new BaseTransportResponseHandler<QuerySearchResult>() {
+            transportService.sendRequest(node, SCAN_ACTION_NAME, request, new BaseTransportResponseHandler<QuerySearchResult>() {
 
                 @Override
                 public QuerySearchResult newInstance() {
@@ -479,7 +492,7 @@ public class SearchServiceTransportAction extends AbstractComponent {
                 }
             }, listener);
         } else {
-            transportService.sendRequest(node, SearchScanScrollTransportHandler.ACTION, request, new BaseTransportResponseHandler<ScrollQueryFetchSearchResult>() {
+            transportService.sendRequest(node, SCAN_SCROLL_ACTION_NAME, request, new BaseTransportResponseHandler<ScrollQueryFetchSearchResult>() {
 
                 @Override
                 public ScrollQueryFetchSearchResult newInstance() {
@@ -598,8 +611,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     class SearchFreeContextTransportHandler extends BaseTransportRequestHandler<SearchFreeContextRequest> {
 
-        static final String ACTION = "search/freeContext";
-
         @Override
         public SearchFreeContextRequest newInstance() {
             return new SearchFreeContextRequest();
@@ -632,8 +643,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     class ClearScrollContextsTransportHandler extends BaseTransportRequestHandler<ClearScrollContextsRequest> {
 
-        static final String ACTION = "search/clearScrollContexts";
-
         @Override
         public ClearScrollContextsRequest newInstance() {
             return new ClearScrollContextsRequest();
@@ -655,8 +664,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     private class SearchDfsTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
 
-        static final String ACTION = "search/phase/dfs";
-
         @Override
         public ShardSearchRequest newInstance() {
             return new ShardSearchRequest();
@@ -675,8 +682,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
     }
 
     private class SearchQueryTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
-
-        static final String ACTION = "search/phase/query";
 
         @Override
         public ShardSearchRequest newInstance() {
@@ -697,8 +702,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     private class SearchQueryByIdTransportHandler extends BaseTransportRequestHandler<QuerySearchRequest> {
 
-        static final String ACTION = "search/phase/query/id";
-
         @Override
         public QuerySearchRequest newInstance() {
             return new QuerySearchRequest();
@@ -717,8 +720,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
     }
 
     private class SearchQueryScrollTransportHandler extends BaseTransportRequestHandler<InternalScrollSearchRequest> {
-
-        static final String ACTION = "search/phase/query/scroll";
 
         @Override
         public InternalScrollSearchRequest newInstance() {
@@ -739,8 +740,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     private class SearchQueryFetchTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
 
-        static final String ACTION = "search/phase/query+fetch";
-
         @Override
         public ShardSearchRequest newInstance() {
             return new ShardSearchRequest();
@@ -759,8 +758,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
     }
 
     private class SearchQueryQueryFetchTransportHandler extends BaseTransportRequestHandler<QuerySearchRequest> {
-
-        static final String ACTION = "search/phase/query/query+fetch";
 
         @Override
         public QuerySearchRequest newInstance() {
@@ -781,8 +778,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     private class SearchFetchByIdTransportHandler extends BaseTransportRequestHandler<FetchSearchRequest> {
 
-        static final String ACTION = "search/phase/fetch/id";
-
         @Override
         public FetchSearchRequest newInstance() {
             return new FetchSearchRequest();
@@ -801,8 +796,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
     }
 
     private class SearchQueryFetchScrollTransportHandler extends BaseTransportRequestHandler<InternalScrollSearchRequest> {
-
-        static final String ACTION = "search/phase/query+fetch/scroll";
 
         @Override
         public InternalScrollSearchRequest newInstance() {
@@ -823,8 +816,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
 
     private class SearchScanTransportHandler extends BaseTransportRequestHandler<ShardSearchRequest> {
 
-        static final String ACTION = "search/phase/scan";
-
         @Override
         public ShardSearchRequest newInstance() {
             return new ShardSearchRequest();
@@ -843,8 +834,6 @@ public class SearchServiceTransportAction extends AbstractComponent {
     }
 
     private class SearchScanScrollTransportHandler extends BaseTransportRequestHandler<InternalScrollSearchRequest> {
-
-        static final String ACTION = "search/phase/scan/scroll";
 
         @Override
         public InternalScrollSearchRequest newInstance() {

--- a/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -80,6 +80,8 @@ import static org.elasticsearch.cluster.metadata.MetaDataIndexStateService.INDEX
  */
 public class RestoreService extends AbstractComponent implements ClusterStateListener {
 
+    public static final String UPDATE_RESTORE_ACTION_NAME = "internal:cluster/snapshot/update_restore";
+
     private final ClusterService clusterService;
 
     private final RepositoriesService repositoriesService;
@@ -100,7 +102,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
         this.transportService = transportService;
         this.allocationService = allocationService;
         this.createIndexService = createIndexService;
-        transportService.registerHandler(UpdateRestoreStateRequestHandler.ACTION, new UpdateRestoreStateRequestHandler());
+        transportService.registerHandler(UPDATE_RESTORE_ACTION_NAME, new UpdateRestoreStateRequestHandler());
         clusterService.add(this);
     }
 
@@ -322,7 +324,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
             innerUpdateRestoreState(request);
         } else {
             transportService.sendRequest(clusterService.state().nodes().masterNode(),
-                    UpdateRestoreStateRequestHandler.ACTION, request, EmptyTransportResponseHandler.INSTANCE_SAME);
+                    UPDATE_RESTORE_ACTION_NAME, request, EmptyTransportResponseHandler.INSTANCE_SAME);
         }
     }
 
@@ -488,7 +490,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
             innerUpdateRestoreState(request);
         } else {
             transportService.sendRequest(clusterService.state().nodes().masterNode(),
-                    UpdateRestoreStateRequestHandler.ACTION, request, EmptyTransportResponseHandler.INSTANCE_SAME);
+                    UPDATE_RESTORE_ACTION_NAME, request, EmptyTransportResponseHandler.INSTANCE_SAME);
         }
     }
 
@@ -813,8 +815,6 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
      * Internal class that is used to send notifications about finished shard restore operations to master node
      */
     private class UpdateRestoreStateRequestHandler extends BaseTransportRequestHandler<UpdateIndexShardRestoreStatusRequest> {
-
-        static final String ACTION = "cluster/snapshot/update_restore";
 
         @Override
         public UpdateIndexShardRestoreStatusRequest newInstance() {

--- a/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -87,6 +87,8 @@ import static com.google.common.collect.Sets.newHashSet;
  */
 public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsService> implements ClusterStateListener {
 
+    public static final String UPDATE_SNAPSHOT_ACTION_NAME = "internal:cluster/snapshot/update_snapshot";
+
     private final ClusterService clusterService;
 
     private final RepositoriesService repositoriesService;
@@ -116,7 +118,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
         this.indicesService = indicesService;
         this.transportService = transportService;
 
-        transportService.registerHandler(UpdateSnapshotStateRequestHandler.ACTION, new UpdateSnapshotStateRequestHandler());
+        transportService.registerHandler(UPDATE_SNAPSHOT_ACTION_NAME, new UpdateSnapshotStateRequestHandler());
 
         // addLast to make sure that Repository will be created before snapshot
         clusterService.addLast(this);
@@ -853,7 +855,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                 innerUpdateSnapshotState(request);
             } else {
                 transportService.sendRequest(clusterService.state().nodes().masterNode(),
-                        UpdateSnapshotStateRequestHandler.ACTION, request, EmptyTransportResponseHandler.INSTANCE_SAME);
+                        UPDATE_SNAPSHOT_ACTION_NAME, request, EmptyTransportResponseHandler.INSTANCE_SAME);
             }
         } catch (Throwable t) {
             logger.warn("[{}] [{}] failed to update snapshot state", t, request.snapshotId(), request.status());
@@ -1540,8 +1542,6 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
      * Transport request handler that is used to send changes in snapshot status to master
      */
     private class UpdateSnapshotStateRequestHandler extends BaseTransportRequestHandler<UpdateIndexShardSnapshotStatusRequest> {
-
-        static final String ACTION = "cluster/snapshot/update_snapshot";
 
         @Override
         public UpdateIndexShardSnapshotStatusRequest newInstance() {

--- a/src/main/java/org/elasticsearch/transport/ActionNames.java
+++ b/src/main/java/org/elasticsearch/transport/ActionNames.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import com.google.common.collect.ImmutableBiMap;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
+import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.restart.NodesRestartAction;
+import org.elasticsearch.action.admin.cluster.node.shutdown.NodesShutdownAction;
+import org.elasticsearch.action.admin.cluster.node.shutdown.TransportNodesShutdownAction;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
+import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction;
+import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesAction;
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryAction;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusAction;
+import org.elasticsearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction;
+import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksAction;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
+import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistAction;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
+import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheAction;
+import org.elasticsearch.action.admin.indices.close.CloseIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsAction;
+import org.elasticsearch.action.admin.indices.exists.types.TypesExistsAction;
+import org.elasticsearch.action.admin.indices.flush.FlushAction;
+import org.elasticsearch.action.admin.indices.mapping.delete.DeleteMappingAction;
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsAction;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
+import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
+import org.elasticsearch.action.admin.indices.optimize.OptimizeAction;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
+import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
+import org.elasticsearch.action.admin.indices.status.IndicesStatusAction;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryAction;
+import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerAction;
+import org.elasticsearch.action.admin.indices.warmer.get.GetWarmersAction;
+import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerAction;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.count.CountAction;
+import org.elasticsearch.action.delete.DeleteAction;
+import org.elasticsearch.action.deletebyquery.DeleteByQueryAction;
+import org.elasticsearch.action.explain.ExplainAction;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.MultiGetAction;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptAction;
+import org.elasticsearch.action.mlt.MoreLikeThisAction;
+import org.elasticsearch.action.percolate.MultiPercolateAction;
+import org.elasticsearch.action.percolate.PercolateAction;
+import org.elasticsearch.action.search.ClearScrollAction;
+import org.elasticsearch.action.search.MultiSearchAction;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchScrollAction;
+import org.elasticsearch.action.suggest.SuggestAction;
+import org.elasticsearch.action.termvector.MultiTermVectorsAction;
+import org.elasticsearch.action.termvector.TermVectorAction;
+import org.elasticsearch.action.update.UpdateAction;
+import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.cluster.action.index.NodeIndexDeletedAction;
+import org.elasticsearch.cluster.action.index.NodeMappingRefreshAction;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.discovery.zen.ZenDiscovery;
+import org.elasticsearch.discovery.zen.fd.MasterFaultDetection;
+import org.elasticsearch.discovery.zen.fd.NodesFaultDetection;
+import org.elasticsearch.discovery.zen.membership.MembershipAction;
+import org.elasticsearch.discovery.zen.ping.multicast.MulticastZenPing;
+import org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing;
+import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
+import org.elasticsearch.gateway.local.state.meta.LocalAllocateDangledIndices;
+import org.elasticsearch.gateway.local.state.meta.TransportNodesListGatewayMetaState;
+import org.elasticsearch.gateway.local.state.shards.TransportNodesListGatewayStartedShards;
+import org.elasticsearch.indices.recovery.RecoverySource;
+import org.elasticsearch.indices.recovery.RecoveryTarget;
+import org.elasticsearch.indices.store.IndicesStore;
+import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
+import org.elasticsearch.river.cluster.PublishRiverClusterStateAction;
+import org.elasticsearch.search.action.SearchServiceTransportAction;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.snapshots.SnapshotsService;
+
+final class ActionNames {
+
+    static final ImmutableBiMap<String, String> ACTION_NAMES = createActionNamesMap();
+
+    private ActionNames() {
+
+    }
+
+    static String incomingAction(String action, Version version) {
+        if (version.before(Version.V_1_4_0)) {
+            String post_1_4_action = post_1_4_action(action);
+            //custom action e.g. registered through plugin are not mapped, fallback to the original one
+            if (post_1_4_action != null) {
+                return post_1_4_action;
+            }
+        }
+        return action;
+    }
+
+    static String outgoingAction(String action, Version version) {
+        if (version.before(Version.V_1_4_0)) {
+            String pre_1_4_Action = pre_1_4_Action(action);
+            //custom actions e.g. registered through plugins are not mapped, fallback to the original one
+            if (pre_1_4_Action != null) {
+                return pre_1_4_Action;
+            }
+        }
+        return action;
+    }
+
+    static String post_1_4_action(String action) {
+        return ACTION_NAMES.inverse().get(action);
+    }
+
+    static String pre_1_4_Action(String action) {
+        return ACTION_NAMES.get(action);
+    }
+
+    private static ImmutableBiMap<String, String> createActionNamesMap() {
+        ImmutableBiMap.Builder<String, String> builder = ImmutableBiMap.builder();
+
+        addNodeAction(NodesRestartAction.NAME, "cluster/nodes/restart", builder);
+        builder.put(NodesShutdownAction.NAME, "cluster/nodes/shutdown");
+        builder.put(TransportNodesShutdownAction.SHUTDOWN_NODE_ACTION_NAME, "/cluster/nodes/shutdown/node");
+
+        builder.put(DeleteRepositoryAction.NAME, "cluster/repository/delete");
+        builder.put(GetRepositoriesAction.NAME, "cluster/repository/get");
+        builder.put(PutRepositoryAction.NAME, "cluster/repository/put");
+
+        builder.put(ClusterRerouteAction.NAME, "cluster/reroute");
+
+        builder.put(ClusterUpdateSettingsAction.NAME, "cluster/settings/update");
+
+        builder.put(CreateSnapshotAction.NAME, "cluster/snapshot/create");
+        builder.put(DeleteSnapshotAction.NAME, "cluster/snapshot/delete");
+        builder.put(GetSnapshotsAction.NAME, "cluster/snapshot/get");
+        builder.put(RestoreSnapshotAction.NAME, "cluster/snapshot/restore");
+
+        builder.put(ClusterHealthAction.NAME, "cluster/health");
+        addNodeAction(NodesHotThreadsAction.NAME, "cluster/nodes/hot_threads", builder);
+        addNodeAction(NodesInfoAction.NAME, "cluster/nodes/info", builder);
+        addNodeAction(NodesStatsAction.NAME, "cluster/nodes/stats", builder);
+
+        builder.put(SnapshotsStatusAction.NAME, "cluster/snapshot/status");
+        addNodeAction(TransportNodesSnapshotsStatus.ACTION_NAME, "cluster/snapshot/status/nodes", builder);
+
+        builder.put(ClusterStateAction.NAME, "cluster/state");
+        addNodeAction(ClusterStatsAction.NAME, "cluster/stats", builder);
+
+        builder.put(PendingClusterTasksAction.NAME, "cluster/task");
+
+        builder.put(IndicesAliasesAction.NAME, "indices/aliases");
+        builder.put(AliasesExistAction.NAME, "indices/exists/aliases");
+        builder.put(GetAliasesAction.NAME, "indices/get/aliases");
+
+        addShardAction(AnalyzeAction.NAME, "indices/analyze", builder);
+        addShardAction(ClearIndicesCacheAction.NAME, "indices/cache/clear", builder);
+
+        builder.put(CloseIndexAction.NAME, "indices/close");
+        builder.put(CreateIndexAction.NAME, "indices/create");
+        builder.put(DeleteIndexAction.NAME, "indices/delete");
+        builder.put(IndicesExistsAction.NAME, "indices/exists");
+        addShardAction(FlushAction.NAME, "indices/flush", builder);
+
+        builder.put(DeleteMappingAction.NAME, "indices/mapping/delete");
+        builder.put(PutMappingAction.NAME, "indices/mapping/put");
+        builder.put(GetFieldMappingsAction.NAME, "mappings/fields/get");
+        builder.put(GetFieldMappingsAction.NAME + "[index]", "mappings/fields/get/index");
+        builder.put(GetFieldMappingsAction.NAME + "[index][s]", "mappings/fields/get/index/s");
+        builder.put(GetMappingsAction.NAME, "mappings/get");
+
+        builder.put(OpenIndexAction.NAME, "indices/open");
+
+        addShardAction(OptimizeAction.NAME, "indices/optimize", builder);
+        addShardAction(RefreshAction.NAME, "indices/refresh", builder);
+        builder.put(UpdateSettingsAction.NAME, "indices/settings/update");
+        builder.put(ClusterSearchShardsAction.NAME, "cluster/shards/search_shards");
+
+        builder.put(DeleteIndexTemplateAction.NAME, "indices/template/delete");
+        builder.put(GetIndexTemplatesAction.NAME, "indices/template/get");
+        builder.put(PutIndexTemplateAction.NAME, "indices/template/put");
+
+        builder.put(TypesExistsAction.NAME, "indices/types/exists");
+        addShardAction(ValidateQueryAction.NAME, "indices/validate/query", builder);
+
+        builder.put(DeleteWarmerAction.NAME, "indices/warmer/delete");
+        builder.put(GetWarmersAction.NAME, "warmers/get");
+        builder.put(PutWarmerAction.NAME, "indices/warmer/put");
+
+        addShardAction(CountAction.NAME, "count", builder);
+        addShardAction(ExplainAction.NAME, "explain", builder);
+        addShardAction(GetAction.NAME, "get", builder);
+        builder.put(MultiGetAction.NAME, "mget");
+        addShardAction(MultiGetAction.NAME + "[shard]", "mget/shard", builder);
+
+        builder.put(GetIndexedScriptAction.NAME, "getIndexedScript");
+        builder.put(PutIndexedScriptAction.NAME, "putIndexedScript");
+        builder.put(DeleteIndexedScriptAction.NAME, "deleteIndexedScript");
+
+        builder.put(MoreLikeThisAction.NAME, "mlt");
+
+        builder.put(MultiPercolateAction.NAME, "mpercolate");
+        addShardAction(MultiPercolateAction.NAME + "[shard]", "mpercolate/shard", builder);
+
+        builder.put(MultiSearchAction.NAME, "msearch");
+
+        builder.put(MultiTermVectorsAction.NAME, "mtv");
+        addShardAction(MultiTermVectorsAction.NAME + "[shard]", "mtv/shard", builder);
+
+        addShardAction(PercolateAction.NAME, "percolate", builder);
+
+        builder.put(SearchScrollAction.NAME, "search/scroll");
+        builder.put(ClearScrollAction.NAME, "clear_sc");
+
+        builder.put(SearchAction.NAME, "search");
+        builder.put(SearchServiceTransportAction.FREE_CONTEXT_ACTION_NAME, "search/freeContext");
+        builder.put(SearchServiceTransportAction.CLEAR_SCROLL_CONTEXTS_ACTION_NAME, "search/clearScrollContexts");
+        builder.put(SearchServiceTransportAction.DFS_ACTION_NAME, "search/phase/dfs");
+        builder.put(SearchServiceTransportAction.QUERY_ACTION_NAME, "search/phase/query");
+        builder.put(SearchServiceTransportAction.QUERY_ID_ACTION_NAME, "search/phase/query/id");
+        builder.put(SearchServiceTransportAction.QUERY_SCROLL_ACTION_NAME, "search/phase/query/scroll");
+        builder.put(SearchServiceTransportAction.QUERY_FETCH_ACTION_NAME, "search/phase/query+fetch");
+        builder.put(SearchServiceTransportAction.QUERY_QUERY_FETCH_ACTION_NAME, "search/phase/query/query+fetch");
+        builder.put(SearchServiceTransportAction.QUERY_FETCH_SCROLL_ACTION_NAME, "search/phase/query+fetch/scroll");
+        builder.put(SearchServiceTransportAction.FETCH_ID_ACTION_NAME, "search/phase/fetch/id");
+        builder.put(SearchServiceTransportAction.SCAN_ACTION_NAME, "search/phase/scan");
+        builder.put(SearchServiceTransportAction.SCAN_SCROLL_ACTION_NAME, "search/phase/scan/scroll");
+
+        addShardAction(SuggestAction.NAME, "suggest", builder);
+        addShardAction(TermVectorAction.NAME, "tv", builder);
+
+        builder.put(BulkAction.NAME, "bulk");
+        builder.put(BulkAction.NAME + "[s]", "bulk/shard");
+        builder.put(BulkAction.NAME + "[s][r]", "bulk/shard/replica");
+
+        builder.put(DeleteAction.NAME, "delete");
+        builder.put(DeleteAction.NAME + "[r]", "delete/replica");
+        builder.put(DeleteAction.NAME + "[index]", "indices/index/delete");
+        builder.put(DeleteAction.NAME + "[s]", "indices/index/b_shard/delete");
+        builder.put(DeleteAction.NAME + "[s][r]", "indices/index/b_shard/delete/replica");
+
+        builder.put(DeleteByQueryAction.NAME, "deleteByQuery");
+        builder.put(DeleteByQueryAction.NAME + "[index]", "deleteByQuery/index");
+        builder.put(DeleteByQueryAction.NAME + "[s]", "deleteByQuery/shard");
+        builder.put(DeleteByQueryAction.NAME + "[s][r]", "deleteByQuery/shard/replica");
+
+        builder.put(IndexAction.NAME, "index");
+        builder.put(IndexAction.NAME + "[r]", "index/replica");
+
+        builder.put(UpdateAction.NAME, "update");
+
+        addShardAction(RecoveryAction.NAME, "indices/recovery", builder);
+        addShardAction(IndicesSegmentsAction.NAME, "indices/segments", builder);
+        addShardAction(IndicesStatsAction.NAME, "indices/stats", builder);
+        addShardAction(IndicesStatusAction.NAME, "indices/status", builder);
+
+        builder.put(GetSettingsAction.NAME, "indices/settings/get");
+
+        builder.put(MappingUpdatedAction.ACTION_NAME, "cluster/mappingUpdated");
+        builder.put(NodeIndexDeletedAction.INDEX_DELETED_ACTION_NAME, "cluster/nodeIndexDeleted");
+        builder.put(NodeIndexDeletedAction.INDEX_STORE_DELETED_ACTION_NAME, "cluster/nodeIndexStoreDeleted");
+        builder.put(NodeMappingRefreshAction.ACTION_NAME, "cluster/nodeMappingRefresh");
+        addNodeAction(TransportNodesListShardStoreMetaData.ACTION_NAME, "/cluster/nodes/indices/shard/store", builder);
+        builder.put(ShardStateAction.SHARD_STARTED_ACTION_NAME, "cluster/shardStarted");
+        builder.put(ShardStateAction.SHARD_FAILED_ACTION_NAME, "cluster/shardFailure");
+        builder.put(RestoreService.UPDATE_RESTORE_ACTION_NAME, "cluster/snapshot/update_restore");
+        builder.put(SnapshotsService.UPDATE_SNAPSHOT_ACTION_NAME, "cluster/snapshot/update_snapshot");
+        builder.put(MasterFaultDetection.MASTER_PING_ACTION_NAME, "discovery/zen/fd/masterPing");
+        builder.put(NodesFaultDetection.PING_ACTION_NAME, "discovery/zen/fd/ping");
+        builder.put(MembershipAction.DISCOVERY_JOIN_ACTION_NAME, "discovery/zen/join");
+        builder.put(ZenDiscovery.DISCOVERY_REJOIN_ACTION_NAME, "discovery/zen/rejoin");
+        builder.put(MembershipAction.DISCOVERY_JOIN_VALIDATE_ACTION_NAME, "discovery/zen/join/validate");
+        builder.put(MembershipAction.DISCOVERY_LEAVE_ACTION_NAME, "discovery/zen/leave");
+        builder.put(MulticastZenPing.ACTION_NAME, "discovery/zen/multicast");
+        builder.put(PublishClusterStateAction.ACTION_NAME, "discovery/zen/publish");
+        builder.put(UnicastZenPing.ACTION_NAME, "discovery/zen/unicast");
+        builder.put(LocalAllocateDangledIndices.ACTION_NAME, "/gateway/local/allocate_dangled");
+        addNodeAction(TransportNodesListGatewayMetaState.ACTION_NAME, "/gateway/local/meta-state", builder);
+        addNodeAction(TransportNodesListGatewayStartedShards.ACTION_NAME, "/gateway/local/started-shards", builder);
+
+        builder.put(RecoveryTarget.Actions.CLEAN_FILES, "index/shard/recovery/cleanFiles");
+        builder.put(RecoveryTarget.Actions.FILE_CHUNK, "index/shard/recovery/fileChunk");
+        builder.put(RecoveryTarget.Actions.FILES_INFO, "index/shard/recovery/filesInfo");
+        builder.put(RecoveryTarget.Actions.FINALIZE, "index/shard/recovery/finalize");
+        builder.put(RecoveryTarget.Actions.PREPARE_TRANSLOG, "index/shard/recovery/prepareTranslog");
+        builder.put(RecoveryTarget.Actions.TRANSLOG_OPS, "index/shard/recovery/translogOps");
+        builder.put(RecoverySource.Actions.START_RECOVERY, "index/shard/recovery/startRecovery");
+
+        builder.put(IndicesStore.ACTION_SHARD_EXISTS, "index/shard/exists");
+
+        builder.put(PublishRiverClusterStateAction.ACTION_NAME, "river/state/publish");
+
+        return builder.build();
+    }
+
+    private static void addNodeAction(String name, String pre_14_name, ImmutableBiMap.Builder<String, String> builder) {
+        builder.put(name, pre_14_name);
+        builder.put(name + "[n]", pre_14_name + "/n");
+    }
+
+    private static void addShardAction(String name, String pre_14_name, ImmutableBiMap.Builder<String, String> builder) {
+        builder.put(name, pre_14_name);
+        builder.put(name + "[s]", pre_14_name + "/s");
+    }
+}

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -19,9 +19,90 @@
 
 package org.elasticsearch.transport;
 
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
+import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.restart.NodesRestartAction;
+import org.elasticsearch.action.admin.cluster.node.shutdown.NodesShutdownAction;
+import org.elasticsearch.action.admin.cluster.node.shutdown.TransportNodesShutdownAction;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
+import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction;
+import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesAction;
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryAction;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
+import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusAction;
+import org.elasticsearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction;
+import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksAction;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
+import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistAction;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
+import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheAction;
+import org.elasticsearch.action.admin.indices.close.CloseIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsAction;
+import org.elasticsearch.action.admin.indices.exists.types.TypesExistsAction;
+import org.elasticsearch.action.admin.indices.flush.FlushAction;
+import org.elasticsearch.action.admin.indices.mapping.delete.DeleteMappingAction;
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsAction;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
+import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
+import org.elasticsearch.action.admin.indices.optimize.OptimizeAction;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
+import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
+import org.elasticsearch.action.admin.indices.status.IndicesStatusAction;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
+import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryAction;
+import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerAction;
+import org.elasticsearch.action.admin.indices.warmer.get.GetWarmersAction;
+import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerAction;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.count.CountAction;
+import org.elasticsearch.action.delete.DeleteAction;
+import org.elasticsearch.action.deletebyquery.DeleteByQueryAction;
+import org.elasticsearch.action.explain.ExplainAction;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.MultiGetAction;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptAction;
+import org.elasticsearch.action.mlt.MoreLikeThisAction;
+import org.elasticsearch.action.percolate.MultiPercolateAction;
+import org.elasticsearch.action.percolate.PercolateAction;
+import org.elasticsearch.action.search.ClearScrollAction;
+import org.elasticsearch.action.search.MultiSearchAction;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchScrollAction;
+import org.elasticsearch.action.suggest.SuggestAction;
+import org.elasticsearch.action.termvector.MultiTermVectorsAction;
+import org.elasticsearch.action.termvector.TermVectorAction;
+import org.elasticsearch.action.update.UpdateAction;
+import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.cluster.action.index.NodeIndexDeletedAction;
+import org.elasticsearch.cluster.action.index.NodeMappingRefreshAction;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -33,6 +114,24 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.discovery.zen.ZenDiscovery;
+import org.elasticsearch.discovery.zen.fd.MasterFaultDetection;
+import org.elasticsearch.discovery.zen.fd.NodesFaultDetection;
+import org.elasticsearch.discovery.zen.membership.MembershipAction;
+import org.elasticsearch.discovery.zen.ping.multicast.MulticastZenPing;
+import org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing;
+import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
+import org.elasticsearch.gateway.local.state.meta.LocalAllocateDangledIndices;
+import org.elasticsearch.gateway.local.state.meta.TransportNodesListGatewayMetaState;
+import org.elasticsearch.gateway.local.state.shards.TransportNodesListGatewayStartedShards;
+import org.elasticsearch.indices.recovery.RecoverySource;
+import org.elasticsearch.indices.recovery.RecoveryTarget;
+import org.elasticsearch.indices.store.IndicesStore;
+import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
+import org.elasticsearch.river.cluster.PublishRiverClusterStateAction;
+import org.elasticsearch.search.action.SearchServiceTransportAction;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
@@ -48,6 +147,8 @@ import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_
  *
  */
 public class TransportService extends AbstractLifecycleComponent<TransportService> {
+
+    final ImmutableBiMap<String, String> actionNamesMapping;
 
     protected final Transport transport;
     protected final ThreadPool threadPool;
@@ -80,6 +181,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         super(settings);
         this.transport = transport;
         this.threadPool = threadPool;
+        this.actionNamesMapping = createActionNamesMap();
     }
 
     @Override
@@ -260,7 +362,14 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         }
 
         @Override
-        public TransportRequestHandler handler(String action) {
+        public TransportRequestHandler handler(String action, Version version) {
+            if (version.before(Version.V_1_4_0)) {
+                String newActionName = actionNamesMapping.inverse().get(action);
+                //custom action e.g. registered through plugin are not mapped, fallback to the original action
+                if (newActionName != null) {
+                    return serverHandlers.get(newActionName);
+                }
+            }
             return serverHandlers.get(action);
         }
 
@@ -325,6 +434,18 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                 logger.debug("Rejected execution on NodeDisconnected", ex);
             }
         }
+
+        @Override
+        public String action(String action, Version version) {
+            if (version.before(Version.V_1_4_0)) {
+                String oldActionName = actionNamesMapping.get(action);
+                //custom actions e.g. registered through plugins are not mapped, fallback to the original one
+                if (oldActionName != null) {
+                    return oldActionName;
+                }
+            }
+            return action;
+        }
     }
 
     class TimeoutHandler implements Runnable {
@@ -357,7 +478,6 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
             }
         }
     }
-
 
     static class TimeoutInfoHolder {
 
@@ -427,5 +547,192 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                 timeout.future.cancel(false);
             }
         }
+    }
+
+    private static ImmutableBiMap<String, String> createActionNamesMap() {
+        ImmutableBiMap.Builder<String, String> builder = ImmutableBiMap.builder();
+
+        addNodeAction(NodesRestartAction.NAME, "cluster/nodes/restart", builder);
+        builder.put(NodesShutdownAction.NAME, "cluster/nodes/shutdown");
+        builder.put(TransportNodesShutdownAction.SHUTDOWN_NODE_ACTION_NAME, "/cluster/nodes/shutdown/node");
+
+        builder.put(DeleteRepositoryAction.NAME, "cluster/repository/delete");
+        builder.put(GetRepositoriesAction.NAME, "cluster/repository/get");
+        builder.put(PutRepositoryAction.NAME, "cluster/repository/put");
+
+        builder.put(ClusterRerouteAction.NAME, "cluster/reroute");
+
+        builder.put(ClusterUpdateSettingsAction.NAME, "cluster/settings/update");
+
+        builder.put(CreateSnapshotAction.NAME, "cluster/snapshot/create");
+        builder.put(DeleteSnapshotAction.NAME, "cluster/snapshot/delete");
+        builder.put(GetSnapshotsAction.NAME, "cluster/snapshot/get");
+        builder.put(RestoreSnapshotAction.NAME, "cluster/snapshot/restore");
+
+        builder.put(ClusterHealthAction.NAME, "cluster/health");
+        addNodeAction(NodesHotThreadsAction.NAME, "cluster/nodes/hot_threads", builder);
+        addNodeAction(NodesInfoAction.NAME, "cluster/nodes/info", builder);
+        addNodeAction(NodesStatsAction.NAME, "cluster/nodes/stats", builder);
+
+        builder.put(SnapshotsStatusAction.NAME, "cluster/snapshot/status");
+        addNodeAction(TransportNodesSnapshotsStatus.ACTION_NAME, "cluster/snapshot/status/nodes", builder);
+
+        builder.put(ClusterStateAction.NAME, "cluster/state");
+        addNodeAction(ClusterStatsAction.NAME, "cluster/stats", builder);
+
+        builder.put(PendingClusterTasksAction.NAME, "cluster/task");
+
+        builder.put(IndicesAliasesAction.NAME, "indices/aliases");
+        builder.put(AliasesExistAction.NAME, "indices/exists/aliases");
+        builder.put(GetAliasesAction.NAME, "indices/get/aliases");
+
+        addShardAction(AnalyzeAction.NAME, "indices/analyze", builder);
+        addShardAction(ClearIndicesCacheAction.NAME, "indices/cache/clear", builder);
+
+        builder.put(CloseIndexAction.NAME, "indices/close");
+        builder.put(CreateIndexAction.NAME, "indices/create");
+        builder.put(DeleteIndexAction.NAME, "indices/delete");
+        builder.put(IndicesExistsAction.NAME, "indices/exists");
+        addShardAction(FlushAction.NAME, "indices/flush", builder);
+
+        builder.put(DeleteMappingAction.NAME, "indices/mapping/delete");
+        builder.put(PutMappingAction.NAME, "indices/mapping/put");
+        builder.put(GetFieldMappingsAction.NAME, "mappings/fields/get");
+        builder.put(GetFieldMappingsAction.NAME + "[index]", "mappings/fields/get/index");
+        builder.put(GetFieldMappingsAction.NAME + "[index][s]", "mappings/fields/get/index/s");
+        builder.put(GetMappingsAction.NAME, "mappings/get");
+
+        builder.put(OpenIndexAction.NAME, "indices/open");
+
+        addShardAction(OptimizeAction.NAME, "indices/optimize", builder);
+        addShardAction(RefreshAction.NAME, "indices/refresh", builder);
+        builder.put(UpdateSettingsAction.NAME, "indices/settings/update");
+        builder.put(ClusterSearchShardsAction.NAME, "cluster/shards/search_shards");
+
+        builder.put(DeleteIndexTemplateAction.NAME, "indices/template/delete");
+        builder.put(GetIndexTemplatesAction.NAME, "indices/template/get");
+        builder.put(PutIndexTemplateAction.NAME, "indices/template/put");
+
+        builder.put(TypesExistsAction.NAME, "indices/types/exists");
+        addShardAction(ValidateQueryAction.NAME, "indices/validate/query", builder);
+
+        builder.put(DeleteWarmerAction.NAME, "indices/warmer/delete");
+        builder.put(GetWarmersAction.NAME, "warmers/get");
+        builder.put(PutWarmerAction.NAME, "indices/warmer/put");
+
+        addShardAction(CountAction.NAME, "count", builder);
+        addShardAction(ExplainAction.NAME, "explain", builder);
+        addShardAction(GetAction.NAME, "get", builder);
+        builder.put(MultiGetAction.NAME, "mget");
+        addShardAction(MultiGetAction.NAME + "[shard]", "mget/shard", builder);
+
+        builder.put(GetIndexedScriptAction.NAME, "getIndexedScript");
+        builder.put(PutIndexedScriptAction.NAME, "putIndexedScript");
+        builder.put(DeleteIndexedScriptAction.NAME, "deleteIndexedScript");
+
+        builder.put(MoreLikeThisAction.NAME, "mlt");
+
+        builder.put(MultiPercolateAction.NAME, "mpercolate");
+        addShardAction(MultiPercolateAction.NAME + "[shard]", "mpercolate/shard", builder);
+
+        builder.put(MultiSearchAction.NAME, "msearch");
+
+        builder.put(MultiTermVectorsAction.NAME, "mtv");
+        addShardAction(MultiTermVectorsAction.NAME + "[shard]", "mtv/shard", builder);
+
+        addShardAction(PercolateAction.NAME, "percolate", builder);
+
+        builder.put(SearchScrollAction.NAME, "search/scroll");
+        builder.put(ClearScrollAction.NAME, "clear_sc");
+
+        builder.put(SearchAction.NAME, "search");
+        builder.put(SearchServiceTransportAction.FREE_CONTEXT_ACTION_NAME, "search/freeContext");
+        builder.put(SearchServiceTransportAction.CLEAR_SCROLL_CONTEXTS_ACTION_NAME, "search/clearScrollContexts");
+        builder.put(SearchServiceTransportAction.DFS_ACTION_NAME, "search/phase/dfs");
+        builder.put(SearchServiceTransportAction.QUERY_ACTION_NAME, "search/phase/query");
+        builder.put(SearchServiceTransportAction.QUERY_ID_ACTION_NAME, "search/phase/query/id");
+        builder.put(SearchServiceTransportAction.QUERY_SCROLL_ACTION_NAME, "search/phase/query/scroll");
+        builder.put(SearchServiceTransportAction.QUERY_FETCH_ACTION_NAME, "search/phase/query+fetch");
+        builder.put(SearchServiceTransportAction.QUERY_QUERY_FETCH_ACTION_NAME, "search/phase/query/query+fetch");
+        builder.put(SearchServiceTransportAction.QUERY_FETCH_SCROLL_ACTION_NAME, "search/phase/query+fetch/scroll");
+        builder.put(SearchServiceTransportAction.FETCH_ID_ACTION_NAME, "search/phase/fetch/id");
+        builder.put(SearchServiceTransportAction.SCAN_ACTION_NAME, "search/phase/scan");
+        builder.put(SearchServiceTransportAction.SCAN_SCROLL_ACTION_NAME, "search/phase/scan/scroll");
+
+        addShardAction(SuggestAction.NAME, "suggest", builder);
+        addShardAction(TermVectorAction.NAME, "tv", builder);
+
+        builder.put(BulkAction.NAME, "bulk");
+        builder.put(BulkAction.NAME + "[s]", "bulk/shard");
+        builder.put(BulkAction.NAME + "[s][r]", "bulk/shard/replica");
+
+        builder.put(DeleteAction.NAME, "delete");
+        builder.put(DeleteAction.NAME + "[r]", "delete/replica");
+        builder.put(DeleteAction.NAME + "[index]", "indices/index/delete");
+        builder.put(DeleteAction.NAME + "[s]", "indices/index/b_shard/delete");
+        builder.put(DeleteAction.NAME + "[s][r]", "indices/index/b_shard/delete/replica");
+
+        builder.put(DeleteByQueryAction.NAME, "deleteByQuery");
+        builder.put(DeleteByQueryAction.NAME + "[index]", "deleteByQuery/index");
+        builder.put(DeleteByQueryAction.NAME + "[s]", "deleteByQuery/shard");
+        builder.put(DeleteByQueryAction.NAME + "[s][r]", "deleteByQuery/shard/replica");
+
+        builder.put(IndexAction.NAME, "index");
+        builder.put(IndexAction.NAME + "[r]", "index/replica");
+
+        builder.put(UpdateAction.NAME, "update");
+
+        addShardAction(RecoveryAction.NAME, "indices/recovery", builder);
+        addShardAction(IndicesSegmentsAction.NAME, "indices/segments", builder);
+        addShardAction(IndicesStatsAction.NAME, "indices/stats", builder);
+        addShardAction(IndicesStatusAction.NAME, "indices/status", builder);
+
+        builder.put(GetSettingsAction.NAME, "indices/settings/get");
+
+        builder.put(MappingUpdatedAction.ACTION_NAME, "cluster/mappingUpdated");
+        builder.put(NodeIndexDeletedAction.INDEX_DELETED_ACTION_NAME, "cluster/nodeIndexDeleted");
+        builder.put(NodeIndexDeletedAction.INDEX_STORE_DELETED_ACTION_NAME, "cluster/nodeIndexStoreDeleted");
+        builder.put(NodeMappingRefreshAction.ACTION_NAME, "cluster/nodeMappingRefresh");
+        addNodeAction(TransportNodesListShardStoreMetaData.ACTION_NAME, "/cluster/nodes/indices/shard/store", builder);
+        builder.put(ShardStateAction.SHARD_STARTED_ACTION_NAME, "cluster/shardStarted");
+        builder.put(ShardStateAction.SHARD_FAILED_ACTION_NAME, "cluster/shardFailure");
+        builder.put(RestoreService.UPDATE_RESTORE_ACTION_NAME, "cluster/snapshot/update_restore");
+        builder.put(SnapshotsService.UPDATE_SNAPSHOT_ACTION_NAME, "cluster/snapshot/update_snapshot");
+        builder.put(MasterFaultDetection.MASTER_PING_ACTION_NAME, "discovery/zen/fd/masterPing");
+        builder.put(NodesFaultDetection.PING_ACTION_NAME, "discovery/zen/fd/ping");
+        builder.put(MembershipAction.DISCOVERY_JOIN_ACTION_NAME, "discovery/zen/join");
+        builder.put(ZenDiscovery.DISCOVERY_REJOIN_ACTION_NAME, "discovery/zen/rejoin");
+        builder.put(MembershipAction.DISCOVERY_JOIN_VALIDATE_ACTION_NAME, "discovery/zen/join/validate");
+        builder.put(MembershipAction.DISCOVERY_LEAVE_ACTION_NAME, "discovery/zen/leave");
+        builder.put(MulticastZenPing.ACTION_NAME, "discovery/zen/multicast");
+        builder.put(PublishClusterStateAction.ACTION_NAME, "discovery/zen/publish");
+        builder.put(UnicastZenPing.ACTION_NAME, "discovery/zen/unicast");
+        builder.put(LocalAllocateDangledIndices.ACTION_NAME, "/gateway/local/allocate_dangled");
+        addNodeAction(TransportNodesListGatewayMetaState.ACTION_NAME, "/gateway/local/meta-state", builder);
+        addNodeAction(TransportNodesListGatewayStartedShards.ACTION_NAME, "/gateway/local/started-shards", builder);
+
+        builder.put(RecoveryTarget.Actions.CLEAN_FILES, "index/shard/recovery/cleanFiles");
+        builder.put(RecoveryTarget.Actions.FILE_CHUNK, "index/shard/recovery/fileChunk");
+        builder.put(RecoveryTarget.Actions.FILES_INFO, "index/shard/recovery/filesInfo");
+        builder.put(RecoveryTarget.Actions.FINALIZE, "index/shard/recovery/finalize");
+        builder.put(RecoveryTarget.Actions.PREPARE_TRANSLOG, "index/shard/recovery/prepareTranslog");
+        builder.put(RecoveryTarget.Actions.TRANSLOG_OPS, "index/shard/recovery/translogOps");
+        builder.put(RecoverySource.Actions.START_RECOVERY, "index/shard/recovery/startRecovery");
+
+        builder.put(IndicesStore.ACTION_SHARD_EXISTS, "index/shard/exists");
+
+        builder.put(PublishRiverClusterStateAction.ACTION_NAME, "river/state/publish");
+
+        return builder.build();
+    }
+
+    private static void addNodeAction(String name, String pre_13_name, ImmutableBiMap.Builder<String, String> builder) {
+        builder.put(name, pre_13_name);
+        builder.put(name + "[n]", pre_13_name + "/n");
+    }
+
+    private static void addShardAction(String name, String pre_13_name, ImmutableBiMap.Builder<String, String> builder) {
+        builder.put(name, pre_13_name);
+        builder.put(name + "[s]", pre_13_name + "/s");
     }
 }

--- a/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -19,90 +19,10 @@
 
 package org.elasticsearch.transport;
 
-import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalStateException;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
-import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction;
-import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
-import org.elasticsearch.action.admin.cluster.node.restart.NodesRestartAction;
-import org.elasticsearch.action.admin.cluster.node.shutdown.NodesShutdownAction;
-import org.elasticsearch.action.admin.cluster.node.shutdown.TransportNodesShutdownAction;
-import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
-import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction;
-import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesAction;
-import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryAction;
-import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
-import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
-import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotAction;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
-import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotAction;
-import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusAction;
-import org.elasticsearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
-import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
-import org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction;
-import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksAction;
-import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
-import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistAction;
-import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
-import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
-import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheAction;
-import org.elasticsearch.action.admin.indices.close.CloseIndexAction;
-import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
-import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsAction;
-import org.elasticsearch.action.admin.indices.exists.types.TypesExistsAction;
-import org.elasticsearch.action.admin.indices.flush.FlushAction;
-import org.elasticsearch.action.admin.indices.mapping.delete.DeleteMappingAction;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsAction;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
-import org.elasticsearch.action.admin.indices.open.OpenIndexAction;
-import org.elasticsearch.action.admin.indices.optimize.OptimizeAction;
-import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
-import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
-import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
-import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction;
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
-import org.elasticsearch.action.admin.indices.status.IndicesStatusAction;
-import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
-import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
-import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
-import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryAction;
-import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerAction;
-import org.elasticsearch.action.admin.indices.warmer.get.GetWarmersAction;
-import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerAction;
-import org.elasticsearch.action.bulk.BulkAction;
-import org.elasticsearch.action.count.CountAction;
-import org.elasticsearch.action.delete.DeleteAction;
-import org.elasticsearch.action.deletebyquery.DeleteByQueryAction;
-import org.elasticsearch.action.explain.ExplainAction;
-import org.elasticsearch.action.get.GetAction;
-import org.elasticsearch.action.get.MultiGetAction;
-import org.elasticsearch.action.index.IndexAction;
-import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptAction;
-import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptAction;
-import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptAction;
-import org.elasticsearch.action.mlt.MoreLikeThisAction;
-import org.elasticsearch.action.percolate.MultiPercolateAction;
-import org.elasticsearch.action.percolate.PercolateAction;
-import org.elasticsearch.action.search.ClearScrollAction;
-import org.elasticsearch.action.search.MultiSearchAction;
-import org.elasticsearch.action.search.SearchAction;
-import org.elasticsearch.action.search.SearchScrollAction;
-import org.elasticsearch.action.suggest.SuggestAction;
-import org.elasticsearch.action.termvector.MultiTermVectorsAction;
-import org.elasticsearch.action.termvector.TermVectorAction;
-import org.elasticsearch.action.update.UpdateAction;
-import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
-import org.elasticsearch.cluster.action.index.NodeIndexDeletedAction;
-import org.elasticsearch.cluster.action.index.NodeMappingRefreshAction;
-import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -114,24 +34,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.discovery.zen.ZenDiscovery;
-import org.elasticsearch.discovery.zen.fd.MasterFaultDetection;
-import org.elasticsearch.discovery.zen.fd.NodesFaultDetection;
-import org.elasticsearch.discovery.zen.membership.MembershipAction;
-import org.elasticsearch.discovery.zen.ping.multicast.MulticastZenPing;
-import org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing;
-import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
-import org.elasticsearch.gateway.local.state.meta.LocalAllocateDangledIndices;
-import org.elasticsearch.gateway.local.state.meta.TransportNodesListGatewayMetaState;
-import org.elasticsearch.gateway.local.state.shards.TransportNodesListGatewayStartedShards;
-import org.elasticsearch.indices.recovery.RecoverySource;
-import org.elasticsearch.indices.recovery.RecoveryTarget;
-import org.elasticsearch.indices.store.IndicesStore;
-import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
-import org.elasticsearch.river.cluster.PublishRiverClusterStateAction;
-import org.elasticsearch.search.action.SearchServiceTransportAction;
-import org.elasticsearch.snapshots.RestoreService;
-import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
@@ -147,8 +49,6 @@ import static org.elasticsearch.common.settings.ImmutableSettings.Builder.EMPTY_
  *
  */
 public class TransportService extends AbstractLifecycleComponent<TransportService> {
-
-    final ImmutableBiMap<String, String> actionNamesMapping;
 
     protected final Transport transport;
     protected final ThreadPool threadPool;
@@ -181,7 +81,6 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         super(settings);
         this.transport = transport;
         this.threadPool = threadPool;
-        this.actionNamesMapping = createActionNamesMap();
     }
 
     @Override
@@ -363,14 +262,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
 
         @Override
         public TransportRequestHandler handler(String action, Version version) {
-            if (version.before(Version.V_1_4_0)) {
-                String newActionName = actionNamesMapping.inverse().get(action);
-                //custom action e.g. registered through plugin are not mapped, fallback to the original action
-                if (newActionName != null) {
-                    return serverHandlers.get(newActionName);
-                }
-            }
-            return serverHandlers.get(action);
+            return serverHandlers.get(ActionNames.incomingAction(action, version));
         }
 
         @Override
@@ -437,14 +329,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
 
         @Override
         public String action(String action, Version version) {
-            if (version.before(Version.V_1_4_0)) {
-                String oldActionName = actionNamesMapping.get(action);
-                //custom actions e.g. registered through plugins are not mapped, fallback to the original one
-                if (oldActionName != null) {
-                    return oldActionName;
-                }
-            }
-            return action;
+            return ActionNames.outgoingAction(action, version);
         }
     }
 
@@ -547,192 +432,5 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                 timeout.future.cancel(false);
             }
         }
-    }
-
-    private static ImmutableBiMap<String, String> createActionNamesMap() {
-        ImmutableBiMap.Builder<String, String> builder = ImmutableBiMap.builder();
-
-        addNodeAction(NodesRestartAction.NAME, "cluster/nodes/restart", builder);
-        builder.put(NodesShutdownAction.NAME, "cluster/nodes/shutdown");
-        builder.put(TransportNodesShutdownAction.SHUTDOWN_NODE_ACTION_NAME, "/cluster/nodes/shutdown/node");
-
-        builder.put(DeleteRepositoryAction.NAME, "cluster/repository/delete");
-        builder.put(GetRepositoriesAction.NAME, "cluster/repository/get");
-        builder.put(PutRepositoryAction.NAME, "cluster/repository/put");
-
-        builder.put(ClusterRerouteAction.NAME, "cluster/reroute");
-
-        builder.put(ClusterUpdateSettingsAction.NAME, "cluster/settings/update");
-
-        builder.put(CreateSnapshotAction.NAME, "cluster/snapshot/create");
-        builder.put(DeleteSnapshotAction.NAME, "cluster/snapshot/delete");
-        builder.put(GetSnapshotsAction.NAME, "cluster/snapshot/get");
-        builder.put(RestoreSnapshotAction.NAME, "cluster/snapshot/restore");
-
-        builder.put(ClusterHealthAction.NAME, "cluster/health");
-        addNodeAction(NodesHotThreadsAction.NAME, "cluster/nodes/hot_threads", builder);
-        addNodeAction(NodesInfoAction.NAME, "cluster/nodes/info", builder);
-        addNodeAction(NodesStatsAction.NAME, "cluster/nodes/stats", builder);
-
-        builder.put(SnapshotsStatusAction.NAME, "cluster/snapshot/status");
-        addNodeAction(TransportNodesSnapshotsStatus.ACTION_NAME, "cluster/snapshot/status/nodes", builder);
-
-        builder.put(ClusterStateAction.NAME, "cluster/state");
-        addNodeAction(ClusterStatsAction.NAME, "cluster/stats", builder);
-
-        builder.put(PendingClusterTasksAction.NAME, "cluster/task");
-
-        builder.put(IndicesAliasesAction.NAME, "indices/aliases");
-        builder.put(AliasesExistAction.NAME, "indices/exists/aliases");
-        builder.put(GetAliasesAction.NAME, "indices/get/aliases");
-
-        addShardAction(AnalyzeAction.NAME, "indices/analyze", builder);
-        addShardAction(ClearIndicesCacheAction.NAME, "indices/cache/clear", builder);
-
-        builder.put(CloseIndexAction.NAME, "indices/close");
-        builder.put(CreateIndexAction.NAME, "indices/create");
-        builder.put(DeleteIndexAction.NAME, "indices/delete");
-        builder.put(IndicesExistsAction.NAME, "indices/exists");
-        addShardAction(FlushAction.NAME, "indices/flush", builder);
-
-        builder.put(DeleteMappingAction.NAME, "indices/mapping/delete");
-        builder.put(PutMappingAction.NAME, "indices/mapping/put");
-        builder.put(GetFieldMappingsAction.NAME, "mappings/fields/get");
-        builder.put(GetFieldMappingsAction.NAME + "[index]", "mappings/fields/get/index");
-        builder.put(GetFieldMappingsAction.NAME + "[index][s]", "mappings/fields/get/index/s");
-        builder.put(GetMappingsAction.NAME, "mappings/get");
-
-        builder.put(OpenIndexAction.NAME, "indices/open");
-
-        addShardAction(OptimizeAction.NAME, "indices/optimize", builder);
-        addShardAction(RefreshAction.NAME, "indices/refresh", builder);
-        builder.put(UpdateSettingsAction.NAME, "indices/settings/update");
-        builder.put(ClusterSearchShardsAction.NAME, "cluster/shards/search_shards");
-
-        builder.put(DeleteIndexTemplateAction.NAME, "indices/template/delete");
-        builder.put(GetIndexTemplatesAction.NAME, "indices/template/get");
-        builder.put(PutIndexTemplateAction.NAME, "indices/template/put");
-
-        builder.put(TypesExistsAction.NAME, "indices/types/exists");
-        addShardAction(ValidateQueryAction.NAME, "indices/validate/query", builder);
-
-        builder.put(DeleteWarmerAction.NAME, "indices/warmer/delete");
-        builder.put(GetWarmersAction.NAME, "warmers/get");
-        builder.put(PutWarmerAction.NAME, "indices/warmer/put");
-
-        addShardAction(CountAction.NAME, "count", builder);
-        addShardAction(ExplainAction.NAME, "explain", builder);
-        addShardAction(GetAction.NAME, "get", builder);
-        builder.put(MultiGetAction.NAME, "mget");
-        addShardAction(MultiGetAction.NAME + "[shard]", "mget/shard", builder);
-
-        builder.put(GetIndexedScriptAction.NAME, "getIndexedScript");
-        builder.put(PutIndexedScriptAction.NAME, "putIndexedScript");
-        builder.put(DeleteIndexedScriptAction.NAME, "deleteIndexedScript");
-
-        builder.put(MoreLikeThisAction.NAME, "mlt");
-
-        builder.put(MultiPercolateAction.NAME, "mpercolate");
-        addShardAction(MultiPercolateAction.NAME + "[shard]", "mpercolate/shard", builder);
-
-        builder.put(MultiSearchAction.NAME, "msearch");
-
-        builder.put(MultiTermVectorsAction.NAME, "mtv");
-        addShardAction(MultiTermVectorsAction.NAME + "[shard]", "mtv/shard", builder);
-
-        addShardAction(PercolateAction.NAME, "percolate", builder);
-
-        builder.put(SearchScrollAction.NAME, "search/scroll");
-        builder.put(ClearScrollAction.NAME, "clear_sc");
-
-        builder.put(SearchAction.NAME, "search");
-        builder.put(SearchServiceTransportAction.FREE_CONTEXT_ACTION_NAME, "search/freeContext");
-        builder.put(SearchServiceTransportAction.CLEAR_SCROLL_CONTEXTS_ACTION_NAME, "search/clearScrollContexts");
-        builder.put(SearchServiceTransportAction.DFS_ACTION_NAME, "search/phase/dfs");
-        builder.put(SearchServiceTransportAction.QUERY_ACTION_NAME, "search/phase/query");
-        builder.put(SearchServiceTransportAction.QUERY_ID_ACTION_NAME, "search/phase/query/id");
-        builder.put(SearchServiceTransportAction.QUERY_SCROLL_ACTION_NAME, "search/phase/query/scroll");
-        builder.put(SearchServiceTransportAction.QUERY_FETCH_ACTION_NAME, "search/phase/query+fetch");
-        builder.put(SearchServiceTransportAction.QUERY_QUERY_FETCH_ACTION_NAME, "search/phase/query/query+fetch");
-        builder.put(SearchServiceTransportAction.QUERY_FETCH_SCROLL_ACTION_NAME, "search/phase/query+fetch/scroll");
-        builder.put(SearchServiceTransportAction.FETCH_ID_ACTION_NAME, "search/phase/fetch/id");
-        builder.put(SearchServiceTransportAction.SCAN_ACTION_NAME, "search/phase/scan");
-        builder.put(SearchServiceTransportAction.SCAN_SCROLL_ACTION_NAME, "search/phase/scan/scroll");
-
-        addShardAction(SuggestAction.NAME, "suggest", builder);
-        addShardAction(TermVectorAction.NAME, "tv", builder);
-
-        builder.put(BulkAction.NAME, "bulk");
-        builder.put(BulkAction.NAME + "[s]", "bulk/shard");
-        builder.put(BulkAction.NAME + "[s][r]", "bulk/shard/replica");
-
-        builder.put(DeleteAction.NAME, "delete");
-        builder.put(DeleteAction.NAME + "[r]", "delete/replica");
-        builder.put(DeleteAction.NAME + "[index]", "indices/index/delete");
-        builder.put(DeleteAction.NAME + "[s]", "indices/index/b_shard/delete");
-        builder.put(DeleteAction.NAME + "[s][r]", "indices/index/b_shard/delete/replica");
-
-        builder.put(DeleteByQueryAction.NAME, "deleteByQuery");
-        builder.put(DeleteByQueryAction.NAME + "[index]", "deleteByQuery/index");
-        builder.put(DeleteByQueryAction.NAME + "[s]", "deleteByQuery/shard");
-        builder.put(DeleteByQueryAction.NAME + "[s][r]", "deleteByQuery/shard/replica");
-
-        builder.put(IndexAction.NAME, "index");
-        builder.put(IndexAction.NAME + "[r]", "index/replica");
-
-        builder.put(UpdateAction.NAME, "update");
-
-        addShardAction(RecoveryAction.NAME, "indices/recovery", builder);
-        addShardAction(IndicesSegmentsAction.NAME, "indices/segments", builder);
-        addShardAction(IndicesStatsAction.NAME, "indices/stats", builder);
-        addShardAction(IndicesStatusAction.NAME, "indices/status", builder);
-
-        builder.put(GetSettingsAction.NAME, "indices/settings/get");
-
-        builder.put(MappingUpdatedAction.ACTION_NAME, "cluster/mappingUpdated");
-        builder.put(NodeIndexDeletedAction.INDEX_DELETED_ACTION_NAME, "cluster/nodeIndexDeleted");
-        builder.put(NodeIndexDeletedAction.INDEX_STORE_DELETED_ACTION_NAME, "cluster/nodeIndexStoreDeleted");
-        builder.put(NodeMappingRefreshAction.ACTION_NAME, "cluster/nodeMappingRefresh");
-        addNodeAction(TransportNodesListShardStoreMetaData.ACTION_NAME, "/cluster/nodes/indices/shard/store", builder);
-        builder.put(ShardStateAction.SHARD_STARTED_ACTION_NAME, "cluster/shardStarted");
-        builder.put(ShardStateAction.SHARD_FAILED_ACTION_NAME, "cluster/shardFailure");
-        builder.put(RestoreService.UPDATE_RESTORE_ACTION_NAME, "cluster/snapshot/update_restore");
-        builder.put(SnapshotsService.UPDATE_SNAPSHOT_ACTION_NAME, "cluster/snapshot/update_snapshot");
-        builder.put(MasterFaultDetection.MASTER_PING_ACTION_NAME, "discovery/zen/fd/masterPing");
-        builder.put(NodesFaultDetection.PING_ACTION_NAME, "discovery/zen/fd/ping");
-        builder.put(MembershipAction.DISCOVERY_JOIN_ACTION_NAME, "discovery/zen/join");
-        builder.put(ZenDiscovery.DISCOVERY_REJOIN_ACTION_NAME, "discovery/zen/rejoin");
-        builder.put(MembershipAction.DISCOVERY_JOIN_VALIDATE_ACTION_NAME, "discovery/zen/join/validate");
-        builder.put(MembershipAction.DISCOVERY_LEAVE_ACTION_NAME, "discovery/zen/leave");
-        builder.put(MulticastZenPing.ACTION_NAME, "discovery/zen/multicast");
-        builder.put(PublishClusterStateAction.ACTION_NAME, "discovery/zen/publish");
-        builder.put(UnicastZenPing.ACTION_NAME, "discovery/zen/unicast");
-        builder.put(LocalAllocateDangledIndices.ACTION_NAME, "/gateway/local/allocate_dangled");
-        addNodeAction(TransportNodesListGatewayMetaState.ACTION_NAME, "/gateway/local/meta-state", builder);
-        addNodeAction(TransportNodesListGatewayStartedShards.ACTION_NAME, "/gateway/local/started-shards", builder);
-
-        builder.put(RecoveryTarget.Actions.CLEAN_FILES, "index/shard/recovery/cleanFiles");
-        builder.put(RecoveryTarget.Actions.FILE_CHUNK, "index/shard/recovery/fileChunk");
-        builder.put(RecoveryTarget.Actions.FILES_INFO, "index/shard/recovery/filesInfo");
-        builder.put(RecoveryTarget.Actions.FINALIZE, "index/shard/recovery/finalize");
-        builder.put(RecoveryTarget.Actions.PREPARE_TRANSLOG, "index/shard/recovery/prepareTranslog");
-        builder.put(RecoveryTarget.Actions.TRANSLOG_OPS, "index/shard/recovery/translogOps");
-        builder.put(RecoverySource.Actions.START_RECOVERY, "index/shard/recovery/startRecovery");
-
-        builder.put(IndicesStore.ACTION_SHARD_EXISTS, "index/shard/exists");
-
-        builder.put(PublishRiverClusterStateAction.ACTION_NAME, "river/state/publish");
-
-        return builder.build();
-    }
-
-    private static void addNodeAction(String name, String pre_13_name, ImmutableBiMap.Builder<String, String> builder) {
-        builder.put(name, pre_13_name);
-        builder.put(name + "[n]", pre_13_name + "/n");
-    }
-
-    private static void addShardAction(String name, String pre_13_name, ImmutableBiMap.Builder<String, String> builder) {
-        builder.put(name, pre_13_name);
-        builder.put(name + "[s]", pre_13_name + "/s");
     }
 }

--- a/src/main/java/org/elasticsearch/transport/TransportServiceAdapter.java
+++ b/src/main/java/org/elasticsearch/transport/TransportServiceAdapter.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 
 /**
@@ -30,11 +31,13 @@ public interface TransportServiceAdapter {
 
     void sent(long size);
 
-    TransportRequestHandler handler(String action);
+    TransportRequestHandler handler(String action, Version version);
 
     TransportResponseHandler remove(long requestId);
 
     void raiseNodeConnected(DiscoveryNode node);
 
     void raiseNodeDisconnected(DiscoveryNode node);
+
+    String action(String action, Version version);
 }

--- a/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -171,7 +171,7 @@ public class LocalTransport extends AbstractLifecycleComponent<Transport> implem
         status = TransportStatus.setRequest(status);
         stream.writeByte(status); // 0 for request, 1 for response.
 
-        stream.writeString(action);
+        stream.writeString(transportServiceAdapter.action(action, version));
         request.writeTo(stream);
 
         stream.close();
@@ -237,7 +237,7 @@ public class LocalTransport extends AbstractLifecycleComponent<Transport> implem
         final String action = stream.readString();
         final LocalTransportChannel transportChannel = new LocalTransportChannel(this, sourceTransport, action, requestId, version);
         try {
-            final TransportRequestHandler handler = transportServiceAdapter.handler(action);
+            final TransportRequestHandler handler = transportServiceAdapter.handler(action, version);
             if (handler == null) {
                 throw new ActionNotFoundTransportException("Action [" + action + "] not found");
             }

--- a/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
+++ b/src/main/java/org/elasticsearch/transport/netty/MessageChannelHandler.java
@@ -205,7 +205,7 @@ public class MessageChannelHandler extends SimpleChannelUpstreamHandler {
 
         final NettyTransportChannel transportChannel = new NettyTransportChannel(transport, action, channel, requestId, version);
         try {
-            final TransportRequestHandler handler = transportServiceAdapter.handler(action);
+            final TransportRequestHandler handler = transportServiceAdapter.handler(action, version);
             if (handler == null) {
                 throw new ActionNotFoundTransportException(action);
             }

--- a/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -56,7 +56,6 @@ import org.elasticsearch.transport.support.TransportStatus;
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.CompositeChannelBuffer;
 import org.jboss.netty.channel.*;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
@@ -507,6 +506,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
 
     @Override
     public void sendRequest(final DiscoveryNode node, final long requestId, final String action, final TransportRequest request, TransportRequestOptions options) throws IOException, TransportException {
+
         Channel targetChannel = nodeChannel(node, options);
 
         if (compress) {
@@ -535,7 +535,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
             Version version = Version.smallest(this.version, node.version());
 
             stream.setVersion(version);
-            stream.writeString(action);
+            stream.writeString(transportServiceAdapter.action(action, version));
 
             ReleasableBytesReference bytes;
             ChannelBuffer buffer;

--- a/src/test/java/org/elasticsearch/bwcompat/ActionNamesBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/ActionNamesBackwardsCompatibilityTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bwcompat;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.bench.AbortBenchmarkAction;
+import org.elasticsearch.action.bench.BenchmarkAction;
+import org.elasticsearch.action.bench.BenchmarkService;
+import org.elasticsearch.action.bench.BenchmarkStatusAction;
+import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptAction;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.indices.store.IndicesStore;
+import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.*;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.*;
+
+public class ActionNamesBackwardsCompatibilityTest extends ElasticsearchBackwardsCompatIntegrationTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTransportHandlers() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+        InternalTestCluster internalCluster = backwardsCluster().internalCluster();
+        TransportService transportService = internalCluster.getInstance(TransportService.class);
+        Field field = transportService.getClass().getDeclaredField("serverHandlers");
+        field.setAccessible(true);
+        ImmutableMap<String, TransportRequestHandler> requestHandlers = (ImmutableMap<String, TransportRequestHandler>) field.get(transportService);
+
+        DiscoveryNodes nodes = client().admin().cluster().prepareState().get().getState().nodes();
+
+        DiscoveryNode selectedNode = null;
+        for (DiscoveryNode node : nodes) {
+            if (node.getVersion().before(Version.CURRENT)) {
+                selectedNode = node;
+                break;
+            }
+        }
+        assertThat(selectedNode, notNullValue());
+
+        final TransportRequest transportRequest = new TransportRequest() {};
+
+        for (String action : requestHandlers.keySet()) {
+
+            final CountDownLatch latch = new CountDownLatch(1);
+            final AtomicReference<TransportException> failure = new AtomicReference<>();
+            transportService.sendRequest(selectedNode, action, transportRequest, new TransportResponseHandler<TransportResponse>() {
+                @Override
+                public TransportResponse newInstance() {
+                    return new TransportResponse() {};
+                }
+
+                @Override
+                public void handleResponse(TransportResponse response) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    failure.set(exp);
+                    latch.countDown();
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.SAME;
+                }
+            });
+            assertThat(latch.await(5, TimeUnit.SECONDS), equalTo(true));
+
+            if (failure.get() != null) {
+                Throwable cause = failure.get().unwrapCause();
+                if (isActionNotFoundExpected(selectedNode.version(), action)) {
+                    assertThat(cause, instanceOf(ActionNotFoundTransportException.class));
+                } else {
+                    assertThat(cause, not(instanceOf(ActionNotFoundTransportException.class)));
+                    if (! (cause instanceof IndexOutOfBoundsException)) {
+                        cause.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isActionNotFoundExpected(Version version, String action) {
+        Version actionVersion = actionsVersions.get(action);
+        return actionVersion != null && version.before(actionVersion);
+    }
+
+    private static final Map<String, Version> actionsVersions = new HashMap<>();
+
+    static {
+        actionsVersions.put(BenchmarkService.STATUS_ACTION_NAME, Version.V_1_4_0);
+        actionsVersions.put(BenchmarkService.START_ACTION_NAME, Version.V_1_4_0);
+        actionsVersions.put(BenchmarkService.ABORT_ACTION_NAME, Version.V_1_4_0);
+        actionsVersions.put(BenchmarkAction.NAME, Version.V_1_4_0);
+        actionsVersions.put(BenchmarkStatusAction.NAME, Version.V_1_4_0);
+        actionsVersions.put(AbortBenchmarkAction.NAME, Version.V_1_4_0);
+
+        actionsVersions.put(IndicesStore.ACTION_SHARD_EXISTS, Version.V_1_3_0);
+
+        actionsVersions.put(GetIndexedScriptAction.NAME, Version.V_1_3_0);
+        actionsVersions.put(DeleteIndexedScriptAction.NAME, Version.V_1_3_0);
+        actionsVersions.put(PutIndexedScriptAction.NAME, Version.V_1_3_0);
+
+    }
+}

--- a/src/test/java/org/elasticsearch/bwcompat/TransportClientBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/TransportClientBackwardsCompatibilityTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bwcompat;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.CompositeTestCluster;
+import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class TransportClientBackwardsCompatibilityTest extends ElasticsearchBackwardsCompatIntegrationTest {
+
+    @Test
+    public void testSniffMode() throws ExecutionException, InterruptedException {
+
+        Settings settings = ImmutableSettings.builder().put("client.transport.nodes_sampler_interval", "1s")
+                .put("name", "transport_client_sniff_mode").put(ClusterName.SETTING, cluster().getClusterName())
+                .put("client.transport.sniff", true).build();
+
+        CompositeTestCluster compositeTestCluster = backwardsCluster();
+        TransportAddress transportAddress = compositeTestCluster.externalTransportAddress();
+
+        try(TransportClient client = new TransportClient(settings)) {
+            client.addTransportAddress(transportAddress);
+
+            assertAcked(client.admin().indices().prepareCreate("test"));
+            ensureYellow("test");
+
+            int numDocs = iterations(10, 100);
+            IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
+            for (int i = 0; i < numDocs; i++) {
+                String id = "id" + i;
+                indexRequestBuilders[i] = client.prepareIndex("test", "test", id).setSource("field", "value" + i);
+            }
+            indexRandom(false, indexRequestBuilders);
+
+            String randomId = "id" + randomInt(numDocs-1);
+            GetResponse getResponse = client.prepareGet("test", "test", randomId).get();
+            assertThat(getResponse.isExists(), equalTo(true));
+
+            refresh();
+
+            SearchResponse searchResponse = client.prepareSearch("test").get();
+            assertThat(searchResponse.getHits().totalHits(), equalTo((long)numDocs));
+
+            int randomDocId = randomInt(numDocs-1);
+            String fieldValue = "value" + randomDocId;
+            String id = "id" + randomDocId;
+            searchResponse = client.prepareSearch("test").setQuery(QueryBuilders.termQuery("field", fieldValue)).get();
+            assertSearchHits(searchResponse, id);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/bwcompat/UnicastBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/bwcompat/UnicastBackwardsCompatibilityTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bwcompat;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class UnicastBackwardsCompatibilityTest extends ElasticsearchBackwardsCompatIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder()
+                .put("discovery.zen.ping.multicast.enabled", false)
+                .put("discovery.zen.ping.unicast.hosts", "localhost")
+                .put(super.nodeSettings(nodeOrdinal))
+                .build();
+    }
+
+    @Override
+    protected Settings externalNodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("discovery.zen.ping.multicast.enabled", false)
+                .put("discovery.zen.ping.unicast.hosts", "localhost")
+                .put(super.nodeSettings(nodeOrdinal))
+                .build();
+    }
+
+    @Test
+    public void testUnicastDiscovery() {
+        for (Client client : clients()) {
+            ClusterState state = client.admin().cluster().prepareState().setLocal(true).get().getState();
+            int dataNodes = 0;
+            for (DiscoveryNode discoveryNode : state.nodes()) {
+                if (discoveryNode.isDataNode()) {
+                    dataNodes++;
+                }
+            }
+            assertThat(dataNodes, equalTo(cluster().numDataNodes()));
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/index/TransportIndexFailuresTest.java
+++ b/src/test/java/org/elasticsearch/index/TransportIndexFailuresTest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -112,12 +113,12 @@ public class TransportIndexFailuresTest extends ElasticsearchIntegrationTest {
         TransportService mockTransportService = internalCluster().getInstance(TransportService.class, primaryNode);
         ((MockTransportService) mockTransportService).addFailToSendNoConnectRule(
                 internalCluster().getInstance(Discovery.class, replicaNode).localNode(),
-                ImmutableSet.of("index/replica")
+                ImmutableSet.of(IndexAction.NAME + "[r]")
         );
         mockTransportService = internalCluster().getInstance(TransportService.class, replicaNode);
         ((MockTransportService) mockTransportService).addFailToSendNoConnectRule(
                 internalCluster().getInstance(Discovery.class, primaryNode).localNode(),
-                ImmutableSet.of("index/replica")
+                ImmutableSet.of(IndexAction.NAME + "[r]")
         );
 
         logger.info("--> indexing into primary");

--- a/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -32,6 +32,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -247,6 +248,11 @@ public class CompositeTestCluster extends TestCluster {
     }
 
     @Override
+    public String getClusterName() {
+        return cluster.getClusterName();
+    }
+
+    @Override
     public synchronized Iterator<Client> iterator() {
         return Iterators.singletonIterator(client());
     }
@@ -270,6 +276,14 @@ public class CompositeTestCluster extends TestCluster {
      */
     public int numBackwardsDataNodes() {
         return runningNodes().size();
+    }
+
+    public TransportAddress externalTransportAddress() {
+        return RandomPicks.randomFrom(random, externalNodes).getTransportAddress();
+    }
+
+    public InternalTestCluster internalCluster() {
+        return cluster;
     }
 
     private synchronized Client internalClient() {

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -158,13 +158,6 @@ final class ExternalNode implements Closeable {
         return nodeInfo.getTransport().getAddress().publishAddress();
     }
 
-    TransportAddress address() {
-        if (nodeInfo == null) {
-            throw new IllegalStateException("Node has not started yet");
-        }
-        return nodeInfo.getTransport().getAddress().publishAddress();
-    }
-
     synchronized Client getClient() {
         if (nodeInfo == null) {
             throw new IllegalStateException("Node has not started yet");

--- a/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -53,6 +53,8 @@ public final class ExternalTestCluster extends TestCluster {
 
     private final InetSocketAddress[] httpAddresses;
 
+    private final String clusterName;
+
     private final int numDataNodes;
     private final int numBenchNodes;
 
@@ -64,6 +66,7 @@ public final class ExternalTestCluster extends TestCluster {
 
         NodesInfoResponse nodeInfos = this.client.admin().cluster().prepareNodesInfo().clear().setSettings(true).setHttp(true).get();
         httpAddresses = new InetSocketAddress[nodeInfos.getNodes().length];
+        this.clusterName = nodeInfos.getClusterName().value();
         int dataNodes = 0;
         int benchNodes = 0;
         for (int i = 0; i < nodeInfos.getNodes().length; i++) {
@@ -142,5 +145,10 @@ public final class ExternalTestCluster extends TestCluster {
     @Override
     public boolean hasFilterCache() {
         return true; // default
+    }
+
+    @Override
+    public String getClusterName() {
+        return clusterName;
     }
 }

--- a/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -282,6 +282,7 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
+    @Override
     public String getClusterName() {
         return clusterName;
     }

--- a/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -193,4 +193,8 @@ public abstract class TestCluster implements Iterable<Client>, Closeable {
      */
     public abstract boolean hasFilterCache();
 
+    /**
+     * Returns the cluster name
+     */
+    public abstract String getClusterName();
 }

--- a/src/test/java/org/elasticsearch/test/transport/ConfigurableErrorNettyTransportModule.java
+++ b/src/test/java/org/elasticsearch/test/transport/ConfigurableErrorNettyTransportModule.java
@@ -88,7 +88,7 @@ public class ConfigurableErrorNettyTransportModule extends AbstractModule {
 
                         final NettyTransportChannel transportChannel = new NettyTransportChannel(transport, action, channel, requestId, version);
                         try {
-                            final TransportRequestHandler handler = transportServiceAdapter.handler(action);
+                            final TransportRequestHandler handler = transportServiceAdapter.handler(action, version);
                             if (handler == null) {
                                 throw new ActionNotFoundTransportException(action);
                             }

--- a/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesBackwardsCompatibilityTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.bwcompat;
+package org.elasticsearch.transport;
 
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
@@ -34,10 +34,8 @@ import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.test.ElasticsearchBackwardsCompatIntegrationTest;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.*;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -53,9 +51,7 @@ public class ActionNamesBackwardsCompatibilityTest extends ElasticsearchBackward
     public void testTransportHandlers() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
         InternalTestCluster internalCluster = backwardsCluster().internalCluster();
         TransportService transportService = internalCluster.getInstance(TransportService.class);
-        Field field = transportService.getClass().getDeclaredField("serverHandlers");
-        field.setAccessible(true);
-        ImmutableMap<String, TransportRequestHandler> requestHandlers = (ImmutableMap<String, TransportRequestHandler>) field.get(transportService);
+        ImmutableMap<String, TransportRequestHandler> requestHandlers = transportService.serverHandlers;
 
         DiscoveryNodes nodes = client().admin().cluster().prepareState().get().getState().nodes();
 

--- a/src/test/java/org/elasticsearch/transport/ActionNamesTests.java
+++ b/src/test/java/org/elasticsearch/transport/ActionNamesTests.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.action.bench.AbortBenchmarkAction;
+import org.elasticsearch.action.bench.BenchmarkAction;
+import org.elasticsearch.action.bench.BenchmarkService;
+import org.elasticsearch.action.bench.BenchmarkStatusAction;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.*;
+
+public class ActionNamesTests extends ElasticsearchIntegrationTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testActionNamesCategories() throws NoSuchFieldException, IllegalAccessException {
+        TransportService transportService = internalCluster().getInstance(TransportService.class);
+        for (String action : transportService.serverHandlers.keySet()) {
+            assertThat("action doesn't belong to known category", action, either(startsWith("indices:admin")).or(startsWith("indices:monitor"))
+                    .or(startsWith("indices:data/read")).or(startsWith("indices:data/write"))
+                    .or(startsWith("indices:data/benchmark"))
+                    .or(startsWith("cluster:admin")).or(startsWith("cluster:monitor"))
+                    .or(startsWith("internal:")));
+        }
+    }
+
+    @Test
+    public void testActionNamesMapping() {
+        TransportService transportService = internalCluster().getInstance(TransportService.class);
+        for (String action : transportService.serverHandlers.keySet()) {
+            if (post_1_3_actions.contains(action)) {
+                continue;
+            }
+            String oldName = transportService.actionNamesMapping.get(action);
+            assertThat("no pre 1.4 name for action " + action, oldName, notNullValue());
+            String newName = transportService.actionNamesMapping.inverse().get(oldName);
+            assertThat(newName, equalTo(action));
+        }
+    }
+
+    private static final Set<String> post_1_3_actions = new HashSet<>();
+
+    static {
+        //add here new actions that don't need a mapping as they weren't available prior to 1.4
+        post_1_3_actions.add(BenchmarkService.STATUS_ACTION_NAME);
+        post_1_3_actions.add(BenchmarkService.START_ACTION_NAME);
+        post_1_3_actions.add(BenchmarkService.ABORT_ACTION_NAME);
+        post_1_3_actions.add(BenchmarkAction.NAME);
+        post_1_3_actions.add(BenchmarkStatusAction.NAME);
+        post_1_3_actions.add(AbortBenchmarkAction.NAME);
+    }
+}


### PR DESCRIPTION
Our transport relies on action names that tell what we need to do with each message received and sent on any node, together with the content of the request itself.
The action names could use a better categorization and more consistent naming though, the following are the categories introduced with this commit:
- `indices`: for all the apis that execute against indices
  - `admin`: for the apis that allow to perform administration tasks against indices
  - `data`: for the apis that are about data
    - `read`: apis that read data
    - `write`: apis that write data
    - `benchmark`: apis that run benchmarks
- `cluster`: for all the cluster apis
  - `admin`: for the cluster apis that allow to perform administration tasks
  - `monitor`: for the cluster apis that allow to monitor the system
- `internal`: for all the internal actions that are used from node to node but not directly exposed to users

The change is applied in a backwards compatible manner: we keep the mapping old-to-new action name around, and when receiving a message, depending on the version of the node we receive it from, we use the received action name or we convert it to the previous version (old to new if version < 1.4). When sending a message, depending on the version of the node we talk to, we use the updated action or we convert it to the previous version (new to old if version < 1.4).
For the cases where we don't know the version of the node we talk to, namely unicast ping, transport client nodes info and transport client sniff mode (which calls cluster state), we just use a lower bound for the version, thus we will always use the old action name, which can be understood by both old nodes and new nodes.

Added test that enforces known updated categories for transport action names and test that verifies all action names have a pre 1.4 version for bw compatibility

Added backwards compatibility tests for unicast and transport client in sniff mode, the one for the ordinary transport client (that call nodes info) is implicit as it's used all the time in our bw comp tests.
Added also backwards comp test that sends an empty message to any of the registered transport handler exposed by older nodes and verifies that what gets back is not `ActionNotFoundTransportException`, which would mean that there is a problem in the actions mappings.

Added `TestCluster#getClusterName` abstract method and allow to retrieve externalTransportAddress and internalCluster from `CompositeTestCluster`.
