### PR TITLE
Update API: Add support for scripted upserts.

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -153,7 +153,7 @@ new `scripted_upsert` parameter with the value `true`.
 [source,js]
 --------------------------------------------------
 curl -XPOST 'localhost:9200/sessions/session/dh3sgudg8gsrgl/_update' -d '{
-    "script_id" : "myWebSessionSummariser",
+    "script_id" : "my_web_session_summariser",
     "scripted_upsert":true,
     "params" : {
         "pageViewEvent" : {
@@ -174,7 +174,7 @@ client can supply a blank "upsert" document and allow the script to fill in most
 using the events passed in the `params` element.  
 
 
-Last it also supports `doc_as_upsert`. So that the
+Last, the upsert facility also supports `doc_as_upsert`. So that the
 provided document will be inserted if the document does not already
 exist. This will reduce the amount of data that needs to be sent to
 elasticsearch.

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -126,6 +126,7 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
 If `name` was `new_name` before the request was sent then the entire update
 request is ignored.
 
+=== Upserts
 There is also support for `upsert`. If the document does
 not already exists, the content of the `upsert` element will be used to
 index the fresh doc:
@@ -142,6 +143,36 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
     }
 }'
 --------------------------------------------------
+added[1.4.0]
+
+If the document does not exist you may want your update script to
+run anyway in order to initialize the document contents using 
+business logic unknown to the client. In this case pass the
+new `scripted_upsert` parameter with the value `true`. 
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'localhost:9200/sessions/session/dh3sgudg8gsrgl/_update' -d '{
+    "script_id" : "myWebSessionSummariser",
+    "scripted_upsert":true,
+    "params" : {
+        "pageViewEvent" : {
+        	"url":"foo.com/bar",
+        	"response":404,
+        	"time":"2014-01-01 12:32"
+        }
+    },
+    "upsert" : {
+    }
+}'
+--------------------------------------------------
+The default `scripted_upsert` setting is `false` meaning the script is not executed for inserts.
+However, in scenarios like the one above we may be using a non-trivial script stored
+using the new "indexed scripts" feature. The script may be deriving properties 
+like the duration of our web session based on observing multiple page view events so the 
+client can supply a blank "upsert" document and allow the script to fill in most of the details
+using the events passed in the `params` element.  
+
 
 Last it also supports `doc_as_upsert`. So that the
 provided document will be inserted if the document does not already
@@ -157,6 +188,9 @@ curl -XPOST 'localhost:9200/test/type1/1/_update' -d '{
     "doc_as_upsert" : true
 }'
 --------------------------------------------------
+
+
+=== Parameters
 
 The update operation supports similar parameters as the index API,
 including:

--- a/rest-api-spec/api/update.json
+++ b/rest-api-spec/api/update.json
@@ -61,6 +61,13 @@
         "script": {
           "description": "The URL-encoded script definition (instead of using request body)"
         },
