### PR TITLE
Added missing percolate API parameters to the rest spec

### DIFF
--- a/rest-api-spec/api/percolate.json
+++ b/rest-api-spec/api/percolate.json
@@ -53,6 +53,14 @@
           "type" : "string",
           "description" : "The type to percolate document into. Defaults to type."
         },
+        "percolate_routing": {
+          "type" : "string",
+          "description" : "The routing value to use when percolating the existing document."
+        },
+        "percolate_preference": {
+          "type" : "string",
+          "description" : "Which shard to prefer when executing the percolate request."
+        },
         "percolate_format": {
           "type" : "enum",
           "options" : ["ids"],


### PR DESCRIPTION
(percolate_routing, percolate_preference) to the REST API Spec

https://github.com/elasticsearch/elasticsearch/issues/3380
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html#_percolating_an_existing_document
