### PR TITLE
Refactored TransportSingleCustomOperationAction, subclasses and requests

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -20,8 +20,6 @@ package org.elasticsearch.action.admin.indices.analyze;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.single.custom.SingleCustomOperationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -36,9 +34,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * A request to analyze a text associated with a specific index. Allow to provide
  * the actual analyzer name to perform the analysis with.
  */
-public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest> implements IndicesRequest {
-
-    private String index;
+public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest> {
 
     private String text;
 
@@ -72,34 +68,12 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
      * @param text  The text to analyze
      */
     public AnalyzeRequest(@Nullable String index, String text) {
-        this.index = index;
+        this.index(index);
         this.text = text;
     }
 
     public String text() {
         return this.text;
-    }
-
-    public AnalyzeRequest index(String index) {
-        this.index = index;
-        return this;
-    }
-
-    public String index() {
-        return this.index;
-    }
-
-    @Override
-    public String[] indices() {
-        if (index == null) {
-            return Strings.EMPTY_ARRAY;
-        }
-        return new String[]{index};
-    }
-
-    @Override
-    public IndicesOptions indicesOptions() {
-        return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
     }
 
     public AnalyzeRequest analyzer(String analyzer) {
@@ -165,7 +139,9 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readOptionalString();
+        if (in.getVersion().before(Version.V_1_4_0)) {
+            index(in.readOptionalString());
+        }
         text = in.readString();
         analyzer = in.readOptionalString();
         tokenizer = in.readOptionalString();
@@ -179,7 +155,9 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(index);
+        if (out.getVersion().before(Version.V_1_4_0)) {
+            out.writeOptionalString(index());
+        }
         out.writeString(text);
         out.writeOptionalString(analyzer);
         out.writeOptionalString(tokenizer);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -139,9 +139,6 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().before(Version.V_1_4_0)) {
-            index(in.readOptionalString());
-        }
         text = in.readString();
         analyzer = in.readOptionalString();
         tokenizer = in.readOptionalString();
@@ -155,9 +152,6 @@ public class AnalyzeRequest extends SingleCustomOperationRequest<AnalyzeRequest>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_1_4_0)) {
-            out.writeOptionalString(index());
-        }
         out.writeString(text);
         out.writeOptionalString(analyzer);
         out.writeOptionalString(tokenizer);

--- a/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -27,12 +27,12 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.custom.TransportSingleCustomOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -44,13 +44,15 @@ import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.BaseTransportRequestHandler;
+import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.List;
 
 /**
- *
+ * Transport action used to execute analyze requests
  */
 public class TransportAnalyzeAction extends TransportSingleCustomOperationAction<AnalyzeRequest, AnalyzeResponse> {
 
@@ -64,6 +66,7 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
         super(settings, AnalyzeAction.NAME, threadPool, clusterService, transportService, actionFilters);
         this.indicesService = indicesService;
         this.indicesAnalysisService = indicesAnalysisService;
+        transportService.registerHandler(AnalyzeAction.NAME, new TransportHandler());
     }
 
     @Override
@@ -82,15 +85,10 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
     }
 
     @Override
-    protected ClusterBlockException checkGlobalBlock(ClusterState state, AnalyzeRequest request) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
-    }
-
-    @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, AnalyzeRequest request) {
         if (request.index() != null) {
             request.index(state.metaData().concreteSingleIndex(request.index(), request.indicesOptions()));
-            return state.blocks().indexBlockedException(ClusterBlockLevel.READ, request.index());
+            return super.checkRequestBlock(state, request);
         }
         return null;
     }
@@ -252,5 +250,45 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
         }
 
         return new AnalyzeResponse(tokens);
