### PR TITLE
Test: Added custom transport client settings to test infra

### DIFF
--- a/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchBackwardsCompatIntegrationTest.java
@@ -32,7 +32,6 @@ import org.elasticsearch.discovery.zen.ZenDiscoveryModule;
 import org.elasticsearch.transport.TransportModule;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.netty.NettyTransportModule;
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Ignore;
 
@@ -101,10 +100,15 @@ public abstract class ElasticsearchBackwardsCompatIntegrationTest extends Elasti
 
     protected TestCluster buildTestCluster(Scope scope) throws IOException {
         TestCluster cluster = super.buildTestCluster(scope);
-        ExternalNode externalNode = new ExternalNode(backwardsCompatibilityPath(), randomLong(), new NodeSettingsSource() {
+        ExternalNode externalNode = new ExternalNode(backwardsCompatibilityPath(), randomLong(), new SettingsSource() {
             @Override
-            public Settings settings(int nodeOrdinal) {
+            public Settings node(int nodeOrdinal) {
                 return externalNodeSettings(nodeOrdinal);
+            }
+
+            @Override
+            public Settings transportClient() {
+                return transportClientSettings();
             }
         });
         return new CompositeTestCluster((InternalTestCluster) cluster, between(minExternalNodes(), maxExternalNodes()), externalNode);

--- a/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1440,13 +1440,28 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
         return ImmutableSettings.EMPTY;
     }
 
+    /**
+     * This method is used to obtain additional settings for clients created by the internal cluster.
+     * These settings will be applied on the client in addition to some randomized settings defined in
+     * the cluster. These setttings will also override any other settings the internal cluster might
+     * add by default.
+     */
+    protected Settings transportClientSettings() {
+        return ImmutableSettings.EMPTY;
+    }
+
     protected TestCluster buildTestCluster(Scope scope) throws IOException {
         long currentClusterSeed = randomLong();
 
-        NodeSettingsSource nodeSettingsSource = new NodeSettingsSource() {
+        SettingsSource settingsSource = new SettingsSource() {
             @Override
-            public Settings settings(int nodeOrdinal) {
+            public Settings node(int nodeOrdinal) {
                 return nodeSettings(nodeOrdinal);
+            }
+
+            @Override
+            public Settings transportClient() {
+                return transportClientSettings();
             }
         };
 
@@ -1461,7 +1476,7 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 
         int numClientNodes = getNumClientNodes();
         boolean enableRandomBenchNodes = enableRandomBenchNodes();
-        return new InternalTestCluster(currentClusterSeed, minNumDataNodes, maxNumDataNodes, clusterName(scope.name(), ElasticsearchTestCase.CHILD_VM_ID, currentClusterSeed), nodeSettingsSource, numClientNodes, enableRandomBenchNodes);
+        return new InternalTestCluster(currentClusterSeed, minNumDataNodes, maxNumDataNodes, clusterName(scope.name(), ElasticsearchTestCase.CHILD_VM_ID, currentClusterSeed), settingsSource, numClientNodes, enableRandomBenchNodes);
     }
 
     /**

--- a/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -46,29 +46,29 @@ final class ExternalNode implements Closeable {
 
     private final File path;
     private final Random random;
-    private final NodeSettingsSource nodeSettingsSource;
+    private final SettingsSource settingsSource;
     private Process process;
     private NodeInfo nodeInfo;
     private final String clusterName;
     private TransportClient client;
 
-    ExternalNode(File path, long seed, NodeSettingsSource nodeSettingsSource) {
-        this(path, null, seed, nodeSettingsSource);
+    ExternalNode(File path, long seed, SettingsSource settingsSource) {
+        this(path, null, seed, settingsSource);
     }
 
-    ExternalNode(File path, String clusterName, long seed, NodeSettingsSource nodeSettingsSource) {
+    ExternalNode(File path, String clusterName, long seed, SettingsSource settingsSource) {
         if (!path.isDirectory()) {
             throw new IllegalArgumentException("path must be a directory");
         }
         this.path = path;
         this.clusterName = clusterName;
         this.random = new Random(seed);
-        this.nodeSettingsSource = nodeSettingsSource;
+        this.settingsSource = settingsSource;
     }
 
     synchronized ExternalNode start(Client localNode, Settings defaultSettings, String nodeName, String clusterName, int nodeOrdinal) throws IOException, InterruptedException {
-        ExternalNode externalNode = new ExternalNode(path, clusterName, random.nextLong(), nodeSettingsSource);
-        Settings settings = ImmutableSettings.builder().put(nodeSettingsSource.settings(nodeOrdinal)).put(defaultSettings).build();
+        ExternalNode externalNode = new ExternalNode(path, clusterName, random.nextLong(), settingsSource);
+        Settings settings = ImmutableSettings.builder().put(settingsSource.node(nodeOrdinal)).put(defaultSettings).build();
         externalNode.startInternal(localNode, settings, nodeName, clusterName);
         return externalNode;
     }

--- a/src/test/java/org/elasticsearch/test/SettingsSource.java
+++ b/src/test/java/org/elasticsearch/test/SettingsSource.java
@@ -20,11 +20,16 @@ package org.elasticsearch.test;
 
 import org.elasticsearch.common.settings.Settings;
 
-abstract class NodeSettingsSource {
+abstract class SettingsSource {
 
-    public static final NodeSettingsSource EMPTY = new NodeSettingsSource() {
+    public static final SettingsSource EMPTY = new SettingsSource() {
         @Override
-        public Settings settings(int nodeOrdinal) {
+        public Settings node(int nodeOrdinal) {
+            return null;
+        }
+
+        @Override
+        public Settings transportClient() {
             return null;
         }
     };
@@ -32,6 +37,8 @@ abstract class NodeSettingsSource {
     /**
      * @return  the settings for the node represented by the given ordinal, or {@code null} if there are no settings defined
      */
-    public abstract Settings settings(int nodeOrdinal);
+    public abstract Settings node(int nodeOrdinal);
+
+    public abstract Settings transportClient();
 
 }


### PR DESCRIPTION
It's now possible to define the additional customesettings for transport clients by extending `transportClientSettings` callback method on `ElasticsearchIntegrationTest`.
