### PR TITLE
XContentBuilder.map(Map) method modified to use a wildcard for value's type.

### DIFF
--- a/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -1008,7 +1008,7 @@ public final class XContentBuilder implements BytesStream {
         return this;
     }
 
-    public XContentBuilder map(Map<String, Object> map) throws IOException {
+    public XContentBuilder map(Map<String, ?> map) throws IOException {
         if (map == null) {
             return nullValue();
         }
@@ -1088,10 +1088,10 @@ public final class XContentBuilder implements BytesStream {
     }
 
 
-    private void writeMap(Map<String, Object> map) throws IOException {
+    private void writeMap(Map<String, ?> map) throws IOException {
         generator.writeStartObject();
 
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
             field(entry.getKey());
             Object value = entry.getValue();
             if (value == null) {


### PR DESCRIPTION
The XContentBuilder.map(Map<String, Object>) method could be modified to use a wildcard for value's type.

This could make the API slightly more convenient. 
For exemple, when I got a org.elasticsearch.common.settings.Settings and call getAsMap(), it returns a Map<String, String> that can not be passed to map(Map<String, Object>).

Users of the current API are forced to pass a Map<String, Object>, but any reference with such type can be passed to Map<String, ?>, so they will require no changes.
Consumers of a Map<String, ?> get Object as type for the entry.getValue(), as in XContentBuilder.writeMap(), so it will require no changes here.

This could be backported easily to other branches.
