### PR TITLE
Test: Allow CliTool to write out stacktraces

### DIFF
--- a/src/main/java/org/elasticsearch/common/cli/CliTool.java
+++ b/src/main/java/org/elasticsearch/common/cli/CliTool.java
@@ -144,13 +144,13 @@ public abstract class CliTool {
             return command.execute(settings, env).status;
 
         } catch (IOException ioe) {
-            terminal.printError(ioe.getMessage());
+            terminal.printError(ioe);
             return ExitStatus.IO_ERROR.status;
         } catch (IllegalArgumentException | ElasticsearchIllegalArgumentException ilae) {
-            terminal.printError(ilae.getMessage());
+            terminal.printError(ilae);
             return ExitStatus.USAGE.status;
         } catch (Throwable t) {
-            terminal.printError(t.getMessage());
+            terminal.printError(t);
             if (command == null) {
                 return ExitStatus.USAGE.status;
             }

--- a/src/test/java/org/elasticsearch/common/cli/CliToolTestCase.java
+++ b/src/test/java/org/elasticsearch/common/cli/CliToolTestCase.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.cli;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ElasticsearchTestCase;
 
@@ -75,6 +76,11 @@ public class CliToolTestCase extends ElasticsearchTestCase {
         }
 
         @Override
+        public void printStackTrace(Throwable t) {
+            return;
+        }
+
+        @Override
         public PrintWriter writer() {
             return DEV_NULL;
         }
@@ -118,6 +124,11 @@ public class CliToolTestCase extends ElasticsearchTestCase {
         @Override
         public void print(String msg, Object... args) {
             doPrint(msg, args);
+        }
+
+        @Override
+        public void printStackTrace(Throwable t) {
+            terminalOutput.add(ExceptionsHelper.stackTrace(t));
         }
 
         public List<String> getTerminalOutput() {


### PR DESCRIPTION
In order to have the possibility of debugging on the command line, the user
now can either set the ES_CLI_DEBUG environment variable or at es.cli.debug system
property which results in stack traces being written to stdout.
