### PR TITLE
MultiGet: Fail when using no routing on an alias to an index that requires routing

### DIFF
--- a/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -32,8 +31,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.BaseTransportRequestHandler;
-import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.HashMap;
@@ -73,13 +70,14 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
                 responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(), "[" + item.index() + "] missing")));
                 continue;
             }
-            if (item.routing() == null && clusterState.getMetaData().routingRequired(item.index(), item.type())) {
-                responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(), "routing is required, but hasn't been specified")));
-                continue;
-            }
 
             item.routing(clusterState.metaData().resolveIndexRouting(item.routing(), item.index()));
             item.index(clusterState.metaData().concreteSingleIndex(item.index(), item.indicesOptions()));
+            if (item.routing() == null && clusterState.getMetaData().routingRequired(item.index(), item.type())) {
+                responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(),
+                        "routing is required for [" + item.index() + "]/[" + item.type() + "]/[" + item.id() + "]")));
+                continue;
+            }
             ShardId shardId = clusterService.operationRouting()
                     .getShards(clusterState, item.index(), item.type(), item.id(), item.routing(), null).shardId();
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);

--- a/src/test/java/org/elasticsearch/mget/SimpleMgetTests.java
+++ b/src/test/java/org/elasticsearch/mget/SimpleMgetTests.java
@@ -98,7 +98,7 @@ public class SimpleMgetTests extends ElasticsearchIntegrationTest {
 
         assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
         assertThat(mgetResponse.getResponses()[1].getResponse(), nullValue());
-        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required for [test]/[test]/[1]"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
+++ b/src/test/java/org/elasticsearch/routing/SimpleRoutingTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.routing;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.RoutingMissingException;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetResponse;
@@ -176,18 +177,18 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testRequiredRoutingMapping() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        client().admin().indices().prepareCreate("test").addAlias(new Alias("alias"))
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_routing").field("required", true).endObject().endObject().endObject())
                 .execute().actionGet();
         ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
-        client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
+        client().prepareIndex(indexOrAlias(), "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
         logger.info("--> verifying get with no routing, should fail");
 
         logger.info("--> indexing with id [1], with no routing, should fail");
         try {
-            client().prepareIndex("test", "type1", "1").setSource("field", "value1").setRefresh(true).execute().actionGet();
+            client().prepareIndex(indexOrAlias(), "type1", "1").setSource("field", "value1").setRefresh(true).execute().actionGet();
             fail();
         } catch (ElasticsearchException e) {
             assertThat(e.unwrapCause(), instanceOf(RoutingMissingException.class));
@@ -195,44 +196,45 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
         }
 
         logger.info("--> deleting with no routing, should broadcast the delete since _routing is required");
-        client().prepareDelete("test", "type1", "1").setRefresh(true).execute().actionGet();
+        client().prepareDelete(indexOrAlias(), "type1", "1").setRefresh(true).execute().actionGet();
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "type1", "1").execute().actionGet().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
                 assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
             }
-            assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
         }
 
         logger.info("--> indexing with id [1], and routing [0]");
-        client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
+        client().prepareIndex(indexOrAlias(), "type1", "1").setRouting("0").setSource("field", "value1").setRefresh(true).execute().actionGet();
         logger.info("--> verifying get with no routing, should not find anything");
 
         logger.info("--> bulk deleting with no routing, should broadcast the delete since _routing is required");
-        client().prepareBulk().add(Requests.deleteRequest("test").type("type1").id("1")).execute().actionGet();
+        client().prepareBulk().add(Requests.deleteRequest(indexOrAlias()).type("type1").id("1")).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "type1", "1").execute().actionGet().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
                 assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
             }
-            assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(false));
         }
     }
 
     @Test
     public void testRequiredRoutingWithPathMapping() throws Exception {
         client().admin().indices().prepareCreate("test")
+                .addAlias(new Alias("alias"))
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject().startObject("properties")
                         .startObject("routing_field").field("type", "string").field("index", randomBoolean() ? "no" : "not_analyzed").field("doc_values", randomBoolean() ? "yes" : "no").endObject().endObject()
@@ -241,11 +243,11 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
-        client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", "0").setRefresh(true).execute().actionGet();
+        client().prepareIndex(indexOrAlias(), "type1", "1").setSource("field", "value1", "routing_field", "0").setRefresh(true).execute().actionGet();
 
         logger.info("--> check failure with different routing");
         try {
-            client().prepareIndex("test", "type1", "1").setRouting("1").setSource("field", "value1", "routing_field", "0").setRefresh(true).execute().actionGet();
+            client().prepareIndex(indexOrAlias(), "type1", "1").setRouting("1").setSource("field", "value1", "routing_field", "0").setRefresh(true).execute().actionGet();
             fail();
         } catch (ElasticsearchException e) {
             assertThat(e.unwrapCause(), instanceOf(MapperParsingException.class));
@@ -255,7 +257,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         logger.info("--> verifying get with no routing, should fail");
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "type1", "1").execute().actionGet().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
@@ -264,13 +266,14 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
         }
     }
 
     @Test
     public void testRequiredRoutingWithPathMappingBulk() throws Exception {
         client().admin().indices().prepareCreate("test")
+                .addAlias(new Alias("alias"))
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
                         .endObject().endObject())
