### PR TITLE
Fix geo_shapes which intersect dateline

### DIFF
--- a/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/BasePolygonBuilder.java
@@ -417,7 +417,7 @@ public abstract class BasePolygonBuilder<E extends BasePolygonBuilder<E>> extend
                 in.next = new Edge(in.intersect, out.next, in.intersect);
             }
             out.next = new Edge(out.intersect, e1, out.intersect);
-        } else {
+        } else if (in.next != out){
             // first edge intersects with dateline
             Edge e2 = new Edge(out.intersect, in.next, out.intersect);
 

--- a/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -293,12 +293,6 @@ public abstract class ShapeBuilder implements ToXContent {
 
             double position = intersection(p1, p2, dateline);
             if (!Double.isNaN(position)) {
-                if (position == 1) {
-                    if (Double.compare(p1.x, dateline) == Double.compare(edges[i].next.next.coordinate.x, dateline)) {
-                        // Ignore the ear
-                        continue;
-                    }
-                }
                 edges[i].intersection(position);
                 numIntersections++;
             }

--- a/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -308,4 +308,66 @@ public class ShapeBuilderTests extends ElasticsearchTestCase {
 
          assertPolygon(shape);
      }
+
+    @Test
+    public void testShapeWithHoleAtEdgeEndPoints() {
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(-4, 2)
+                .point(4, 2)
+                .point(6, 0)
+                .point(4, -2)
+                .point(-4, -2)
+                .point(-6, 0)
+                .point(-4, 2);
+
+        builder.hole()
+            .point(4, 1)
+            .point(4, -1)
+            .point(-4, -1)
+            .point(-4, 1)
+            .point(4, 1);
+
+        Shape shape = builder.close().build();
+
+         assertPolygon(shape);
+     }
+
+    @Test
+    public void testShapeWithPointOnDateline() {
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(180, 0)
+                .point(176, 4)
+                .point(176, -4)
+                .point(180, 0);
+
+        Shape shape = builder.close().build();
+
+         assertPolygon(shape);
+     }
+
+    @Test
+    public void testShapeWithEdgeAlongDateline() {
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(180, 0)
+                .point(176, 4)
+                .point(180, -4)
+                .point(180, 0);
+
+        Shape shape = builder.close().build();
+
+         assertPolygon(shape);
+     }
+
+    @Test
+    public void testShapeWithEdgeAcrossDateline() {
+        PolygonBuilder builder = ShapeBuilder.newPolygon()
+                .point(180, 0)
+                .point(176, 4)
+                .point(-176, 4)
+                .point(180, 0);
+
+        Shape shape = builder.close().build();
+
+         assertPolygon(shape);
+     }
 }


### PR DESCRIPTION
If a geo_shape had edges which either ran vertically along the dateline or touched the date line but did not cross it they would fail to parse.  This is because the code which splits a polygon along the dateline did not take into account the case where the polygon touched but did not cross the dateline.  This PR fixes those issues and provides tests for them.

Close #7016
