### PR TITLE
Update README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -37,6 +37,8 @@ First of all, DON'T PANIC. It will take 5 minutes to get the gist of what Elasti
 h3. Installation
 
 * "Download":http://www.elasticsearch.org/download and unzip the Elasticsearch official distribution.
+* Build using Maven: Run @mvn compile@
+    Note: you will need java jdk 1.7 or greater and JAVA_HOME defined.
 * Run @bin/elasticsearch@ on unix, or @bin\elasticsearch.bat@ on windows.
 * Run @curl -X GET http://localhost:9200/@.
 * Start more servers ...

--- a/README.textile
+++ b/README.textile
@@ -37,7 +37,7 @@ First of all, DON'T PANIC. It will take 5 minutes to get the gist of what Elasti
 h3. Installation
 
 * "Download":http://www.elasticsearch.org/download and unzip the Elasticsearch official distribution.
-* Build using Maven: Run @mvn compile@
+* Build using Maven: Run @mvn clean package -DskipTests@
     Note: you will need java jdk 1.7 or greater and JAVA_HOME defined.
 * Run @bin/elasticsearch@ on unix, or @bin\elasticsearch.bat@ on windows.
 * Run @curl -X GET http://localhost:9200/@.


### PR DESCRIPTION
With a raw checkout, people need to build the thing.  I realize there is more to do here, the maven build just creates an installer?  The suggestion here is that it would be nice to clone the repo and have all the instructions necessary to build and run to get it running quickly from source.

So it could go something like this:

Configure the install package type that will be built: how to set buidl of tar vs deb installer?
Build using Maven: Run @mvn clean package -DskipTests@
     Note: you will need java jdk 1.7 or greater and JAVA_HOME defined.
Find the installer package and run: .... 
cd [intstall location] 
untar -tvf blah.tar.gz
Change to the installation: cd blah

then the rest...
