### PR TITLE
Add suggestRequest to Requests and fix broken javadocs in client

### DIFF
--- a/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
+++ b/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
@@ -38,8 +38,8 @@ import org.elasticsearch.common.xcontent.XContentType;
  * A request to get suggestions for corrections of phrases. Best created with
  * {@link org.elasticsearch.client.Requests#suggestRequest(String...)}.
  * <p/>
- * <p>The request requires the query source to be set either using {@link #query(org.elasticsearch.index.query.QueryBuilder)},
- * or {@link #query(byte[])}.
+ * <p>The request requires the suggest query source to be set either using {@link #suggest(org.elasticsearch.common.bytes.BytesReference)},
+ * or {@link #suggest(org.elasticsearch.common.bytes.BytesReference, boolean)}.
  *
  * @see SuggestResponse
  * @see org.elasticsearch.client.Client#suggest(SuggestRequest)

--- a/src/main/java/org/elasticsearch/client/Requests.java
+++ b/src/main/java/org/elasticsearch/client/Requests.java
@@ -61,6 +61,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.mlt.MoreLikeThisRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.suggest.SuggestRequest;
 import org.elasticsearch.common.xcontent.XContentType;
 
 /**
@@ -159,6 +160,16 @@ public class Requests {
      */
     public static ExistsRequest existsRequest(String... indices) {
         return new ExistsRequest(indices);
+    }
+
+    /**
+     * Creates a suggest request for getting suggestions from provided <code>indices</code>.
+     * The suggest query has to be set using the JSON source using {@link org.elasticsearch.action.suggest.SuggestRequest#suggest(org.elasticsearch.common.bytes.BytesReference)}.
+     * @param indices The indices to suggest from. Use <tt>null</tt> or <tt>_all</tt> to execute against all indices
+     * @see org.elasticsearch.client.Client#suggest(org.elasticsearch.action.suggest.SuggestRequest)
+     */
+    public static SuggestRequest suggestRequest(String... indices) {
+        return new SuggestRequest(indices);
     }
 
     /**


### PR DESCRIPTION
Added missing suggestRequest to Requests to fix broken java docs and updated suggest client javadocs

closes #7206