+    }
+
+    private class TransportHandler extends BaseTransportRequestHandler<AnalyzeRequest> {
+
+        @Override
+        public AnalyzeRequest newInstance() {
+            return newRequest();
+        }
+
+        @Override
+        public void messageReceived(AnalyzeRequest request, final TransportChannel channel) throws Exception {
+            // no need to have a threaded listener since we just send back a response
+            request.listenerThreaded(false);
+            // if we have a local operation, execute it on a thread since we don't spawn
+            request.operationThreaded(true);
+            execute(request, new ActionListener<AnalyzeResponse>() {
+                @Override
+                public void onResponse(AnalyzeResponse result) {
+                    try {
+                        channel.sendResponse(result);
+                    } catch (Throwable e) {
+                        onFailure(e);
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable e) {
+                    try {
+                        channel.sendResponse(e);
+                    } catch (Exception e1) {
+                        logger.warn("Failed to send response for get", e1);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.SAME;
+        }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.mapping.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.single.custom.SingleCustomOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -66,9 +65,6 @@ class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetField
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_1_4_0)) {
-            out.writeString(index());
-        }
         out.writeStringArray(types);
         out.writeStringArray(fields);
         out.writeBoolean(includeDefaults);
@@ -76,14 +72,21 @@ class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetField
     }
 
     @Override
+    protected void writeIndex(StreamOutput out) throws IOException {
+        out.writeString(index());
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        if (in.getVersion().before(Version.V_1_4_0)) {
-            index(in.readString());
-        }
         types = in.readStringArray();
         fields = in.readStringArray();
         includeDefaults = in.readBoolean();
         probablySingleFieldRequest = in.readBoolean();
+    }
+
+    @Override
+    protected void readIndex(StreamInput in) throws IOException {
+        index(in.readString());
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.mapping.get;
 
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.single.custom.SingleCustomOperationRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,9 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetFieldMappingsIndexRequest> implements IndicesRequest {
-
-    private String index;
+class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetFieldMappingsIndexRequest> {
 
     private boolean probablySingleFieldRequest;
     private boolean includeDefaults;
@@ -48,21 +44,7 @@ class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetField
         this.types = other.types();
         this.fields = other.fields();
         assert index != null;
-        this.index = index;
-    }
-
-    public String index() {
-        return index;
-    }
-
-    @Override
-    public IndicesOptions indicesOptions() {
-        return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
-    }
-
-    @Override
-    public String[] indices() {
-        return new String[]{index};
+        this.index(index);
     }
 
     public String[] types() {
@@ -81,21 +63,12 @@ class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetField
         return includeDefaults;
     }
 
-    /** Indicates whether default mapping settings should be returned */
-    public GetFieldMappingsIndexRequest includeDefaults(boolean includeDefaults) {
-        this.includeDefaults = includeDefaults;
-        return this;
-    }
-
-    @Override
-    public ActionRequestValidationException validate() {
-        return null;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
+        if (out.getVersion().before(Version.V_1_4_0)) {
+            out.writeString(index());
+        }
         out.writeStringArray(types);
         out.writeStringArray(fields);
         out.writeBoolean(includeDefaults);
@@ -105,7 +78,9 @@ class GetFieldMappingsIndexRequest extends SingleCustomOperationRequest<GetField
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
+        if (in.getVersion().before(Version.V_1_4_0)) {
+            index(in.readString());
+        }
         types = in.readStringArray();
         fields = in.readStringArray();
         includeDefaults = in.readBoolean();

--- a/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -28,8 +28,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.custom.TransportSingleCustomOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
@@ -53,6 +51,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
+ * Transport action used to retrieve the mappings related to fields that belong to a specific index
  */
 public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomOperationAction<GetFieldMappingsIndexRequest, GetFieldMappingsResponse> {
 
@@ -123,16 +122,6 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
     @Override
     protected GetFieldMappingsResponse newResponse() {
         return new GetFieldMappingsResponse();
-    }
-
-    @Override
-    protected ClusterBlockException checkGlobalBlock(ClusterState state, GetFieldMappingsIndexRequest request) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
-    }
-
-    @Override
-    protected ClusterBlockException checkRequestBlock(ClusterState state, GetFieldMappingsIndexRequest request) {
-        return state.blocks().indexBlockedException(ClusterBlockLevel.READ, request.index());
     }
 
     private static final ToXContent.Params includeDefaultsParams = new ToXContent.Params() {

--- a/src/main/java/org/elasticsearch/action/support/single/custom/SingleCustomOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/single/custom/SingleCustomOperationRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.support.single.custom;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -111,18 +110,22 @@ public abstract class SingleCustomOperationRequest<T extends SingleCustomOperati
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         preferLocal = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_1_4_0)) {
-            index = in.readOptionalString();
-        }
+        readIndex(in);
+    }
+
+    protected void readIndex(StreamInput in) throws IOException {
+        index = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(preferLocal);
-        if (out.getVersion().onOrAfter(Version.V_1_4_0)) {
-            out.writeOptionalString(index);
-        }
+        writeIndex(out);
+    }
+
+    protected void writeIndex(StreamOutput out) throws IOException {
+        out.writeOptionalString(index);
     }
 }
 

--- a/src/main/java/org/elasticsearch/transport/ActionNames.java
+++ b/src/main/java/org/elasticsearch/transport/ActionNames.java
@@ -206,7 +206,6 @@ final class ActionNames {
         builder.put(DeleteMappingAction.NAME, "indices/mapping/delete");
         builder.put(PutMappingAction.NAME, "indices/mapping/put");
         builder.put(GetFieldMappingsAction.NAME, "mappings/fields/get");
-        builder.put(GetFieldMappingsAction.NAME + "[index]", "mappings/fields/get/index");
         builder.put(GetFieldMappingsAction.NAME + "[index][s]", "mappings/fields/get/index/s");
         builder.put(GetMappingsAction.NAME, "mappings/get");
 


### PR DESCRIPTION
`TransportSingleCustomOperationAction` is subclassed by two similar, yet different transport actions: `TransportAnalyzeAction` and `TransportGetFieldMappingsIndexAction`. Made their difference and similarities more explicit by sharing common code and moving specific code to subclasses:
- moved index field to the parent `SingleCustomOperationAction` class
- moved the common check blocks code to the parent transport action class
- moved the main transport handler to the `TransportAnalyzeAction` subclass as it is only used to receive external requests through clients. In the case of the `TransportGetFieldMappingsIndexAction` instead, the action is internal and executed only locally as part of the user facing `TransportGetFieldMappingsAction`. The corresponding request gets sent over the transport though as part of the related shard request
- removed the get field mappings index action from the action names mapping as it is not a transport handler anymore. It was before although never used.