+        "script_id": {
+          "description": "The id of a stored script"
+        },
+        "scripted_upsert": {
+          "type": "boolean",        
+          "description": "True if the script referenced in script or script_id should be called to perform inserts - defaults to false"
+        },
         "timeout": {
           "type": "time",
           "description": "Explicit operation timeout"

--- a/rest-api-spec/test/update/25_script_upsert.yaml
+++ b/rest-api-spec/test/update/25_script_upsert.yaml
@@ -37,5 +37,24 @@
           id:     1
 
   - match:  { _source.foo: xxx }
+  
+  - do:
+      update:
+          index:    test_1
+          type:     test
+          id:       2
+          body:
+            script: "ctx._source.foo = bar"
+            params: { bar: 'xxx' }
+            upsert: { foo: baz }
+            scripted_upsert: true
+
+  - do:
+      get:
+          index:  test_1
+          type:   test
+          id:     2
+
+  - match:  { _source.foo: xxx }  
 
 

--- a/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -92,7 +92,7 @@ public class UpdateHelper extends AbstractComponent {
             }
             Long ttl = null;
             IndexRequest indexRequest = request.docAsUpsert() ? request.doc() : request.upsertRequest();
-            if(request.scriptedUpsert()&&(request.script() != null)){
+            if (request.scriptedUpsert() && (request.script() != null)) {
                 // Run the script to perform the create logic
                 IndexRequest upsert = request.upsertRequest();               
                 Map<String, Object> upsertDoc = upsert.sourceAsMap();
@@ -113,23 +113,17 @@ public class UpdateHelper extends AbstractComponent {
                 ttl = getTTLFromScriptContext(ctx);
                 //Allow the script to abort the create by setting "op" to "none"
                 String scriptOpChoice = (String) ctx.get("op");
-                if (scriptOpChoice != null) {
-                    if ("none".equals(scriptOpChoice)) {
-                        // Script has requested silent abort of insert
-                        UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(),
-                                getResult.getVersion(), false);
-                        update.setGetResult(getResult);
-                        return new Result(update, Operation.NONE, upsertDoc, XContentType.JSON);
-                    }
-                    if (!"create".equals(scriptOpChoice)) {
-                        // Only valid options for an upsert script are "create"
-                        // (the default) or "none", meaning abort upsert
+                
+                // Only valid options for an upsert script are "create"
+                // (the default) or "none", meaning abort upsert
+                if (!"create".equals(scriptOpChoice)) {
+                    if (!"none".equals(scriptOpChoice)) {
                         logger.warn("Used upsert operation [{}] for script [{}], doing nothing...", scriptOpChoice, request.script);
-                        UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(),
-                                getResult.getVersion(), false);
-                        update.setGetResult(getResult);
-                        return new Result(update, Operation.NONE, upsertDoc, XContentType.JSON);
                     }
+                    UpdateResponse update = new UpdateResponse(getResult.getIndex(), getResult.getType(), getResult.getId(),
+                            getResult.getVersion(), false);
+                    update.setGetResult(getResult);
+                    return new Result(update, Operation.NONE, upsertDoc, XContentType.JSON);
                 }
                 indexRequest.source((Map)ctx.get("_source"));
             }

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -76,6 +76,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
 
     private IndexRequest upsertRequest;
 
+    private boolean scriptedUpsert = false;
     private boolean docAsUpsert = false;
     private boolean detectNoop = false;
 
@@ -596,6 +597,8 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
                     scriptParams = parser.map();
                 } else if ("lang".equals(currentFieldName)) {
                     scriptLang = parser.text();
+                } else if ("scripted_upsert".equals(currentFieldName)) {
+                    scriptedUpsert = parser.booleanValue();
                 } else if ("upsert".equals(currentFieldName)) {
                     XContentBuilder builder = XContentFactory.contentBuilder(xContentType);
                     builder.copyCurrentStructure(parser);
@@ -621,6 +624,15 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
     public void docAsUpsert(boolean shouldUpsertDoc) {
         this.docAsUpsert = shouldUpsertDoc;
     }
+    
+    public boolean scriptedUpsert(){
+        return this.scriptedUpsert;
+    }
+    
+    public void scriptedUpsert(boolean scriptedUpsert) {
+        this.scriptedUpsert = scriptedUpsert;
+    }
+    
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
@@ -662,6 +674,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         versionType = VersionType.fromValue(in.readByte());
         if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
             detectNoop = in.readBoolean();
+        }
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            scriptedUpsert = in.readBoolean();
         }
     }
 
@@ -714,6 +729,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest> 
         out.writeByte(versionType.getValue());
         if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
             out.writeBoolean(detectNoop);
+        }
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeBoolean(scriptedUpsert);
         }
     }
 

--- a/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -353,6 +353,15 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
         request.detectNoop(detectNoop);
         return this;
     }
+    
+
+    /**
+     * Sets whether the script should be run in the case of an insert
+     */
+    public UpdateRequestBuilder setScriptedUpsert(boolean scriptedUpsert) {
+        request.scriptedUpsert(scriptedUpsert);
+        return this;
+    }    
 
     @Override
     protected void doExecute(ActionListener<UpdateResponse> listener) {


### PR DESCRIPTION
In the case of inserts the UpdateHelper class will now allow the script used to apply updates to run on the upsert doc provided by clients. This allows the logic for managing the internal state of the data item to be managed by the script and is not reliant on clients performing the initialisation of data structures managed by the script.
Associated issue: https://github.com/elasticsearch/elasticsearch/issues/7143
