### PR TITLE
Plugins with only  `bin` and `config` do not install correctly

### DIFF
--- a/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugin/PluginManagerTests.java
@@ -125,6 +125,30 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
         }
     }
 
+    // For #7152
+    @Test
+    public void testLocalPluginInstallWithBinOnly_7152() throws Exception {
+        String pluginName = "plugin-test";
+        Tuple<Settings, Environment> initialSettings = InternalSettingsPreparer.prepareSettings(
+                ImmutableSettings.settingsBuilder().build(), false);
+        Environment env = initialSettings.v2();
+        File binDir = new File(env.homeFile(), "bin");
+        if (!binDir.exists() && !FileSystemUtils.mkdirs(binDir)) {
+            throw new IOException("Could not create bin directory [" + binDir.getAbsolutePath() + "]");
+        }
+        File pluginBinDir = new File(binDir, pluginName);
+        try {
+            PluginManager pluginManager = pluginManager(getPluginUrlForResource("plugin_with_bin_only.zip"), initialSettings);
+            pluginManager.downloadAndExtract(pluginName);
+            File[] plugins = pluginManager.getListInstalledPlugins();
+            assertThat(plugins.length, is(1));
+            assertTrue(pluginBinDir.exists());
+        } finally {
+            // we need to clean up the copied dirs
+            FileSystemUtils.deleteRecursively(pluginBinDir);
+        }
+    }
+
     @Test
     public void testLocalPluginInstallSiteFolder() throws Exception {
         //When we have only a folder in top-level (no files either) but it's called _site, we make it work


### PR DESCRIPTION
When installing a bin only plugin, it is identified as a site plugin.

A current workaround would be to create in the zip file another empty dir. So if you have:
- `bin/myfile.sh`
- `empty/empty.txt`

the `bin` content will be extracted as expected.

Closes #7152.
