### PR TITLE
Improve IP address validation

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper.ip;
 
+import com.google.common.net.InetAddresses;
 import org.apache.lucene.analysis.NumericTokenStream;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -79,9 +80,12 @@ public class IpFieldMapper extends NumberFieldMapper<Long> {
 
     public static long ipToLong(String ip) throws ElasticsearchIllegalArgumentException {
         try {
+            if (!InetAddresses.isInetAddress(ip)) {
+                throw new ElasticsearchIllegalArgumentException("failed to parse ip [" + ip + "], not a valid ip address");
+            }
             String[] octets = pattern.split(ip);
             if (octets.length != 4) {
-                throw new ElasticsearchIllegalArgumentException("failed to parse ip [" + ip + "], not full ip address (4 dots)");
+                throw new ElasticsearchIllegalArgumentException("failed to parse ip [" + ip + "], not a valid ipv4 address (4 dots)");
             }
             return (Long.parseLong(octets[0]) << 24) + (Integer.parseInt(octets[1]) << 16) +
                     (Integer.parseInt(octets[2]) << 8) + Integer.parseInt(octets[3]);


### PR DESCRIPTION
Until now, IP addresses were only checked for four dots, which
allowed invalid values like 127.0.0.111111

This adds an additional check for validation.

**Note**: This does have a performance impact in the log file indexing case as it adds an additional parsing step. Maybe this was the reason, why it had not been implemented in the first case? We could potentially just reuse the code from guavas `InetAddresses.textToNumericFormatV4()` which is unfortunately private

Closes #7131
