### PR TITLE
Add executable flag to every file in bin/ after install

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -43,6 +43,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -235,6 +240,16 @@ public class PluginManager {
             if (!binFile.renameTo(toLocation)) {
                 throw new IOException("Could not move ["+ binFile.getAbsolutePath() + "] to [" + toLocation.getAbsolutePath() + "]");
             }
+            // Make everything in bin/ executable
+            Files.walkFileTree(toLocation.toPath(), new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (attrs.isRegularFile()) {
+                        file.toFile().setExecutable(true);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
             debug("Installed " + name + " into " + toLocation.getAbsolutePath());
             potentialSitePlugin = false;
         }

--- a/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -116,7 +116,9 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
             assertThat(plugins.length, is(1));
             assertTrue(pluginBinDir.exists());
             assertTrue(pluginConfigDir.exists());
-
+            File toolFile = new File(pluginBinDir, "tool");
+            assertThat(toolFile.exists(), is(true));
+            assertThat(toolFile.canExecute(), is(true));
         } finally {
             // we need to clean up the copied dirs
             FileSystemUtils.deleteRecursively(pluginBinDir);


### PR DESCRIPTION
The PluginManager does not preserve permissions on install due to using platform independent `ZipEntry` class. This patch sets the executable flag on every file in bin/ on plugin install as one is supposed to install executables in there.
