### PR TITLE
Fix BytesStreamInput(BytesReference) ctor with nonzero offset

### DIFF
--- a/src/main/java/org/elasticsearch/common/io/stream/BytesStreamInput.java
+++ b/src/main/java/org/elasticsearch/common/io/stream/BytesStreamInput.java
@@ -35,7 +35,7 @@ public class BytesStreamInput extends StreamInput {
 
     protected int pos;
 
-    protected int count;
+    protected int end;
 
     private final boolean unsafe;
 
@@ -45,7 +45,7 @@ public class BytesStreamInput extends StreamInput {
         }
         this.buf = bytes.array();
         this.pos = bytes.arrayOffset();
-        this.count = bytes.length();
+        this.end = pos + bytes.length();
         this.unsafe = false;
     }
 
@@ -56,7 +56,7 @@ public class BytesStreamInput extends StreamInput {
     public BytesStreamInput(byte buf[], int offset, int length, boolean unsafe) {
         this.buf = buf;
         this.pos = offset;
-        this.count = Math.min(offset + length, buf.length);
+        this.end = offset + length;
         this.unsafe = unsafe;
     }
 
@@ -82,8 +82,8 @@ public class BytesStreamInput extends StreamInput {
 
     @Override
     public long skip(long n) throws IOException {
-        if (pos + n > count) {
-            n = count - pos;
+        if (pos + n > end) {
+            n = end - pos;
         }
         if (n < 0) {
             return 0;
@@ -98,7 +98,7 @@ public class BytesStreamInput extends StreamInput {
 
     @Override
     public int read() throws IOException {
-        return (pos < count) ? (buf[pos++] & 0xff) : -1;
+        return (pos < end) ? (buf[pos++] & 0xff) : -1;
     }
 
     @Override
@@ -108,11 +108,11 @@ public class BytesStreamInput extends StreamInput {
         } else if (off < 0 || len < 0 || len > b.length - off) {
             throw new IndexOutOfBoundsException();
         }
-        if (pos >= count) {
+        if (pos >= end) {
             return -1;
         }
-        if (pos + len > count) {
-            len = count - pos;
+        if (pos + len > end) {
+            len = end - pos;
         }
         if (len <= 0) {
             return 0;
@@ -128,7 +128,7 @@ public class BytesStreamInput extends StreamInput {
 
     @Override
     public byte readByte() throws IOException {
-        if (pos >= count) {
+        if (pos >= end) {
             throw new EOFException();
         }
         return buf[pos++];
@@ -139,11 +139,11 @@ public class BytesStreamInput extends StreamInput {
         if (len == 0) {
             return;
         }
-        if (pos >= count) {
+        if (pos >= end) {
             throw new EOFException();
         }
-        if (pos + len > count) {
-            len = count - pos;
+        if (pos + len > end) {
+            len = end - pos;
         }
         if (len <= 0) {
             throw new EOFException();

--- a/src/test/java/org/elasticsearch/common/io/StreamsTests.java
+++ b/src/test/java/org/elasticsearch/common/io/StreamsTests.java
@@ -20,6 +20,9 @@
 package org.elasticsearch.common.io;
 
 import com.google.common.base.Charsets;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
@@ -27,7 +30,6 @@ import java.io.*;
 import java.util.Arrays;
 
 import static org.elasticsearch.common.io.Streams.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -86,6 +88,18 @@ public class StreamsTests extends ElasticsearchTestCase {
         StringReader in = new StringReader(content);
         String result = copyToString(in);
         assertThat(result, equalTo(content));
+    }
+    
+    @Test
+    public void testBytesStreamInput() throws IOException {
+        byte stuff[] = new byte[] { 0, 1, 2, 3 };
+        BytesRef stuffRef = new BytesRef(stuff, 2, 2);
+        BytesArray stuffArray = new BytesArray(stuffRef);
+        BytesStreamInput input = new BytesStreamInput(stuffArray);
+        assertEquals(2, input.read());
+        assertEquals(3, input.read());
+        assertEquals(-1, input.read());
+        input.close();
     }
 
 }


### PR DESCRIPTION
I renamed 'count' to 'end', since thats what it actually means for this class.

ctor 1 was broken, only worked if offset is zero.
ctor 2 had unnecessary leniency.
