### PR TITLE
Adjusted visibility for BroadcastShardOperationRequest subclasses and their constructors

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ShardClearIndicesCacheRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -43,8 +44,8 @@ class ShardClearIndicesCacheRequest extends BroadcastShardOperationRequest {
     ShardClearIndicesCacheRequest() {
     }
 
-    public ShardClearIndicesCacheRequest(String index, int shardId, ClearIndicesCacheRequest request) {
-        super(index, shardId, request);
+    ShardClearIndicesCacheRequest(ShardId shardId, ClearIndicesCacheRequest request) {
+        super(shardId, request);
         filterCache = request.filterCache();
         fieldDataCache = request.fieldDataCache();
         idCache = request.idCache();

--- a/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.TransportBroadcastOperationAction;
-import org.elasticsearch.cache.recycler.CacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -106,7 +105,7 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastOperatio
 
     @Override
     protected ShardClearIndicesCacheRequest newShardRequest(int numShards, ShardRouting shard, ClearIndicesCacheRequest request) {
-        return new ShardClearIndicesCacheRequest(shard.index(), shard.id(), request);
+        return new ShardClearIndicesCacheRequest(shard.shardId(), request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -38,8 +39,8 @@ class ShardFlushRequest extends BroadcastShardOperationRequest {
     ShardFlushRequest() {
     }
 
-    public ShardFlushRequest(String index, int shardId, FlushRequest request) {
-        super(index, shardId, request);
+    ShardFlushRequest(ShardId shardId, FlushRequest request) {
+        super(shardId, request);
         this.full = request.full();
         this.force = request.force();
         this.waitIfOngoing = request.waitIfOngoing();

--- a/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -96,7 +96,7 @@ public class TransportFlushAction extends TransportBroadcastOperationAction<Flus
 
     @Override
     protected ShardFlushRequest newShardRequest(int numShards, ShardRouting shard, FlushRequest request) {
-        return new ShardFlushRequest(shard.index(), shard.id(), request);
+        return new ShardFlushRequest(shard.shardId(), request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/ShardOptimizeRequest.java
@@ -24,6 +24,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -41,8 +42,8 @@ class ShardOptimizeRequest extends BroadcastShardOperationRequest {
     ShardOptimizeRequest() {
     }
 
-    public ShardOptimizeRequest(String index, int shardId, OptimizeRequest request) {
-        super(index, shardId, request);
+    ShardOptimizeRequest(ShardId shardId, OptimizeRequest request) {
+        super(shardId, request);
         waitForMerge = request.waitForMerge();
         maxNumSegments = request.maxNumSegments();
         onlyExpungeDeletes = request.onlyExpungeDeletes();

--- a/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -97,7 +97,7 @@ public class TransportOptimizeAction extends TransportBroadcastOperationAction<O
 
     @Override
     protected ShardOptimizeRequest newShardRequest(int numShards, ShardRouting shard, OptimizeRequest request) {
-        return new ShardOptimizeRequest(shard.index(), shard.id(), request);
+        return new ShardOptimizeRequest(shard.shardId(), request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -33,11 +33,10 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.gateway.IndexShardGatewayService;
 import org.elasticsearch.index.service.InternalIndexService;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.RecoveryState;
@@ -46,7 +45,6 @@ import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -133,7 +131,7 @@ public class TransportRecoveryAction extends
 
     @Override
     protected ShardRecoveryRequest newShardRequest(int numShards, ShardRouting shard, RecoveryRequest request) {
-        return new ShardRecoveryRequest(shard.index(), shard.id(), request);
+        return new ShardRecoveryRequest(shard.shardId(), request);
     }
 
     @Override
@@ -183,22 +181,12 @@ public class TransportRecoveryAction extends
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA, concreteIndices);
     }
 
-    public static class ShardRecoveryRequest extends BroadcastShardOperationRequest {
+    static class ShardRecoveryRequest extends BroadcastShardOperationRequest {
 
         ShardRecoveryRequest() { }
 
-        ShardRecoveryRequest(String index, int shardId, RecoveryRequest request) {
-            super(index, shardId, request);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
+        ShardRecoveryRequest(ShardId shardId, RecoveryRequest request) {
+            super(shardId, request);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.refresh;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -35,8 +36,8 @@ class ShardRefreshRequest extends BroadcastShardOperationRequest {
     ShardRefreshRequest() {
     }
 
-    public ShardRefreshRequest(String index, int shardId, RefreshRequest request) {
-        super(index, shardId, request);
+    ShardRefreshRequest(ShardId shardId, RefreshRequest request) {
+        super(shardId, request);
         force = request.force();
     }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -97,7 +97,7 @@ public class TransportRefreshAction extends TransportBroadcastOperationAction<Re
 
     @Override
     protected ShardRefreshRequest newShardRequest(int numShards, ShardRouting shard, RefreshRequest request) {
-        return new ShardRefreshRequest(shard.index(), shard.id(), request);
+        return new ShardRefreshRequest(shard.shardId(), request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -33,16 +33,14 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.service.InternalIndexService;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -121,7 +119,7 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
 
     @Override
     protected IndexShardSegmentRequest newShardRequest(int numShards, ShardRouting shard, IndicesSegmentsRequest request) {
-        return new IndexShardSegmentRequest(shard.index(), shard.id(), request);
+        return new IndexShardSegmentRequest(shard.shardId(), request);
     }
 
     @Override
@@ -141,18 +139,8 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastOperationA
         IndexShardSegmentRequest() {
         }
 
-        IndexShardSegmentRequest(String index, int shardId, IndicesSegmentsRequest request) {
-            super(index, shardId, request);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
+        IndexShardSegmentRequest(ShardId shardId, IndicesSegmentsRequest request) {
+            super(shardId, request);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.service.InternalIndexService;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -122,7 +123,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
 
     @Override
     protected IndexShardStatsRequest newShardRequest(int numShards, ShardRouting shard, IndicesStatsRequest request) {
-        return new IndexShardStatsRequest(shard.index(), shard.id(), request);
+        return new IndexShardStatsRequest(shard.shardId(), request);
     }
 
     @Override
@@ -207,8 +208,8 @@ public class TransportIndicesStatsAction extends TransportBroadcastOperationActi
         IndexShardStatsRequest() {
         }
 
-        IndexShardStatsRequest(String index, int shardId, IndicesStatsRequest request) {
-            super(index, shardId, request);
+        IndexShardStatsRequest(ShardId shardId, IndicesStatsRequest request) {
+            super(shardId, request);
             this.request = request;
         }
 

--- a/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/status/TransportIndicesStatusAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.gateway.IndexShardGatewayService;
 import org.elasticsearch.index.service.InternalIndexService;
 import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.service.InternalIndexShard;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.IndicesService;
@@ -135,7 +136,7 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
 
     @Override
     protected IndexShardStatusRequest newShardRequest(int numShards, ShardRouting shard, IndicesStatusRequest request) {
-        return new IndexShardStatusRequest(shard.index(), shard.id(), request);
+        return new IndexShardStatusRequest(shard.shardId(), request);
     }
 
     @Override
@@ -247,8 +248,8 @@ public class TransportIndicesStatusAction extends TransportBroadcastOperationAct
         IndexShardStatusRequest() {
         }
 
-        IndexShardStatusRequest(String index, int shardId, IndicesStatusRequest request) {
-            super(index, shardId, request);
+        IndexShardStatusRequest(ShardId shardId, IndicesStatusRequest request) {
+            super(shardId, request);
             recovery = request.recovery();
             snapshot = request.snapshot();
         }

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -45,8 +46,8 @@ class ShardValidateQueryRequest extends BroadcastShardOperationRequest {
 
     }
 
-    public ShardValidateQueryRequest(String index, int shardId, @Nullable String[] filteringAliases, ValidateQueryRequest request) {
-        super(index, shardId, request);
+    ShardValidateQueryRequest(ShardId shardId, @Nullable String[] filteringAliases, ValidateQueryRequest request) {
+        super(shardId, request);
         this.source = request.source();
         this.types = request.types();
         this.explain = request.explain();

--- a/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -106,7 +106,7 @@ public class TransportValidateQueryAction extends TransportBroadcastOperationAct
     @Override
     protected ShardValidateQueryRequest newShardRequest(int numShards, ShardRouting shard, ValidateQueryRequest request) {
         String[] filteringAliases = clusterService.state().metaData().filteringAliases(shard.index(), request.indices());
-        return new ShardValidateQueryRequest(shard.index(), shard.id(), filteringAliases, request);
+        return new ShardValidateQueryRequest(shard.shardId(), filteringAliases, request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
+++ b/src/main/java/org/elasticsearch/action/count/ShardCountRequest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -52,8 +53,8 @@ class ShardCountRequest extends BroadcastShardOperationRequest {
 
     }
 
-    public ShardCountRequest(String index, int shardId, @Nullable String[] filteringAliases, CountRequest request) {
-        super(index, shardId, request);
+    ShardCountRequest(ShardId shardId, @Nullable String[] filteringAliases, CountRequest request) {
+        super(shardId, request);
         this.minScore = request.minScore();
         this.querySource = request.source();
         this.types = request.types();

--- a/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
+++ b/src/main/java/org/elasticsearch/action/count/TransportCountAction.java
@@ -111,7 +111,7 @@ public class TransportCountAction extends TransportBroadcastOperationAction<Coun
     @Override
     protected ShardCountRequest newShardRequest(int numShards, ShardRouting shard, CountRequest request) {
         String[] filteringAliases = clusterService.state().metaData().filteringAliases(shard.index(), request.indices());
-        return new ShardCountRequest(shard.index(), shard.id(), filteringAliases, request);
+        return new ShardCountRequest(shard.shardId(), filteringAliases, request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/exists/ShardExistsRequest.java
+++ b/src/main/java/org/elasticsearch/action/exists/ShardExistsRequest.java
@@ -25,10 +25,11 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-public class ShardExistsRequest extends BroadcastShardOperationRequest {
+class ShardExistsRequest extends BroadcastShardOperationRequest {
 
     private float minScore;
 
@@ -44,8 +45,8 @@ public class ShardExistsRequest extends BroadcastShardOperationRequest {
     ShardExistsRequest() {
     }
 
-    public ShardExistsRequest(String index, int shardId, @Nullable String[] filteringAliases, ExistsRequest request) {
-        super(index, shardId, request);
+    ShardExistsRequest(ShardId shardId, @Nullable String[] filteringAliases, ExistsRequest request) {
+        super(shardId, request);
         this.minScore = request.minScore();
         this.querySource = request.source();
         this.types = request.types();

--- a/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
+++ b/src/main/java/org/elasticsearch/action/exists/TransportExistsAction.java
@@ -111,7 +111,7 @@ public class TransportExistsAction extends TransportBroadcastOperationAction<Exi
     @Override
     protected ShardExistsRequest newShardRequest(int numShards, ShardRouting shard, ExistsRequest request) {
         String[] filteringAliases = clusterService.state().metaData().filteringAliases(shard.index(), request.indices());
-        return new ShardExistsRequest(shard.index(), shard.id(), filteringAliases, request);
+        return new ShardExistsRequest(shard.shardId(), filteringAliases, request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/percolate/PercolateShardRequest.java
+++ b/src/main/java/org/elasticsearch/action/percolate/PercolateShardRequest.java
@@ -38,15 +38,15 @@ public class PercolateShardRequest extends BroadcastShardOperationRequest {
     private boolean onlyCount;
     private int numberOfShards;
 
-    public PercolateShardRequest() {
+    PercolateShardRequest() {
     }
 
-    public PercolateShardRequest(String index, int shardId) {
-        super(index, shardId);
+    PercolateShardRequest(ShardId shardId) {
+        super(shardId);
     }
 
-    public PercolateShardRequest(String index, int shardId, int numberOfShards, PercolateRequest request) {
-        super(index, shardId, request);
+    PercolateShardRequest(ShardId shardId, int numberOfShards, PercolateRequest request) {
+        super(shardId, request);
         this.documentType = request.documentType();
         this.source = request.source();
         this.docSource = request.docSource();
@@ -54,8 +54,8 @@ public class PercolateShardRequest extends BroadcastShardOperationRequest {
         this.numberOfShards = numberOfShards;
     }
 
-    public PercolateShardRequest(ShardId shardId, PercolateRequest request) {
-        super(shardId.index().name(), shardId.id());
+    PercolateShardRequest(ShardId shardId, PercolateRequest request) {
+        super(shardId, request);
         this.documentType = request.documentType();
         this.source = request.source();
         this.docSource = request.docSource();

--- a/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -170,7 +170,7 @@ public class TransportPercolateAction extends TransportBroadcastOperationAction<
 
     @Override
     protected PercolateShardRequest newShardRequest(int numShards, ShardRouting shard, PercolateRequest request) {
-        return new PercolateShardRequest(shard.index(), shard.id(), numShards, request);
+        return new PercolateShardRequest(shard.shardId(), numShards, request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -152,7 +152,7 @@ public class TransportShardMultiPercolateAction extends TransportShardSingleOper
             items = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
                 int slot = in.readVInt();
-                PercolateShardRequest shardRequest = new PercolateShardRequest(index(), shardId);
+                PercolateShardRequest shardRequest = new PercolateShardRequest(new ShardId(index, shardId));
                 shardRequest.documentType(in.readString());
                 shardRequest.source(in.readBytesReference());
                 shardRequest.docSource(in.readBytesReference());

--- a/src/main/java/org/elasticsearch/action/suggest/ShardSuggestRequest.java
+++ b/src/main/java/org/elasticsearch/action/suggest/ShardSuggestRequest.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.action.suggest;
 
-import java.io.IOException;
-
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
 
 /**
  * Internal suggest request executed directly against a specific index shard.
@@ -36,8 +37,8 @@ final class ShardSuggestRequest extends BroadcastShardOperationRequest {
     ShardSuggestRequest() {
     }
 
-    public ShardSuggestRequest(String index, int shardId, SuggestRequest request) {
-        super(index, shardId, request);
+    ShardSuggestRequest(ShardId shardId, SuggestRequest request) {
+        super(shardId, request);
         this.suggestSource = request.suggest();
     }
 

--- a/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -90,7 +90,7 @@ public class TransportSuggestAction extends TransportBroadcastOperationAction<Su
 
     @Override
     protected ShardSuggestRequest newShardRequest(int numShards, ShardRouting shard, SuggestRequest request) {
-        return new ShardSuggestRequest(shard.index(), shard.id(), request);
+        return new ShardSuggestRequest(shard.shardId(), request);
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationRequest.java
+++ b/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
@@ -32,31 +33,27 @@ import java.io.IOException;
  */
 public abstract class BroadcastShardOperationRequest extends TransportRequest implements IndicesRequest {
 
-    private String index;
-    private int shardId;
+    private ShardId shardId;
 
     protected BroadcastShardOperationRequest() {
     }
 
-    protected BroadcastShardOperationRequest(String index, int shardId, BroadcastOperationRequest request) {
+    protected BroadcastShardOperationRequest(ShardId shardId, BroadcastOperationRequest request) {
         super(request);
-        assert index != null;
-        this.index = index;
         this.shardId = shardId;
     }
 
-    public BroadcastShardOperationRequest(String index, int shardId) {
-        this.index = index;
+    protected BroadcastShardOperationRequest(ShardId shardId) {
         this.shardId = shardId;
     }
 
     public String index() {
-        return this.index;
+        return this.shardId.getIndex();
     }
 
     @Override
     public String[] indices() {
-        return new String[]{index};
+        return new String[]{shardId.getIndex()};
     }
 
     @Override
@@ -65,20 +62,18 @@ public abstract class BroadcastShardOperationRequest extends TransportRequest im
     }
 
     public int shardId() {
-        return this.shardId;
+        return this.shardId.id();
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
-        shardId = in.readVInt();
+        shardId = ShardId.readShardId(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
-        out.writeVInt(shardId);
+        shardId.writeTo(out);
     }
 }


### PR DESCRIPTION
Adjusted visibility to package private for BroadcastShardOperationRequest subclasses and their constructors

Also replaced the String,int pair for index and shard_id with `ShardId` object that holds the same info and serializes it the same way too.
