### PR TITLE
Cache range filter on date field by default

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/RangeFilterParser.java
@@ -125,10 +125,10 @@ public class RangeFilterParser implements FilterParser {
         }
 
         Filter filter = null;
+        Boolean explicitlyCached = cache;
         MapperService.SmartNameFieldMappers smartNameFieldMappers = parseContext.smartFieldMappers(fieldName);
         if (smartNameFieldMappers != null) {
             if (smartNameFieldMappers.hasMapper()) {
-                boolean explicitlyCached = cache != null && cache;
                 if (execution.equals("index")) {
                     if (cache == null) {
                         cache = true;
@@ -177,8 +177,10 @@ public class RangeFilterParser implements FilterParser {
             filter = new TermRangeFilter(fieldName, BytesRefs.toBytesRef(from), BytesRefs.toBytesRef(to), includeLower, includeUpper);
         }
 
-        if (cache) {
-            filter = parseContext.cacheFilter(filter, cacheKey);
+        if (explicitlyCached == null || explicitlyCached) {
+            if (cache) {
+                filter = parseContext.cacheFilter(filter, cacheKey);
+            }
         }
 
         filter = wrapSmartNameFilter(filter, smartNameFieldMappers, parseContext);

--- a/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_with_long_value.json
+++ b/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_with_long_value.json
@@ -2,7 +2,6 @@
     "constant_score": {
         "filter": {
             "bool": {
-                "_cache" : true,
                 "must": [
                     {
                         "term": {
@@ -14,8 +13,8 @@
                     {
                         "range" : {
                             "born" : {
-                                "gte": "2012-01-01",
-                                "lte": "2013-01-01"
+                                "gte": 1325376000,
+                                "lte": 1577836800
                             }
                         }
                     }

--- a/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_with_long_value_not_cached.json
+++ b/src/test/java/org/elasticsearch/index/query/date_range_in_boolean_with_long_value_not_cached.json
@@ -2,7 +2,6 @@
     "constant_score": {
         "filter": {
             "bool": {
-                "_cache" : true,
                 "must": [
                     {
                         "term": {
@@ -13,9 +12,10 @@
                     },
                     {
                         "range" : {
+                            "_cache" : false,
                             "born" : {
-                                "gte": "2012-01-01",
-                                "lte": "2013-01-01"
+                                "gte": 1325376000,
+                                "lte": 1577836800
                             }
                         }
                     }

--- a/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SimpleQueryTests.java
@@ -2340,9 +2340,9 @@ public class SimpleQueryTests extends ElasticsearchIntegrationTest {
                 .get();
         assertHitCount(searchResponse, 1l);
 
-        // The range filter is now explicitly cached, so it now it is in the filter cache.
+        // The range filter is now explicitly cached but we don't want to cache now even if the user asked for it
         statsResponse = client().admin().indices().prepareStats("test").clear().setFilterCache(true).get();
-        assertThat(statsResponse.getIndex("test").getTotal().getFilterCache().getMemorySizeInBytes(), cluster().hasFilterCache() ? greaterThan(filtercacheSize) : is(filtercacheSize));
+        assertThat(statsResponse.getIndex("test").getTotal().getFilterCache().getMemorySizeInBytes(), is(filtercacheSize));
     }
 
     @Test


### PR DESCRIPTION
A range filter on a date field with a numeric `from`/`to` value is **not** cached by default:

```
DELETE /test

PUT /test/t/1
{
  "date": "2014-01-01"
}

GET /_validate/query?explain
{
  "query": {
    "filtered": {
      "filter": {
        "range": {
          "date": {
            "from": 0
          }
        }
      }
    }
  }
}
```

Returns:

```
"explanation": "ConstantScore(no_cache(date:[0 TO *]))"
```

This patch fixes as well not caching `from`/`to` when using `now` value not rounded.
Previously, a query like:

```
GET /_validate/query?explain
{
  "query": {
    "filtered": {
      "filter": {
        "range": {
          "date": {
            "from": "now"
            "to": "now/d+1"
          }
        }
      }
    }
  }
}
```

was cached.

Also, this patch does not cache anymore `now` even if the user asked for caching it.
As it won't be cached at all by definition.

Added as well tests for all possible combinations.

Closes #7114.
