### PR TITLE
Resolve wording inconsistency

### DIFF
--- a/docs/reference/query-dsl/filters/and-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/and-filter.asciidoc
@@ -1,7 +1,7 @@
 [[query-dsl-and-filter]]
 === And Filter
 
-A filter that matches documents using `AND` boolean operator on other
+A filter that matches documents using the `AND` boolean operator on other
 filters. Can be placed within queries that accept a filter.
 
 [source,js]

--- a/docs/reference/query-dsl/filters/or-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/or-filter.asciidoc
@@ -1,8 +1,8 @@
 [[query-dsl-or-filter]]
 === Or Filter
 
-A filter that matches documents using `OR` boolean operator on other
-queries. Can be placed within queries that accept a filter.
+A filter that matches documents using the `OR` boolean operator on other
+filters. Can be placed within queries that accept a filter.
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
AND and OR filter docs talk about different targets for the operators. I
believe that both should be described in terms of modifying other 'filters'.
I also added articles for easier (human) parsing. This fixes #4762
