### PR TITLE
Scripting: Add configuration parameter to control execution of indexed s...

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -179,6 +179,7 @@ following setting to the `config/elasticsearch.yml` file on every node:
 -----------------------------------
 script.disable_dynamic: false
 -----------------------------------
+deprecated[1.4.0,Replaced by `script.enable_dynamic`]
 
 While this still allows execution of named scripts provided in the config, or
 _native_ Java scripts registered through plugins, it also allows users to run
@@ -198,8 +199,33 @@ setting, the default value is `sandbox`:
 
 [source,yaml]
 -----------------------------------
+script.enable_dynamic: false
+-----------------------------------
+added[1.4.0]
+
+While this still allows execution of named scripts provided in the config, or
+_native_ Java scripts registered through plugins, it also allows users to run
+arbitrary scripts via the API. Instead of sending the name of the file as the
+script, the body of the script can be sent instead.
+
+There are three possible configuration values for the `script.enable_dynamic`
+setting, the default value is `sandbox`:
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Value |Description
+| `true` |all dynamic scripting is enabled, scripts may be sent as strings in requests.
+| `false` |all dynamic scripting is disabled, scripts must be placed in the `config/scripts` directory.
+| `sandbox` |scripts may be sent as strings for languages that are sandboxed.
+|=======================================================================
+
+[source,yaml]
+-----------------------------------
 script.disable_indexed: false
 -----------------------------------
+added[1.4.0]
+deprecated[1.4.0,Replaced by `script.enable_indexed`]
+
 
 While this still allows execution of indexed scripts using _native_ Java scripts
 registered through plugins, it also allows users to store and run aribtary scripts
@@ -217,6 +243,30 @@ setting, the default value is `sandbox`:
 |Value |Description
 | `true` |all indexed scripting is disabled, scripts may not be registered via the API, or referenced from queries by id.
 | `false` |all indexed scripting is enabled, scripts may be registered via the API and referenced from queries by id.
+| `sandbox` |scripts may be registered via the API and referenced from queries only for languages that are sandboxed.
+|=======================================================================
+
+[source,yaml]
+-----------------------------------
+script.enable_indexed: false
+-----------------------------------
+added[1.4.0]
+
+This allows users to store and run aribtary scriptsv ia the indexed scripts API. 
+This setting is independent of the dynamic script setting. This can be used in 
+conjunction with a proxy to restrict access to script creation but still allow script
+usage at query time. Note that if access to elasticsearch
+is not controlled setting `script.enabled_indexed` to `true` may expose the elasticsearch
+server to malicious attacks.
+
+There are three possible configuration values for the `script.enable_indexed`
+setting, the default value is `sandbox`:
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Value |Description
+| `true` |all indexed scripting is enabled, scripts may be registered via the API and referenced from queries by id.
+| `false` |all indexed scripting is disabled, scripts may not be registered via the API, or referenced from queries by id.
 | `sandbox` |scripts may be registered via the API and referenced from queries only for languages that are sandboxed.
 |=======================================================================
 

--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -201,7 +201,7 @@ setting, the default value is `sandbox`:
 -----------------------------------
 script.enable_dynamic: false
 -----------------------------------
-added[1.4.0]
+coming[1.4.0]
 
 While this still allows execution of named scripts provided in the config, or
 _native_ Java scripts registered through plugins, it also allows users to run
@@ -223,7 +223,7 @@ setting, the default value is `sandbox`:
 -----------------------------------
 script.disable_indexed: false
 -----------------------------------
-added[1.4.0]
+coming[1.4.0]
 deprecated[1.4.0,Replaced by `script.enable_indexed`]
 
 
@@ -250,7 +250,7 @@ setting, the default value is `sandbox`:
 -----------------------------------
 script.enable_indexed: false
 -----------------------------------
-added[1.4.0]
+coming[1.4.0]
 
 This allows users to store and run aribtary scriptsv ia the indexed scripts API. 
 This setting is independent of the dynamic script setting. This can be used in 

--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -196,6 +196,30 @@ setting, the default value is `sandbox`:
 | `sandbox` |scripts may be sent as strings for languages that are sandboxed.
 |=======================================================================
 
+[source,yaml]
+-----------------------------------
+script.disable_indexed: false
+-----------------------------------
+
+While this still allows execution of indexed scripts using _native_ Java scripts
+registered through plugins, it also allows users to store and run aribtary scripts
+via the indexed scripts API. This setting is independent of the dynamic script
+setting. This can be used in conjunction with a proxy to restrict access to script
+creation but still allow script usage at query time. Note that if access to elasticsearch
+is not controlled setting `script.disable_indexed` to `false` may expose the elasticsearch
+server to malicious attacks.
+
+There are three possible configuration values for the `script.disable_indexed`
+setting, the default value is `sandbox`:
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Value |Description
+| `true` |all indexed scripting is disabled, scripts may not be registered via the API, or referenced from queries by id.
+| `false` |all indexed scripting is enabled, scripts may be registered via the API and referenced from queries by id.
+| `sandbox` |scripts may be registered via the API and referenced from queries only for languages that are sandboxed.
+|=======================================================================
+
 [float]
 === Default Scripting Language
 