@@ -279,13 +282,13 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> indexing with id [1], and routing [0]");
         client().prepareBulk().add(
-                client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", "0")).execute().actionGet();
+                client().prepareIndex(indexOrAlias(), "type1", "1").setSource("field", "value1", "routing_field", "0")).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
         logger.info("--> verifying get with no routing, should fail");
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "type1", "1").execute().actionGet().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
@@ -294,7 +297,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
         }
     }
 
@@ -302,6 +305,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
     public void testRequiredRoutingWithPathNumericType() throws Exception {
 
         client().admin().indices().prepareCreate("test")
+                .addAlias(new Alias("alias"))
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1")
                         .startObject("_routing").field("required", true).field("path", "routing_field").endObject()
                         .endObject().endObject())
@@ -309,13 +313,13 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
-        client().prepareIndex("test", "type1", "1").setSource("field", "value1", "routing_field", 0).execute().actionGet();
+        client().prepareIndex(indexOrAlias(), "type1", "1").setSource("field", "value1", "routing_field", 0).execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
         logger.info("--> verifying get with no routing, should fail");
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet("test", "type1", "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "type1", "1").execute().actionGet().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
@@ -324,35 +328,35 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
         }
     }
 
     @Test
     public void testRequiredRoutingMapping_variousAPIs() throws Exception {
-        client().admin().indices().prepareCreate("test")
+        client().admin().indices().prepareCreate("test").addAlias(new Alias("alias"))
                 .addMapping("type1", XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("_routing").field("required", true).endObject().endObject().endObject())
                 .execute().actionGet();
         ensureGreen();
 
         logger.info("--> indexing with id [1], and routing [0]");
-        client().prepareIndex("test", "type1", "1").setRouting("0").setSource("field", "value1").get();
+        client().prepareIndex(indexOrAlias(), "type1", "1").setRouting("0").setSource("field", "value1").get();
         logger.info("--> indexing with id [2], and routing [0]");
-        client().prepareIndex("test", "type1", "2").setRouting("0").setSource("field", "value2").setRefresh(true).get();
+        client().prepareIndex(indexOrAlias(), "type1", "2").setRouting("0").setSource("field", "value2").setRefresh(true).get();
 
         logger.info("--> verifying get with id [1] with routing [0], should succeed");
-        assertThat(client().prepareGet("test", "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
+        assertThat(client().prepareGet(indexOrAlias(), "type1", "1").setRouting("0").execute().actionGet().isExists(), equalTo(true));
 
         logger.info("--> verifying get with id [1], with no routing, should fail");
         try {
-            client().prepareGet("test", "type1", "1").get();
+            client().prepareGet(indexOrAlias(), "type1", "1").get();
             fail();
         } catch (RoutingMissingException e) {
             assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
         }
 
         logger.info("--> verifying explain with id [2], with routing [0], should succeed");
-        ExplainResponse explainResponse = client().prepareExplain("test", "type1", "2")
+        ExplainResponse explainResponse = client().prepareExplain(indexOrAlias(), "type1", "2")
                 .setQuery(QueryBuilders.matchAllQuery())
                 .setRouting("0").get();
         assertThat(explainResponse.isExists(), equalTo(true));
@@ -360,7 +364,7 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> verifying explain with id [2], with no routing, should fail");
         try {
-            client().prepareExplain("test", "type1", "2")
+            client().prepareExplain(indexOrAlias(), "type1", "2")
                     .setQuery(QueryBuilders.matchAllQuery()).get();
             fail();
         } catch (RoutingMissingException e) {
@@ -368,24 +372,24 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         }
 
         logger.info("--> verifying term vector with id [1], with routing [0], should succeed");
-        TermVectorResponse termVectorResponse = client().prepareTermVector("test", "type1", "1").setRouting("0").get();
+        TermVectorResponse termVectorResponse = client().prepareTermVector(indexOrAlias(), "type1", "1").setRouting("0").get();
         assertThat(termVectorResponse.isExists(), equalTo(true));
         assertThat(termVectorResponse.getId(), equalTo("1"));
 
         try {
-            client().prepareTermVector("test", "type1", "1").get();
+            client().prepareTermVector(indexOrAlias(), "type1", "1").get();
             fail();
         } catch (RoutingMissingException e) {
             assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
         }
 
-        UpdateResponse updateResponse = client().prepareUpdate("test", "type1", "1").setRouting("0")
+        UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1").setRouting("0")
                 .setDoc("field1", "value1").get();
         assertThat(updateResponse.getId(), equalTo("1"));
         assertThat(updateResponse.getVersion(), equalTo(2l));
 
         try {
-            client().prepareUpdate("test", "type1", "1").setDoc("field1", "value1").get();
+            client().prepareUpdate(indexOrAlias(), "type1", "1").setDoc("field1", "value1").get();
             fail();
         } catch (RoutingMissingException e) {
             assertThat(e.getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
@@ -393,8 +397,8 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> verifying mget with ids [1,2], with routing [0], should succeed");
         MultiGetResponse multiGetResponse = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item("test", "type1", "1").routing("0"))
-                .add(new MultiGetRequest.Item("test", "type1", "2").routing("0")).get();
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1").routing("0"))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2").routing("0")).get();
         assertThat(multiGetResponse.getResponses().length, equalTo(2));
         assertThat(multiGetResponse.getResponses()[0].isFailed(), equalTo(false));
         assertThat(multiGetResponse.getResponses()[0].getResponse().getId(), equalTo("1"));
@@ -403,19 +407,19 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
 
         logger.info("--> verifying mget with ids [1,2], with no routing, should fail");
         multiGetResponse = client().prepareMultiGet()
-                .add(new MultiGetRequest.Item("test", "type1", "1"))
-                .add(new MultiGetRequest.Item("test", "type1", "2")).get();
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "1"))
+                .add(new MultiGetRequest.Item(indexOrAlias(), "type1", "2")).get();
         assertThat(multiGetResponse.getResponses().length, equalTo(2));
         assertThat(multiGetResponse.getResponses()[0].isFailed(), equalTo(true));
         assertThat(multiGetResponse.getResponses()[0].getFailure().getId(), equalTo("1"));
