### PR TITLE
Add index, type and id to ExplainResponse

### DIFF
--- a/rest-api-spec/test/explain/10_basic.yaml
+++ b/rest-api-spec/test/explain/10_basic.yaml
@@ -1,10 +1,10 @@
 ---
-"Basic mlt":
+"Basic explain":
   - do:
       index:
           index:  test_1
           type:   test
-          id:     1
+          id:     id_1
           body:   { foo: bar, title: howdy }
 
   - do:
@@ -14,10 +14,52 @@
       explain:
           index:  test_1
           type:   test
-          id:     1
+          id:     id_1
           body:
             query:
               match_all: {}
 
   - is_true: matched
   - match: { explanation.value: 1 }
+  - match: { _index: test_1 }
+  - match: { _type: test }
+  - match: { _id: id_1 }
+
+---
+"Basic explain with alias":
+  - do:
+      indices.create:
+          index: test_1
+          body:
+              aliases:
+                alias_1: {}
+
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+
+  - do:
+      index:
+          index:  test_1
+          type:   test
+          id:     id_1
+          body:   { foo: bar, title: howdy }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      explain:
+          index:  alias_1
+          type:   test
+          id:     id_1
+          body:
+            query:
+              match_all: {}
+
+  - is_true: matched
+  - match: { explanation.value: 1 }
+  - match: { _index: test_1 }
+  - match: { _type: test }
+  - match: { _id: id_1 }
+

