### PR TITLE
Updated typo in getting-started.asciidoc

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -459,7 +459,7 @@ curl -XPOST 'localhost:9200/customer/external/1/_update?pretty' -d '
 
 In the above example, `ctx._source` refers to the current source document that is about to be updated.
 
-Note that as if this writing, updates can only be performed on a single document at a time. In the future, Elasticsearch will provide the ability to update multiple documents given a query condition (like an `SQL UPDATE-WHERE` statement).
+Note that as of this writing, updates can only be performed on a single document at a time. In the future, Elasticsearch will provide the ability to update multiple documents given a query condition (like an `SQL UPDATE-WHERE` statement).
 
 === Deleting Documents
 


### PR DESCRIPTION
A very small typo in the description.