-        assertThat(multiGetResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(multiGetResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
         assertThat(multiGetResponse.getResponses()[1].isFailed(), equalTo(true));
         assertThat(multiGetResponse.getResponses()[1].getFailure().getId(), equalTo("2"));
-        assertThat(multiGetResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(multiGetResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required for [test]/[type1]/[2]"));
 
         MultiTermVectorsResponse multiTermVectorsResponse = client().prepareMultiTermVectors()
-                .add(new TermVectorRequest("test", "type1", "1").routing("0"))
-                .add(new TermVectorRequest("test", "type1", "2").routing("0")).get();
+                .add(new TermVectorRequest(indexOrAlias(), "type1", "1").routing("0"))
+                .add(new TermVectorRequest(indexOrAlias(), "type1", "2").routing("0")).get();
         assertThat(multiTermVectorsResponse.getResponses().length, equalTo(2));
         assertThat(multiTermVectorsResponse.getResponses()[0].getId(), equalTo("1"));
         assertThat(multiTermVectorsResponse.getResponses()[0].isFailed(), equalTo(false));
@@ -427,16 +431,20 @@ public class SimpleRoutingTests extends ElasticsearchIntegrationTest {
         assertThat(multiTermVectorsResponse.getResponses()[1].getResponse().isExists(), equalTo(true));
 
         multiTermVectorsResponse = client().prepareMultiTermVectors()
-                .add(new TermVectorRequest("test", "type1", "1"))
-                .add(new TermVectorRequest("test", "type1", "2")).get();
+                .add(new TermVectorRequest(indexOrAlias(), "type1", "1"))
+                .add(new TermVectorRequest(indexOrAlias(), "type1", "2")).get();
         assertThat(multiTermVectorsResponse.getResponses().length, equalTo(2));
         assertThat(multiTermVectorsResponse.getResponses()[0].getId(), equalTo("1"));
         assertThat(multiTermVectorsResponse.getResponses()[0].isFailed(), equalTo(true));
-        assertThat(multiTermVectorsResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
         assertThat(multiTermVectorsResponse.getResponses()[0].getResponse(), nullValue());
         assertThat(multiTermVectorsResponse.getResponses()[1].getId(), equalTo("2"));
         assertThat(multiTermVectorsResponse.getResponses()[1].isFailed(), equalTo(true));
         assertThat(multiTermVectorsResponse.getResponses()[1].getResponse(),nullValue());
-        assertThat(multiTermVectorsResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required, but hasn't been specified"));
+        assertThat(multiTermVectorsResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required for [test]/[type1]/[2]"));
+    }
+
+    private static String indexOrAlias() {
+        return randomBoolean() ? "test" : "alias";
     }
 }


### PR DESCRIPTION
The multi_get api and multi_term_vector apis should always return an error when trying to get a document without routing if the routing is set to required. Yet, when using an alias a failure is not returned.

The problem is that the`routingRequired` check needs to be done passing in the resolved concrete index.