--- a/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
+++ b/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.explain;
 
 import org.apache.lucene.search.Explanation;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,6 +36,9 @@ import static org.elasticsearch.common.lucene.Lucene.writeExplanation;
  */
 public class ExplainResponse extends ActionResponse {
 
+    private String index;
+    private String type;
+    private String id;
     private boolean exists;
     private Explanation explanation;
     private GetResult getResult;
@@ -42,19 +46,33 @@ public class ExplainResponse extends ActionResponse {
     ExplainResponse() {
     }
 
-    public ExplainResponse(boolean exists) {
+    public ExplainResponse(String index, String type, String id, boolean exists) {
+        this.index = index;
+        this.type = type;
+        this.id = id;
         this.exists = exists;
     }
 
-    public ExplainResponse(boolean exists, Explanation explanation) {
-        this.exists = exists;
+    public ExplainResponse(String index, String type, String id, boolean exists, Explanation explanation) {
+        this(index, type, id, exists);
         this.explanation = explanation;
     }
 
-    public ExplainResponse(boolean exists, Explanation explanation, GetResult getResult) {
-        this.exists = exists;
-        this.explanation = explanation;
+    public ExplainResponse(String index, String type, String id, boolean exists, Explanation explanation, GetResult getResult) {
+        this(index, type, id, exists, explanation);
         this.getResult = getResult;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getId() {
+        return id;
     }
 
     public Explanation getExplanation() {
@@ -79,6 +97,11 @@ public class ExplainResponse extends ActionResponse {
 
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
+        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
+            index = in.readString();
+            type = in.readString();
+            id = in.readString();
+        }
         exists = in.readBoolean();
         if (in.readBoolean()) {
             explanation = readExplanation(in);
@@ -90,6 +113,11 @@ public class ExplainResponse extends ActionResponse {
 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
+            out.writeString(index);
+            out.writeString(type);
+            out.writeString(id);
+        }
         out.writeBoolean(exists);
         if (explanation == null) {
             out.writeBoolean(false);

--- a/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -111,7 +111,7 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
         Term uidTerm = new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(request.type(), request.id()));
         Engine.GetResult result = indexShard.get(new Engine.Get(false, uidTerm));
         if (!result.exists()) {
-            return new ExplainResponse(false);
+            return new ExplainResponse(request.index(), request.type(), request.id(), false);
         }
 
         SearchContext context = new DefaultSearchContext(
@@ -139,9 +139,9 @@ public class TransportExplainAction extends TransportShardSingleOperationAction<
                 // because we are working in the same searcher in engineGetResult we can be sure that a
                 // doc isn't deleted between the initial get and this call.
                 GetResult getResult = indexShard.getService().get(result, request.id(), request.type(), request.fields(), request.fetchSourceContext(), false);
-                return new ExplainResponse(true, explanation, getResult);
+                return new ExplainResponse(request.index(), request.type(), request.id(), true, explanation, getResult);
             } else {
-                return new ExplainResponse(true, explanation);
+                return new ExplainResponse(request.index(), request.type(), request.id(), true, explanation);
             }
         } catch (IOException e) {
             throw new ElasticsearchException("Could not explain", e);

--- a/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/explain/RestExplainAction.java
@@ -106,9 +106,10 @@ public class RestExplainAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(ExplainResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                builder.field(Fields._INDEX, explainRequest.index())
-                        .field(Fields._TYPE, explainRequest.type())
-                        .field(Fields._ID, explainRequest.id())
+                //null checks for bw comp, since we only added in 1.4 index, type and id to ExplainResponse
+                builder.field(Fields._INDEX, response.getIndex() != null ? response.getIndex() : explainRequest.index())
+                        .field(Fields._TYPE, response.getType() != null ? response.getType() : explainRequest.type())
+                        .field(Fields._ID, response.getId() != null ? response.getId() : explainRequest.id())
                         .field(Fields.MATCHED, response.isMatch());
 
                 if (response.hasExplanation()) {

--- a/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
+++ b/src/test/java/org/elasticsearch/explain/ExplainActionTests.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class ExplainActionTests extends ElasticsearchIntegrationTest {
 
-
     @Test
     public void testSimple() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(
@@ -56,6 +55,9 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
                 .execute().actionGet();
         assertNotNull(response);
         assertFalse(response.isExists()); // not a match b/c not realtime
+        assertThat(response.getIndex(), equalTo("test"));
+        assertThat(response.getType(), equalTo("test"));
+        assertThat(response.getId(), equalTo("1"));
         assertFalse(response.isMatch()); // not a match b/c not realtime
 
         client().admin().indices().prepareRefresh("test").execute().actionGet();
@@ -66,6 +68,9 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
         assertTrue(response.isMatch());
         assertNotNull(response.getExplanation());
         assertTrue(response.getExplanation().isMatch());
+        assertThat(response.getIndex(), equalTo("test"));
+        assertThat(response.getType(), equalTo("test"));
+        assertThat(response.getId(), equalTo("1"));
         assertThat(response.getExplanation().getValue(), equalTo(1.0f));
 
         client().admin().indices().prepareRefresh("test").execute().actionGet();
@@ -75,6 +80,9 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
         assertNotNull(response);
         assertTrue(response.isExists());
         assertFalse(response.isMatch());
+        assertThat(response.getIndex(), equalTo("test"));
+        assertThat(response.getType(), equalTo("test"));
+        assertThat(response.getId(), equalTo("1"));
         assertNotNull(response.getExplanation());
         assertFalse(response.getExplanation().isMatch());
 
@@ -88,6 +96,9 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
         assertNotNull(response);
         assertTrue(response.isExists());
         assertFalse(response.isMatch());
+        assertThat(response.getIndex(), equalTo("test"));
+        assertThat(response.getType(), equalTo("test"));
+        assertThat(response.getId(), equalTo("1"));
         assertNotNull(response.getExplanation());
         assertFalse(response.getExplanation().isMatch());
         assertThat(response.getExplanation().getDetails().length, equalTo(2));
@@ -98,6 +109,9 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
         assertNotNull(response);
         assertFalse(response.isExists());
         assertFalse(response.isMatch());
+        assertThat(response.getIndex(), equalTo("test"));
+        assertThat(response.getType(), equalTo("test"));
+        assertThat(response.getId(), equalTo("2"));
     }
 
     @SuppressWarnings("unchecked")
@@ -218,6 +232,9 @@ public class ExplainActionTests extends ElasticsearchIntegrationTest {
         assertNotNull(response);
         assertTrue(response.isExists());
         assertFalse(response.isMatch());
+        assertThat(response.getIndex(), equalTo("test"));
+        assertThat(response.getType(), equalTo("test"));
+        assertThat(response.getId(), equalTo("1"));
     }
 
     @Test


### PR DESCRIPTION
Index, type and id were returned as part of the REST explain api response, but not through java api. That info was read out of the request, relying on the fact that the index would get overridden with the concrete one within that same request instance.