--- a/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -296,13 +296,16 @@ public class ScriptService extends AbstractComponent {
             this.dynamicScriptingDisabled = DynamicScriptDisabling.parseEnabled(settings.get(ENABLE_DYNAMIC_SCRIPTING_SETTING, DISABLE_DYNAMIC_SCRIPTING_DEFAULT));
         } else {
             this.dynamicScriptingDisabled = DynamicScriptDisabling.parse(settings.get(DISABLE_DYNAMIC_SCRIPTING_SETTING, DISABLE_DYNAMIC_SCRIPTING_DEFAULT));
+            logger.warn("Used [{}], this setting is deprecated please use [{}] instead.", DISABLE_DYNAMIC_SCRIPTING_SETTING, ENABLE_DYNAMIC_SCRIPTING_SETTING);
         }
+
         if (settings.names().contains(ENABLE_INDEXED_SCRIPTING_SETTING) ) {
             this.indexedScriptDisabled = IndexedScriptDisabling.parseEnabled(settings.get(ENABLE_INDEXED_SCRIPTING_SETTING,
                     DISABLE_INDEXED_SCRIPTING_DEFAULT));
         } else {
             this.indexedScriptDisabled = IndexedScriptDisabling.parse(settings.get(DISABLE_INDEXED_SCRIPTING_SETTING,
                     DISABLE_INDEXED_SCRIPTING_DEFAULT));
+            logger.warn("Used [{}], this setting is deprecated please use [{}] instead.", DISABLE_INDEXED_SCRIPTING_SETTING, ENABLE_INDEXED_SCRIPTING_SETTING);
         }
 
 

--- a/src/test/java/org/elasticsearch/script/IndexedScriptDisabledTest.java
+++ b/src/test/java/org/elasticsearch/script/IndexedScriptDisabledTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.equalTo;
+
+
+//Use Suite scope so that we can disable indexed scripts get set correctly
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+public class IndexedScriptDisabledTest extends ElasticsearchIntegrationTest {
+
+    @Override
+    public Settings nodeSettings(int nodeOrdinal) {
+        return settingsBuilder()
+                .put(ScriptService.DISABLE_INDEXED_SCRIPTING_SETTING, "true")
+                .build();
+    }
+
+    @Test(expected= ScriptException.class)
+    public void testIndexedScriptsAreDisabledForCreation() {
+        client().preparePutIndexedScript()
+                .setId("foobar")
+                .setScriptLang("groovy")
+                .setSource("{\"script\" : 2}").execute().actionGet();
+    }
+
+    @Test(expected= SearchPhaseExecutionException.class)
+    public void testIndexedScriptsAreDisabledForSearch() throws ExecutionException, InterruptedException{
+        List<IndexRequestBuilder> builders = new ArrayList();
+        builders.add(client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "2").setSource("{\"theField\":\"foo 2\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "3").setSource("{\"theField\":\"foo 3\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "4").setSource("{\"theField\":\"foo 4\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "5").setSource("{\"theField\":\"bar\"}"));
+
+        indexRandom(true,builders);
+        String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script_id\" : \"script1\", \"lang\":\"groovy\" }, \"test2\" : { \"script_id\" : \"script2\", \"lang\":\"groovy\", \"params\":{\"factor\":3}  }}, size:1}";
+        client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
+    }
+
+
+    @Test
+    public void testInlineGroovyScriptsStillWorkIfIndexedScriptsAreDisabled() throws ExecutionException, InterruptedException {
+        List<IndexRequestBuilder> builders = new ArrayList();
+        builders.add(client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "2").setSource("{\"theField\":\"foo 2\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "3").setSource("{\"theField\":\"foo 3\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "4").setSource("{\"theField\":\"foo 4\"}"));
+        builders.add(client().prepareIndex("test", "scriptTest", "5").setSource("{\"theField\":\"bar\"}"));
+
+        indexRandom(true,builders);
+        SearchResponse searchResponse;
+        String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script\" : \"2\", \"lang\":\"groovy\" }, \"test2\" : { \"script\" : \"factor*2\", \"lang\":\"groovy\", \"params\":{\"factor\":3}  }}, size:1}";
+        searchResponse = client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
+        assertHitCount(searchResponse,5);
+        assertTrue(searchResponse.getHits().hits().length == 1);
+        SearchHit sh = searchResponse.getHits().getAt(0);
+        assertThat((Integer)sh.field("test1").getValue(), equalTo(2));
+        assertThat((Integer)sh.field("test2").getValue(), equalTo(6));
+    }
+}

--- a/src/test/java/org/elasticsearch/script/IndexedScriptDisabledTest.java
+++ b/src/test/java/org/elasticsearch/script/IndexedScriptDisabledTest.java
@@ -42,9 +42,15 @@ public class IndexedScriptDisabledTest extends ElasticsearchIntegrationTest {
 
     @Override
     public Settings nodeSettings(int nodeOrdinal) {
-        return settingsBuilder()
-                .put(ScriptService.DISABLE_INDEXED_SCRIPTING_SETTING, "true")
-                .build();
+        if (randomBoolean()) {
+            return settingsBuilder()
+                    .put(ScriptService.DISABLE_INDEXED_SCRIPTING_SETTING, "true")
+                    .build();
+        } else {
+            return settingsBuilder()
+                    .put(ScriptService.ENABLE_INDEXED_SCRIPTING_SETTING, "false")
+                    .build();
+        }
     }
 
     @Test(expected= ScriptException.class)


### PR DESCRIPTION
...cripts.

This commit adds the `script.disable_indexed` parameter to the config system.
If this is set to `true` indexed scripts cannot be created or used at search time.
If this is set to `sandbox` only indexed script that use sandboxed languages can be created or
used at search time.
If this is set to `false` indexed scripts from any supported language can be created or used at
search time.
The default value is `sandbox`.
This setting is independent of the `script.disable_dynamic` setting.

See #6922
