### PR TITLE
Add a request level flag to control Query Cache

### DIFF
--- a/rest-api-spec/api/search.json
+++ b/rest-api-spec/api/search.json
@@ -146,6 +146,10 @@
         "version": {
           "type" : "boolean",
           "description" : "Specify whether to return document version as part of a hit"
+        },
+        "query_cache": {
+          "type" : "boolean",
+          "description" : "Specify if query cache should be used for this request or not, defaults to index level setting"
         }
       }
     },

--- a/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -137,6 +137,8 @@ public class MultiSearchRequest extends ActionRequest<MultiSearchRequest> implem
                                     searchRequest.types(Strings.splitStringByCommaToArray(parser.text()));
                                 } else if ("search_type".equals(currentFieldName) || "searchType".equals(currentFieldName)) {
                                     searchRequest.searchType(parser.text());
+                                } else if ("query_cache".equals(currentFieldName) || "queryCache".equals(currentFieldName)) {
+                                    searchRequest.queryCache(parser.booleanValue());
                                 } else if ("preference".equals(currentFieldName)) {
                                     searchRequest.preference(parser.text());
                                 } else if ("routing".equals(currentFieldName)) {

--- a/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -81,6 +81,7 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
 
     private BytesReference extraSource;
     private boolean extraSourceUnsafe;
+    private Boolean queryCache;
 
     private Scroll scroll;
 
@@ -493,6 +494,20 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
         return scroll(new Scroll(TimeValue.parseTimeValue(keepAlive, null)));
     }
 
+    /**
+     * Sets if this request should use the query cache or not, assuming that it can (for
+     * example, if "now" is used, it will never be cached). By default (not set, or null,
+     * will default to the index level setting if query cache is enabled or not).
+     */
+    public SearchRequest queryCache(Boolean queryCache) {
+        this.queryCache = queryCache;
+        return this;
+    }
+
+    public Boolean queryCache() {
+        return this.queryCache;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -532,6 +547,10 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
             if (in.readBoolean()) {
                 templateParams = (Map<String, String>) in.readGenericValue();
             }
+        }
+
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            queryCache = in.readOptionalBoolean();
         }
     }
 
@@ -573,6 +592,10 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
             if (existTemplateParams) {
                 out.writeGenericValue(templateParams);
             }
+        }
+
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeOptionalBoolean(queryCache);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -1069,6 +1069,16 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Sets if this request should use the query cache or not, assuming that it can (for
+     * example, if "now" is used, it will never be cached). By default (not set, or null,
+     * will default to the index level setting if query cache is enabled or not).
+     */
+    public SearchRequestBuilder setQueryCache(Boolean queryCache) {
+        request.queryCache(queryCache);
+        return this;
+    }
+
+    /**
      * Sets the source builder to be used with this request. Note, any operations done
      * on this require builder before are discarded as this internal builder replaces
      * what has been built up until this point.

--- a/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
+++ b/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
@@ -187,7 +187,12 @@ public class IndicesQueryCache extends AbstractComponent implements RemovalListe
         if (index == null) { // in case we didn't yet have the cluster state, or it just got deleted
             return false;
         }
-        if (!index.settings().getAsBoolean(INDEX_CACHE_QUERY_ENABLED, Boolean.FALSE)) {
+        // if not explicitly set in the request, use the index setting, if not, use the request
+        if (request.queryCache() == null) {
+            if (!index.settings().getAsBoolean(INDEX_CACHE_QUERY_ENABLED, Boolean.FALSE)) {
+                return false;
+            }
+        } else if (!request.queryCache()) {
             return false;
         }
         // if the reader is not a directory reader, we can't get the version from it
@@ -199,7 +204,6 @@ public class IndicesQueryCache extends AbstractComponent implements RemovalListe
         if (context.nowInMillisUsed()) {
             return false;
         }
-        // TODO allow to have a queryCache level flag on the request as well
         return true;
     }
 

--- a/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -109,6 +109,7 @@ public class RestSearchAction extends BaseRestHandler {
 
         searchRequest.extraSource(parseSearchSource(request));
         searchRequest.searchType(request.param("search_type"));
+        searchRequest.queryCache(request.paramAsBoolean("query_cache", null));
 
         String scroll = request.param("scroll");
         if (scroll != null) {

--- a/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -78,6 +78,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
     private String templateName;
     private ScriptService.ScriptType templateType;
     private Map<String, String> templateParams;
+    private Boolean queryCache;
 
     private long nowInMillis;
 
@@ -101,6 +102,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         this.scroll = searchRequest.scroll();
         this.types = searchRequest.types();
         this.useSlowScroll = useSlowScroll;
+        this.queryCache = searchRequest.queryCache();
     }
 
     public ShardSearchRequest(ShardRouting shardRouting, int numberOfShards, SearchType searchType) {
@@ -221,6 +223,10 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         return useSlowScroll;
     }
 
+    public Boolean queryCache() {
+        return this.queryCache;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -254,6 +260,10 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         } else {
             // This means that this request was send from a 1.0.x or 1.1.x node and we need to fallback to slow scroll.
             useSlowScroll = in.getVersion().before(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION);
+        }
+
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            queryCache = in.readOptionalBoolean();
         }
     }
 
@@ -298,6 +308,10 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         }
         if (out.getVersion().onOrAfter(ParsedScrollId.SCROLL_SEARCH_AFTER_MINIMUM_VERSION)) {
             out.writeBoolean(useSlowScroll);
+        }
+
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeOptionalBoolean(queryCache);
         }
     }
 }


### PR DESCRIPTION
A request level flag, defaults to be unset, to control the query cache. When not set, it defaults to the index level settings, when explicitly set, will override the index level setting
