### PR TITLE
Make sure that multi fields are serialized in a consistent order.

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -60,10 +60,7 @@ import org.elasticsearch.index.similarity.SimilarityLookupService;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 /**
  *
@@ -995,9 +992,17 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
                 builder.field("path", pathType.name().toLowerCase(Locale.ROOT));
             }
             if (!mappers.isEmpty()) {
+                // sort the mappers so we get consistent serialization format
+                Mapper[] sortedMappers = mappers.values().toArray(Mapper.class);
+                Arrays.sort(sortedMappers, new Comparator<Mapper>() {
+                    @Override
+                    public int compare(Mapper o1, Mapper o2) {
+                        return o1.name().compareTo(o2.name());
+                    }
+                });
                 builder.startObject("fields");
-                for (ObjectCursor<Mapper> cursor : mappers.values()) {
-                    cursor.value.toXContent(builder, params);
+                for (Mapper mapper : sortedMappers) {
+                    mapper.toXContent(builder, params);
                 }
                 builder.endObject();
             }

--- a/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -23,6 +23,9 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -32,6 +35,9 @@ import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.test.ElasticsearchSingleNodeTest;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
 
 import static org.elasticsearch.common.io.Streams.copyToBytesFromClasspath;
 import static org.elasticsearch.common.io.Streams.copyToStringFromClasspath;
@@ -407,5 +413,36 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         assertThat(f.stringValue(), equalTo("complete me"));
         assertThat(f.fieldType().stored(), equalTo(false));
         assertThat(f.fieldType().indexed(), equalTo(true));
+    }
+
+    @Test
+    // The underlying order of the fields in multi fields in the mapping source should always be consistent, if not this
+    // can to unnecessary re-syncing of the mappings between the local instance and cluster state
+    public void testMultiFieldsInConsistentOrder() throws Exception {
+        String[] multiFieldNames = new String[randomIntBetween(2, 10)];
+        for (int i = 0; i < multiFieldNames.length; i++) {
+            multiFieldNames[i] = randomAsciiOfLength(4);
+        }
+
+        XContentBuilder builder = jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject("my_field").field("type", "string").startObject("fields");
+        for (String multiFieldName : multiFieldNames) {
+            builder = builder.startObject(multiFieldName).field("type", "string").endObject();
+        }
+        builder = builder.endObject().endObject().endObject().endObject().endObject();
+        String mapping = builder.string();
+        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        Arrays.sort(multiFieldNames);
+
+        Map<String, Object> sourceAsMap = XContentHelper.convertToMap(docMapper.mappingSource().compressed(), true).v2();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> multiFields = (Map<String, Object>) XContentMapValues.extractValue("type.properties.my_field.fields", sourceAsMap);
+        assertThat(multiFields.size(), equalTo(multiFieldNames.length));
+
+        int i = 0;
+        // underlying map is LinkedHashMap, so this ok:
+        for (String field : multiFields.keySet()) {
+            assertThat(field, equalTo(multiFieldNames[i++]));
+        }
     }
 }


### PR DESCRIPTION
This ensure that the source is the same and avoids unnecessary mapping re-syncs.

PR for #7215
